### PR TITLE
Add environment-controlled source parallelism

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/source/Source.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/source/Source.java
@@ -24,6 +24,26 @@ public interface Source<SplitT extends SourceSplit>
             throws Exception;
 
     /**
+     * Creates the splits for an execution with the supplied reader parallelism.
+     * <p>
+     * Connectors that can use the parallelism while planning (for example to
+     * cap JDBC range splits) should override this method. The default keeps
+     * existing connectors source-compatible and lets the framework distribute
+     * their returned splits among reader tasks.
+     */
+    default List<SplitT> createSplits(
+            Map<TablePath, CatalogTable> tables,
+            int parallelism)
+            throws Exception {
+
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException(
+                    "parallelism must be greater than 0");
+        }
+        return createSplits(tables);
+    }
+
+    /**
      * 创建 SourceReader。
      * <p>
      * 每个执行任务必须使用独立 Reader，

--- a/baize-flux-connectors/baize-flux-connector-jdbc/README.md
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/README.md
@@ -49,4 +49,16 @@ The result columns retain their query order and use JDBC column labels as the
 
 `partition_column`, `partition_lower_bound`, `partition_upper_bound`, and `partition_num` split a table into deterministic, non-overlapping ranges. Numeric columns use `FixedChunkSplitter`; fixed-width ASCII keys use `AsciiStringRangeSplitter`. The final range is upper-bound inclusive, so no boundary row is lost. Partition bounds are required deliberately: this bounded source does not issue an unbounded `MIN`/`MAX` analysis query during planning.
 
+## Execution parallelism
+
+Configure job-level reader concurrency outside the connector configuration:
+
+```hocon
+env {
+  parallelism = 4
+}
+```
+
+The launcher creates at most `parallelism` source readers and assigns every split to one reader exactly once. JDBC uses this value while planning range splits, so an unspecified `partition_num` produces no more than this many chunks per table. Batches from different tables or ranges can be read concurrently, while the local sink remains single-threaded because the current `SinkWriter` owns one transactional JDBC connection and is not safe to share across writers.
+
 For string keys, configure a fixed-width ASCII column using a binary/ASCII-compatible database collation. Locale-aware and variable-width strings are not safe range keys.

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSource.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSource.java
@@ -34,6 +34,15 @@ public final class JdbcSource
             Map<TablePath, CatalogTable> tables)
             throws Exception {
 
+        return createSplits(tables, 1);
+    }
+
+    @Override
+    public List<JdbcSourceSplit> createSplits(
+            Map<TablePath, CatalogTable> tables,
+            int parallelism)
+            throws Exception {
+
         /*
          * 这里替换成你现有的分片生成器。
          *
@@ -43,7 +52,8 @@ public final class JdbcSource
          */
         return JdbcSourceSplitGenerator.generate(
                 config,
-                tables);
+                tables,
+                parallelism);
     }
 
     @Override

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceSplitGenerator.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceSplitGenerator.java
@@ -21,11 +21,15 @@ final class JdbcSourceSplitGenerator {
 
     static List<JdbcSourceSplit> generate(
             JdbcSourceConfig config,
-            Map<TablePath, CatalogTable> tables)
+            Map<TablePath, CatalogTable> tables,
+            int parallelism)
             throws Exception {
 
         Objects.requireNonNull(config, "config must not be null");
         Objects.requireNonNull(tables, "tables must not be null");
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException("parallelism must be greater than 0");
+        }
 
         JdbcDialect dialect = JdbcDialectLoader.load(config.getConnectionConfig());
         Map<TablePath, JdbcSourceTable> sourceTables =
@@ -39,7 +43,7 @@ final class JdbcSourceSplitGenerator {
             }
         }
 
-        return new JdbcSourceSplitEnumerator(config, sourceTables, 1)
+        return new JdbcSourceSplitEnumerator(config, sourceTables, parallelism)
                 .enumerateSplits();
     }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/source/SourceExecuteProcessor.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/source/SourceExecuteProcessor.java
@@ -6,19 +6,35 @@ import com.baize.flux.api.source.SourceSplit;
 import com.baize.flux.api.table.type.FluxRow;
 import com.baize.flux.framework.factory.PreparedSource;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * 离线 Source 执行处理器。
  * <p>
