### PR TITLE
Initialize sink writers during job preparation

### DIFF
--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
@@ -62,14 +62,16 @@ public final class ConnectorPreparer {
                 prepareSource(
                         definition.getSource());
 
-        PreparedSink sink =
-                prepareSink(
-                        definition.getSink());
+        List<PreparedSink> sinks =
+                prepareSinks(
+                        definition.getSink(),
+                        definition.getExecutionConfig()
+                                .getSinkParallelism());
 
         return new PreparedJob(
                 definition.getName(),
                 source,
-                sink,
+                sinks,
                 definition.getExecutionConfig());
     }
 
@@ -126,8 +128,9 @@ public final class ConnectorPreparer {
                 tableMap);
     }
 
-    private PreparedSink prepareSink(
-            SinkDefinition definition) {
+    private List<PreparedSink> prepareSinks(
+            SinkDefinition definition,
+            int parallelism) {
 
         SinkFactory factory =
                 registry.getSinkFactory(
@@ -138,10 +141,19 @@ public final class ConnectorPreparer {
                 .validate(
                         factory.optionRule());
 
-        return new PreparedSink(
-                definition.getType(),
-                factory,
-                definition.getOptions());
+        List<PreparedSink> sinks =
+                new java.util.ArrayList<PreparedSink>(
+                        parallelism);
+
+        for (int i = 0; i < parallelism; i++) {
+            sinks.add(
+                    new PreparedSink(
+                            definition.getType(),
+                            factory,
+                            definition.getOptions()));
+        }
+
+        return sinks;
     }
 
     private Map<TablePath, CatalogTable> buildTableMap(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedJob.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedJob.java
@@ -2,6 +2,9 @@ package com.baize.flux.framework.connector;
 
 import com.baize.flux.framework.job.ExecutionConfig;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -13,14 +16,14 @@ public final class PreparedJob {
 
     private final PreparedSource<?> source;
 
-    private final PreparedSink sink;
+    private final List<PreparedSink> sinks;
 
     private final ExecutionConfig executionConfig;
 
     public PreparedJob(
             String jobName,
             PreparedSource<?> source,
-            PreparedSink sink,
+            List<PreparedSink> sinks,
             ExecutionConfig executionConfig) {
 
         this.jobName =
@@ -33,10 +36,17 @@ public final class PreparedJob {
                         source,
                         "source must not be null");
 
-        this.sink =
-                Objects.requireNonNull(
-                        sink,
-                        "sink must not be null");
+        this.sinks =
+                Collections.unmodifiableList(
+                        new ArrayList<PreparedSink>(
+                                Objects.requireNonNull(
+                                        sinks,
+                                        "sinks must not be null")));
+
+        if (this.sinks.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "sinks must not be empty");
+        }
 
         this.executionConfig =
                 Objects.requireNonNull(
@@ -52,8 +62,8 @@ public final class PreparedJob {
         return source;
     }
 
-    public PreparedSink getSink() {
-        return sink;
+    public List<PreparedSink> getSinks() {
+        return sinks;
     }
 
     public ExecutionConfig getExecutionConfig() {

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSink.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSink.java
@@ -8,17 +8,17 @@ import com.baize.flux.api.table.type.FluxRow;
 import java.util.Objects;
 
 /**
- * 已完成 Factory 发现和配置校验的 Sink。
+ * 已完成 Factory 发现、配置校验和 Writer 初始化的 Sink。
  *
- * <p>每个 SinkTask 通过该对象创建独立 SinkWriter。
+ * <p>SinkWriter 在 Job Prepare 阶段创建，并在对应的 SinkTask 中执行。
  */
 public final class PreparedSink {
 
     private final String factoryIdentifier;
 
-    private final SinkFactory factory;
-
     private final ReadonlyConfig options;
+
+    private final SinkWriter<FluxRow> writer;
 
     public PreparedSink(
             String factoryIdentifier,
@@ -30,28 +30,28 @@ public final class PreparedSink {
                         factoryIdentifier,
                         "factoryIdentifier must not be null");
 
-        this.factory =
-                Objects.requireNonNull(
-                        factory,
-                        "factory must not be null");
-
         this.options =
                 Objects.requireNonNull(
                         options,
                         "options must not be null");
-    }
 
-    public SinkWriter<FluxRow> createWriter() {
-        SinkWriter<FluxRow> writer =
-                factory.createSink(options);
+        SinkFactory nonNullFactory =
+                Objects.requireNonNull(
+                        factory,
+                        "factory must not be null");
 
-        if (writer == null) {
+        this.writer =
+                nonNullFactory.createSink(options);
+
+        if (this.writer == null) {
             throw new ConnectorException(
                     "Sink factory '"
                             + factoryIdentifier
                             + "' returned a null writer");
         }
+    }
 
+    public SinkWriter<FluxRow> getWriter() {
         return writer;
     }
 

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
@@ -57,7 +57,7 @@ public final class SinkTask
         try {
             writer =
                     plan.getPreparedSink()
-                            .createWriter();
+                            .getWriter();
 
             writer.open();
 

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
@@ -3,6 +3,7 @@ package com.baize.flux.framework.planner;
 import com.baize.flux.api.source.Source;
 import com.baize.flux.api.source.SourceSplit;
 import com.baize.flux.framework.connector.PreparedJob;
+import com.baize.flux.framework.connector.PreparedSink;
 import com.baize.flux.framework.connector.PreparedSource;
 import com.baize.flux.framework.execution.TaskId;
 import com.baize.flux.framework.job.ExecutionConfig;
@@ -97,6 +98,14 @@ public final class JobPlanner {
             int sinkParallelism =
                     config.getSinkParallelism();
 
+            List<PreparedSink> preparedSinks =
+                    preparedJob.getSinks();
+
+            if (preparedSinks.size() != sinkParallelism) {
+                throw new IllegalStateException(
+                        "Prepared sink count does not match sink parallelism");
+            }
+
             for (int i = 0; i < sinkParallelism; i++) {
                 sinkPlans.add(
                         new SinkTaskPlan(
@@ -104,7 +113,7 @@ public final class JobPlanner {
                                         "sink",
                                         i,
                                         sinkParallelism),
-                                preparedJob.getSink()));
+                                preparedSinks.get(i)));
             }
         }
 

--- a/baize-flux-framework/src/test/java/com/baize/flux/framework/connector/PreparedSinkTest.java
+++ b/baize-flux-framework/src/test/java/com/baize/flux/framework/connector/PreparedSinkTest.java
@@ -1,0 +1,74 @@
+package com.baize.flux.framework.connector;
+
+import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.configuration.util.OptionRule;
+import com.baize.flux.api.factory.SinkFactory;
+import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.source.RecordBatch;
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.type.FluxRow;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class PreparedSinkTest {
+
+    @Test
+    public void initializesWriterDuringPreparation() {
+        AtomicInteger createCount = new AtomicInteger();
+        SinkWriter<FluxRow> writer = new NoOpSinkWriter();
+
+        PreparedSink preparedSink =
+                new PreparedSink(
+                        "test",
+                        new TestingSinkFactory(createCount, writer),
+                        ReadonlyConfig.fromMap(Collections.<String, Object>emptyMap()));
+
+        assertEquals(1, createCount.get());
+        assertSame(writer, preparedSink.getWriter());
+    }
+
+    private static final class TestingSinkFactory implements SinkFactory {
+
+        private final AtomicInteger createCount;
+        private final SinkWriter<FluxRow> writer;
+
+        private TestingSinkFactory(
+                AtomicInteger createCount,
+                SinkWriter<FluxRow> writer) {
+            this.createCount = createCount;
+            this.writer = writer;
+        }
+
+        @Override
+        public String factoryIdentifier() {
+            return "test";
+        }
+
+        @Override
+        public OptionRule optionRule() {
+            return OptionRule.builder().build();
+        }
+
+        @Override
+        public SinkWriter<FluxRow> createSink(ReadonlyConfig config) {
+            createCount.incrementAndGet();
+            return writer;
+        }
+    }
+
+    private static final class NoOpSinkWriter implements SinkWriter<FluxRow> {
+
+        @Override
+        public void write(RecordBatch<FluxRow> batch, CatalogTable sourceTable) {
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Move Sink initialization out of `SinkTask` execution and perform it during Job preparation so writers are created once per configured sink task and available to task plans.
- Reduce runtime overhead and ensure early validation of sink factories and options.

### Description
- `PreparedSink` now initializes a `SinkWriter<FluxRow>` in its constructor and exposes it via `getWriter()` instead of creating writers on demand.
- `PreparedJob` was changed to hold a `List<PreparedSink>` (immutable) and validates the list is non-empty.
- `ConnectorPreparer` gained `prepareSinks(...)` which creates one `PreparedSink` per configured `sinkParallelism` using the discovered `SinkFactory` and validated options.
- `JobPlanner` now retrieves the prepared sink list via `preparedJob.getSinks()`, checks the prepared sink count matches `ExecutionConfig.getSinkParallelism()`, and binds each `PreparedSink` to a `SinkTaskPlan` accordingly.
- `SinkTask` uses `plan.getPreparedSink().getWriter()` and no longer calls a factory during task execution; transaction lifecycle (open/write/commit/rollback/close) remains in `SinkTask`.
- Added unit test `baize-flux-framework/src/test/java/com/baize/flux/framework/connector/PreparedSinkTest.java` to verify a `SinkWriter` is created during `PreparedSink` construction.

### Testing
- Ran `git diff --check` to validate workspace changes (passed).
- Attempted `mvn -pl baize-flux-framework -am test`, which failed due to plugin resolution: Maven Central returned HTTP 403 while resolving `maven-resources-plugin:3.3.1` (test run blocked).
- Attempted offline Maven run `mvn -o -pl baize-flux-framework -am test`, which failed because the required plugin is not cached locally (test run blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62c7666ee48326ac7084784e012503)