### PR TITLE
perf(jdbc): cache sink prepared statements

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfig.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfig.java
@@ -48,6 +48,8 @@ public final class JdbcSinkConfig
     private final List<String> primaryKeys;
 
     private final int batchSize;
+    private final int preparedStatementCacheSize;
+    private final int queryTimeoutSec;
     private final int maxRetries;
     private final DirtyDataPolicy dirtyDataPolicy;
     private final boolean createPrimaryKey;
@@ -61,6 +63,8 @@ public final class JdbcSinkConfig
             String customSql,
             List<String> primaryKeys,
             int batchSize,
+            int preparedStatementCacheSize,
+            int queryTimeoutSec,
             int maxRetries,
             DirtyDataPolicy dirtyDataPolicy,
             boolean createPrimaryKey) {
@@ -105,12 +109,24 @@ public final class JdbcSinkConfig
                     "batchSize must be greater than 0");
         }
 
+        if (preparedStatementCacheSize <= 0) {
+            throw new IllegalArgumentException(
+                    "preparedStatementCacheSize must be greater than 0");
+        }
+
+        if (queryTimeoutSec < 0) {
+            throw new IllegalArgumentException(
+                    "queryTimeoutSec must not be negative");
+        }
+
         if (maxRetries < 0) {
             throw new IllegalArgumentException(
                     "maxRetries must not be negative");
         }
 
         this.batchSize = batchSize;
+        this.preparedStatementCacheSize = preparedStatementCacheSize;
+        this.queryTimeoutSec = queryTimeoutSec;
         this.maxRetries = maxRetries;
         this.dirtyDataPolicy = Objects.requireNonNull(
                 dirtyDataPolicy, "dirtyDataPolicy must not be null");
@@ -141,6 +157,10 @@ public final class JdbcSinkConfig
                         .orElse(Collections.emptyList()),
                 config.get(
                         JdbcSinkOptions.BATCH_SIZE),
+                config.get(
+                        JdbcSinkOptions.PREPARED_STATEMENT_CACHE_SIZE),
+                config.get(
+                        JdbcSinkOptions.QUERY_TIMEOUT_SEC),
                 config.get(
                         JdbcSinkOptions.MAX_RETRIES),
                 config.get(JdbcSinkOptions.DIRTY_DATA_POLICY),

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkOptions.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkOptions.java
@@ -92,6 +92,26 @@ public final class JdbcSinkOptions
                     .defaultValue(1000)
                     .withDescription("JDBC executeBatch 每批写入数量");
 
+    /**
+     * Number of write statements retained per SinkTask. The cache is bounded
+     * so dynamic multi-table routing cannot grow JDBC driver resources without limit.
+     */
+    public static final Option<Integer> PREPARED_STATEMENT_CACHE_SIZE =
+            Options.key("prepared_statement_cache_size")
+                    .intType()
+                    .defaultValue(32)
+                    .withDescription("每个 SinkTask 缓存的目标表 PreparedStatement 数量上限");
+
+    /**
+     * JDBC query timeout applied to every cached write statement. A value of
+     * {@code 0} leaves timeout handling to the JDBC driver.
+     */
+    public static final Option<Integer> QUERY_TIMEOUT_SEC =
+            Options.key("query_timeout_sec")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription("写入 PreparedStatement 的查询超时时间，单位秒，0 表示不主动限制");
+
     public static final Option<Integer> MAX_RETRIES =
             Options.key("max_retries")
                     .intType()

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
@@ -20,7 +20,9 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -67,6 +69,10 @@ public final class JdbcOutputFormat
             new ArrayList<JdbcRowError>();
 
     private Connection connection;
+
+    /** Statements are reused across internal batches and bounded for multi-table jobs. */
+    private final Map<TablePath, CachedStatement> preparedStatementCache =
+            new LinkedHashMap<TablePath, CachedStatement>(16, 0.75F, true);
 
     private Boolean supportsSavepoints;
 
