### PR TITLE
feat: support JDBC multi-table sink templates

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/README.md
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/README.md
@@ -1,14 +1,43 @@
-# JDBC source connector
+# JDBC connector
 
-The `jdbc` source executes one SQL query and emits its result set once. It is a bounded source intended for offline
-synchronization; it does not poll for changes or implement CDC.
+The `jdbc` source is bounded and can synchronize one or more tables in one
+offline job. It does not poll for changes or implement CDC. Configure
+`table_list` with table objects for a multi-table job; each emitted batch keeps
+its source table identity so the JDBC sink can create and write the matching
+target table.
+
+```hocon
+source {
+  type = "jdbc"
+  url = "jdbc:mysql://localhost:3306/flux_test"
+  table_list = [
+    { table_path = "flux_test.user_info" },
+    { table_path = "flux_test.orders" }
+  ]
+}
+
+sink {
+  type = "jdbc"
+  url = "jdbc:mysql://localhost:3306/flux_test"
+  # `table` is an alias for `table_path`.
+  table = "sink_${schema_name}_${table_name}"
+}
+```
+
+The sink expands `${table_name}` with the source table name. `${schema_name}`
+uses the source schema; for MySQL's `database.table` paths it uses the database
+name. A fixed `table` value, such as `public.sink_table`, writes all input to
+that target. If `table`/`table_path` is configured, Flux generates the
+INSERT/UPSERT SQL for the resolved target and ignores `custom_sql`/`query`.
 
 ## Options
 
 | Option | Required | Default | Description |
 | --- | --- | --- | --- |
 | `url` | yes | — | JDBC connection URL. |
-| `query` | yes | — | SQL query to read. |
+| `table_path` | one of `table_path` or `table_list` | — | Source table path. |
+| `table_list` | one of `table_path` or `table_list` | — | List of `{ table_path = "..." }` source-table objects. |
+| `query` | no | — | SQL query to read for a single table; requires `table_path`. |
 | `username` | no | empty | JDBC user name. |
 | `password` | no | empty | JDBC password. |
 | `driver` | no | — | JDBC driver class to load before connecting. |

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfig.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfig.java
@@ -1,6 +1,7 @@
 package com.baize.flux.connector.jdbc.config;
 
 import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.connector.jdbc.sink.DataSaveMode;
 import com.baize.flux.connector.jdbc.sink.SchemaSaveMode;
 import lombok.Getter;
