### PR TITLE
feat(jdbc): add chunk-based partition splitters

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/README.md
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/README.md
@@ -45,3 +45,8 @@ INSERT/UPSERT SQL for the resolved target and ignores `custom_sql`/`query`.
 
 The result columns retain their query order and use JDBC column labels as the
 `FluxRow` field names.
+## Partitioned reads
+
+`partition_column`, `partition_lower_bound`, `partition_upper_bound`, and `partition_num` split a table into deterministic, non-overlapping ranges. Numeric columns use `FixedChunkSplitter`; fixed-width ASCII keys use `AsciiStringRangeSplitter`. The final range is upper-bound inclusive, so no boundary row is lost. Partition bounds are required deliberately: this bounded source does not issue an unbounded `MIN`/`MAX` analysis query during planning.
+
+For string keys, configure a fixed-width ASCII column using a binary/ASCII-compatible database collation. Locale-aware and variable-width strings are not safe range keys.

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/AsciiStringRangeSplitter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/AsciiStringRangeSplitter.java
@@ -1,0 +1,41 @@
+package com.baize.flux.connector.jdbc.core.split;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Splits fixed-width printable ASCII keys in binary lexical order.
+ * Database collations are not assumed: callers must use a binary/ASCII compatible key column.
+ */
+public final class AsciiStringRangeSplitter implements ChunkSplitter<String> {
+    @Override
+    public List<Chunk<String>> split(String lower, String upper, int count) {
+        validate(lower, upper, count);
+        BigInteger low = encode(lower);
+        BigInteger high = encode(upper);
+        if (low.equals(high)) return Collections.singletonList(new Chunk<>(lower, upper, true));
+        BigInteger width = high.subtract(low).add(BigInteger.valueOf(count - 1)).divide(BigInteger.valueOf(count));
+        List<Chunk<String>> result = new ArrayList<>();
+        BigInteger start = low;
+        for (int i = 0; i < count && start.compareTo(high) < 0; i++) {
+            BigInteger end = i == count - 1 ? high : start.add(width).min(high);
+            result.add(new Chunk<>(decode(start, lower.length()), decode(end, lower.length()), end.equals(high)));
+            start = end;
+        }
+        return Collections.unmodifiableList(result);
+    }
+    private static void validate(String lower, String upper, int count) {
+        if (lower == null || upper == null || lower.length() == 0 || lower.length() != upper.length()) throw new IllegalArgumentException("ASCII bounds must be non-empty and have the same length");
+        if (count <= 0 || lower.compareTo(upper) > 0) throw new IllegalArgumentException("chunkCount must be positive and bounds ordered");
+        for (char c : (lower + upper).toCharArray()) if (c > 127) throw new IllegalArgumentException("only ASCII bounds are supported");
+    }
+    private static BigInteger encode(String value) { return new BigInteger(1, value.getBytes(java.nio.charset.StandardCharsets.US_ASCII)); }
+    private static String decode(BigInteger value, int length) {
+        byte[] source = value.toByteArray(); byte[] result = new byte[length];
+        int sourceOffset = Math.max(0, source.length - length); int targetOffset = Math.max(0, length - source.length);
+        System.arraycopy(source, sourceOffset, result, targetOffset, Math.min(length, source.length));
+        return new String(result, java.nio.charset.StandardCharsets.US_ASCII);
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/Chunk.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/Chunk.java
@@ -1,0 +1,20 @@
+package com.baize.flux.connector.jdbc.core.split;
+
+import java.util.Objects;
+
+/** A half-open key range; the last chunk may include its upper bound. */
+public final class Chunk<T> {
+    private final T start;
+    private final T end;
+    private final boolean endInclusive;
+
+    public Chunk(T start, T end, boolean endInclusive) {
+        this.start = Objects.requireNonNull(start, "start must not be null");
+        this.end = Objects.requireNonNull(end, "end must not be null");
+        this.endInclusive = endInclusive;
+    }
+
+    public T getStart() { return start; }
+    public T getEnd() { return end; }
+    public boolean isEndInclusive() { return endInclusive; }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/ChunkSplitter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/ChunkSplitter.java
@@ -1,0 +1,8 @@
+package com.baize.flux.connector.jdbc.core.split;
+
+import java.util.List;
+
+/** Splits an already known key range into non-overlapping chunks. */
+public interface ChunkSplitter<T> {
+    List<Chunk<T>> split(T lowerBound, T upperBound, int chunkCount);
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/DynamicChunkSplitter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/DynamicChunkSplitter.java
@@ -1,0 +1,22 @@
+package com.baize.flux.connector.jdbc.core.split;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Startup-time adaptive splitter. It caps planned chunks at the available reader parallelism;
+ * scheduling remains the responsibility of the source enumerator.
+ */
+public final class DynamicChunkSplitter<T> implements ChunkSplitter<T> {
+    private final ChunkSplitter<T> delegate;
+    private final int maxChunks;
+    public DynamicChunkSplitter(ChunkSplitter<T> delegate, int maxChunks) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate must not be null");
+        if (maxChunks <= 0) throw new IllegalArgumentException("maxChunks must be greater than 0");
+        this.maxChunks = maxChunks;
+    }
+    @Override public List<Chunk<T>> split(T lower, T upper, int requestedChunks) {
+        if (requestedChunks <= 0) throw new IllegalArgumentException("chunkCount must be greater than 0");
+        return delegate.split(lower, upper, Math.min(maxChunks, requestedChunks));
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/FixedChunkSplitter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/FixedChunkSplitter.java
@@ -1,0 +1,28 @@
+package com.baize.flux.connector.jdbc.core.split;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Deterministically divides a numeric range into equally sized chunks. */
+public final class FixedChunkSplitter implements ChunkSplitter<BigDecimal> {
+    @Override
+    public List<Chunk<BigDecimal>> split(BigDecimal lower, BigDecimal upper, int count) {
+        if (lower == null || upper == null || lower.compareTo(upper) > 0) {
+            throw new IllegalArgumentException("numeric bounds must be non-null and ordered");
+        }
+        if (count <= 0) throw new IllegalArgumentException("chunkCount must be greater than 0");
+        if (lower.compareTo(upper) == 0) return Collections.singletonList(new Chunk<>(lower, upper, true));
+        BigDecimal width = upper.subtract(lower).divide(BigDecimal.valueOf(count), 20, RoundingMode.CEILING);
+        List<Chunk<BigDecimal>> result = new ArrayList<>();
+        BigDecimal start = lower;
+        for (int index = 0; index < count && start.compareTo(upper) < 0; index++) {
+            BigDecimal end = index == count - 1 ? upper : start.add(width).min(upper);
+            result.add(new Chunk<>(start, end, end.compareTo(upper) == 0));
+            start = end;
+        }
+        return Collections.unmodifiableList(result);
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/JdbcSplitPlanner.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/JdbcSplitPlanner.java
@@ -1,6 +1,8 @@
 package com.baize.flux.connector.jdbc.core.split;
 
 import com.baize.flux.api.table.catalog.TablePath;
+import com.baize.flux.api.table.catalog.Column;
+import com.baize.flux.api.table.type.FluxDataType;
 import com.baize.flux.connector.jdbc.config.JdbcSourceConfig;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialectLoader;
@@ -8,6 +10,7 @@ import com.baize.flux.connector.jdbc.source.JdbcSourceSplit;
 import com.baize.flux.connector.jdbc.source.JdbcSourceTable;
 
 import java.util.*;
+import java.math.BigDecimal;
 
 /**
  * Plans the static, table-level splits used by the bounded JDBC source.
@@ -34,11 +37,40 @@ public final class JdbcSplitPlanner {
 
         for (JdbcSourceTable table : sourceTables.values()) {
             String query = dialect.buildSelectSql(table, config.getWhereCondition());
-            String splitId = table.getTablePath() + "-0";
-            splits.add(new JdbcSourceSplit(
-                    table.getTablePath(), splitId, query, null, null, null, null));
+            if (!hasText(table.getPartitionColumn())) {
+                splits.add(split(table, query, 0, null, null, null, null));
+                continue;
+            }
+            Column column = findColumn(table, table.getPartitionColumn());
+            if (!hasText(table.getPartitionStart()) || !hasText(table.getPartitionEnd())) {
+                throw new IllegalArgumentException("partition_lower_bound and partition_upper_bound are required for partitioned table " + table.getTablePath());
+            }
+            List<? extends Chunk<?>> chunks = splitChunks(table, column, parallelism);
+            for (int index = 0; index < chunks.size(); index++) {
+                Chunk<?> chunk = chunks.get(index);
+                String predicate = dialect.quoteIdentifier(column.getName()) + " >= " + literal(chunk.getStart())
+                        + " AND " + dialect.quoteIdentifier(column.getName()) + (chunk.isEndInclusive() ? " <= " : " < ") + literal(chunk.getEnd());
+                splits.add(split(table, appendPredicate(query, predicate), index, column.getName(), column.getDataType(), chunk.getStart(), chunk.getEnd()));
+            }
         }
 
         return Collections.unmodifiableList(splits);
     }
+
+    private static JdbcSourceSplit split(JdbcSourceTable table, String query, int index, String key, FluxDataType<?> type, Object start, Object end) {
+        return new JdbcSourceSplit(table.getTablePath(), table.getTablePath() + "-" + index, query, key, type, start, end);
+    }
+    private static Column findColumn(JdbcSourceTable table, String name) {
+        for (Column column : table.getCatalogTable().getTableSchema().getColumns()) if (column.getName().equalsIgnoreCase(name)) return column;
+        throw new IllegalArgumentException("partition_column does not exist in source table: " + name + ", table=" + table.getTablePath());
+    }
+    private static List<? extends Chunk<?>> splitChunks(JdbcSourceTable table, Column column, int parallelism) {
+        int count = table.getPartitionNumber() == null ? parallelism : table.getPartitionNumber();
+        if (String.class.equals(column.getDataType().getTypeClass())) return new DynamicChunkSplitter<String>(new AsciiStringRangeSplitter(), count).split(table.getPartitionStart(), table.getPartitionEnd(), count);
+        try { return new DynamicChunkSplitter<BigDecimal>(new FixedChunkSplitter(), count).split(new BigDecimal(table.getPartitionStart()), new BigDecimal(table.getPartitionEnd()), count); }
+        catch (NumberFormatException e) { throw new IllegalArgumentException("partition bounds must be numeric for column " + column.getName(), e); }
+    }
+    private static String appendPredicate(String query, String predicate) { return "SELECT * FROM (" + query + ") AS flux_split WHERE " + predicate; }
+    private static String literal(Object value) { return value instanceof Number || value instanceof BigDecimal ? value.toString() : "'" + value.toString().replace("'", "''") + "'"; }
+    private static boolean hasText(String value) { return value != null && !value.trim().isEmpty(); }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/core/split/ChunkSplitterTest.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/core/split/ChunkSplitterTest.java
@@ -1,0 +1,38 @@
+package com.baize.flux.connector.jdbc.core.split;
+
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ChunkSplitterTest {
+    @Test
+    public void fixedSplitterCreatesContiguousNumericRanges() {
+        List<Chunk<BigDecimal>> chunks = new FixedChunkSplitter().split(new BigDecimal("0"), new BigDecimal("10"), 3);
+        assertEquals(3, chunks.size());
+        assertEquals(new BigDecimal("0"), chunks.get(0).getStart());
+        assertEquals(chunks.get(0).getEnd(), chunks.get(1).getStart());
+        assertEquals(new BigDecimal("10"), chunks.get(2).getEnd());
+        assertTrue(chunks.get(2).isEndInclusive());
+    }
+
+    @Test
+    public void asciiSplitterCreatesContiguousRanges() {
+        List<Chunk<String>> chunks = new AsciiStringRangeSplitter().split("AA", "AZ", 4);
+        assertEquals(4, chunks.size());
+        assertEquals("AA", chunks.get(0).getStart());
+        assertEquals(chunks.get(0).getEnd(), chunks.get(1).getStart());
+        assertEquals("AZ", chunks.get(3).getEnd());
+        assertTrue(chunks.get(3).isEndInclusive());
+    }
+
+    @Test
+    public void dynamicSplitterCapsRequestedChunks() {
+        List<Chunk<BigDecimal>> chunks = new DynamicChunkSplitter<BigDecimal>(new FixedChunkSplitter(), 2)
+                .split(BigDecimal.ZERO, new BigDecimal("10"), 8);
+        assertEquals(2, chunks.size());
+    }
+}


### PR DESCRIPTION
### Motivation

- Enable deterministic, non-overlapping partitioned reads for the JDBC source by splitting an explicit key range into chunks for parallel readers.
- Provide reusable splitters for numeric and fixed-width ASCII keys and a dynamic wrapper to cap planned chunks to reader parallelism.

### Description

- Add a generic `Chunk<T>` model and `ChunkSplitter<T>` interface, implemented by `FixedChunkSplitter` (numeric) and `AsciiStringRangeSplitter` (fixed-width ASCII), plus `DynamicChunkSplitter` to cap requested chunks. (files added under `.../core/split/`)
- Integrate chunk-based splitting into `JdbcSplitPlanner`: validate `partition_column` and explicit `partition_lower_bound`/`partition_upper_bound`, produce per-chunk predicates and create `JdbcSourceSplit` entries with `>= lower AND < upper` (last chunk `<= upper`). (updated `JdbcSplitPlanner.java`)
- Add unit tests covering the numeric, ASCII and dynamic splitters in `ChunkSplitterTest.java` and document the partition-read constraints in the JDBC connector `README.md`.
- Minor planner behavior: use `partition_num` when present (otherwise use parallelism) and build split queries by wrapping the original query with a filtering subquery.

### Testing

- Ran `git diff --check` to verify the patch formatting and found no issues (success).
- Attempted `mvn -q -pl baize-flux-connectors/baize-flux-connector-jdbc -am test -DskipTests`, but execution failed due to remote Maven Central plugin resolution returning HTTP 403 in this environment, so the new unit tests were added but could not be executed here.
- The changes have been committed on the current branch (`e0f32f1 feat(jdbc): add chunk-based partition splitters`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61f71cfcb88326b63ef58fe69ba5d7)