@@ -168,6 +174,7 @@ public final class JdbcOutputFormat
                             rows.size());
 
             executeBatch(
+                    targetTable.getTablePath(),
                     sql,
                     rows.subList(start, end),
                     targetTable.getTableSchema());
@@ -234,6 +241,7 @@ public final class JdbcOutputFormat
      * 这里通过 Savepoint 只回滚当前失败批次。
      */
     private void executeBatch(
+            TablePath tablePath,
             String sql,
             List<FluxRow> rows,
             TableSchema schema)
@@ -242,7 +250,7 @@ public final class JdbcOutputFormat
         ensureTransactionConnection();
 
         try {
-            executeRows(sql, rows, schema);
+            executeRows(tablePath, sql, rows, schema);
         } catch (Exception batchFailure) {
             if (!config.shouldSkipDirtyData()) {
                 throw batchFailure;
@@ -259,7 +267,7 @@ public final class JdbcOutputFormat
              */
             for (FluxRow row : rows) {
                 try {
-                    executeRows(sql, Collections.singletonList(row), schema);
+                    executeRows(tablePath, sql, Collections.singletonList(row), schema);
                 } catch (Exception rowFailure) {
                     if (!isTransactionConnectionValid()) {
                         throw rowFailure;
@@ -271,6 +279,7 @@ public final class JdbcOutputFormat
     }
 
     private void executeRows(
+            TablePath tablePath,
             String sql,
             List<FluxRow> rows,
             TableSchema schema)
@@ -307,25 +316,18 @@ public final class JdbcOutputFormat
                                         + attempt);
             }
 
-            try (PreparedStatement statement =
-                         connection.prepareStatement(sql)) {
+            try {
+                PreparedStatement statement = getPreparedStatement(tablePath, sql);
+                statement.clearBatch();
 
                 for (FluxRow row : rows) {
-                    dialect.rowConverter()
-                            .write(
-                                    statement,
-                                    row,
-                                    schema);
-
+                    dialect.rowConverter().write(statement, row, schema);
                     statement.addBatch();
                 }
 
                 statement.executeBatch();
-
-                releaseSavepointQuietly(
-                        savepoint,
-                        null);
-
+                statement.clearBatch();
+                releaseSavepointQuietly(savepoint, null);
                 return;
 
             } catch (Exception exception) {
@@ -379,6 +381,58 @@ public final class JdbcOutputFormat
                 ? new IllegalStateException(
                 "JDBC batch execution failed")
                 : lastFailure;
+    }
+
+    private PreparedStatement getPreparedStatement(
+            TablePath tablePath, String sql) throws SQLException {
+        CachedStatement cached = preparedStatementCache.get(tablePath);
+        if (cached != null && cached.sql.equals(sql) && !cached.statement.isClosed()) {
+            return cached.statement;
+        }
+        if (cached != null) {
+            closeStatementQuietly(cached.statement);
+            preparedStatementCache.remove(tablePath);
+        }
+        PreparedStatement statement = connection.prepareStatement(sql);
+        if (config.getQueryTimeoutSec() > 0) {
+            statement.setQueryTimeout(config.getQueryTimeoutSec());
+        }
+        preparedStatementCache.put(tablePath, new CachedStatement(sql, statement));
+        evictPreparedStatements();
+        return statement;
+    }
+
+    private void evictPreparedStatements() {
+        while (preparedStatementCache.size() > config.getPreparedStatementCacheSize()) {
+            TablePath eldest = preparedStatementCache.keySet().iterator().next();
+            CachedStatement evicted = preparedStatementCache.remove(eldest);
+            closeStatementQuietly(evicted.statement);
+        }
+    }
+
+    private void closePreparedStatements() {
+        for (CachedStatement cached : preparedStatementCache.values()) {
+            closeStatementQuietly(cached.statement);
+        }
+        preparedStatementCache.clear();
+    }
+
+    private void closeStatementQuietly(PreparedStatement statement) {
+        try {
+            statement.close();
+        } catch (SQLException ignored) {
+            // Connection close is still attempted below.
+        }
+    }
+
+    private static final class CachedStatement {
+        private final String sql;
+        private final PreparedStatement statement;
+
+        private CachedStatement(String sql, PreparedStatement statement) {
+            this.sql = sql;
+            this.statement = statement;
+        }
     }
 
     /**
@@ -623,6 +677,7 @@ public final class JdbcOutputFormat
         }
 
         try {
+            closePreparedStatements();
             connectionProvider.closeConnection();
         } catch (Exception closeFailure) {
             if (failure == null) {

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkFactory.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkFactory.java
@@ -26,7 +26,9 @@ public final class JdbcSinkFactory implements SinkFactory {
                 JdbcSinkOptions.TABLE_PATH, JdbcSinkOptions.SCHEMA_SAVE_MODE,
                 JdbcSinkOptions.DATA_SAVE_MODE, JdbcSinkOptions.WRITE_MODE,
                 JdbcSinkOptions.CUSTOM_SQL, JdbcSinkOptions.PRIMARY_KEYS,
-                JdbcSinkOptions.BATCH_SIZE, JdbcSinkOptions.MAX_RETRIES,
+                JdbcSinkOptions.BATCH_SIZE, JdbcSinkOptions.PREPARED_STATEMENT_CACHE_SIZE,
+                JdbcSinkOptions.QUERY_TIMEOUT_SEC, JdbcSinkOptions.MAX_RETRIES,
+                JdbcSinkOptions.DIRTY_DATA_POLICY,
                 JdbcSinkOptions.CREATE_PRIMARY_KEY).build();
     }
 

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfigTest.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfigTest.java
@@ -62,6 +62,14 @@ public class JdbcSinkConfigTest {
     }
 
     @Test
+    public void shouldUseBoundedPreparedStatementCacheAndQueryTimeout() {
+        JdbcSinkConfig config = config("prepared_statement_cache_size = 8\nquery_timeout_sec = 15");
+
+        assertEquals(8, config.getPreparedStatementCacheSize());
+        assertEquals(15, config.getQueryTimeoutSec());
+    }
+
+    @Test
     public void shouldAllowSkippingDirtyRows() {
         JdbcSinkConfig config = config("dirty_data_policy = SKIP");
 


### PR DESCRIPTION
### Motivation

- Reduce per-internal-batch `PreparedStatement` recreation and improve JDBC sink write throughput for multi-table and high-rate workloads.
- Prevent unbounded JDBC driver resource growth when dynamic multi-table routing creates many target tables.
- Provide configuration knobs for statement caching and query timeouts so deployments can tune behavior per database and workload.

### Description

- Add a bounded LRU cache of write `PreparedStatement` instances keyed by resolved `TablePath` in `JdbcOutputFormat`, reusing statements across internal batches and clearing batches before/after execution. (`JdbcOutputFormat`)
- Evict and close statements when the cache exceeds the configured capacity and close cached statements on sink shutdown. (`JdbcOutputFormat`)
- Introduce two sink options: `prepared_statement_cache_size` (default 32) and `query_timeout_sec` (default 0) in `JdbcSinkOptions`, expose them through the sink factory, and surface them in runtime config (`JdbcSinkConfig`, `JdbcSinkFactory`).
- Apply `query_timeout_sec` to prepared statements created by the cache and add validation for the new config values in `JdbcSinkConfig`.
- Update config unit tests to assert the new options are parsed (`JdbcSinkConfigTest`).

### Testing

- Ran `git diff --check` to validate whitespace and basic diffs (passed). 
- Attempted `mvn -pl baize-flux-connectors/baize-flux-connector-jdbc -am test -DskipTests=false`, but the build/test run could not start because Maven failed to resolve `maven-resources-plugin:3.3.1` from Maven Central (HTTP 403), so automated tests in CI/local could not complete.
- Added a unit test (`shouldUseBoundedPreparedStatementCacheAndQueryTimeout`) in `JdbcSinkConfigTest` to verify parsing of `prepared_statement_cache_size` and `query_timeout_sec` (test present but not executed due to the dependency resolution failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62cd99faac83268e1fca80c63806eb)