### PR TITLE
Log JDBC rows skipped by dirty-data policy

### DIFF
--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
@@ -13,6 +13,9 @@ import com.baize.flux.connector.jdbc.core.dialect.JdbcDialectLoader;
 import com.baize.flux.connector.jdbc.internal.JdbcConnectionProvider;
 import com.baize.flux.connector.jdbc.sink.savemode.JdbcSaveModeHandler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.Savepoint;
@@ -51,6 +54,9 @@ import java.util.stream.Collectors;
  */
 public final class JdbcOutputFormat
         implements AutoCloseable {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(JdbcOutputFormat.class);
 
     private final JdbcSinkConfig config;
 
@@ -273,6 +279,11 @@ public final class JdbcOutputFormat
                         throw rowFailure;
                     }
                     rowErrors.add(new JdbcRowError(row, rowFailure));
+                    LOG.warn(
+                            "Skipping dirty JDBC row because dirty_data_policy=SKIP; table={}, row={}",
+                            tablePath,
+                            row,
+                            rowFailure);
                 }
             }
         }


### PR DESCRIPTION
### Motivation
- When `dirty_data_policy = SKIP` the connector isolates failing rows and those skipped rows should be observable to aid debugging and triage.
- Add a concise warning log to record the target table, the skipped `FluxRow` and the underlying exception for each discarded row.

### Description
- Add SLF4J imports and a `private static final Logger LOG` to `JdbcOutputFormat`.
- Emit a `LOG.warn(...)` immediately after a `JdbcRowError` is recorded so each row skipped under `dirty_data_policy=SKIP` is logged with the target `TablePath`, the `FluxRow` contents, and the write exception in `baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java`.

### Testing
- Ran the pre-commit whitespace check using `git diff --check`, which reported no issues.
- Ran `mvn -pl baize-flux-connectors/baize-flux-connector-jdbc -am test`, which could not complete because Maven Central returned HTTP 403 while resolving `maven-resources-plugin`, so module tests were not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62d89b3d448326b58a8674c5434b12)