@@ -188,7 +189,43 @@ public final class JdbcSinkConfig
     }
 
     public boolean hasCustomSql() {
-        return customSql != null;
+        // A configured table is the authoritative routing instruction for a
+        // multi-table job.  In that case SQL must be generated for each
+        // resolved target table instead of reusing a statement that can only
+        // address one table.
+        return customSql != null && targetTablePath == null;
+    }
+
+    /**
+     * Resolves the configured target-table template for one source table.
+     *
+     * <p>{@code ${table_name}} is replaced with the source table name. {@code
+     * ${schema_name}} is replaced with the source schema; for two-part paths
+     * (the usual MySQL {@code database.table} form), the database is used as
+     * the schema name. A target table without placeholders remains a fixed
+     * target, which is useful for single-table jobs.
+     *
+     * @param sourceTablePath the table that produced the current batch
+     * @return the configured and expanded target table path, or {@code null}
+     *     when the source path should be retained
+     */
+    public String resolveTargetTablePath(TablePath sourceTablePath) {
+        if (targetTablePath == null) {
+            return null;
+        }
+        Objects.requireNonNull(sourceTablePath, "sourceTablePath must not be null");
+
+        String schemaName = sourceTablePath.getSchemaName();
+        if (schemaName == null) {
+            schemaName = sourceTablePath.getDatabaseName();
+        }
+        if (schemaName == null) {
+            schemaName = "";
+        }
+
+        return targetTablePath
+                .replace("${schema_name}", schemaName)
+                .replace("${table_name}", sourceTablePath.getTableName());
     }
 
     public boolean hasConfiguredPrimaryKeys() {

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkOptions.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkOptions.java
@@ -21,17 +21,19 @@ public final class JdbcSinkOptions
      * <p>
      * database.table
      * <p>
-     * 多表可以不配置，默认沿用 Source 表路径；
-     * 后续也可以支持占位符：
+     * 多表可以不配置，默认沿用 Source 表路径。支持
+     * {@code ${schema_name}} 和 {@code ${table_name}} 占位符，例如
+     * {@code archive.${schema_name}_${table_name}}。
      * <p>
-     * target_${table}
+     * 配置目标表时优先使用自动生成的 INSERT/UPSERT SQL，忽略
+     * {@code custom_sql}（以及其 {@code query} 别名）。
      */
     public static final Option<String> TABLE_PATH =
             Options.key("table_path")
                     .stringType()
                     .noDefaultValue()
                     .withFallbackKeys("table")
-                    .withDescription("目标表路径或目标表模板");
+                    .withDescription("目标表路径或多表目标模板，支持 ${schema_name} 和 ${table_name}");
 
     public static final Option<SchemaSaveMode>
             SCHEMA_SAVE_MODE =

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
@@ -99,7 +99,11 @@ public final class JdbcOutputFormat implements AutoCloseable {
     }
 
     private CatalogTable targetTable(CatalogTable source) {
-        TablePath path = config.getTargetTablePath() == null ? source.getTablePath() : dialect.parseTablePath(config.getTargetTablePath());
+        String targetTablePath = config.resolveTargetTablePath(source.getTablePath());
+        TablePath path =
+                targetTablePath == null
+                        ? source.getTablePath()
+                        : dialect.parseTablePath(targetTablePath);
         return source.withPath(path);
     }
 

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfigTest.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfigTest.java
@@ -1,0 +1,46 @@
+package com.baize.flux.connector.jdbc.config;
+
+import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.table.catalog.TablePath;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcSinkConfigTest {
+
+    @Test
+    public void shouldResolveTargetTableTemplateForMySqlPath() {
+        JdbcSinkConfig config = config("table = \"sink_${schema_name}_${table_name}\"");
+
+        assertEquals(
+                "sink_flux_test_orders",
+                config.resolveTargetTablePath(TablePath.of("flux_test", "orders")));
+    }
+
+    @Test
+    public void shouldResolveTargetTableTemplateForSchemaPath() {
+        JdbcSinkConfig config = config("table_path = \"${schema_name}.${table_name}_copy\"");
+
+        assertEquals(
+                "public.orders_copy",
+                config.resolveTargetTablePath(TablePath.of("catalog", "public", "orders")));
+    }
+
+    @Test
+    public void shouldPreferConfiguredTableOverCustomSql() {
+        JdbcSinkConfig config = config("table = \"sink_${table_name}\"\ncustom_sql = \"INSERT INTO ignored VALUES (?)\"");
+
+        assertFalse(config.hasCustomSql());
+        assertTrue(config.resolveTargetTablePath(TablePath.of("orders")).equals("sink_orders"));
+    }
+
+    private JdbcSinkConfig config(String sinkOptions) {
+        return JdbcSinkConfig.of(
+                ReadonlyConfig.fromConfig(
+                        ConfigFactory.parseString(
+                                "url = \"jdbc:mysql://localhost:3306/flux_test\"\n" + sinkOptions)));
+    }
+}

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JdbcMultiTableSyncExample.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JdbcMultiTableSyncExample.java
@@ -1,0 +1,48 @@
+package com.baize.flux.launcher;
+
+/**
+ * Runnable JDBC multi-table synchronization example.
+ *
+ * <p>Update the connection properties and source table names before running
+ * this class. Pass a complete HOCON job as the sole argument to override the
+ * example configuration.
+ */
+public final class JdbcMultiTableSyncExample {
+
+    private static final String EXAMPLE_HOCON =
+            "source {\n"
+                    + "  type = \"jdbc\"\n"
+                    + "  batch-size = 1000\n"
+                    + "  url = \"jdbc:mysql://127.0.0.1:3306/flux_test?useSSL=false&serverTimezone=UTC\"\n"
+                    + "  driver = \"com.mysql.cj.jdbc.Driver\"\n"
+                    + "  user = \"root\"\n"
+                    + "  password = \"123456\"\n"
+                    + "  table_list = [\n"
+                    + "    { table_path = \"flux_test.user_info\" },\n"
+                    + "    { table_path = \"flux_test.orders\" }\n"
+                    + "  ]\n"
+                    + "}\n"
+                    + "sink {\n"
+                    + "  type = \"jdbc\"\n"
+                    + "  url = \"jdbc:mysql://127.0.0.1:3306/flux_test?useSSL=false&serverTimezone=UTC\"\n"
+                    + "  driver = \"com.mysql.cj.jdbc.Driver\"\n"
+                    + "  user = \"root\"\n"
+                    + "  password = \"123456\"\n"
+                    + "  # `table` is an alias for table_path. Each source table gets its own target.\n"
+                    + "  table = \"sink_${schema_name}_${table_name}\"\n"
+                    + "  schema_save_mode = CREATE_SCHEMA_WHEN_NOT_EXIST\n"
+                    + "  data_save_mode = APPEND_DATA\n"
+                    + "}\n";
+
+    private JdbcMultiTableSyncExample() {}
+
+    public static void main(String[] args) throws Exception {
+        if (args.length > 1) {
+            throw new IllegalArgumentException(
+                    "Usage: JdbcMultiTableSyncExample [\"<HOCON job configuration>\"]");
+        }
+        LocalSyncLauncher.run(
+                args.length == 1 ? args[0] : EXAMPLE_HOCON,
+                Thread.currentThread().getContextClassLoader());
+    }
+}


### PR DESCRIPTION
### Motivation
- Enable multi-table offline synchronization by allowing sink table templates so each source table can route to its own destination.
- Make SQL generation robust for multi-table jobs by preferring per-target generated INSERT/UPSERT statements over a single shared `custom_sql` when a target template is configured.
- Provide a runnable example and unit coverage to ease local testing and document template semantics.

### Description
- Add `resolveTargetTablePath(TablePath)` to `JdbcSinkConfig` to expand `${schema_name}` and `${table_name}` (with MySQL two-part path fallback of database→schema) and to return `null` when no target template is configured.
- Change `hasCustomSql()` so configured target templates disable use of a global `custom_sql`, forcing generated SQL per resolved target.
- Apply the resolved target path in `JdbcOutputFormat.targetTable(...)` so table preparation and SQL generation operate on the expanded target for each source table.
- Add a runnable example `JdbcMultiTableSyncExample` with a HOCON two-table `table_list` demonstration and update README to document the `table`/`table_path` template semantics.
- Add unit tests `JdbcSinkConfigTest` exercising template expansion and the precedence of configured table over `custom_sql`.

### Testing
- Added `JdbcSinkConfigTest` JUnit tests (new test file `baize-flux-connector-jdbc/src/test/java/.../JdbcSinkConfigTest.java`).
- Attempted to run the connector module tests with `mvn -pl baize-flux-connectors/baize-flux-connector-jdbc -am test`, but the Maven build failed due to external plugin resolution (`maven-resources-plugin:3.3.1`) returning HTTP 403 from Maven Central, so the new unit tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61ec1f7f7083269bece39abfc3e2e7)