### PR TITLE
feat: add bounded JDBC source connector and simplify job model to bounded-only

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/job/Boundedness.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/job/Boundedness.java
@@ -1,3 +1,0 @@
-package com.baize.flux.api.job;
-
-public enum Boundedness {BOUNDED, UNBOUNDED}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/job/JobDefinition.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/job/JobDefinition.java
@@ -7,16 +7,14 @@ import com.baize.flux.api.configuration.ReadonlyConfig;
  */
 public final class JobDefinition {
     private final String name;
-    private final Boundedness boundedness;
     private final int batchSize;
     private final String sourceType;
     private final ReadonlyConfig sourceOptions;
     private final String sinkType;
     private final ReadonlyConfig sinkOptions;
 
-    public JobDefinition(String name, Boundedness boundedness, int batchSize, String sourceType, ReadonlyConfig sourceOptions, String sinkType, ReadonlyConfig sinkOptions) {
+    public JobDefinition(String name, int batchSize, String sourceType, ReadonlyConfig sourceOptions, String sinkType, ReadonlyConfig sinkOptions) {
         this.name = name;
-        this.boundedness = boundedness;
         this.batchSize = batchSize;
         this.sourceType = sourceType;
         this.sourceOptions = sourceOptions;
@@ -26,10 +24,6 @@ public final class JobDefinition {
 
     public String name() {
         return name;
-    }
-
-    public Boundedness boundedness() {
-        return boundedness;
     }
 
     public int batchSize() {

--- a/baize-flux-connectors/baize-flux-connector-jdbc/README.md
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/README.md
@@ -1,0 +1,19 @@
+# JDBC source connector
+
+The `jdbc` source executes one SQL query and emits its result set once. It is a
+bounded source intended for offline synchronization; it does not poll for
+changes or implement CDC.
+
+## Options
+
+| Option | Required | Default | Description |
+| --- | --- | --- | --- |
+| `url` | yes | — | JDBC connection URL. |
+| `query` | yes | — | SQL query to read. |
+| `username` | no | empty | JDBC user name. |
+| `password` | no | empty | JDBC password. |
+| `driver` | no | — | JDBC driver class to load before connecting. |
+| `fetch-size` | no | `1000` | Maximum number of rows emitted in one batch. |
+
+The result columns retain their query order and use JDBC column labels as the
+`FluxRow` field names.

--- a/baize-flux-connectors/baize-flux-connector-jdbc/pom.xml
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/pom.xml
@@ -13,5 +13,4 @@
     <artifactId>baize-flux-connector-jdbc</artifactId>
     <version>1.0.0</version>
 
-
 </project>

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connectors/jdbc/JdbcSource.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connectors/jdbc/JdbcSource.java
@@ -1,0 +1,38 @@
+package com.baize.flux.connectors.jdbc;
+
+import com.baize.flux.api.source.BoundedSource;
+import com.baize.flux.api.source.SourceReader;
+import com.baize.flux.api.table.FluxRow;
+
+import java.util.Collections;
+import java.util.List;
+
+/** A single-query, single-split JDBC source. */
+final class JdbcSource implements BoundedSource<FluxRow, JdbcSourceSplit> {
+    private final String url;
+    private final String query;
+    private final String username;
+    private final String password;
+    private final String driver;
+    private final int fetchSize;
+
+    JdbcSource(String url, String query, String username, String password, String driver, int fetchSize) {
+        this.url = url;
+        this.query = query;
+        this.username = username;
+        this.password = password;
+        this.driver = driver;
+        this.fetchSize = fetchSize;
+    }
+
+    @Override
+    public List<JdbcSourceSplit> planSplits(int parallelism) {
+        if (parallelism < 1) throw new IllegalArgumentException("parallelism must be at least 1");
+        return Collections.singletonList(new JdbcSourceSplit("jdbc-query"));
+    }
+
+    @Override
+    public SourceReader<FluxRow, JdbcSourceSplit> createReader() {
+        return new JdbcSourceReader(url, query, username, password, driver, fetchSize);
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connectors/jdbc/JdbcSourceFactory.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connectors/jdbc/JdbcSourceFactory.java
@@ -1,0 +1,46 @@
+package com.baize.flux.connectors.jdbc;
+
+import com.baize.flux.api.configuration.Constraints;
+import com.baize.flux.api.configuration.Option;
+import com.baize.flux.api.configuration.OptionRule;
+import com.baize.flux.api.configuration.Options;
+import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.factory.SourceFactory;
+import com.baize.flux.api.source.BoundedSource;
+import com.baize.flux.api.table.FluxRow;
+
+/** Creates a finite JDBC query source for offline synchronization. */
+public final class JdbcSourceFactory implements SourceFactory {
+    static final Option<String> URL = Options.key("url").stringType().noDefaultValue();
+    static final Option<String> QUERY = Options.key("query").stringType().noDefaultValue();
+    static final Option<String> USERNAME = Options.key("username").stringType().defaultValue("");
+    static final Option<String> PASSWORD = Options.key("password").stringType().sensitive().defaultValue("");
+    static final Option<String> DRIVER = Options.key("driver").stringType().noDefaultValue();
+    static final Option<Integer> FETCH_SIZE = Options.key("fetch-size").intType().defaultValue(1_000);
+
+    private static final OptionRule OPTION_RULE = OptionRule.builder()
+            .required(URL, QUERY)
+            .optional(USERNAME, PASSWORD, DRIVER, FETCH_SIZE)
+            .constrain(URL, Constraints.notBlank())
+            .constrain(QUERY, Constraints.notBlank())
+            .constrain(FETCH_SIZE, Constraints.greaterOrEqual(1))
+            .build();
+
+    @Override
+    public String factoryIdentifier() {
+        return "jdbc";
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OPTION_RULE;
+    }
+
+    @Override
+    public BoundedSource<FluxRow, ?> createSource(ReadonlyConfig config) {
+        return new JdbcSource(
+                config.get(URL), config.get(QUERY), config.get(USERNAME),
+                config.get(PASSWORD), config.getResolvedOptional(DRIVER).orElse(null),
+                config.get(FETCH_SIZE));
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connectors/jdbc/JdbcSourceReader.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connectors/jdbc/JdbcSourceReader.java
@@ -1,0 +1,87 @@
+package com.baize.flux.connectors.jdbc;
+
+import com.baize.flux.api.source.SourceReader;
+import com.baize.flux.api.table.FluxRow;
+import com.baize.flux.api.table.RecordBatch;
+import com.baize.flux.api.table.RowType;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Reads one JDBC result set in finite batches. */
+final class JdbcSourceReader implements SourceReader<FluxRow, JdbcSourceSplit> {
+    private final String url;
+    private final String query;
+    private final String username;
+    private final String password;
+    private final String driver;
+    private final int fetchSize;
+    private Connection connection;
+    private Statement statement;
+    private ResultSet resultSet;
+    private RowType rowType;
+    private boolean finished;
+
+    JdbcSourceReader(String url, String query, String username, String password, String driver, int fetchSize) {
+        this.url = url;
+        this.query = query;
+        this.username = username;
+        this.password = password;
+        this.driver = driver;
+        this.fetchSize = fetchSize;
+    }
+
+    @Override
+    public void open(JdbcSourceSplit split) throws Exception {
+        if (connection != null) throw new IllegalStateException("Reader is already open");
+        if (driver != null && !driver.trim().isEmpty()) Class.forName(driver);
+        connection = DriverManager.getConnection(url, username, password);
+        statement = connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        statement.setFetchSize(fetchSize);
+        resultSet = statement.executeQuery(query);
+        ResultSetMetaData metadata = resultSet.getMetaData();
+        List<String> fields = new ArrayList<String>(metadata.getColumnCount());
+        for (int index = 1; index <= metadata.getColumnCount(); index++) fields.add(metadata.getColumnLabel(index));
+        rowType = new RowType(fields);
+    }
+
+    @Override
+    public RecordBatch<FluxRow> pollBatch() throws Exception {
+        ensureOpen();
+        if (finished) return RecordBatch.endOfInput();
+        List<FluxRow> rows = new ArrayList<FluxRow>(fetchSize);
+        while (rows.size() < fetchSize && resultSet.next()) {
+            List<Object> values = new ArrayList<Object>(rowType.fieldCount());
+            for (int index = 1; index <= rowType.fieldCount(); index++) values.add(resultSet.getObject(index));
+            rows.add(new FluxRow(rowType, values));
+        }
+        if (rows.isEmpty()) finished = true;
+        return rows.isEmpty() ? RecordBatch.<FluxRow>endOfInput() : RecordBatch.of(rows);
+    }
+
+    @Override
+    public boolean isFinished() {
+        return finished;
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        try { if (resultSet != null) resultSet.close(); } catch (Exception e) { failure = e; }
+        try { if (statement != null) statement.close(); } catch (Exception e) { if (failure == null) failure = e; else failure.addSuppressed(e); }
+        try { if (connection != null) connection.close(); } catch (Exception e) { if (failure == null) failure = e; else failure.addSuppressed(e); }
+        resultSet = null;
+        statement = null;
+        connection = null;
+        if (failure != null) throw failure;
+    }
+
+    private void ensureOpen() {
+        if (resultSet == null) throw new IllegalStateException("Reader is not open");
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connectors/jdbc/JdbcSourceSplit.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connectors/jdbc/JdbcSourceSplit.java
@@ -1,0 +1,16 @@
+package com.baize.flux.connectors.jdbc;
+
+import com.baize.flux.api.source.SourceSplit;
+
+final class JdbcSourceSplit implements SourceSplit {
+    private final String splitId;
+
+    JdbcSourceSplit(String splitId) {
+        this.splitId = splitId;
+    }
+
+    @Override
+    public String splitId() {
+        return splitId;
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/resources/META-INF/services/com.baize.flux.api.factory.SourceFactory
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/resources/META-INF/services/com.baize.flux.api.factory.SourceFactory
@@ -1,0 +1,1 @@
+com.baize.flux.connectors.jdbc.JdbcSourceFactory

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connectors/jdbc/JdbcSourceFactoryTest.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connectors/jdbc/JdbcSourceFactoryTest.java
@@ -1,0 +1,79 @@
+package com.baize.flux.connectors.jdbc;
+
+import com.baize.flux.api.configuration.ConfigValidator;
+import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.source.BoundedSource;
+import com.baize.flux.api.source.SourceReader;
+import com.baize.flux.api.source.SourceSplit;
+import com.baize.flux.api.table.FluxRow;
+import com.baize.flux.api.table.RecordBatch;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcSourceFactoryTest {
+    private static final String URL = "jdbc:h2:mem:jdbc_source;DB_CLOSE_DELAY=-1";
+
+    @Before
+    public void setUp() throws Exception {
+        Class.forName("org.h2.Driver");
+        try (Connection connection = DriverManager.getConnection(URL); Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE IF EXISTS source_rows");
+            statement.execute("CREATE TABLE source_rows (id INT PRIMARY KEY, name VARCHAR(32))");
+            statement.execute("INSERT INTO source_rows VALUES (1, 'one'), (2, 'two'), (3, 'three')");
+        }
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try (Connection connection = DriverManager.getConnection(URL); Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE IF EXISTS source_rows");
+        }
+    }
+
+    @Test
+    public void readsFiniteQueryInConfiguredBatches() throws Exception {
+        JdbcSourceFactory factory = new JdbcSourceFactory();
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("url", URL);
+        values.put("query", "SELECT id, name FROM source_rows ORDER BY id");
+        values.put("fetch-size", 2);
+        ReadonlyConfig config = ReadonlyConfig.fromMap(values);
+        ConfigValidator.strict().validate(config, factory.optionRule()).throwIfInvalid();
+
+        BoundedSource<FluxRow, ?> source = factory.createSource(config);
+        List<?> splits = source.planSplits(1);
+        assertEquals(1, splits.size());
+        SourceReader reader = source.createReader();
+        try {
+            reader.open((SourceSplit) splits.get(0));
+            RecordBatch<FluxRow> first = (RecordBatch<FluxRow>) reader.pollBatch();
+            assertEquals(2, first.records().size());
+            assertEquals("ID", first.records().get(0).rowType().fieldNames().get(0));
+            assertEquals(1, first.records().get(0).getField(0));
+            assertEquals("two", first.records().get(1).getField(1));
+
+            RecordBatch<FluxRow> second = (RecordBatch<FluxRow>) reader.pollBatch();
+            assertEquals(1, second.records().size());
+            assertEquals(3, second.records().get(0).getField(0));
+            assertFalse(reader.isFinished());
+
+            RecordBatch<FluxRow> end = (RecordBatch<FluxRow>) reader.pollBatch();
+            assertTrue(end.isEndOfInput());
+            assertTrue(reader.isFinished());
+        } finally {
+            reader.close();
+        }
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
@@ -2,7 +2,7 @@ package com.baize.flux.framework.planner;
 
 import com.baize.flux.api.configuration.ConfigValidator;
 import com.baize.flux.api.factory.*;
-import com.baize.flux.api.job.*;
+import com.baize.flux.api.job.JobDefinition;
 import com.baize.flux.api.source.BoundedSource;
 import com.baize.flux.api.table.FluxRow;
 import com.baize.flux.framework.plugin.FactoryRegistry;
@@ -18,8 +18,6 @@ public final class JobPlanner {
     }
 
     public PhysicalPlan plan(JobDefinition job) {
-        if (job.boundedness() != Boundedness.BOUNDED)
-            throw new UnsupportedOperationException("Unbounded source is not supported yet");
         SourceFactory sf = registry.getSourceFactory(job.sourceType());
         SinkFactory kf = registry.getSinkFactory(job.sinkType());
         ConfigValidator.strict().validate(job.sourceOptions(), sf.optionRule()).throwIfInvalid();

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LauncherConfigurationExample.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LauncherConfigurationExample.java
@@ -1,7 +1,6 @@
 package com.baize.flux.launcher;
 
 import com.baize.flux.api.configuration.*;
-import com.baize.flux.api.job.Boundedness;
 import com.baize.flux.api.job.JobDefinition;
 import com.baize.flux.framework.configuration.HoconConfigLoader;
 import com.baize.flux.framework.execution.JobResult;
@@ -36,6 +35,6 @@ public final class LauncherConfigurationExample {
 
     public static JobDefinition toJobDefinition(ReadonlyConfig config) {
         ConfigValidator.strict().validate(config, JOB_RULE).throwIfInvalid();
-        return new JobDefinition(config.get(NAME), Boundedness.BOUNDED, config.get(BATCH_SIZE), config.get(SOURCE_TYPE), ReadonlyConfig.fromMap(config.get(SOURCE_OPTIONS)), config.get(SINK_TYPE), ReadonlyConfig.fromMap(config.get(SINK_OPTIONS)));
+        return new JobDefinition(config.get(NAME), config.get(BATCH_SIZE), config.get(SOURCE_TYPE), ReadonlyConfig.fromMap(config.get(SOURCE_OPTIONS)), config.get(SINK_TYPE), ReadonlyConfig.fromMap(config.get(SINK_OPTIONS)));
     }
 }


### PR DESCRIPTION
### Motivation
- Move the runtime model to a simple source → channel → sink offline-only flow and remove realtime/unbounded complexity. 
- Provide a JDBC-backed bounded source to support one-shot/offline data synchronization from relational databases.

### Description
- Add a ServiceLoader-discoverable JDBC connector with `JdbcSourceFactory`, `JdbcSource`, `JdbcSourceReader`, `JdbcSourceSplit`, service registration file, a connector `README`, and a unit test `JdbcSourceFactoryTest` under `baize-flux-connectors/baize-flux-connector-jdbc`.
- Implement `JdbcSourceFactory` (factory id `jdbc`) with validated options `url`, `query`, `username`, `password`, `driver`, and `fetch-size` via an `OptionRule`, and produce a `BoundedSource<FluxRow,?>` from `createSource`.
- Implement `JdbcSourceReader` to execute a single SQL query (optional driver load), emit rows in finite batches controlled by `fetch-size`, preserve JDBC column labels as the `FluxRow` `RowType`, and close JDBC resources on `close()`.
- Simplify the job model by removing the `Boundedness` enum and the `boundedness` field from `JobDefinition`, remove the planner check for unbounded sources in `JobPlanner`, and update the launcher `toJobDefinition` to construct bounded-only jobs.

### Testing
- Added `JdbcSourceFactoryTest` (H2 in-memory) which exercises configuration validation, single-split planning, batch emission, field mapping, and end-of-input behavior; the test is included under `src/test/java`.
- Ran `git diff --check` which reported no index errors.
- Running `mvn test -q` in this environment was blocked because Maven Central returned HTTP 403 while resolving `maven-resources-plugin:3.3.1`, so automated tests could not complete here.
- A manual `javac` attempt failed to fully compile the full project in this environment due to missing Lombok artifacts in the local toolchain, so a full local compile/test was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61842d1d6083269e64d83d6585e0d8)