### PR TITLE
feat: validate and evolve JDBC sink schemas

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/table/catalog/SchemaCompatibilityReport.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/table/catalog/SchemaCompatibilityReport.java
@@ -1,0 +1,103 @@
+package com.baize.flux.api.table.catalog;
+
+import com.baize.flux.api.table.type.SqlType;
+import com.baize.flux.api.table.type.TypeUtil;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * Compares a source schema with a target schema before data is written.
+ *
+ * <p>The report deliberately matches names case-insensitively.  JDBC metadata
+ * is not consistent about identifier casing and positional matching can write
+ * values into the wrong columns when a target has extra columns.</p>
+ */
+public final class SchemaCompatibilityReport implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final List<Column> missingTargetColumns;
+    private final List<String> incompatibleColumns;
+    private final List<String> warnings;
+    private final Map<String, String> sourceToTarget;
+
+    private SchemaCompatibilityReport(List<Column> missing, List<String> incompatible,
+            List<String> warnings, Map<String, String> mapping) {
+        this.missingTargetColumns = Collections.unmodifiableList(new ArrayList<>(missing));
+        this.incompatibleColumns = Collections.unmodifiableList(new ArrayList<>(incompatible));
+        this.warnings = Collections.unmodifiableList(new ArrayList<>(warnings));
+        this.sourceToTarget = Collections.unmodifiableMap(new LinkedHashMap<>(mapping));
+    }
+
+    public static SchemaCompatibilityReport compare(TableSchema source, TableSchema target) {
+        Objects.requireNonNull(source, "source must not be null");
+        Objects.requireNonNull(target, "target must not be null");
+        Map<String, Column> targetByName = new HashMap<>();
+        for (Column column : target.getColumns()) {
+            targetByName.put(normalize(column.getName()), column);
+        }
+        List<Column> missing = new ArrayList<>();
+        List<String> incompatible = new ArrayList<>();
+        List<String> warnings = new ArrayList<>();
+        Map<String, String> mapping = new LinkedHashMap<>();
+        for (Column sourceColumn : source.getColumns()) {
+            Column targetColumn = targetByName.get(normalize(sourceColumn.getName()));
+            if (targetColumn == null) {
+                missing.add(sourceColumn);
+                continue;
+            }
+            mapping.put(sourceColumn.getName(), targetColumn.getName());
+            if (!isCompatible(sourceColumn, targetColumn)) {
+                incompatible.add(describe(sourceColumn, targetColumn));
+            }
+            if (sourceColumn.isNullable() && !targetColumn.isNullable()) {
+                warnings.add("source column '" + sourceColumn.getName()
+                        + "' is nullable but target is NOT NULL");
+            }
+            if (!sourceColumn.getName().equals(targetColumn.getName())) {
+                warnings.add("column case differs: source '" + sourceColumn.getName()
+                        + "', target '" + targetColumn.getName() + "'");
+            }
+        }
+        for (Column targetColumn : target.getColumns()) {
+            if (!targetColumn.isNullable() && targetColumn.getDefaultValue() == null
+                    && !targetColumn.isAutoIncrement()
+                    && !targetColumn.getAttributes().containsKey("generated")) {
+                if (!mapping.containsValue(targetColumn.getName())) {
+                    incompatible.add("target required column '" + targetColumn.getName()
+                            + "' is absent from source and has no default");
+                }
+            }
+        }
+        return new SchemaCompatibilityReport(missing, incompatible, warnings, mapping);
+    }
+
+    private static boolean isCompatible(Column source, Column target) {
+        if (!TypeUtil.canConvert(source.getDataType(), target.getDataType())) return false;
+        if (source.getDataType().getSqlType() == SqlType.DECIMAL) {
+            if (source.getPrecision() != null && target.getPrecision() != null
+                    && source.getPrecision() > target.getPrecision()) return false;
+            if (source.getScale() != null && target.getScale() != null
+                    && source.getScale() > target.getScale()) return false;
+        }
+        if ((source.getDataType().getSqlType() == SqlType.STRING || source.getDataType().getSqlType() == SqlType.BYTES)
+                && source.getLength() != null && target.getLength() != null
+                && source.getLength() > target.getLength()) return false;
+        String sourceUnsigned = source.getAttributes().get("unsigned");
+        String targetUnsigned = target.getAttributes().get("unsigned");
+        return !("true".equalsIgnoreCase(sourceUnsigned) && !"true".equalsIgnoreCase(targetUnsigned));
+    }
+
+    private static String describe(Column source, Column target) {
+        return "source column '" + source.getName() + "' (" + source.getSourceType()
+                + ") is incompatible with target column '" + target.getName() + "' ("
+                + target.getSourceType() + ")";
+    }
+
+    private static String normalize(String name) { return name.toLowerCase(Locale.ROOT); }
+    public List<Column> getMissingTargetColumns() { return missingTargetColumns; }
+    public List<String> getIncompatibleColumns() { return incompatibleColumns; }
+    public List<String> getWarnings() { return warnings; }
+    public Map<String, String> getSourceToTarget() { return sourceToTarget; }
+    public boolean isCompatible() { return incompatibleColumns.isEmpty(); }
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/table/catalog/WritableCatalog.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/table/catalog/WritableCatalog.java
@@ -42,6 +42,16 @@ public interface WritableCatalog extends Catalog {
             TableAlreadyExistsException;
 
     /**
+     * Adds a column without changing existing data. Implementations that do
+     * not support schema evolution should fail explicitly instead of silently
+     * accepting a schema that cannot receive the source rows.
+     */
+    default void addColumn(TablePath tablePath, Column column)
+            throws CatalogException, TableNotFoundException {
+        throw new UnsupportedOperationException("Catalog does not support ADD COLUMN: " + name());
+    }
+
+    /**
      * 删除表。
      */
     void dropTable(

--- a/baize-flux-api/src/test/java/com/baize/flux/api/table/catalog/SchemaCompatibilityReportTest.java
+++ b/baize-flux-api/src/test/java/com/baize/flux/api/table/catalog/SchemaCompatibilityReportTest.java
@@ -1,0 +1,59 @@
+package com.baize.flux.api.table.catalog;
+
+import com.baize.flux.api.table.type.BasicType;
+import com.baize.flux.api.table.type.DecimalType;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SchemaCompatibilityReportTest {
+
+    @Test
+    public void matchesColumnsByNameRatherThanPositionAndIgnoresCase() {
+        TableSchema source = TableSchema.builder()
+                .column(Column.builder("ID", BasicType.INT_TYPE).nullable(false).build())
+                .column(Column.builder("payload", BasicType.STRING_TYPE).length(100L).build())
+                .build();
+        TableSchema target = TableSchema.builder()
+                .column(Column.builder("payload", BasicType.STRING_TYPE).length(200L).build())
+                .column(Column.builder("id", BasicType.LONG_TYPE).nullable(false).build())
+                .build();
+
+        SchemaCompatibilityReport report = SchemaCompatibilityReport.compare(source, target);
+
+        assertTrue(report.isCompatible());
+        assertEquals("id", report.getSourceToTarget().get("ID"));
+        assertTrue(report.getWarnings().get(0).contains("case differs"));
+    }
+
+    @Test
+    public void reportsDecimalBinaryAndRequiredColumnHazards() {
+        TableSchema source = TableSchema.builder()
+                .column(Column.builder("amount", new DecimalType(20, 6)).precision(20).scale(6).build())
+                .column(Column.builder("blob", BasicType.BYTES_TYPE).length(4096L).build())
+                .build();
+        TableSchema target = TableSchema.builder()
+                .column(Column.builder("amount", new DecimalType(10, 2)).precision(10).scale(2).build())
+                .column(Column.builder("blob", BasicType.BYTES_TYPE).length(1024L).build())
+                .column(Column.builder("required", BasicType.INT_TYPE).nullable(false).build())
+                .build();
+
+        SchemaCompatibilityReport report = SchemaCompatibilityReport.compare(source, target);
+
+        assertFalse(report.isCompatible());
+        assertEquals(3, report.getIncompatibleColumns().size());
+    }
+
+    @Test
+    public void reportsMissingColumnsForSchemaEvolution() {
+        TableSchema source = TableSchema.builder()
+                .column(Column.builder("new_column", BasicType.STRING_TYPE).build()).build();
+        TableSchema target = TableSchema.builder()
+                .column(Column.builder("id", BasicType.INT_TYPE).build()).build();
+
+        SchemaCompatibilityReport report = SchemaCompatibilityReport.compare(source, target);
+
+        assertEquals(1, report.getMissingTargetColumns().size());
+        assertEquals("new_column", report.getMissingTargetColumns().get(0).getName());
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/catalog/mysql/MySqlCatalog.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/catalog/mysql/MySqlCatalog.java
@@ -524,6 +524,26 @@ public final class MySqlCatalog
     }
 
     @Override
+    public void addColumn(TablePath tablePath, Column column)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath normalized = normalizeTablePath(tablePath);
+        if (!tableExists(normalized)) {
+            throw new TableNotFoundException(catalogName, normalized);
+        }
+        CatalogTable table = getTable(normalized);
+        String definition = new MySqlCreateTableSqlBuilder(normalized, table, typeMapper)
+                .buildColumnDefinition(column);
+        String sql = "ALTER TABLE " + quoteTable(normalized) + " ADD COLUMN " + definition;
+        try (Connection connection = openDatabaseConnection(normalized.getDatabaseName())) {
+            execute(connection, sql);
+        } catch (SQLException e) {
+            throw new CatalogException("增加 MySQL 字段失败，table=" + normalized
+                    + ", column=" + column.getName(), e);
+        }
+    }
+
+    @Override
     public void dropTable(
             TablePath tablePath,
             boolean ignoreIfNotExists)

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/catalog/mysql/MySqlCreateTableSqlBuilder.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/catalog/mysql/MySqlCreateTableSqlBuilder.java
@@ -199,12 +199,18 @@ public final class MySqlCreateTableSqlBuilder {
                         column,
                         preserveSourceType));
 
-        definitions.add(
-                column.isNullable()
-                        ? "NULL"
-                        : "NOT NULL");
+        String generated = column.getAttributes().get("generated");
 
-        if (!column.isAutoIncrement()
+        if (hasText(generated)) {
+            definitions.add("GENERATED ALWAYS AS (" + generated + ")");
+            String storage = column.getAttributes().get("generated_storage");
+            definitions.add("STORED".equalsIgnoreCase(storage) ? "STORED" : "VIRTUAL");
+        } else {
+            definitions.add(column.isNullable() ? "NULL" : "NOT NULL");
+        }
+
+        if (!hasText(generated)
+                && !column.isAutoIncrement()
                 && column.getDefaultValue() != null) {
 
             definitions.add(
@@ -213,7 +219,7 @@ public final class MySqlCreateTableSqlBuilder {
                             column));
         }
 
-        if (column.isAutoIncrement()) {
+        if (!hasText(generated) && column.isAutoIncrement()) {
             definitions.add(
                     "AUTO_INCREMENT");
         }
@@ -246,6 +252,13 @@ public final class MySqlCreateTableSqlBuilder {
         return String.join(
                 " ",
                 definitions);
+    }
+
+    /** Builds a reusable escaped column definition for ALTER TABLE ADD COLUMN. */
+    public String buildColumnDefinition(Column column) {
+        boolean preserveSourceType = "mysql".equalsIgnoreCase(
+                catalogTable.getOptions().get("dialect"));
+        return buildColumn(column, preserveSourceType);
     }
 
     private String buildPrimaryKey(

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/SchemaSaveMode.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/SchemaSaveMode.java
@@ -8,6 +8,9 @@ public enum SchemaSaveMode {
     // Will Created when the table does not exist, skipped when the table is saved
     CREATE_SCHEMA_WHEN_NOT_EXIST,
 
+    // Create when missing; when present, add source columns absent from target.
+    CREATE_OR_ADD_COLUMNS,
+
     // Error will be reported when the table does not exist
     ERROR_WHEN_SCHEMA_NOT_EXIST,
 

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/savemode/DefaultSaveModeHandler.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/savemode/DefaultSaveModeHandler.java
@@ -2,6 +2,7 @@ package com.baize.flux.connector.jdbc.sink.savemode;
 
 import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.catalog.TablePath;
+import com.baize.flux.api.table.catalog.SchemaCompatibilityReport;
 import com.baize.flux.api.table.catalog.WritableCatalog;
 import com.baize.flux.api.table.catalog.exception.TableNotFoundException;
 import com.baize.flux.connector.jdbc.sink.DataSaveMode;
@@ -50,21 +51,48 @@ public class DefaultSaveModeHandler implements SaveModeHandler {
                 if (!exists) {
                     createTable();
                 }
+                if (exists) {
+                    validateExistingSchema(false);
+                }
+                return;
+            case CREATE_OR_ADD_COLUMNS:
+                if (!exists) {
+                    createTable();
+                    return;
+                }
+                SchemaCompatibilityReport report = validateExistingSchema(true);
+                for (com.baize.flux.api.table.catalog.Column column : report.getMissingTargetColumns()) {
+                    catalog.addColumn(tablePath, column);
+                }
                 return;
             case ERROR_WHEN_SCHEMA_NOT_EXIST:
                 if (!exists) {
                     throw new TableNotFoundException(catalog.name(), tablePath);
                 }
+                validateExistingSchema(false);
                 return;
             case IGNORE:
                 if (!exists) {
                     throw new TableNotFoundException(catalog.name(), tablePath);
                 }
+                validateExistingSchema(false);
                 return;
             default:
                 throw new UnsupportedOperationException(
                         "Unsupported schema save mode: " + schemaSaveMode);
         }
+    }
+
+    private SchemaCompatibilityReport validateExistingSchema(boolean allowMissingColumns) {
+        SchemaCompatibilityReport report = SchemaCompatibilityReport.compare(
+                table.getTableSchema(), catalog.getTable(tablePath).getTableSchema());
+        if (!report.getIncompatibleColumns().isEmpty()
+                || (!allowMissingColumns && !report.getMissingTargetColumns().isEmpty())) {
+            throw new IllegalArgumentException("Incompatible target schema: "
+                    + report.getIncompatibleColumns() + "; missing target columns: "
+                    + report.getMissingTargetColumns());
+        }
+        return report;
     }
 
     @Override


### PR DESCRIPTION
### Motivation
- 提高 JDBC Sink 在写入前对源/目标 Schema 的兼容性检查，避免因字段名大小写、字段缺失或类型不兼容导致的数据错配或写入错误。 
- 支持在可控的保存模式下对目标表做安全的模式演进（自动增加列），并处理常见的不兼容风险（Decimal 精度、字符串/二进制长度、unsigned 等）。

### Description
- 新增 `SchemaCompatibilityReport`（`com.baize.flux.api.table.catalog.SchemaCompatibilityReport`），按大小写不敏感列名做源到目标映射并报告缺失字段、类型不兼容、精度/长度溢出、unsigned 不匹配、以及 NOT NULL/默认值风险与列名大小写差异等检查逻辑。  
- 为 `WritableCatalog` 增加默认方法 `addColumn(TablePath, Column)`，用于目录实现提供可选的列添加能力（默认抛出 `UnsupportedOperationException`）。
- 扩展 `SchemaSaveMode` 增加 `CREATE_OR_ADD_COLUMNS` 模式并在 `DefaultSaveModeHandler` 中实现：在目标表存在时先运行兼容性检查，若允许演进则通过目录的 `addColumn` 自动增加缺失字段，若发现不可兼容项则抛出明确错误。  
- 在 MySQL 实现中新增对生成列的支持与安全的 ALTER-ADD 路径：`MySqlCreateTableSqlBuilder` 支持 `GENERATED ALWAYS AS (...) STORED|VIRTUAL` 并避免为生成列生成默认/自增定义，同时新增 `buildColumnDefinition` 以生成可重用的 `ALTER TABLE ADD COLUMN` 定义；`MySqlCatalog` 实现了 `addColumn`，执行 `ALTER TABLE ... ADD COLUMN <definition>`。 
- 新增单元测试 `SchemaCompatibilityReportTest` 覆盖按名匹配（忽略大小写）、Decimal/二进制溢出、必填字段与自动增加字段等场景（文件 `baize-flux-api/src/test/java/.../SchemaCompatibilityReportTest.java`）。

### Testing
- 新增的单元测试类 `SchemaCompatibilityReportTest` 已加入源码树但未能在 CI 环境完成执行。  
- 尝试运行 `mvn test -pl baize-flux-api,baize-flux-connectors/baize-flux-connector-jdbc -am` 时，构建被 Maven 插件解析错误中断（无法从 Maven Central 下载 `maven-resources-plugin:3.3.1`，返回 403），因此自动化测试未能在当前环境完成执行.
- 本地代码静态检查（暂未在 CI 上全面运行单元测试）并已包含用于运行单元测试的目标模块与用例。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62ce96ebc48326ab736f0b730657a5)