- * 当前采用单 Reader 顺序读取全部分片。
- * 后续可扩展为多个 SourceTask 并行执行。
+ * A bounded source executor which assigns every split to exactly one reader.
+ * Readers own their connections and may run concurrently; emitted batches are
+ * handed to the caller's thread-safe consumer.
  */
 public final class SourceExecuteProcessor {
 
+    /** Executes with one reader for callers that do not configure an environment. */
     public <SplitT extends SourceSplit> void execute(
             SourceAction<SplitT> action,
+            RecordBatchConsumer<FluxRow> consumer)
+            throws Exception {
+
+        execute(action, 1, consumer);
+    }
+
+    public <SplitT extends SourceSplit> void execute(
+            SourceAction<SplitT> action,
+            int parallelism,
             RecordBatchConsumer<FluxRow> consumer)
             throws Exception {
 
@@ -30,6 +46,11 @@ public final class SourceExecuteProcessor {
                 consumer,
                 "consumer must not be null");
 
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException(
+                    "parallelism must be greater than 0");
+        }
+
         PreparedSource<SplitT> preparedSource =
                 action.getPreparedSource();
 
@@ -38,7 +59,8 @@ public final class SourceExecuteProcessor {
 
         List<SplitT> splits =
                 source.createSplits(
-                        preparedSource.getTables());
+                        preparedSource.getTables(),
+                        parallelism);
 
         if (splits == null) {
             throw new IllegalStateException(
@@ -49,17 +71,60 @@ public final class SourceExecuteProcessor {
             return;
         }
 
-        SourceReader<FluxRow, SplitT> reader =
-                source.createReader(
-                        preparedSource.getTables(),
-                        action.getBatchSize());
+        List<List<SplitT>> assignments = assignSplits(splits, parallelism);
+        ExecutorService executor = Executors.newFixedThreadPool(
+                assignments.size());
+        List<Future<?>> futures = new ArrayList<>(assignments.size());
+        try {
+            for (List<SplitT> assignment : assignments) {
+                futures.add(executor.submit(() -> {
+                    SourceReader<FluxRow, SplitT> reader = source.createReader(
+                            preparedSource.getTables(), action.getBatchSize());
+                    new SourceTask<FluxRow, SplitT>(reader, assignment, consumer).execute();
+                    return null;
+                }));
+            }
+            for (Future<?> future : futures) {
+                future.get();
+            }
+        } catch (Exception failure) {
+            for (Future<?> future : futures) {
+                future.cancel(true);
+            }
+            Throwable cause = failure instanceof java.util.concurrent.ExecutionException
+                    ? failure.getCause() : failure;
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            if (cause instanceof Error) {
+                throw (Error) cause;
+            }
+            throw new RuntimeException(cause);
+        } finally {
+            executor.shutdownNow();
+        }
+    }
 
-        SourceTask<FluxRow, SplitT> task =
-                new SourceTask<>(
-                        reader,
-                        splits,
-                        consumer);
-
-        task.execute();
+    /** Round-robin assignment balances table and range splits without duplication. */
+    static <SplitT extends SourceSplit> List<List<SplitT>> assignSplits(
+            List<SplitT> splits, int parallelism) {
+        Objects.requireNonNull(splits, "splits must not be null");
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException(
+                    "parallelism must be greater than 0");
+        }
+        int taskCount = Math.min(splits.size(), parallelism);
+        List<List<SplitT>> assignments = new ArrayList<>(taskCount);
+        for (int i = 0; i < taskCount; i++) {
+            assignments.add(new ArrayList<SplitT>());
+        }
+        for (int i = 0; i < splits.size(); i++) {
+            assignments.get(i % taskCount).add(splits.get(i));
+        }
+        List<List<SplitT>> immutable = new ArrayList<>(taskCount);
+        for (List<SplitT> assignment : assignments) {
+            immutable.add(Collections.unmodifiableList(assignment));
+        }
+        return Collections.unmodifiableList(immutable);
     }
 }

