### PR TITLE
Add runnable launcher examples and detailed metrics

### DIFF
--- a/baize-flux-launcher/examples/README.md
+++ b/baize-flux-launcher/examples/README.md
@@ -1,0 +1,21 @@
+# Launcher examples
+
+These HOCON files are executable JDBC sync templates. Copy one, set the JDBC URLs,
+credentials, and table names, then run it from the repository root:
+
+```bash
+mvn -pl baize-flux-launcher -am compile exec:java \
+  -Dexec.mainClass=com.baize.flux.launcher.LocalSyncLauncher \
+  -Dexec.args=baize-flux-launcher/examples/jdbc-single-table.conf
+```
+
+`jdbc-single-table.conf` copies one source table to a fixed destination table.
+`jdbc-multi-table.conf` copies two tables concurrently and uses the connector's
+`${table_name}` placeholder to generate a destination table per source table.
+
+The launcher also accepts an inline HOCON string, but passing a configuration file
+is recommended because it keeps credentials and table configuration out of shell history.
+
+On completion it prints aggregate throughput, record/byte counts, failures, retries,
+SQL and commit timing, plus per-task and per-channel metrics. Do not commit real
+credentials in copied configuration files.

--- a/baize-flux-launcher/examples/jdbc-multi-table.conf
+++ b/baize-flux-launcher/examples/jdbc-multi-table.conf
@@ -1,0 +1,34 @@
+# Copy this file and replace all connection values before running it.
+# This example preserves each source table name by using ${table_name} in the sink table.
+job.name = "jdbc-multi-table-sync-example"
+
+env {
+  source-parallelism = 4
+  sink-parallelism = 2
+  channel-capacity = 32
+}
+
+source {
+  type = "jdbc"
+  batch-size = 1000
+  url = "jdbc:mysql://127.0.0.1:3306/source_db?useSSL=false&serverTimezone=UTC"
+  driver = "com.mysql.cj.jdbc.Driver"
+  user = "root"
+  password = "change-me"
+  fetch_size = 1000
+  table_list = [
+    { table_path = "source_db.orders" },
+    { table_path = "source_db.customers" }
+  ]
+}
+
+sink {
+  type = "jdbc"
+  url = "jdbc:mysql://127.0.0.1:3306/target_db?useSSL=false&serverTimezone=UTC"
+  driver = "com.mysql.cj.jdbc.Driver"
+  user = "root"
+  password = "change-me"
+  table = "target_db.copy_${table_name}"
+  schema_save_mode = CREATE_SCHEMA_WHEN_NOT_EXIST
+  data_save_mode = APPEND_DATA
+}

