### PR TITLE
Improve JDBC connection lifecycle and retries

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/internal/JdbcConnectionProvider.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/internal/JdbcConnectionProvider.java
@@ -2,21 +2,125 @@ package com.baize.flux.connector.jdbc.internal;
 
 import com.baize.flux.connector.jdbc.config.JdbcConnectionConfig;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
+
+import java.io.Serializable;
 import java.sql.Connection;
+import java.sql.Driver;
 import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.util.Enumeration;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
-/** Creates connections with dialect defaults followed by user properties. */
-public final class JdbcConnectionProvider {
+/**
+ * Owns one lazily-created JDBC connection and recreates it when it is no longer usable.
+ *
+ * <p>Dialect defaults are applied first. Explicit connector properties, including credentials,
+ * always take precedence over those defaults.</p>
+ */
+public final class JdbcConnectionProvider implements AutoCloseable, Serializable {
+
+    private static final long serialVersionUID = 1L;
+
     private final JdbcConnectionConfig config;
     private final JdbcDialect dialect;
-    public JdbcConnectionProvider(JdbcConnectionConfig config, JdbcDialect dialect) { this.config = Objects.requireNonNull(config, "config must not be null"); this.dialect = Objects.requireNonNull(dialect, "dialect must not be null"); }
-    public Connection getConnection() throws Exception {
-        Class.forName(config.getDriverName());
-        Properties properties = config.toProperties();
-        for (Map.Entry<String, String> entry : dialect.resolveConnectionProperties(config.getProperties()).entrySet()) properties.setProperty(entry.getKey(), entry.getValue());
-        return DriverManager.getConnection(config.getUrl(), properties);
+
+    private transient Driver loadedDriver;
+    private transient Connection connection;
+
+    public JdbcConnectionProvider(JdbcConnectionConfig config, JdbcDialect dialect) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.dialect = Objects.requireNonNull(dialect, "dialect must not be null");
+    }
+
+    /** Returns the managed connection, creating it when necessary. */
+    public synchronized Connection getOrEstablishConnection() throws SQLException, ClassNotFoundException {
+        if (isConnectionValid()) {
+            return connection;
+        }
+
+        closeConnection();
+        connection = getLoadedDriver().connect(config.getUrl(), createProperties());
+        if (connection == null) {
+            throw new SQLException("No suitable driver found for configured JDBC URL: " + config.getUrl());
+        }
+        return connection;
+    }
+
+    /** Returns the currently managed connection, or {@code null} before it has been opened. */
+    public synchronized Connection getConnection() {
+        return connection;
+    }
+
+    public synchronized boolean isConnectionValid() {
+        if (connection == null) {
+            return false;
+        }
+        try {
+            return !connection.isClosed()
+                    && connection.isValid(config.getConnectionCheckTimeoutSeconds());
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    /** Closes any managed connection and creates a replacement. */
+    public synchronized Connection reestablishConnection() throws SQLException, ClassNotFoundException {
+        closeConnection();
+        return getOrEstablishConnection();
+    }
+
+    public synchronized void closeConnection() {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException ignored) {
+                // Closing is best effort; clearing the stale reference is still essential.
+            } finally {
+                connection = null;
+            }
+        }
+    }
+
+    @Override
+    public void close() {
+        closeConnection();
+    }
+
+    private Properties createProperties() {
+        Properties result = new Properties();
+        for (Map.Entry<String, String> entry : dialect.resolveConnectionProperties(config.getProperties()).entrySet()) {
+            result.setProperty(entry.getKey(), entry.getValue());
+        }
+        result.putAll(config.toProperties());
+        return result;
+    }
+
+    private Driver getLoadedDriver() throws ClassNotFoundException, SQLException {
+        if (loadedDriver == null) {
+            loadedDriver = loadDriver(config.getDriverName());
+        }
+        return loadedDriver;
+    }
+
+    private static Driver loadDriver(String driverName) throws ClassNotFoundException, SQLException {
+        Enumeration<Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            Driver driver = drivers.nextElement();
+            if (driver.getClass().getName().equals(driverName)) {
+                return driver;
+            }
+        }
+
+        Class<?> driverClass = Class.forName(driverName, true, Thread.currentThread().getContextClassLoader());
+        if (!Driver.class.isAssignableFrom(driverClass)) {
+            throw new SQLException("Configured JDBC driver does not implement java.sql.Driver: " + driverName);
+        }
+        try {
+            return (Driver) driverClass.getDeclaredConstructor().newInstance();
+        } catch (ReflectiveOperationException e) {
+            throw new SQLException("Unable to create JDBC driver: " + driverName, e);
+        }
     }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/internal/JdbcInputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/internal/JdbcInputFormat.java
@@ -3,7 +3,6 @@ package com.baize.flux.connector.jdbc.internal;
 import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.api.table.type.FluxRow;
-import com.baize.flux.connector.jdbc.config.JdbcConnectionConfig;
 import com.baize.flux.connector.jdbc.config.JdbcSourceConfig;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialectLoader;
@@ -36,7 +35,7 @@ public final class JdbcInputFormat {
     }
 
     public void openInputFormat() throws Exception {
-        connection = connectionProvider.getConnection();
+        connection = connectionProvider.getOrEstablishConnection();
     }
 
     public void open(JdbcSourceSplit split) throws Exception {
@@ -74,6 +73,7 @@ public final class JdbcInputFormat {
 
     public void closeInputFormat() throws Exception {
         close();
-        if (connection != null) { connection.close(); connection = null; }
+        connectionProvider.closeConnection();
+        connection = null;
     }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
@@ -33,13 +33,36 @@ public final class JdbcOutputFormat implements AutoCloseable {
         CatalogTable target = targetTable(sourceTable); prepareTable(target); ensureConnection();
         List<String> fields = target.getTableSchema().getColumns().stream().map(c -> c.getName()).collect(Collectors.toList());
         String sql = config.hasCustomSql() ? config.getCustomSql() : config.isUpsert() ? dialect.buildUpsertSql(target.getTablePath(), fields, primaryKeys(target)).orElseThrow(() -> new IllegalArgumentException("Dialect does not support UPSERT: " + dialect.name())) : dialect.buildInsertSql(target.getTablePath(), fields);
-        try (PreparedStatement statement = connection.prepareStatement(sql)) {
-            int pending = 0;
-            for (FluxRow row : rows) { dialect.rowConverter().write(statement, row, target.getTableSchema()); statement.addBatch(); if (++pending == config.getBatchSize()) { execute(statement); pending = 0; } }
-            if (pending > 0) execute(statement);
+        for (int start = 0; start < rows.size(); start += config.getBatchSize()) {
+            int end = Math.min(start + config.getBatchSize(), rows.size());
+            executeBatch(sql, rows.subList(start, end), target.getTableSchema());
         }
     }
-    private void execute(PreparedStatement statement) throws Exception { Exception failure = null; for (int attempt = 0; attempt <= config.getMaxRetries(); attempt++) try { statement.executeBatch(); connection.commit(); return; } catch (Exception e) { failure = e; rollback(e); } throw failure; }
+    private void executeBatch(String sql, List<FluxRow> rows, TableSchema schema) throws Exception {
+        Exception failure = null;
+        for (int attempt = 0; attempt <= config.getMaxRetries(); attempt++) {
+            try {
+                ensureConnection();
+                try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                    for (FluxRow row : rows) {
+                        dialect.rowConverter().write(statement, row, schema);
+                        statement.addBatch();
+                    }
+                    statement.executeBatch();
+                    connection.commit();
+                    return;
+                }
+            } catch (Exception e) {
+                failure = e;
+                rollback(e);
+                if (!connectionProvider.isConnectionValid()) {
+                    connection = connectionProvider.reestablishConnection();
+                    connection.setAutoCommit(false);
+                }
+            }
+        }
+        throw failure;
+    }
     private void prepareTable(CatalogTable target) throws Exception {
         if (!preparedTables.add(target.getTablePath())) return;
         Catalog catalog = dialect.createCatalog(config.getConnectionConfig());
@@ -60,7 +83,21 @@ public final class JdbcOutputFormat implements AutoCloseable {
         return target.withSchema(schema);
     }
     private List<String> primaryKeys(CatalogTable table) { if (config.hasConfiguredPrimaryKeys()) return config.getPrimaryKeys(); PrimaryKey key = table.getTableSchema().getPrimaryKey(); return key == null ? new ArrayList<>() : key.getColumnNames(); }
-    private void ensureConnection() throws Exception { if (connection == null || connection.isClosed()) { connection = connectionProvider.getConnection(); connection.setAutoCommit(false); } }
-    private void rollback(Exception original) { try { if (connection != null) connection.rollback(); } catch (Exception e) { original.addSuppressed(e); } }
-    @Override public void close() throws Exception { if (connection != null) try { connection.close(); } finally { connection = null; } }
+    private void ensureConnection() throws Exception {
+        if (connection == null || !connectionProvider.isConnectionValid()) {
+            connection = connectionProvider.getOrEstablishConnection();
+            connection.setAutoCommit(false);
+        }
+    }
+    private void rollback(Exception original) {
+        try {
+            if (connection != null) connection.rollback();
+        } catch (Exception e) {
+            original.addSuppressed(e);
+        }
+    }
+    @Override public void close() {
+        connectionProvider.closeConnection();
+        connection = null;
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a robust, reusable JDBC connection manager that validates and recreates connections and loads JDBC drivers safely.
- Ensure source code uses the managed connection and that sink writes recover gracefully from statement or connection failures.

### Description
- Add a serializable `JdbcConnectionProvider` that lazily loads the configured `Driver`, merges dialect defaults with connector properties via `createProperties()`, manages a single `Connection`, and exposes `getOrEstablishConnection()`, `getConnection()`, `isConnectionValid()`, `reestablishConnection()`, and `closeConnection()` methods.
- Update `JdbcInputFormat` to acquire the managed connection using `connectionProvider.getOrEstablishConnection()` during `openInputFormat()` and to release it via `connectionProvider.closeConnection()` in `closeInputFormat()`.
- Rewrite sink batching in `JdbcOutputFormat` to prepare a fresh `PreparedStatement` per retry attempt, run batches in configurable chunks, call `rollback()` on failure, and reestablish the connection via `connectionProvider.reestablishConnection()` when the provider reports an invalid connection.
- Ensure transactions are explicit (`setAutoCommit(false)`), commit on successful batch, and clear/close connection via the provider on close.

### Testing
- Ran `git diff --check` to validate whitespace and trivial issues, which passed.
- Attempted `mvn -pl baize-flux-connectors/baize-flux-connector-jdbc -am test -DskipTests` to build the connector module, but execution was blocked by Maven Central plugin resolution returning HTTP 403 for `maven-resources-plugin:3.3.1`, so compilation/tests could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61e8e1e62c83268f8da52abd450447)