### PR TITLE
Add distribution packaging, launcher script, default config, logging, CI and Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+**/target/test-classes
+**/target/classes
+**/*.log
+logs
+.env
+.env.*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  push:
+    branches: [work, main]
+  pull_request:
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+      - name: Verify source and build distributions
+        run: mvn --batch-mode --errors --show-version verify
+      - name: Smoke-test distribution command
+        run: |
+          unzip -q baize-flux-launcher/target/baize-flux-1.0.0.zip -d dist
+          dist/baize-flux-1.0.0/bin/baize-flux.sh --help

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
+# Baize Flux
 
+Baize Flux is a local, batch-oriented data synchronization engine. It currently provides JDBC source and sink connectors, HOCON job parsing, parallel source/sink execution, and execution metrics.
+
+## Quick start
+
+Build the complete project and its deployable archives with JDK 8+ and Maven 3.8.1+:
+
+```bash
+mvn --batch-mode clean verify
+```
+
+Run directly from source:
+
+```bash
+mvn -pl baize-flux-launcher -am compile exec:java \
+  -Dexec.mainClass=com.baize.flux.launcher.LocalSyncLauncher \
+  -Dexec.args=baize-flux-launcher/examples/jdbc-single-table.conf
+```
+
+Or extract `baize-flux-launcher/target/baize-flux-1.0.0.tar.gz`, copy and edit `config/baize-flux.yaml`, then run:
+
+```bash
+bin/baize-flux.sh --config config/baize-flux.yaml
+```
+
+The configuration file has a `.yaml` deployment-friendly name but uses HOCON syntax. Do not commit real JDBC credentials. See the [deployment and operations guide](docs/deployment.md) for packaging, CI, Docker, JVM options, Log4j2, security, rollback, and production guidance.

--- a/baize-flux-launcher/pom.xml
+++ b/baize-flux-launcher/pom.xml
@@ -33,10 +33,39 @@
         <dependency>
             <groupId>com.baize.flux</groupId>
             <artifactId>baize-flux-connector-jdbc</artifactId>
-            <version>1.0.0</version>
-            <scope>compile</scope>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.2</version>
         </dependency>
     </dependencies>
 
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
+                <configuration>
+                    <descriptors><descriptor>src/assembly/distribution.xml</descriptor></descriptors>
+                    <finalName>baize-flux-${project.version}</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-distribution</id>
+                        <phase>package</phase>
+                        <goals><goal>single</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/baize-flux-launcher/src/assembly/distribution.xml
+++ b/baize-flux-launcher/src/assembly/distribution.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.0 https://maven.apache.org/xsd/assembly-2.1.0.xsd">
+  <id>distribution</id>
+  <formats><format>tar.gz</format><format>zip</format></formats>
+  <includeBaseDirectory>true</includeBaseDirectory>
+  <dependencySets><dependencySet><outputDirectory>lib</outputDirectory><useProjectArtifact>true</useProjectArtifact><scope>runtime</scope></dependencySet></dependencySets>
+  <fileSets>
+    <fileSet><directory>src/main/dist</directory><outputDirectory>/</outputDirectory><fileMode>0755</fileMode><includes><include>bin/*.sh</include></includes></fileSet>
+    <fileSet><directory>src/main/dist</directory><outputDirectory>/</outputDirectory><fileMode>0644</fileMode><excludes><exclude>bin/*.sh</exclude></excludes></fileSet>
+  </fileSets>
+</assembly>

--- a/baize-flux-launcher/src/main/dist/bin/baize-flux.sh
+++ b/baize-flux-launcher/src/main/dist/bin/baize-flux.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Runs one local, batch Baize Flux job in the foreground.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BAIZE_FLUX_HOME="${BAIZE_FLUX_HOME:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+CONF_DIR="${BAIZE_FLUX_CONF_DIR:-${BAIZE_FLUX_HOME}/config}"
+LOG_DIR="${BAIZE_FLUX_LOG_DIR:-${BAIZE_FLUX_HOME}/logs}"
+JAVA_BIN="${JAVA_HOME:+${JAVA_HOME}/bin/}java"
+if ! command -v "${JAVA_BIN}" >/dev/null 2>&1; then echo "Java 8 or later is required; set JAVA_HOME or add java to PATH." >&2; exit 1; fi
+mkdir -p "${LOG_DIR}"
+if [[ $# -eq 0 ]]; then set -- --config "${CONF_DIR}/baize-flux.yaml"; fi
+JAVA_OPTS=(-Xms256m -Xmx1024m -XX:+ExitOnOutOfMemoryError -Dfile.encoding=UTF-8 -Dlog4j.configurationFile="${CONF_DIR}/log4j2.xml" -Dbaize.flux.log.dir="${LOG_DIR}")
+if [[ -n "${BAIZE_FLUX_JAVA_OPTS:-}" ]]; then
+  # shellcheck disable=SC2206
+  JAVA_OPTS+=( ${BAIZE_FLUX_JAVA_OPTS} )
+fi
+exec "${JAVA_BIN}" "${JAVA_OPTS[@]}" -cp "${BAIZE_FLUX_HOME}/lib/*" com.baize.flux.launcher.LocalSyncLauncher "$@"

--- a/baize-flux-launcher/src/main/dist/config/baize-flux.yaml
+++ b/baize-flux-launcher/src/main/dist/config/baize-flux.yaml
@@ -1,0 +1,24 @@
+# HOCON job configuration. The .yaml extension is retained for deployment conventions.
+# Copy this file, store credentials in a secret manager, and pass the copy with -c.
+job.name = "jdbc-sync"
+env { source-parallelism = 1, sink-parallelism = 1, channel-capacity = 256 }
+source {
+  type = "jdbc"
+  batch-size = 500
+  url = "jdbc:mysql://127.0.0.1:3306/source_db?useSSL=false&serverTimezone=UTC"
+  driver = "com.mysql.cj.jdbc.Driver"
+  user = "change-me"
+  password = "change-me"
+  fetch_size = 500
+  table_list = [{ table_path = "source_db.orders" }]
+}
+sink {
+  type = "jdbc"
+  url = "jdbc:mysql://127.0.0.1:3306/target_db?useSSL=false&serverTimezone=UTC"
+  driver = "com.mysql.cj.jdbc.Driver"
+  user = "change-me"
+  password = "change-me"
+  table = "target_db.orders_copy"
+  schema_save_mode = CREATE_SCHEMA_WHEN_NOT_EXIST
+  data_save_mode = APPEND_DATA
+}

--- a/baize-flux-launcher/src/main/dist/config/log4j2.xml
+++ b/baize-flux-launcher/src/main/dist/config/log4j2.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" monitorInterval="30">
+  <Properties><Property name="LOG_DIR">${sys:baize.flux.log.dir:-logs}</Property><Property name="PATTERN">%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%t] %c{1.} - %msg%n%throwable</Property></Properties>
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT"><PatternLayout pattern="${PATTERN}"/></Console>
+    <RollingFile name="File" fileName="${LOG_DIR}/baize-flux.log" filePattern="${LOG_DIR}/baize-flux-%d{yyyy-MM-dd}-%i.log.gz"><PatternLayout pattern="${PATTERN}"/><Policies><TimeBasedTriggeringPolicy/><SizeBasedTriggeringPolicy size="100 MB"/></Policies><DefaultRolloverStrategy max="14"/></RollingFile>
+  </Appenders>
+  <Loggers><Root level="INFO"><AppenderRef ref="Console"/><AppenderRef ref="File"/></Root></Loggers>
+</Configuration>

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LocalSyncLauncher.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/LocalSyncLauncher.java
@@ -9,6 +9,8 @@ import com.baize.flux.framework.job.JobResult;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * 本地离线同步启动器。
@@ -24,20 +26,35 @@ import java.nio.file.Paths;
  */
 public final class LocalSyncLauncher {
 
+    private static final Logger LOG = LogManager.getLogger(LocalSyncLauncher.class);
+
     private LocalSyncLauncher() {
     }
 
     public static void main(String[] args)
             throws Exception {
 
-        if (args.length != 1) {
-            throw new IllegalArgumentException(
-                    "Usage: LocalSyncLauncher "
-                            + "<job.conf | \"HOCON job configuration\">");
+        if (args.length == 1 && ("--help".equals(args[0]) || "-h".equals(args[0]))) {
+            printUsage();
+            return;
+        }
+        if (args.length == 1 && "--version".equals(args[0])) {
+            System.out.println("Baize Flux 1.0.0");
+            return;
+        }
+        String configuration;
+        if (args.length == 1) {
+            configuration = args[0];
+        } else if (args.length == 2 && ("--config".equals(args[0]) || "-c".equals(args[0]))) {
+            configuration = args[1];
+        } else {
+            printUsage();
+            throw new IllegalArgumentException("A job configuration is required");
         }
 
+        LOG.info("Starting Baize Flux job from {}", configuration);
         run(
-                readConfiguration(args[0]),
+                readConfiguration(configuration),
                 Thread.currentThread()
                         .getContextClassLoader());
     }
@@ -74,5 +91,11 @@ public final class LocalSyncLauncher {
             return new String(Files.readAllBytes(Paths.get(argument)), StandardCharsets.UTF_8);
         }
         return argument;
+    }
+
+    private static void printUsage() {
+        System.out.println("Usage: baize-flux [--config|-c] <job.conf|job.yaml>\n"
+                + "       baize-flux --version\n       baize-flux --help\n\n"
+                + "The job file uses HOCON syntax; the .yaml extension is supported for deployment conventions.");
     }
 }

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,0 +1,13 @@
+# Build first: mvn -pl baize-flux-launcher -am package
+FROM eclipse-temurin:8-jre
+ARG BAIZE_FLUX_VERSION=1.0.0
+WORKDIR /opt
+COPY baize-flux-launcher/target/baize-flux-${BAIZE_FLUX_VERSION}.tar.gz /tmp/baize-flux.tar.gz
+RUN tar -xzf /tmp/baize-flux.tar.gz -C /opt && mv /opt/baize-flux-${BAIZE_FLUX_VERSION} /opt/baize-flux && rm /tmp/baize-flux.tar.gz \
+    && useradd --system --uid 10001 --create-home baizeflux \
+    && mkdir -p /opt/baize-flux/logs && chown -R baizeflux:baizeflux /opt/baize-flux
+USER baizeflux
+ENV BAIZE_FLUX_HOME=/opt/baize-flux
+WORKDIR /opt/baize-flux
+ENTRYPOINT ["/opt/baize-flux/bin/baize-flux.sh"]
+CMD ["--config", "/opt/baize-flux/config/baize-flux.yaml"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,55 @@
+# 部署与运维指南
+
+Baize Flux 当前以**本地批处理进程**运行：一个命令执行一个同步作业，进程退出即代表作业结束。它不提供常驻 Server，因此不应使用后台 `start/stop` 脚本；应由 systemd、Kubernetes Job 或调度器负责重试、超时和退出码处理。
+
+## 构建与安装
+
+要求 JDK 8+、Maven 3.8.1+。在仓库根目录执行：
+
+```bash
+mvn --batch-mode clean verify
+```
+
+产物为 `baize-flux-launcher/target/baize-flux-1.0.0.tar.gz` 和 `.zip`。解压后目录包含 `bin/`、`config/` 和运行时依赖 `lib/`：
+
+```bash
+tar -xzf baize-flux-launcher/target/baize-flux-1.0.0.tar.gz
+cd baize-flux-1.0.0
+cp config/baize-flux.yaml config/orders-prod.yaml
+# Edit URLs, table names, user and password. Do not commit the resulting file.
+bin/baize-flux.sh --config config/orders-prod.yaml
+```
+
+配置文件扩展名可为 `.yaml`，但内容是 HOCON（与现有作业解析器一致），不是 YAML。启动器默认读取 `config/baize-flux.yaml`，因此 `bin/baize-flux.sh` 可直接执行示例配置。`--help` 和 `--version` 可用于探测安装是否完整。
+
+## 配置与机密
+
+`config/baize-flux.yaml` 包含 source/sink JDBC 示例、并行度和通道容量。复制后替换 `change-me`，并将配置设为仅运行账户可读（例如 `chmod 600 config/orders-prod.yaml`）。推荐在 CI/CD 中由 Secret 渲染临时配置文件，或把只读 Secret 挂载到容器；不要把密码放在命令行或提交到 Git。可通过 `BAIZE_FLUX_CONF_DIR`、`BAIZE_FLUX_LOG_DIR`、`BAIZE_FLUX_HOME` 覆盖目录。
+
+## JVM 与日志
+
+默认 JVM 参数：`-Xms256m -Xmx1024m -XX:+ExitOnOutOfMemoryError -Dfile.encoding=UTF-8`。使用 `BAIZE_FLUX_JAVA_OPTS` 追加容器内存比例、GC 或诊断参数，例如：
+
+```bash
+BAIZE_FLUX_JAVA_OPTS='-XX:+UseG1GC -XX:MaxRAMPercentage=70.0' bin/baize-flux.sh -c config/orders-prod.yaml
+```
+
+`config/log4j2.xml` 同时输出控制台和 `${BAIZE_FLUX_LOG_DIR:-logs}/baize-flux.log`。日志按日或 100 MB 滚动，最多保留 14 个归档。对容器运行，优先采集 stdout；需要落盘时挂载日志目录。
+
+## Docker、上线与回滚
+
+先构建分发包，再从仓库根目录构建镜像：
+
+```bash
+mvn -pl baize-flux-launcher -am package
+docker build -f deploy/docker/Dockerfile -t baize-flux:1.0.0 .
+docker run --rm \
+  -v /secure/orders-prod.yaml:/opt/baize-flux/config/job.yaml:ro \
+  baize-flux:1.0.0 --config /opt/baize-flux/config/job.yaml
+```
+
+上线前应执行小表验证、确认目标端写入策略和重复运行行为、设置数据库连接/查询超时，并监控进程退出码、作业汇总指标与错误日志。批任务失败应由调度平台重试；对于非幂等 `APPEND_DATA` 作业，先修复或清理目标数据再重试。回滚使用上一版本的不可变压缩包/镜像和与之匹配的已验证配置，而不是覆盖运行中的目录。
+
+## CI
+
+GitHub Actions 会在 push 和 PR 上用 JDK 8 执行 `mvn verify`，并解压发行包运行 `--help` 冒烟检查。发布流水线应额外保存 tar.gz/zip、生成 SHA-512 校验和、对发布工件签名，并在部署前验证校验和。

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
 
 
     <properties>
+        <project.build.outputTimestamp>2026-07-24T00:00:00Z</project.build.outputTimestamp>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
@@ -55,6 +56,11 @@
                     <configuration>
                         <release>${maven.compiler.release}</release>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>${maven-surefire-plugin.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
### Motivation

- Provide a reproducible, production-friendly distribution (tar.gz/zip) of the launcher so teams can install and run Baize Flux as a packaged artifact. 
- Improve runtime/shipping surfaces: add a foreground startup script, a default job config, and a Log4j2 logging configuration to simplify deployments and log collection. 
- Make the launcher easier to operate: add CLI flags (`--config`/`-c`, `--help`, `--version`), sane JVM defaults and an example Docker/CI flow for packaging and rollout.

### Description

- Add assembly/distribution packaging and launcher distribution layout with `baize-flux-launcher/src/assembly/distribution.xml` and the assembly content under `baize-flux-launcher/src/main/dist/` so `maven-assembly-plugin` produces `tar.gz`/`.zip` releases; update `baize-flux-launcher/pom.xml` to wire assembly execution and `pom.xml` to set reproducible timestamps and `maven-surefire-plugin` in plugin management. 
- Add a foreground start script `baize-flux-launcher/src/main/dist/bin/baize-flux.sh` that supports configurable `BAIZE_FLUX_HOME`, `BAIZE_FLUX_CONF_DIR`, `BAIZE_FLUX_LOG_DIR`, `BAIZE_FLUX_JAVA_OPTS` and default JVM options (`-Xms256m -Xmx1024m -XX:+ExitOnOutOfMemoryError`). 
- Add a default job file `baize-flux-launcher/src/main/dist/config/baize-flux.yaml` (HOCON content, `.yaml` name for deployment convention) and a `log4j2.xml` at `baize-flux-launcher/src/main/dist/config/log4j2.xml` with console + rolling file appenders.
- Wire minimal logging to the launcher: add Log4j dependencies in `baize-flux-launcher/pom.xml` and update `LocalSyncLauncher` to use a `Logger`, add `--config`/`-c`, `--help`, `--version` handling and print usage (`LocalSyncLauncher.java`).
- Add CI and packaging/help smoke verification: add GitHub Actions workflow `.github/workflows/ci.yml` that runs `mvn verify` and extracts the produced `.zip` to run the packaged `bin/baize-flux.sh --help` as an artifact smoke test.
- Add container and ops artifacts: `deploy/docker/Dockerfile`, `docs/deployment.md`, `.dockerignore`, and update `README.md` to document build/run, JVM, logs, secrets and deployment guidance.

### Testing

- Verified the shell script syntax with `bash -n baize-flux-launcher/src/main/dist/bin/baize-flux.sh` (success). 
- Validated XML artifacts by parsing `pom.xml`, `baize-flux-launcher/src/assembly/distribution.xml` and `baize-flux-launcher/src/main/dist/config/log4j2.xml` with Python `xml.etree.ElementTree` (success).
- Ran `git diff --check` and basic repo checks to ensure no whitespace/XML issues (success).
- Attempted `mvn --batch-mode -pl baize-flux-launcher -am verify` to validate packaging and build, but the Maven execution in this environment failed to download required plugins/resources from Maven Central (HTTP 403), so a full Maven build and artifact resolution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62da529060832689195e86deab2185)