### PR TITLE
feat: wire local HOCON source execution

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceFactory.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceFactory.java
@@ -34,7 +34,7 @@ import java.util.Objects;
  *
  * 表读取、分片生成和连接管理不在 Factory 中处理。
  */
-@AutoService(SourceFactory.class)
+@AutoService(TableSourceFactory.class)
 public final class JdbcSourceFactory
         implements TableSourceFactory<JdbcSourceSplit> {
 

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceSplitGenerator.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceSplitGenerator.java
@@ -1,0 +1,43 @@
+package com.baize.flux.connector.jdbc.source;
+
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.catalog.TablePath;
+import com.baize.flux.connector.jdbc.config.JdbcSourceConfig;
+import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
+import com.baize.flux.connector.jdbc.core.dialect.JdbcDialectLoader;
+import com.baize.flux.connector.jdbc.utils.JdbcCatalogUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Creates the bounded JDBC splits for a prepared source. */
+final class JdbcSourceSplitGenerator {
+
+    private JdbcSourceSplitGenerator() {
+    }
+
+    static List<JdbcSourceSplit> generate(
+            JdbcSourceConfig config,
+            Map<TablePath, CatalogTable> tables)
+            throws Exception {
+
+        Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(tables, "tables must not be null");
+
+        JdbcDialect dialect = JdbcDialectLoader.load(config.getConnectionConfig());
+        Map<TablePath, JdbcSourceTable> sourceTables =
+                JdbcCatalogUtils.getTables(config, dialect);
+
+        for (JdbcSourceTable sourceTable : sourceTables.values()) {
+            if (!tables.containsKey(sourceTable.getTablePath())) {
+                throw new IllegalArgumentException(
+                        "No prepared table metadata for "
+                                + sourceTable.getTablePath());
+            }
+        }
+
+        return new JdbcSourceSplitEnumerator(config, sourceTables, 1)
+                .enumerateSplits();
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/util/FactoryUtil.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/util/FactoryUtil.java
@@ -7,7 +7,7 @@ import com.baize.flux.api.source.Source;
 import com.baize.flux.api.source.SourceSplit;
 import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.catalog.TablePath;
-import com.baize.flux.api.table.factory.SourceFactoryContext;
+import com.baize.flux.api.source.SourceFactoryContext;
 import com.baize.flux.api.table.factory.TableSourceFactory;
 import com.baize.flux.framework.factory.FactoryException;
 import com.baize.flux.framework.factory.PreparedSource;

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LocalSyncLauncher.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LocalSyncLauncher.java
@@ -1,13 +1,119 @@
 package com.baize.flux.launcher;
 
+import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.source.RecordBatch;
+import com.baize.flux.api.table.type.FluxRow;
+import com.baize.flux.framework.channel.Channel;
+import com.baize.flux.framework.channel.MemoryFluxChannel;
+import com.baize.flux.framework.execution.source.SourceAction;
+import com.baize.flux.framework.execution.source.SourceExecuteProcessor;
+import com.baize.flux.framework.factory.PreparedSource;
+import com.baize.flux.framework.util.FactoryUtil;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Runs one bounded source locally.
+ *
+ * <p>The sole argument is a HOCON string containing a {@code source} object
+ * with {@code type}, optional {@code batch-size}, and connector options.
+ */
 public final class LocalSyncLauncher {
 
+    private static final int DEFAULT_BATCH_SIZE = 1_000;
 
-    public static void main(String[] args)
-            throws Exception {
-
-
+    private LocalSyncLauncher() {
     }
 
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new IllegalArgumentException(
+                    "Usage: LocalSyncLauncher '<HOCON source configuration>'");
+        }
+        run(args[0], Thread.currentThread().getContextClassLoader());
+    }
+
+    /** Executes a HOCON source configuration and prints every emitted row. */
+    public static void run(String hocon, ClassLoader classLoader) throws Exception {
+        Config root = ConfigFactory.parseString(hocon).resolve();
+        if (!root.hasPath("source")) {
+            throw new IllegalArgumentException(
+                    "HOCON configuration must contain a 'source' object");
+        }
+
+        Config sourceConfig = root.getConfig("source");
+        if (!sourceConfig.hasPath("type")) {
+            throw new IllegalArgumentException(
+                    "HOCON configuration must contain 'source.type'");
+        }
+
+        String factoryIdentifier = sourceConfig.getString("type");
+        int batchSize = sourceConfig.hasPath("batch-size")
+                ? sourceConfig.getInt("batch-size")
+                : DEFAULT_BATCH_SIZE;
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException(
+                    "source.batch-size must be greater than 0");
+        }
+
+        Config connectorConfig = sourceConfig.withoutPath("type")
+                .withoutPath("batch-size");
+        PreparedSource<?> preparedSource = FactoryUtil.createAndPrepareSource(
+                factoryIdentifier,
+                ReadonlyConfig.fromConfig(connectorConfig),
+                classLoader);
+        executeAndPrint(preparedSource, batchSize);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static void executeAndPrint(
+            PreparedSource<?> preparedSource, int batchSize) throws Exception {
+        Channel<RecordBatch<FluxRow>> channel = new MemoryFluxChannel<>(1);
+        AtomicReference<Throwable> producerFailure = new AtomicReference<>();
+
+        Thread producer = new Thread(() -> {
+            try {
+                new SourceExecuteProcessor().execute(
+                        new SourceAction("local-sync", (PreparedSource) preparedSource, batchSize),
+                        batch -> channel.put(batch));
+            } catch (Throwable failure) {
+                producerFailure.set(failure);
+            } finally {
+                try {
+                    channel.put(RecordBatch.endOfInput());
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }, "baize-flux-source-reader");
+
+        producer.start();
+        try {
+            while (true) {
+                RecordBatch<FluxRow> batch = channel.take();
+                if (batch.isEndOfInput()) {
+                    break;
+                }
+                for (FluxRow row : batch.getRecords()) {
+                    System.out.println(row);
+                }
+            }
+        } finally {
+            producer.interrupt();
+            producer.join();
+        }
+
+        Throwable failure = producerFailure.get();
+        if (failure != null) {
+            if (failure instanceof Exception) {
+                throw (Exception) failure;
+            }
+            if (failure instanceof Error) {
+                throw (Error) failure;
+            }
+            throw new RuntimeException(failure);
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a simple end-to-end local path to run a bounded source from a HOCON string so the factory -> source -> reader -> channel -> print flow is exercised.
- Fill missing pieces for JDBC bounded reads and correct SPI wiring so the launcher can discover and prepare connectors via `FactoryUtil`.

### Description
- Add `LocalSyncLauncher` which accepts a HOCON string, parses `source.type` and optional `source.batch-size`, uses `FactoryUtil.createAndPrepareSource` to build a `PreparedSource`, streams `RecordBatch<FluxRow>` through a `MemoryFluxChannel`, and prints rows to stdout.
- Add `JdbcSourceSplitGenerator` to produce bounded `JdbcSourceSplit` instances by loading dialect and table metadata via `JdbcCatalogUtils` and validating prepared table schemas before planning splits.
- Register the JDBC factory with the correct SPI by changing the `@AutoService` target to `TableSourceFactory.class` in `JdbcSourceFactory`.
- Fix a wrong import in `FactoryUtil` by using `com.baize.flux.api.source.SourceFactoryContext` so the factory creation flow compiles and runs.

### Testing
- Ran `mvn -q validate`, which completed successfully.
- Ran `git diff --check` to ensure no whitespace/format issues, which reported no problems.
- Attempted full compilation with `mvn -q -DskipTests compile` but it failed to resolve `maven-resources-plugin:3.3.1` from Maven Central (HTTP 403), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61db37ee648326bb1cafee0a01d6dc)