--- a/baize-flux-framework/src/test/java/com/baize/flux/framework/execution/source/SourceExecuteProcessorTest.java
+++ b/baize-flux-framework/src/test/java/com/baize/flux/framework/execution/source/SourceExecuteProcessorTest.java
@@ -1,0 +1,55 @@
+package com.baize.flux.framework.execution.source;
+
+import com.baize.flux.api.source.SourceSplit;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SourceExecuteProcessorTest {
+
+    @Test
+    public void shouldRoundRobinSplitAssignmentsAcrossReaderTasks() {
+        List<TestSplit> splits = Arrays.asList(
+                new TestSplit("a"), new TestSplit("b"), new TestSplit("c"),
+                new TestSplit("d"), new TestSplit("e"));
+
+        List<List<TestSplit>> assignments =
+                SourceExecuteProcessor.assignSplits(splits, 3);
+
+        assertEquals(3, assignments.size());
+        assertEquals(Arrays.asList(splits.get(0), splits.get(3)), assignments.get(0));
+        assertEquals(Arrays.asList(splits.get(1), splits.get(4)), assignments.get(1));
+        assertEquals(Arrays.asList(splits.get(2)), assignments.get(2));
+    }
+
+    @Test
+    public void shouldNotCreateMoreReaderTasksThanSplits() {
+        List<List<TestSplit>> assignments = SourceExecuteProcessor.assignSplits(
+                Arrays.asList(new TestSplit("only")), 8);
+
+        assertEquals(1, assignments.size());
+        assertEquals(1, assignments.get(0).size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectNonPositiveParallelism() {
+        SourceExecuteProcessor.assignSplits(
+                Arrays.asList(new TestSplit("only")), 0);
+    }
+
+    private static final class TestSplit implements SourceSplit {
+        private final String id;
+
+        private TestSplit(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String splitId() {
+            return id;
+        }
+    }
+}

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LocalSyncLauncher.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LocalSyncLauncher.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public final class LocalSyncLauncher {
 
     private static final int DEFAULT_BATCH_SIZE = 1_000;
+    private static final int DEFAULT_PARALLELISM = 1;
 
     /**
      * 本地测试配置。
@@ -176,6 +177,14 @@ public final class LocalSyncLauncher {
             sinkWriter = sinkFactory.createSink(sinkOptions);
         }
 
+        int parallelism = root.hasPath("env.parallelism")
+                ? root.getInt("env.parallelism")
+                : DEFAULT_PARALLELISM;
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException(
+                    "env.parallelism must be greater than 0");
+        }
+
         PreparedSource<?> preparedSource =
                 FactoryUtil.createAndPrepareSource(
                         factoryIdentifier,
@@ -184,7 +193,7 @@ public final class LocalSyncLauncher {
                         classLoader);
 
         try (SinkWriter<FluxRow> writer = sinkWriter) {
-            executeAndPrint(preparedSource, batchSize, writer);
+            executeAndPrint(preparedSource, batchSize, parallelism, writer);
         }
     }
 
@@ -195,6 +204,7 @@ public final class LocalSyncLauncher {
     private static void executeAndPrint(
             PreparedSource<?> preparedSource,
             int batchSize,
+            int parallelism,
             SinkWriter<FluxRow> sinkWriter)
             throws Exception {
 
@@ -209,6 +219,7 @@ public final class LocalSyncLauncher {
                         () -> executeSource(
                                 preparedSource,
                                 batchSize,
+                                parallelism,
                                 channel,
                                 producerFailure),
                         "baize-flux-source-reader");
@@ -236,6 +247,7 @@ public final class LocalSyncLauncher {
     private static void executeSource(
             PreparedSource<?> preparedSource,
             int batchSize,
+            int parallelism,
             Channel<RecordBatch<FluxRow>> channel,
             AtomicReference<Throwable> producerFailure) {
 
@@ -247,9 +259,10 @@ public final class LocalSyncLauncher {
                             batchSize);
 
             new SourceExecuteProcessor()
-                    .execute(
-                            action,
-                            channel::put);
+                            .execute(
+                                    action,
+                                    parallelism,
+                                    channel::put);
 
         } catch (Throwable failure) {
             producerFailure.set(failure);


### PR DESCRIPTION
### Motivation
- Allow job-level control of source reader concurrency so multi-table/multi-split reads can be executed in parallel. 
- Let connectors (e.g. JDBC) use the configured reader parallelism while planning splits to avoid producing excessive fine-grained splits. 
- Assign every split exactly once to an independent reader and keep sink writes serial because the current `SinkWriter` is single-connection/transactional. 

### Description
- Add a backwards-compatible `createSplits(Map<TablePath, CatalogTable>, int parallelism)` default to the `Source` API so connectors may opt into parallel-aware planning. 
- Wire `env.parallelism` into the launcher (`LocalSyncLauncher`), validate it, and pass it into the source execution path. 
- Extend JDBC connector split generation: `JdbcSource` now forwards a `parallelism` parameter to `JdbcSourceSplitGenerator`, which passes it to the split enumerator. 
- Implement concurrent source execution in `SourceExecuteProcessor` with a new `execute(..., int parallelism, ...)` overload and a compatibility overload that defaults to one reader; splits are round-robin assigned to at most `parallelism` reader tasks and executed in a thread pool, with peer-task cancellation on failure. 
- Add `assignSplits(...)` helper and unit tests (`SourceExecuteProcessorTest`) that validate round-robin assignments, task-count capping, and invalid-parallelism rejection. 
- Document `env.parallelism` in the JDBC connector README and note that sink remains single-threaded. 

### Testing
- `mvn test -q` was executed but failed due to external dependency resolution (Maven Central returned HTTP 403 while resolving `maven-resources-plugin:3.3.1`), so the new unit tests were added but could not be run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61fba5c07c8326acedf83c82b6d1bb)