### PR TITLE
feat: add JDBC dirty data row handling

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfig.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfig.java
@@ -3,6 +3,7 @@ package com.baize.flux.connector.jdbc.config;
 import com.baize.flux.api.configuration.ReadonlyConfig;
 import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.connector.jdbc.sink.DataSaveMode;
+import com.baize.flux.connector.jdbc.sink.DirtyDataPolicy;
 import com.baize.flux.connector.jdbc.sink.SchemaSaveMode;
 import lombok.Getter;
 
@@ -48,6 +49,7 @@ public final class JdbcSinkConfig
 
     private final int batchSize;
     private final int maxRetries;
+    private final DirtyDataPolicy dirtyDataPolicy;
     private final boolean createPrimaryKey;
 
     private JdbcSinkConfig(
@@ -60,6 +62,7 @@ public final class JdbcSinkConfig
             List<String> primaryKeys,
             int batchSize,
             int maxRetries,
+            DirtyDataPolicy dirtyDataPolicy,
             boolean createPrimaryKey) {
 
         this.connectionConfig =
@@ -109,6 +112,8 @@ public final class JdbcSinkConfig
 
         this.batchSize = batchSize;
         this.maxRetries = maxRetries;
+        this.dirtyDataPolicy = Objects.requireNonNull(
+                dirtyDataPolicy, "dirtyDataPolicy must not be null");
         this.createPrimaryKey =
                 createPrimaryKey;
     }
@@ -138,6 +143,7 @@ public final class JdbcSinkConfig
                         JdbcSinkOptions.BATCH_SIZE),
                 config.get(
                         JdbcSinkOptions.MAX_RETRIES),
+                config.get(JdbcSinkOptions.DIRTY_DATA_POLICY),
                 config.get(
                         JdbcSinkOptions
                                 .CREATE_PRIMARY_KEY));
@@ -230,5 +236,9 @@ public final class JdbcSinkConfig
 
     public boolean hasConfiguredPrimaryKeys() {
         return !primaryKeys.isEmpty();
+    }
+
+    public boolean shouldSkipDirtyData() {
+        return dirtyDataPolicy == DirtyDataPolicy.SKIP;
     }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkOptions.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkOptions.java
@@ -3,6 +3,7 @@ package com.baize.flux.connector.jdbc.config;
 import com.baize.flux.api.configuration.Option;
 import com.baize.flux.api.configuration.Options;
 import com.baize.flux.connector.jdbc.sink.DataSaveMode;
+import com.baize.flux.connector.jdbc.sink.DirtyDataPolicy;
 import com.baize.flux.connector.jdbc.sink.SchemaSaveMode;
 
 import java.util.List;
@@ -96,6 +97,16 @@ public final class JdbcSinkOptions
                     .intType()
                     .defaultValue(3)
                     .withDescription("批次写入失败后的最大重试次数");
