### PR TITLE
feat: JobResultPrinter 中文分类展示 & 将部分异常改为继承 FluxRuntimeException

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/table/catalog/exception/CatalogException.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/table/catalog/exception/CatalogException.java
@@ -1,24 +1,27 @@
 package com.baize.flux.api.table.catalog.exception;
 
+import com.baize.flux.common.exception.FluxRuntimeException;
+import com.baize.flux.common.exception.error.FluxAPIErrorCode;
+
 /**
  * Catalog 操作异常。
  */
-public class CatalogException extends RuntimeException {
+public class CatalogException extends FluxRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
     public CatalogException(String message) {
-        super(message);
+        super(FluxAPIErrorCode.CATALOG_INITIALIZE_FAILED, message);
     }
 
     public CatalogException(
             String message,
             Throwable cause) {
 
-        super(message, cause);
+        super(FluxAPIErrorCode.CATALOG_INITIALIZE_FAILED, message, cause);
     }
 
     public CatalogException(Throwable cause) {
-        super(cause);
+        super(FluxAPIErrorCode.CATALOG_INITIALIZE_FAILED, cause);
     }
 }

--- a/baize-flux-common/src/main/java/com/baize/flux/common/exception/error/FluxAPIErrorCode.java
+++ b/baize-flux-common/src/main/java/com/baize/flux/common/exception/error/FluxAPIErrorCode.java
@@ -17,7 +17,8 @@ public enum FluxAPIErrorCode implements FluxErrorCode {
     LIST_DATABASES_FAILED("API-12", "List databases failed"),
     LIST_TABLES_FAILED("API-13", "List tables failed"),
     GET_PRIMARY_KEY_FAILED("API-14", "Get primary key failed"),
-    METADATA_PROVIDER_INITIALIZE_FAILED("API-15", "MetaData provider initialize failed");
+    METADATA_PROVIDER_INITIALIZE_FAILED("API-15", "MetaData provider initialize failed"),
+    CONNECTOR_INITIALIZE_FAILED("API-16", "Connector initialize failed");
 
     private final String code;
     private final String description;

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorException.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorException.java
@@ -1,21 +1,24 @@
 package com.baize.flux.framework.connector;
 
+import com.baize.flux.common.exception.FluxRuntimeException;
+import com.baize.flux.common.exception.error.FluxAPIErrorCode;
+
 /**
  * Connector 发现、校验或准备失败。
  */
 public class ConnectorException
-        extends RuntimeException {
+        extends FluxRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
     public ConnectorException(String message) {
-        super(message);
+        super(FluxAPIErrorCode.CONNECTOR_INITIALIZE_FAILED, message);
     }
 
     public ConnectorException(
             String message,
             Throwable cause) {
 
-        super(message, cause);
+        super(FluxAPIErrorCode.CONNECTOR_INITIALIZE_FAILED, message, cause);
     }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/factory/FactoryException.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/factory/FactoryException.java
@@ -1,19 +1,22 @@
 package com.baize.flux.framework.factory;
 
+import com.baize.flux.common.exception.FluxRuntimeException;
+import com.baize.flux.common.exception.error.FluxAPIErrorCode;
+
 /**
  * Factory 发现、校验或创建失败。
  */
-public class FactoryException extends RuntimeException {
+public class FactoryException extends FluxRuntimeException {
 
     private static final long serialVersionUID = 1L;
 
     public FactoryException(String message) {
-        super(message);
+        super(FluxAPIErrorCode.FACTORY_INITIALIZE_FAILED, message);
     }
 
     public FactoryException(
             String message,
             Throwable cause) {
-        super(message, cause);
+        super(FluxAPIErrorCode.FACTORY_INITIALIZE_FAILED, message, cause);
     }
 }

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java
@@ -11,7 +11,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
-/** Formats a completed job result, including aggregate, task, and channel metrics. */
+/** 以中文分类展示已完成作业的汇总、任务和通道指标。 */
 public final class JobResultPrinter {
 
     private JobResultPrinter() {
@@ -23,48 +23,52 @@ public final class JobResultPrinter {
 
     static void print(JobResult result, PrintStream output) {
         JobMetrics metrics = result.getMetrics();
-        output.println("Flux job finished:");
-        line(output, "job-name", result.getJobName());
-        line(output, "status", result.getStatus());
-        line(output, "duration-ms", result.getDurationMillis());
+        output.println("Flux 作业执行完成：");
+        line(output, "作业名称", result.getJobName());
+        line(output, "执行状态", result.getStatus());
+        line(output, "执行耗时（毫秒）", result.getDurationMillis());
 
-        output.println("  aggregate-metrics:");
-        line(output, "source-batches", metrics.getSourceBatchCount());
-        line(output, "source-records", metrics.getSourceRecordCount());
-        line(output, "source-bytes", metrics.getSourceReadBytes());
-        line(output, "completed-splits", metrics.getCompletedSplitCount());
-        line(output, "sink-batches", metrics.getSinkBatchCount());
-        line(output, "sink-records", metrics.getSinkRecordCount());
-        line(output, "sink-bytes", metrics.getSinkWrittenBytes());
-        line(output, "source-sink-record-difference", metrics.getSourceSinkRecordDifference());
-        line(output, "failed-records", metrics.getFailedRecordCount());
-        line(output, "skipped-records", metrics.getSkippedRecordCount());
-        line(output, "batch-retries", metrics.getBatchRetryCount());
-        line(output, "database-commit-ms", metrics.getDatabaseCommitMillis());
-        line(output, "sql-execution-ms", metrics.getSqlExecutionMillis());
-        line(output, "average-qps", formatRate(metrics.getAverageQps()));
-        line(output, "channel-blocked-ratio", formatRatio(metrics.getChannelBlockedRatio()));
+        output.println("  汇总指标：");
+        output.println("    数据源：");
+        line(output, "批次数", metrics.getSourceBatchCount());
+        line(output, "读取记录数", metrics.getSourceRecordCount());
+        line(output, "读取字节数", metrics.getSourceReadBytes());
+        line(output, "已完成分片数", metrics.getCompletedSplitCount());
+        output.println("    通道：");
+        line(output, "源端与目标端记录数差", metrics.getSourceSinkRecordDifference());
+        line(output, "通道阻塞占比", formatRatio(metrics.getChannelBlockedRatio()));
+        output.println("    数据目标端：");
+        line(output, "批次数", metrics.getSinkBatchCount());
+        line(output, "写入记录数", metrics.getSinkRecordCount());
+        line(output, "写入字节数", metrics.getSinkWrittenBytes());
+        line(output, "数据库提交耗时（毫秒）", metrics.getDatabaseCommitMillis());
+        output.println("    执行与异常：");
+        line(output, "失败记录数", metrics.getFailedRecordCount());
+        line(output, "跳过记录数", metrics.getSkippedRecordCount());
+        line(output, "批次重试次数", metrics.getBatchRetryCount());
+        line(output, "SQL 执行耗时（毫秒）", metrics.getSqlExecutionMillis());
+        line(output, "平均处理速率（条/秒）", formatRate(metrics.getAverageQps()));
 
         printTaskMetrics(metrics, output);
         printChannelMetrics(metrics, output);
-        if (result.getFailure() != null) line(output, "failure", result.getFailure());
+        if (result.getFailure() != null) line(output, "失败原因", result.getFailure());
     }
 
     private static void printTaskMetrics(JobMetrics metrics, PrintStream output) {
         List<TaskMetrics> tasks = new ArrayList<TaskMetrics>(metrics.getTaskMetrics().values());
         tasks.sort(Comparator.comparing(task -> task.getTaskId().toString()));
-        output.println("  task-metrics (" + tasks.size() + "):");
+        output.println("  任务指标（" + tasks.size() + "）：");
         for (TaskMetrics task : tasks) {
-            output.println("    " + task.getTaskId() + ": state=" + task.getState()
-                    + ", batches=" + task.getBatchCount()
-                    + ", records=" + task.getRecordCount()
-                    + ", source-records=" + task.getSourceReadRecordCount()
-                    + ", sink-records=" + task.getSinkWriteSuccessRecordCount()
-                    + ", failed=" + task.getFailedRecordCount()
-                    + ", skipped=" + task.getSkippedRecordCount()
-                    + ", splits=" + task.getCompletedSplitCount()
-                    + ", qps=" + formatRate(task.getAverageQps())
-                    + ", duration-ms=" + task.getDurationMillis()
+            output.println("    " + task.getTaskId() + "：状态=" + task.getState()
+                    + "，批次数=" + task.getBatchCount()
+                    + "，记录数=" + task.getRecordCount()
+                    + "，源端读取记录数=" + task.getSourceReadRecordCount()
+                    + "，目标端写入记录数=" + task.getSinkWriteSuccessRecordCount()
+                    + "，失败记录数=" + task.getFailedRecordCount()
+                    + "，跳过记录数=" + task.getSkippedRecordCount()
+                    + "，已完成分片数=" + task.getCompletedSplitCount()
+                    + "，处理速率（条/秒）=" + formatRate(task.getAverageQps())
+                    + "，执行耗时（毫秒）=" + task.getDurationMillis()
                     + position(task));
         }
     }
@@ -72,23 +76,23 @@ public final class JobResultPrinter {
     private static void printChannelMetrics(JobMetrics metrics, PrintStream output) {
         List<ChannelMetrics> channels = new ArrayList<ChannelMetrics>(metrics.getChannelMetrics());
         channels.sort(Comparator.comparing(ChannelMetrics::getChannelId));
-        output.println("  channel-metrics (" + channels.size() + "):");
+        output.println("  通道指标（" + channels.size() + "）：");
         for (ChannelMetrics channel : channels) {
             output.println("    " + channel.getChannelId()
-                    + ": enqueued=" + channel.getEnqueuedCount()
-                    + ", dequeued=" + channel.getDequeuedCount()
-                    + ", current-size=" + channel.getCurrentSize()
-                    + ", maximum-size=" + channel.getMaximumSize()
-                    + ", write-blocked-ms=" + channel.getWriteBlockedMillis()
-                    + ", read-blocked-ms=" + channel.getReadBlockedMillis()
-                    + ", blocked-ratio=" + formatRatio(channel.getBlockedRatio()));
+                    + "：入队数=" + channel.getEnqueuedCount()
+                    + "，出队数=" + channel.getDequeuedCount()
+                    + "，当前队列长度=" + channel.getCurrentSize()
+                    + "，最大队列长度=" + channel.getMaximumSize()
+                    + "，写入阻塞耗时（毫秒）=" + channel.getWriteBlockedMillis()
+                    + "，读取阻塞耗时（毫秒）=" + channel.getReadBlockedMillis()
+                    + "，阻塞占比=" + formatRatio(channel.getBlockedRatio()));
         }
     }
 
     private static String position(TaskMetrics task) {
         if (task.getCurrentTable() == null && task.getCurrentSplit() == null) return "";
-        return ", table=" + valueOrDash(task.getCurrentTable())
-                + ", split=" + valueOrDash(task.getCurrentSplit());
+        return "，表=" + valueOrDash(task.getCurrentTable())
+                + "，分片=" + valueOrDash(task.getCurrentSplit());
     }
 
     private static String valueOrDash(String value) {
@@ -104,6 +108,6 @@ public final class JobResultPrinter {
     }
 
     private static void line(PrintStream output, String key, Object value) {
-        output.println("  " + key + "=" + value);
+        output.println("      " + key + "：" + value);
     }
 }


### PR DESCRIPTION
### Motivation
- 让 `JobResultPrinter` 以中文直观展示作业的汇总、任务与通道指标，按数据源、通道、目标端和执行/异常分类，便于中文使用者理解输出。 
- 统一关键异常类型以便携带统一的错误码上下文并改善错误信息传递。 
- 为连接器异常保留并新增专用错误码以便区分初始化失败场景。 

### Description
- 将 `JobResultPrinter` 的输出改为中文字段与分组，主要按“数据源 / 通道 / 数据目标端 / 执行与异常”展示汇总指标，并将任务与通道行格式化为中文描述（文件：`baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java`）。
- 将 `CatalogException`、`FactoryException`、`ConnectorException` 修改为继承 `FluxRuntimeException`，并使用对应的 `FluxAPIErrorCode` 枚举来传递错误码与上下文（文件：`baize-flux-api/.../CatalogException.java`、`baize-flux-framework/.../FactoryException.java`、`baize-flux-framework/.../ConnectorException.java`）。
- 在 `FluxAPIErrorCode` 中新增 `CONNECTOR_INITIALIZE_FAILED`（`API-16`）以支持 `ConnectorException` 的统一错误码（文件：`baize-flux-common/src/main/java/com/baize/flux/common/exception/error/FluxAPIErrorCode.java`）。

### Testing
- 运行 `git diff --check` 进行基本检查，结果通过。 
- 使用代码搜索/静态检查确认没有额外类直接继承 `RuntimeException`（仅 `FluxRuntimeException` 直接继承 `RuntimeException`）。
- 尝试运行 `mvn test -q` 时网络依赖解析失败：Maven Central 对 `maven-resources-plugin:3.3.1` 返回 HTTP 403，导致测试无法完成。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62d54f25a08326856ed759978b6bf4)