--- a/baize-flux-launcher/examples/jdbc-single-table.conf
+++ b/baize-flux-launcher/examples/jdbc-single-table.conf
@@ -1,0 +1,34 @@
+# Copy this file and replace all connection values before running it.
+# Run from the repository root:
+# mvn -pl baize-flux-launcher -am compile exec:java \
+#   -Dexec.mainClass=com.baize.flux.launcher.LocalSyncLauncher \
+#   -Dexec.args=baize-flux-launcher/examples/jdbc-single-table.conf
+job.name = "jdbc-single-table-sync-example"
+
+env {
+  source-parallelism = 1
+  sink-parallelism = 1
+  channel-capacity = 64
+}
+
+source {
+  type = "jdbc"
+  batch-size = 500
+  url = "jdbc:mysql://127.0.0.1:3306/source_db?useSSL=false&serverTimezone=UTC"
+  driver = "com.mysql.cj.jdbc.Driver"
+  user = "root"
+  password = "change-me"
+  fetch_size = 500
+  table_list = [{ table_path = "source_db.orders" }]
+}
+
+sink {
+  type = "jdbc"
+  url = "jdbc:mysql://127.0.0.1:3306/target_db?useSSL=false&serverTimezone=UTC"
+  driver = "com.mysql.cj.jdbc.Driver"
+  user = "root"
+  password = "change-me"
+  table = "target_db.orders_copy"
+  schema_save_mode = CREATE_SCHEMA_WHEN_NOT_EXIST
+  data_save_mode = APPEND_DATA
+}

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java
@@ -1,0 +1,109 @@
+package com.baize.flux.launcher;
+
+import com.baize.flux.framework.metrics.ChannelMetrics;
+import com.baize.flux.framework.metrics.JobMetrics;
+import com.baize.flux.framework.metrics.TaskMetrics;
+import com.baize.flux.framework.job.JobResult;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+/** Formats a completed job result, including aggregate, task, and channel metrics. */
+public final class JobResultPrinter {
+
+    private JobResultPrinter() {
+    }
+
+    public static void print(JobResult result) {
+        print(result, System.out);
+    }
+
+    static void print(JobResult result, PrintStream output) {
+        JobMetrics metrics = result.getMetrics();
+        output.println("Flux job finished:");
+        line(output, "job-name", result.getJobName());
+        line(output, "status", result.getStatus());
+        line(output, "duration-ms", result.getDurationMillis());
+
+        output.println("  aggregate-metrics:");
+        line(output, "source-batches", metrics.getSourceBatchCount());
+        line(output, "source-records", metrics.getSourceRecordCount());
+        line(output, "source-bytes", metrics.getSourceReadBytes());
+        line(output, "completed-splits", metrics.getCompletedSplitCount());
+        line(output, "sink-batches", metrics.getSinkBatchCount());
+        line(output, "sink-records", metrics.getSinkRecordCount());
+        line(output, "sink-bytes", metrics.getSinkWrittenBytes());
+        line(output, "source-sink-record-difference", metrics.getSourceSinkRecordDifference());
+        line(output, "failed-records", metrics.getFailedRecordCount());
+        line(output, "skipped-records", metrics.getSkippedRecordCount());
+        line(output, "batch-retries", metrics.getBatchRetryCount());
+        line(output, "database-commit-ms", metrics.getDatabaseCommitMillis());
+        line(output, "sql-execution-ms", metrics.getSqlExecutionMillis());
+        line(output, "average-qps", formatRate(metrics.getAverageQps()));
+        line(output, "channel-blocked-ratio", formatRatio(metrics.getChannelBlockedRatio()));
+
+        printTaskMetrics(metrics, output);
+        printChannelMetrics(metrics, output);
+        if (result.getFailure() != null) line(output, "failure", result.getFailure());
+    }
+
+    private static void printTaskMetrics(JobMetrics metrics, PrintStream output) {
+        List<TaskMetrics> tasks = new ArrayList<TaskMetrics>(metrics.getTaskMetrics().values());
+        tasks.sort(Comparator.comparing(task -> task.getTaskId().toString()));
+        output.println("  task-metrics (" + tasks.size() + "):");
+        for (TaskMetrics task : tasks) {
+            output.println("    " + task.getTaskId() + ": state=" + task.getState()
+                    + ", batches=" + task.getBatchCount()
+                    + ", records=" + task.getRecordCount()
+                    + ", source-records=" + task.getSourceReadRecordCount()
+                    + ", sink-records=" + task.getSinkWriteSuccessRecordCount()
+                    + ", failed=" + task.getFailedRecordCount()
+                    + ", skipped=" + task.getSkippedRecordCount()
+                    + ", splits=" + task.getCompletedSplitCount()
+                    + ", qps=" + formatRate(task.getAverageQps())
+                    + ", duration-ms=" + task.getDurationMillis()
+                    + position(task));
+        }
+    }
+
+    private static void printChannelMetrics(JobMetrics metrics, PrintStream output) {
+        List<ChannelMetrics> channels = new ArrayList<ChannelMetrics>(metrics.getChannelMetrics());
+        channels.sort(Comparator.comparing(ChannelMetrics::getChannelId));
+        output.println("  channel-metrics (" + channels.size() + "):");
+        for (ChannelMetrics channel : channels) {
+            output.println("    " + channel.getChannelId()
+                    + ": enqueued=" + channel.getEnqueuedCount()
+                    + ", dequeued=" + channel.getDequeuedCount()
+                    + ", current-size=" + channel.getCurrentSize()
+                    + ", maximum-size=" + channel.getMaximumSize()
+                    + ", write-blocked-ms=" + channel.getWriteBlockedMillis()
+                    + ", read-blocked-ms=" + channel.getReadBlockedMillis()
+                    + ", blocked-ratio=" + formatRatio(channel.getBlockedRatio()));
+        }
+    }
+
+    private static String position(TaskMetrics task) {
+        if (task.getCurrentTable() == null && task.getCurrentSplit() == null) return "";
+        return ", table=" + valueOrDash(task.getCurrentTable())
+                + ", split=" + valueOrDash(task.getCurrentSplit());
+    }
+
+    private static String valueOrDash(String value) {
+        return value == null ? "-" : value;
+    }
+
+    private static String formatRate(double value) {
+        return String.format(Locale.ROOT, "%.2f", value);
+    }
+
+    private static String formatRatio(double value) {
+        return String.format(Locale.ROOT, "%.2f%%", value * 100D);
+    }
+
+    private static void line(PrintStream output, String key, Object value) {
+        output.println("  " + key + "=" + value);
+    }
+}

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LauncherConfigurationExample.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LauncherConfigurationExample.java
@@ -1,27 +1,20 @@
 package com.baize.flux.launcher;
 
