### PR TITLE
Enforce printable ASCII ranges and tighten dynamic chunk capping

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/AsciiStringRangeSplitter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/AsciiStringRangeSplitter.java
@@ -10,6 +10,10 @@ import java.util.List;
  * Database collations are not assumed: callers must use a binary/ASCII compatible key column.
  */
 public final class AsciiStringRangeSplitter implements ChunkSplitter<String> {
+    private static final char FIRST_PRINTABLE_ASCII = ' ';
+    private static final char LAST_PRINTABLE_ASCII = '~';
+    private static final BigInteger PRINTABLE_ASCII_RADIX = BigInteger.valueOf(95);
+
     @Override
     public List<Chunk<String>> split(String lower, String upper, int count) {
         validate(lower, upper, count);
@@ -29,13 +33,30 @@ public final class AsciiStringRangeSplitter implements ChunkSplitter<String> {
     private static void validate(String lower, String upper, int count) {
         if (lower == null || upper == null || lower.length() == 0 || lower.length() != upper.length()) throw new IllegalArgumentException("ASCII bounds must be non-empty and have the same length");
         if (count <= 0 || lower.compareTo(upper) > 0) throw new IllegalArgumentException("chunkCount must be positive and bounds ordered");
-        for (char c : (lower + upper).toCharArray()) if (c > 127) throw new IllegalArgumentException("only ASCII bounds are supported");
+        for (char c : (lower + upper).toCharArray()) {
+            if (c < FIRST_PRINTABLE_ASCII || c > LAST_PRINTABLE_ASCII) {
+                throw new IllegalArgumentException("only printable ASCII bounds are supported");
+            }
+        }
     }
-    private static BigInteger encode(String value) { return new BigInteger(1, value.getBytes(java.nio.charset.StandardCharsets.US_ASCII)); }
+
+    private static BigInteger encode(String value) {
+        BigInteger result = BigInteger.ZERO;
+        for (int index = 0; index < value.length(); index++) {
+            result = result.multiply(PRINTABLE_ASCII_RADIX)
+                    .add(BigInteger.valueOf(value.charAt(index) - FIRST_PRINTABLE_ASCII));
+        }
+        return result;
+    }
+
     private static String decode(BigInteger value, int length) {
-        byte[] source = value.toByteArray(); byte[] result = new byte[length];
-        int sourceOffset = Math.max(0, source.length - length); int targetOffset = Math.max(0, length - source.length);
-        System.arraycopy(source, sourceOffset, result, targetOffset, Math.min(length, source.length));
-        return new String(result, java.nio.charset.StandardCharsets.US_ASCII);
+        char[] result = new char[length];
+        BigInteger remaining = value;
+        for (int index = length - 1; index >= 0; index--) {
+            BigInteger[] quotientAndRemainder = remaining.divideAndRemainder(PRINTABLE_ASCII_RADIX);
+            result[index] = (char) (quotientAndRemainder[1].intValue() + FIRST_PRINTABLE_ASCII);
+            remaining = quotientAndRemainder[0];
+        }
+        return new String(result);
     }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/DynamicChunkSplitter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/DynamicChunkSplitter.java
@@ -4,8 +4,9 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Startup-time adaptive splitter. It caps planned chunks at the available reader parallelism;
- * scheduling remains the responsibility of the source enumerator.
+ * Startup-time splitter that caps a table's requested chunks at the available reader
+ * parallelism. The delegate owns range-boundary calculation while this class owns the
+ * scheduling constraint.
  */
 public final class DynamicChunkSplitter<T> implements ChunkSplitter<T> {
     private final ChunkSplitter<T> delegate;
@@ -15,8 +16,23 @@ public final class DynamicChunkSplitter<T> implements ChunkSplitter<T> {
         if (maxChunks <= 0) throw new IllegalArgumentException("maxChunks must be greater than 0");
         this.maxChunks = maxChunks;
     }
-    @Override public List<Chunk<T>> split(T lower, T upper, int requestedChunks) {
-        if (requestedChunks <= 0) throw new IllegalArgumentException("chunkCount must be greater than 0");
-        return delegate.split(lower, upper, Math.min(maxChunks, requestedChunks));
+
+    @Override
+    public List<Chunk<T>> split(T lower, T upper, int requestedChunks) {
+        return delegate.split(lower, upper, effectiveChunkCount(requestedChunks, maxChunks));
+    }
+
+    /**
+     * Resolves the number of chunks that may be planned for one table. Kept package-visible so
+     * the planner and tests share the same validation and capping semantics.
+     */
+    static int effectiveChunkCount(int requestedChunks, int parallelism) {
+        if (requestedChunks <= 0) {
+            throw new IllegalArgumentException("requestedChunks must be greater than 0");
+        }
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException("parallelism must be greater than 0");
+        }
+        return Math.min(requestedChunks, parallelism);
     }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/JdbcSplitPlanner.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/JdbcSplitPlanner.java
@@ -65,9 +65,18 @@ public final class JdbcSplitPlanner {
         throw new IllegalArgumentException("partition_column does not exist in source table: " + name + ", table=" + table.getTablePath());
     }
     private static List<? extends Chunk<?>> splitChunks(JdbcSourceTable table, Column column, int parallelism) {
-        int count = table.getPartitionNumber() == null ? parallelism : table.getPartitionNumber();
-        if (String.class.equals(column.getDataType().getTypeClass())) return new DynamicChunkSplitter<String>(new AsciiStringRangeSplitter(), count).split(table.getPartitionStart(), table.getPartitionEnd(), count);
-        try { return new DynamicChunkSplitter<BigDecimal>(new FixedChunkSplitter(), count).split(new BigDecimal(table.getPartitionStart()), new BigDecimal(table.getPartitionEnd()), count); }
+        int requestedChunks = table.getPartitionNumber() == null ? parallelism : table.getPartitionNumber();
+        if (String.class.equals(column.getDataType().getTypeClass())) {
+            return new DynamicChunkSplitter<String>(new AsciiStringRangeSplitter(), parallelism)
+                    .split(table.getPartitionStart(), table.getPartitionEnd(), requestedChunks);
+        }
+        try {
+            return new DynamicChunkSplitter<BigDecimal>(new FixedChunkSplitter(), parallelism)
+                    .split(
+                            new BigDecimal(table.getPartitionStart()),
+                            new BigDecimal(table.getPartitionEnd()),
+                            requestedChunks);
+        }
         catch (NumberFormatException e) { throw new IllegalArgumentException("partition bounds must be numeric for column " + column.getName(), e); }
     }
     private static String appendPredicate(String query, String predicate) { return "SELECT * FROM (" + query + ") AS flux_split WHERE " + predicate; }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/core/split/ChunkSplitterTest.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/core/split/ChunkSplitterTest.java
@@ -30,9 +30,30 @@ public class ChunkSplitterTest {
     }
 
     @Test
+    public void asciiSplitterKeepsIntermediateBoundsPrintable() {
+        List<Chunk<String>> chunks = new AsciiStringRangeSplitter().split("A~", "B~", 4);
+        for (Chunk<String> chunk : chunks) {
+            for (char c : (chunk.getStart() + chunk.getEnd()).toCharArray()) {
+                assertTrue(c >= ' ' && c <= '~');
+            }
+        }
+    }
+
+    @Test
     public void dynamicSplitterCapsRequestedChunks() {
         List<Chunk<BigDecimal>> chunks = new DynamicChunkSplitter<BigDecimal>(new FixedChunkSplitter(), 2)
                 .split(BigDecimal.ZERO, new BigDecimal("10"), 8);
         assertEquals(2, chunks.size());
+    }
+
+    @Test
+    public void dynamicSplitterUsesParallelismAsTheHardCap() {
+        assertEquals(4, DynamicChunkSplitter.effectiveChunkCount(10, 4));
+        assertEquals(3, DynamicChunkSplitter.effectiveChunkCount(3, 4));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void dynamicSplitterRejectsInvalidParallelism() {
+        DynamicChunkSplitter.effectiveChunkCount(1, 0);
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure string range splitting only operates on fixed-width printable ASCII characters so intermediate bounds remain valid for quoted SQL usage.
- Centralize and validate the capping behavior for requested chunk counts against reader parallelism so planners and tests share consistent semantics.

### Description
- Update `AsciiStringRangeSplitter` to restrict bounds to printable ASCII (`' '`..`'~'`) and replace raw byte-based encoding/decoding with a base-95 positional encoding using `FIRST_PRINTABLE_ASCII`, `LAST_PRINTABLE_ASCII`, and `PRINTABLE_ASCII_RADIX` so produced boundaries are printable characters.
- Add argument validation in `AsciiStringRangeSplitter.validate` to reject non-printable ASCII bounds with a clear message.
- Refactor `DynamicChunkSplitter` to expose a package-visible `effectiveChunkCount(int requestedChunks, int parallelism)` method with full argument validation and use it from `split`, keeping the delegate splitter responsibility unchanged.
- Adjust `JdbcSplitPlanner` to compute `requestedChunks` separately from `parallelism` and to instantiate `DynamicChunkSplitter` with the actual `parallelism` while passing `requestedChunks` to `split`, preserving the hard cap semantics.
- Add unit tests in `ChunkSplitterTest` to assert printable intermediate bounds for `AsciiStringRangeSplitter`, verify `effectiveChunkCount` behavior, and validate rejection of invalid parallelism.

### Testing
- Ran unit tests under `baize-flux-connector-jdbc` including `ChunkSplitterTest`, and all tests passed successfully, covering numeric and ASCII splitters and the new `effectiveChunkCount` validations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61f882558c8326ae86516a03cb19aa)