### PR TITLE
Refactor JDBC sink save-mode handling

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
@@ -7,6 +7,7 @@ import com.baize.flux.connector.jdbc.config.JdbcSinkConfig;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialectLoader;
 import com.baize.flux.connector.jdbc.internal.JdbcConnectionProvider;
+import com.baize.flux.connector.jdbc.sink.savemode.JdbcSaveModeHandler;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -74,27 +75,20 @@ public final class JdbcOutputFormat implements AutoCloseable {
     private void prepareTable(CatalogTable target) throws Exception {
         if (!preparedTables.add(target.getTablePath())) return;
         Catalog catalog = dialect.createCatalog(config.getConnectionConfig());
+        if (!(catalog instanceof WritableCatalog))
+            throw new IllegalStateException("JDBC catalog does not support DDL");
+        JdbcSaveModeHandler saveModeHandler =
+                new JdbcSaveModeHandler(
+                        config.getSchemaSaveMode(),
+                        config.getDataSaveMode(),
+                        (WritableCatalog) catalog,
+                        target,
+                        config.isCreatePrimaryKey());
         try {
-            catalog.open();
-            boolean exists = catalog.tableExists(target.getTablePath());
-            if (!(catalog instanceof WritableCatalog))
-                throw new IllegalStateException("JDBC catalog does not support DDL");
-            WritableCatalog writable = (WritableCatalog) catalog;
-            if (config.getSchemaSaveMode() == SchemaSaveMode.RECREATE_SCHEMA && exists) {
-                writable.dropTable(target.getTablePath(), false);
-                exists = false;
-            }
-            if (!exists && config.getSchemaSaveMode() != SchemaSaveMode.IGNORE) {
-                if (config.getSchemaSaveMode() == SchemaSaveMode.ERROR_WHEN_SCHEMA_NOT_EXIST)
-                    throw new TableNotFoundException(catalog.name(), target.getTablePath());
-                writable.createTable(createTableDefinition(target), false);
-                exists = true;
-            }
-            if (!exists) throw new TableNotFoundException(catalog.name(), target.getTablePath());
-            if (config.getDataSaveMode() == DataSaveMode.DROP_DATA)
-                writable.truncateTable(target.getTablePath(), false);
+            saveModeHandler.open();
+            saveModeHandler.handleSaveMode();
         } finally {
-            catalog.close();
+            saveModeHandler.close();
         }
     }
 
@@ -105,12 +99,6 @@ public final class JdbcOutputFormat implements AutoCloseable {
                         ? source.getTablePath()
                         : dialect.parseTablePath(targetTablePath);
         return source.withPath(path);
-    }
-
-    private CatalogTable createTableDefinition(CatalogTable target) {
-        if (config.isCreatePrimaryKey()) return target;
-        TableSchema schema = TableSchema.builder().columns(target.getTableSchema().getColumns()).build();
-        return target.withSchema(schema);
     }
 
     private List<String> primaryKeys(CatalogTable table) {

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/savemode/DefaultSaveModeHandler.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/savemode/DefaultSaveModeHandler.java
@@ -1,0 +1,95 @@
+package com.baize.flux.connector.jdbc.sink.savemode;
+
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.catalog.TablePath;
+import com.baize.flux.api.table.catalog.WritableCatalog;
+import com.baize.flux.api.table.catalog.exception.TableNotFoundException;
+import com.baize.flux.connector.jdbc.sink.DataSaveMode;
+import com.baize.flux.connector.jdbc.sink.SchemaSaveMode;
+
+import java.util.Objects;
+
+/** Default implementation of the JDBC table save-mode lifecycle. */
+public class DefaultSaveModeHandler implements SaveModeHandler {
+    protected final SchemaSaveMode schemaSaveMode;
+    protected final DataSaveMode dataSaveMode;
+    protected final WritableCatalog catalog;
+    protected final CatalogTable table;
+    protected final TablePath tablePath;
+
+    public DefaultSaveModeHandler(
+            SchemaSaveMode schemaSaveMode,
+            DataSaveMode dataSaveMode,
+            WritableCatalog catalog,
+            CatalogTable table) {
+        this.schemaSaveMode =
+                Objects.requireNonNull(schemaSaveMode, "schemaSaveMode must not be null");
+        this.dataSaveMode =
+                Objects.requireNonNull(dataSaveMode, "dataSaveMode must not be null");
+        this.catalog = Objects.requireNonNull(catalog, "catalog must not be null");
+        this.table = Objects.requireNonNull(table, "table must not be null");
+        this.tablePath = table.getTablePath();
+    }
+
+    @Override
+    public void open() {
+        catalog.open();
+    }
+
+    @Override
+    public void handleSchemaSaveMode() {
+        boolean exists = catalog.tableExists(tablePath);
+        switch (schemaSaveMode) {
+            case RECREATE_SCHEMA:
+                if (exists) {
+                    catalog.dropTable(tablePath, false);
+                }
+                createTable();
+                return;
+            case CREATE_SCHEMA_WHEN_NOT_EXIST:
+                if (!exists) {
+                    createTable();
+                }
+                return;
+            case ERROR_WHEN_SCHEMA_NOT_EXIST:
+                if (!exists) {
+                    throw new TableNotFoundException(catalog.name(), tablePath);
+                }
+                return;
+            case IGNORE:
+                if (!exists) {
+                    throw new TableNotFoundException(catalog.name(), tablePath);
+                }
+                return;
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported schema save mode: " + schemaSaveMode);
+        }
+    }
+
+    @Override
+    public void handleDataSaveMode() {
+        switch (dataSaveMode) {
+            case DROP_DATA:
+                catalog.truncateTable(tablePath, false);
+                return;
+            case APPEND_DATA:
+            case CUSTOM_PROCESSING:
+            case ERROR_WHEN_DATA_EXISTS:
+                // Row writing (or the database constraint) owns these modes for JDBC.
+                return;
+            default:
+                throw new UnsupportedOperationException(
+                        "Unsupported data save mode: " + dataSaveMode);
+        }
+    }
+
+    protected void createTable() {
+        catalog.createTable(table, false);
+    }
+
+    @Override
+    public void close() {
+        catalog.close();
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/savemode/JdbcSaveModeHandler.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/savemode/JdbcSaveModeHandler.java
@@ -1,0 +1,38 @@
+package com.baize.flux.connector.jdbc.sink.savemode;
+
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.catalog.TableSchema;
+import com.baize.flux.api.table.catalog.WritableCatalog;
+import com.baize.flux.connector.jdbc.sink.DataSaveMode;
+import com.baize.flux.connector.jdbc.sink.SchemaSaveMode;
+
+/** JDBC-specific save-mode handler that controls whether copied primary keys are created. */
+public final class JdbcSaveModeHandler extends DefaultSaveModeHandler {
+    private final boolean createPrimaryKey;
+
+    public JdbcSaveModeHandler(
+            SchemaSaveMode schemaSaveMode,
+            DataSaveMode dataSaveMode,
+            WritableCatalog catalog,
+            CatalogTable table,
+            boolean createPrimaryKey) {
+        super(schemaSaveMode, dataSaveMode, catalog, table);
+        this.createPrimaryKey = createPrimaryKey;
+    }
+
+    @Override
+    protected void createTable() {
+        catalog.createTable(createTableDefinition(), false);
+    }
+
+    private CatalogTable createTableDefinition() {
+        if (createPrimaryKey) {
+            return table;
+        }
+        TableSchema schema =
+                TableSchema.builder()
+                        .columns(table.getTableSchema().getColumns())
+                        .build();
+        return table.withSchema(schema);
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/savemode/SaveModeHandler.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/savemode/SaveModeHandler.java
@@ -1,0 +1,21 @@
+package com.baize.flux.connector.jdbc.sink.savemode;
+
+/**
+ * Applies schema and data save modes before a JDBC sink writes a table.
+ *
+ * <p>Keeping this lifecycle separate from row writing makes table preparation reusable and keeps
+ * {@code JdbcOutputFormat} focused on batching and transactions.
+ */
+public interface SaveModeHandler extends AutoCloseable {
+
+    void open();
+
+    void handleSchemaSaveMode();
+
+    void handleDataSaveMode();
+
+    default void handleSaveMode() {
+        handleSchemaSaveMode();
+        handleDataSaveMode();
+    }
+}


### PR DESCRIPTION
### Motivation
- Separate table preparation (DDL) from row writing so `JdbcOutputFormat` focuses on batching/transactions and table lifecycle is easier to maintain.
- Provide a JDBC-specific extension to control whether copied primary keys are created when auto-creating tables.

### Description
- Add `SaveModeHandler` interface in `com.baize.flux.connector.jdbc.sink.savemode` with lifecycle methods `open`, `handleSchemaSaveMode`, `handleDataSaveMode`, and `handleSaveMode`.
- Add `DefaultSaveModeHandler` that centralizes common schema/data save-mode logic (handle `RECREATE_SCHEMA`, `CREATE_SCHEMA_WHEN_NOT_EXIST`, `ERROR_WHEN_SCHEMA_NOT_EXIST`, `IGNORE`, and `DROP_DATA` semantics) and manages catalog open/close.
- Add `JdbcSaveModeHandler` that extends `DefaultSaveModeHandler` and implements JDBC-specific table creation behavior including the `createPrimaryKey` toggle (omits primary key from the created schema when disabled).
- Update `JdbcOutputFormat` to instantiate and invoke `JdbcSaveModeHandler` for target-table preparation and remove the embedded DDL logic and the previous `createTableDefinition` helper; add a runtime check that the created `Catalog` implements `WritableCatalog`.

### Testing
- Ran `git diff --check` to validate workspace diffs, which passed.
- Ran `mvn -pl baize-flux-connectors/baize-flux-connector-jdbc -am test`, which was blocked by environment dependency resolution (Maven Central returned HTTP 403 while resolving `maven-resources-plugin:3.3.1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61f4d85cd083268f89b884a6c92935)