### PR TITLE
Fix configured bounds for JDBC HASH splits

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/JdbcSplitPlanner.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/split/JdbcSplitPlanner.java
@@ -309,6 +309,8 @@ public final class JdbcSplitPlanner {
                                 table,
                                 column,
                                 baseQuery,
+                                lower,
+                                upper,
                                 requestedChunks,
                                 parallelism);
 
@@ -388,6 +390,8 @@ public final class JdbcSplitPlanner {
                         table,
                         column,
                         baseQuery,
+                        lower,
+                        upper,
                         requestedChunks,
                         parallelism);
 
@@ -447,6 +451,8 @@ public final class JdbcSplitPlanner {
             JdbcSourceTable table,
             Column column,
             String baseQuery,
+            String lower,
+            String upper,
             int requestedChunks,
             int parallelism) {
 
@@ -474,18 +480,12 @@ public final class JdbcSplitPlanner {
                 return Optional.empty();
             }
 
-            String predicate = predicateOptional.get();
-
-            /*
-             * HASH(NULL) 通常返回 NULL，因此首个桶额外负责读取 NULL。
-             */
-            if (bucket == 0) {
-                predicate = "("
-                        + predicate
-                        + " OR "
-                        + quotedColumn
-                        + " IS NULL)";
-            }
+            String predicate = buildHashPredicate(
+                    quotedColumn,
+                    predicateOptional.get(),
+                    lower,
+                    upper,
+                    bucket == 0);
 
             String query = appendPredicate(
                     baseQuery,
@@ -504,6 +504,44 @@ public final class JdbcSplitPlanner {
 
         return Optional.of(
                 Collections.unmodifiableList(result));
+    }
+
+    /**
+     * Combines a dialect hash expression with the configured partition bounds.
+     *
+     * <p>HASH only assigns rows to splits; it must not expand the range selected
+     * by {@code partition_lower_bound} and {@code partition_upper_bound}. NULL
+     * values retain the same first-split ownership as range splitting.
+     */
+    static String buildHashPredicate(
+            String quotedColumn,
+            String hashPredicate,
+            String lower,
+            String upper,
+            boolean firstChunk) {
+
+        String boundedPredicate = "("
+                + hashPredicate
+                + " AND "
+                + quotedColumn
+                + " >= "
+                + literal(lower)
+                + " AND "
+                + quotedColumn
+                + " <= "
+                + literal(upper)
+                + ")";
+
+        if (!firstChunk) {
+            return boundedPredicate;
+        }
+
+        /* HASH(NULL) 通常返回 NULL，因此首个桶额外负责读取 NULL。 */
+        return "("
+                + boundedPredicate
+                + " OR "
+                + quotedColumn
+                + " IS NULL)";
     }
 
     private static <T> List<JdbcSourceSplit> createRangeSplits(

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/core/split/ChunkSplitterTest.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/core/split/ChunkSplitterTest.java
@@ -52,6 +52,26 @@ public class ChunkSplitterTest {
         assertEquals(3, DynamicChunkSplitter.effectiveChunkCount(3, 4));
     }
 
+    @Test
+    public void hashPredicateRetainsConfiguredBounds() {
+        assertEquals(
+                "((MOD(CRC32(`id`), 4) = 0 AND `id` >= 'A''A' AND `id` <= 'Z') OR `id` IS NULL)",
+                JdbcSplitPlanner.buildHashPredicate(
+                        "`id`",
+                        "MOD(CRC32(`id`), 4) = 0",
+                        "A'A",
+                        "Z",
+                        true));
+        assertEquals(
+                "(MOD(CRC32(`id`), 4) = 1 AND `id` >= 'A' AND `id` <= 'Z')",
+                JdbcSplitPlanner.buildHashPredicate(
+                        "`id`",
+                        "MOD(CRC32(`id`), 4) = 1",
+                        "A",
+                        "Z",
+                        false));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void dynamicSplitterRejectsInvalidParallelism() {
         DynamicChunkSplitter.effectiveChunkCount(1, 0);


### PR DESCRIPTION
### Motivation
- `HASH` string splitting (and the `AUTO` fallback to `HASH`) only applied the dialect hash predicate and ignored configured `partition_lower_bound`/`partition_upper_bound`, which can select rows outside the intended bounds.  
- The intent is to keep `HASH` as an allocation strategy while ensuring rows remain limited to the configured bounds and preserving the single-owner behavior for `NULL` values.

### Description
- Pass configured `lower` and `upper` bounds into `tryPlanHashSplits` and call sites so the hash planning can consider them.  
- Add `static String buildHashPredicate(String quotedColumn, String hashPredicate, String lower, String upper, boolean firstChunk)` to compose the dialect-provided hash expression with `>= lower` and `<= upper` bounds and to preserve `OR <column> IS NULL` for the first split.  
- Replace the earlier raw `predicateOptional.get()` usage with `buildHashPredicate(...)` when creating per-bucket predicates so each hash split is also bounded.  
- Add unit test `hashPredicateRetainsConfiguredBounds` in `ChunkSplitterTest` to verify that the composed hash predicate preserves configured bounds, escapes single quotes properly, and keeps `NULL` owned by the first split.

### Testing
- Ran `git diff --check` and it produced no whitespace/formatting errors.  
- Ran `mvn -pl baize-flux-connectors/baize-flux-connector-jdbc -am test`, but the build/test execution was blocked because Maven Central returned HTTP 403 while resolving `maven-resources-plugin:3.3.1`, preventing the unit tests from being executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6202cb117483268eb7a3ea6e67a5a5)