+
+    /**
+     * 脏数据处理策略。SKIP 会使用 Savepoint 回滚失败批次，然后逐行定位并跳过
+     * 无法写入的记录；FAIL_FAST 保持事务失败即回滚的默认行为。
+     */
+    public static final Option<DirtyDataPolicy> DIRTY_DATA_POLICY =
+            Options.key("dirty_data_policy")
+                    .enumType(DirtyDataPolicy.class)
+                    .defaultValue(DirtyDataPolicy.FAIL_FAST)
+                    .withDescription("脏数据处理策略：FAIL_FAST 或 SKIP");
 
     /**
      * 自动创建目标表时是否创建主键。

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/DirtyDataPolicy.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/DirtyDataPolicy.java
@@ -1,0 +1,12 @@
+package com.baize.flux.connector.jdbc.sink;
+
+/**
+ * Defines how the JDBC sink handles records that cannot be written.
+ */
+public enum DirtyDataPolicy {
+    /** Abort the SinkTask and roll back its transaction. */
+    FAIL_FAST,
+
+    /** Roll back the failed batch, retain its valid rows, and record bad rows. */
+    SKIP
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
@@ -18,6 +18,7 @@ import java.sql.PreparedStatement;
 import java.sql.Savepoint;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -60,6 +61,10 @@ public final class JdbcOutputFormat
      */
     private final Set<TablePath> preparedTables =
             new HashSet<TablePath>();
+
+    /** Rows skipped after the failed batch has been isolated to individual rows. */
+    private final List<JdbcRowError> rowErrors =
+            new ArrayList<JdbcRowError>();
 
     private Connection connection;
 
@@ -215,6 +220,14 @@ public final class JdbcOutputFormat
     }
 
     /**
+     * Returns a snapshot of rows rejected while {@code dirty_data_policy=SKIP}.
+     */
+    public List<JdbcRowError> getRowErrors() {
+        return Collections.unmodifiableList(
+                new ArrayList<JdbcRowError>(rowErrors));
+    }
+
+    /**
      * 执行一个 JDBC Batch。
      *
      * <p>整个 SinkTask 共用一条事务，因此批次重试不能执行完整 rollback。
@@ -228,16 +241,51 @@ public final class JdbcOutputFormat
 
         ensureTransactionConnection();
 
-        int maxRetries =
-                config.getMaxRetries();
+        try {
+            executeRows(sql, rows, schema);
+        } catch (Exception batchFailure) {
+            if (!config.shouldSkipDirtyData()) {
+                throw batchFailure;
+            }
 
-        if (maxRetries > 0
+            if (!isTransactionConnectionValid()) {
+                throw batchFailure;
+            }
+
+            /*
+             * The failed batch has already been rolled back to its savepoint.
+             * Replay it one row at a time so valid rows remain in the task
+             * transaction and only the rows that still fail are discarded.
+             */
+            for (FluxRow row : rows) {
+                try {
+                    executeRows(sql, Collections.singletonList(row), schema);
+                } catch (Exception rowFailure) {
+                    if (!isTransactionConnectionValid()) {
+                        throw rowFailure;
+                    }
+                    rowErrors.add(new JdbcRowError(row, rowFailure));
+                }
+            }
+        }
+    }
+
+    private void executeRows(
+            String sql,
+            List<FluxRow> rows,
+            TableSchema schema)
+            throws Exception {
+
+        int maxRetries = config.getMaxRetries();
+        boolean requiresSavepoint = maxRetries > 0 || config.shouldSkipDirtyData();
+
+        if (requiresSavepoint
                 && !supportsSavepoints()) {
 
             throw new IllegalStateException(
                     "当前 JDBC 数据库或驱动不支持 Savepoint，"
-                            + "无法在任务级事务中安全执行批次重试。"
-                            + "请将 maxRetries 设置为 0，"
+                            + "无法在任务级事务中安全执行批次重试或脏数据隔离。"
+                            + "请关闭重试和脏数据跳过，"
                             + "或者使用支持 Savepoint 的 JDBC 驱动");
         }
 
@@ -252,7 +300,7 @@ public final class JdbcOutputFormat
             /*
              * 配置了批次重试时，为当前批次创建保存点。
              */
-            if (maxRetries > 0) {
+            if (requiresSavepoint) {
                 savepoint =
                         connection.setSavepoint(
                                 "baize_flux_batch_"

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcRowError.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcRowError.java
@@ -1,0 +1,27 @@
+package com.baize.flux.connector.jdbc.sink;
+
+import com.baize.flux.api.table.type.FluxRow;
+
+import java.util.Objects;
+
+/**
+ * A row rejected by the JDBC sink while dirty-data skipping is enabled.
+ */
+public final class JdbcRowError {
+
+    private final FluxRow row;
+    private final Exception cause;
+
+    JdbcRowError(FluxRow row, Exception cause) {
+        this.row = Objects.requireNonNull(row, "row must not be null").copy();
+        this.cause = Objects.requireNonNull(cause, "cause must not be null");
+    }
+
+    public FluxRow getRow() {
+        return row.copy();
+    }
+
+    public Exception getCause() {
+        return cause;
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkWriter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkWriter.java
@@ -6,6 +6,7 @@ import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.type.FluxRow;
 import com.baize.flux.connector.jdbc.config.JdbcSinkConfig;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -66,5 +67,12 @@ public final class JdbcSinkWriter
     @Override
     public void close() throws Exception {
         outputFormat.close();
+    }
+
+    /**
+     * Returns immutable snapshots of rows skipped under {@code dirty_data_policy=SKIP}.
+     */
+    public List<JdbcRowError> getRowErrors() {
+        return outputFormat.getRowErrors();
     }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfigTest.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfigTest.java
@@ -2,6 +2,7 @@ package com.baize.flux.connector.jdbc.config;
 
 import com.baize.flux.api.configuration.ReadonlyConfig;
 import com.baize.flux.api.table.catalog.TablePath;
+import com.baize.flux.connector.jdbc.sink.DirtyDataPolicy;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigResolveOptions;
 import org.junit.Test;
@@ -52,6 +53,20 @@ public class JdbcSinkConfigTest {
         assertEquals(
                 "test1.sink_orders",
                 config.resolveTargetTablePath(TablePath.of("flux_test", "orders")));
+    }
+
+    @Test
+    public void shouldFailFastForDirtyDataByDefault() {
+        assertEquals(DirtyDataPolicy.FAIL_FAST, config("").getDirtyDataPolicy());
+        assertFalse(config("").shouldSkipDirtyData());
+    }
+
+    @Test
+    public void shouldAllowSkippingDirtyRows() {
+        JdbcSinkConfig config = config("dirty_data_policy = SKIP");
+
+        assertEquals(DirtyDataPolicy.SKIP, config.getDirtyDataPolicy());
+        assertTrue(config.shouldSkipDirtyData());
     }
 
     private JdbcSinkConfig config(String sinkOptions) {


### PR DESCRIPTION
### Motivation

- Allow JDBC sink to handle malformed or non-writable rows without aborting the whole task by adding a configurable dirty-data policy.
- Provide an option to isolate failed batches, replay rows individually to keep valid rows in the same transaction, and collect row-level errors for later inspection.
- Expose the collected row errors to callers so callers can inspect or persist the rejected rows.

### Description

- Add `DirtyDataPolicy` enum with `FAIL_FAST` and `SKIP` options and a new `DIRTY_DATA_POLICY` config option in `JdbcSinkOptions` and `JdbcSinkConfig` wiring.
- Add `JdbcRowError` to represent a rejected row and its failure cause, and a `rowErrors` collection on `JdbcOutputFormat` with `getRowErrors()` accessor.
- Refactor batch execution in `JdbcOutputFormat` by introducing `executeRows(...)` and making `executeBatch(...)` replay rows one-by-one when `dirty_data_policy=SKIP`, using savepoints to rollback the failed batch and keeping valid rows in the transaction; connection-lost conditions still abort the task.
- Expose `JdbcOutputFormat.getRowErrors()` via `JdbcSinkWriter.getRowErrors()` so callers can obtain immutable snapshots of skipped row errors.
- Add unit tests to `JdbcSinkConfigTest` covering default `FAIL_FAST` and `SKIP` parsing/behavior of the new option.

### Testing

- Ran `git diff --check` which reported no whitespace problems and showed the intended diffs (success).
- Ran `mvn test -pl baize-flux-connectors/baize-flux-connector-jdbc -am` but the Maven invocation failed to run tests due to a dependency resolution error from Maven Central (HTTP 403 while resolving `maven-resources-plugin:3.3.1`) so full test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62cb1700f883269615034992f27c83)