-import com.baize.flux.api.configuration.Option;
-import com.baize.flux.api.configuration.Options;
-
-import java.util.Map;
-
 /**
- * Command-line entry point for one local bounded sync job.
+ * Runs a local bounded sync job from a HOCON configuration file.
+ *
+ * <p>For example:
+ *
+ * <pre>
+ * java com.baize.flux.launcher.LauncherConfigurationExample \
+ *     examples/jdbc-single-table.conf
+ * </pre>
  */
 public final class LauncherConfigurationExample {
-    private static final Option<String> NAME = Options.key("job.name").stringType().noDefaultValue();
-    private static final Option<Integer> BATCH_SIZE = Options.key("runtime.batch-size").intType().defaultValue(1000);
-    private static final Option<String> SOURCE_TYPE = Options.key("source.type").stringType().noDefaultValue();
-    private static final Option<Map<String, Object>> SOURCE_OPTIONS = Options.key("source.options").mapObjectType().noDefaultValue();
-    private static final Option<String> SINK_TYPE = Options.key("sink.type").stringType().noDefaultValue();
-    private static final Option<Map<String, Object>> SINK_OPTIONS = Options.key("sink.options").mapObjectType().noDefaultValue();
-
     private LauncherConfigurationExample() {
     }
 
     public static void main(String[] args) throws Exception {
-        if (args.length != 1) throw new IllegalArgumentException("Usage: LauncherConfigurationExample <job.conf>");
+        LocalSyncLauncher.main(args);
     }
-
-
 }

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LocalSyncLauncher.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LocalSyncLauncher.java
@@ -6,6 +6,10 @@ import com.baize.flux.framework.job.JobConfigParser;
 import com.baize.flux.framework.job.JobDefinition;
 import com.baize.flux.framework.job.JobResult;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
 /**
  * 本地离线同步启动器。
  *
@@ -29,11 +33,11 @@ public final class LocalSyncLauncher {
         if (args.length != 1) {
             throw new IllegalArgumentException(
                     "Usage: LocalSyncLauncher "
-                            + "\"<HOCON job configuration>\"");
+                            + "<job.conf | \"HOCON job configuration\">");
         }
 
         run(
-                args[0],
+                readConfiguration(args[0]),
                 Thread.currentThread()
                         .getContextClassLoader());
     }
@@ -58,49 +62,17 @@ public final class LocalSyncLauncher {
                             definition);
         }
 
-        printResult(result);
+        JobResultPrinter.print(result);
 
         result.throwIfFailed();
 
         return result;
     }
 
-    private static void printResult(
-            JobResult result) {
-
-        System.out.println(
-                "Flux job finished:");
-
-        System.out.println(
-                "  job-name="
-                        + result.getJobName());
-
-        System.out.println(
-                "  status="
-                        + result.getStatus());
-
-        System.out.println(
-                "  duration-ms="
-                        + result.getDurationMillis());
-
-        System.out.println(
-                "  source-batches="
-                        + result.getMetrics()
-                        .getSourceBatchCount());
-
-        System.out.println(
-                "  source-records="
-                        + result.getMetrics()
-                        .getSourceRecordCount());
-
-        System.out.println(
-                "  sink-batches="
-                        + result.getMetrics()
-                        .getSinkBatchCount());
-
-        System.out.println(
-                "  sink-records="
-                        + result.getMetrics()
-                        .getSinkRecordCount());
+    private static String readConfiguration(String argument) throws Exception {
+        if (Files.isRegularFile(Paths.get(argument))) {
+            return new String(Files.readAllBytes(Paths.get(argument)), StandardCharsets.UTF_8);
+        }
+        return argument;
     }
 }


### PR DESCRIPTION
### Motivation

- Provide ready-to-run HOCON examples so users can execute the local JDBC launcher without crafting configs from scratch.
- Make it easy to pass a configuration file path to the launcher instead of only inline HOCON strings.
- Improve post-run observability by printing richer aggregate, per-task and per-channel metrics for easier debugging and performance analysis.

### Description

- Add two example HOCON configs `baize-flux-launcher/examples/jdbc-single-table.conf` and `baize-flux-launcher/examples/jdbc-multi-table.conf` and a usage `examples/README.md` with `mvn exec:java` instructions.
- Extend `LocalSyncLauncher` to accept either an inline HOCON string or a file path by adding `readConfiguration(String)` and reading file contents when the argument is a regular file, and update `main` to use it.
- Replace the ad-hoc result printing with a new `JobResultPrinter` utility (`baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java`) that prints aggregate metrics, per-task metrics (state, batches, records, qps, duration, current position) and per-channel metrics (enqueue/dequeue counts, sizes, blocked times, blocked ratio).
- Update `LauncherConfigurationExample` to delegate to `LocalSyncLauncher.main(...)` and include an example usage in its JavaDoc.

### Testing

- Ran `git diff --check` to ensure no whitespace errors (succeeded).
- Attempted `mvn -pl baize-flux-launcher -am test -DskipTests=false`, but the build failed in this environment due to a Maven plugin resolution error (Central returned HTTP 403 while resolving `maven-resources-plugin`), so unit test execution was blocked by repository/network access rather than code failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62d07bc8c88326aaefa83afe538bc0)