### PR TITLE
Report task-local sink commit outcomes

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/CommitScope.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/CommitScope.java
@@ -1,0 +1,12 @@
+package com.baize.flux.api.sink;
+
+/**
+ * The scope at which a sink can make data durable.
+ */
+public enum CommitScope {
+
+    /**
+     * Each sink task commits independently. This does not provide Job-level atomicity.
+     */
+    TASK_LOCAL
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkWriter.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkWriter.java
@@ -12,7 +12,9 @@ import com.baize.flux.api.table.catalog.CatalogTable;
  * open
  *   -> write
  *   -> write
- *   -> commit / rollback
+ *   -> prepareCommit
+ *   -> commit
+ *   -> abort (on failure before commit)
  *   -> close
  * </pre>
  */
@@ -37,16 +39,39 @@ public interface SinkWriter<T> extends AutoCloseable {
             CatalogTable sourceTable)
             throws Exception;
 
-    /**
-     * 当前 SinkTask 全部数据写入成功后提交。
-     */
+    /** Called after all writes succeed and before the task-local commit boundary. */
+    default void prepareCommit() throws Exception {
+    }
+
+    /** Commits this writer at {@link #getCommitScope()}; it is not necessarily a Job commit. */
     default void commit() throws Exception {
     }
 
+    /** Aborts uncommitted work after a write or prepare/commit failure. */
+    default void abort() throws Exception {
+        rollback();
+    }
+
     /**
-     * 当前 SinkTask 执行失败时回滚。
+     * Legacy rollback hook. New writers should implement {@link #abort()}.
      */
+    @Deprecated
     default void rollback() throws Exception {
+    }
+
+    /**
+     * Returns the strongest commit scope provided by this writer.
+     *
+     * <p>The default is task-local: independently committing JDBC-style writers do not
+     * guarantee Job-level atomicity or a global rollback.
+     */
+    default CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    /** User-facing advice for safely rerunning a failed job, if the connector can provide it. */
+    default String getRetryAdvice() {
+        return "This sink commits per task; verify already committed target data before rerunning.";
     }
 
     /**

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkWriter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkWriter.java
@@ -1,6 +1,7 @@
 package com.baize.flux.connector.jdbc.sink;
 
 import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.sink.CommitScope;
 import com.baize.flux.api.source.RecordBatch;
 import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.type.FluxRow;
@@ -18,17 +19,21 @@ import java.util.Objects;
 public final class JdbcSinkWriter
         implements SinkWriter<FluxRow> {
 
+    private final JdbcSinkConfig config;
+
     private final JdbcOutputFormat outputFormat;
 
     public JdbcSinkWriter(
             JdbcSinkConfig config) {
 
+        this.config =
+                Objects.requireNonNull(
+                        config,
+                        "config must not be null");
         this.outputFormat =
                 new JdbcOutputFormatBuilder()
                         .withConfig(
-                                Objects.requireNonNull(
-                                        config,
-                                        "config must not be null"))
+                                this.config)
                         .build();
     }
 
@@ -60,8 +65,32 @@ public final class JdbcSinkWriter
     }
 
     @Override
-    public void rollback() throws Exception {
+    public void abort() throws Exception {
         outputFormat.rollback();
+    }
+
+    @Override
+    public CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    @Override
+    public String getRetryAdvice() {
+        if (config.isUpsert()) {
+            return "JDBC UPSERT can usually be rerun when primary keys are stable, but correctness depends on the database dialect's UPSERT semantics.";
+        }
+        switch (config.getDataSaveMode()) {
+            case APPEND_DATA:
+                return "JDBC APPEND_DATA may duplicate rows that were committed before failure; deduplicate or verify target data before rerunning.";
+            case DROP_DATA:
+                return "JDBC DROP_DATA may have cleared target data before failure; validate and restore/reload as needed before rerunning.";
+            case CUSTOM_PROCESSING:
+                return "JDBC CUSTOM_PROCESSING rerun safety is determined by the configured SQL; review its effects before rerunning.";
+            case ERROR_WHEN_DATA_EXISTS:
+                return "JDBC ERROR_WHEN_DATA_EXISTS reruns depend on whether committed data now exists; inspect the target before rerunning.";
+            default:
+                return "JDBC rerun safety depends on the configured save mode; inspect the target before rerunning.";
+        }
     }
 
     @Override

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/ExecutionCoordinator.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/ExecutionCoordinator.java
@@ -1,11 +1,14 @@
 package com.baize.flux.framework.execution;
 
 import com.baize.flux.framework.execution.task.ExecutionTask;
+import com.baize.flux.framework.execution.task.SinkTask;
+import com.baize.flux.framework.job.CommitSummary;
 import com.baize.flux.framework.metrics.JobMetrics;
 import com.baize.flux.framework.metrics.TaskMetrics;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Objects;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -68,8 +71,8 @@ public final class ExecutionCoordinator {
                         "cancellationHook must not be null");
     }
 
-    public Throwable execute(
-            List<ExecutionTask> sinkTasks,
+    public ExecutionOutcome execute(
+            List<SinkTask> sinkTasks,
             List<ExecutionTask> sourceTasks) {
 
         Objects.requireNonNull(
@@ -90,7 +93,7 @@ public final class ExecutionCoordinator {
         allTasks.addAll(sourceTasks);
 
         if (allTasks.isEmpty()) {
-            return null;
+            return new ExecutionOutcome(null, CommitSummary.empty());
         }
 
         List<Future<TaskResult>> futures =
@@ -175,7 +178,21 @@ public final class ExecutionCoordinator {
                     throwable);
         }
 
-        return firstFailure;
+        return new ExecutionOutcome(firstFailure, summarizeCommits(sinkTasks));
+    }
+
+    private CommitSummary summarizeCommits(List<SinkTask> sinkTasks) {
+        int committed = 0;
+        LinkedHashSet<String> advice = new LinkedHashSet<String>();
+        for (SinkTask sinkTask : sinkTasks) {
+            if (sinkTask.isCommitted()) committed++;
+            String taskAdvice = sinkTask.getRetryAdvice();
+            if (taskAdvice != null && !taskAdvice.isEmpty()) advice.add(taskAdvice);
+        }
+        return new CommitSummary(committed, sinkTasks.size() - committed,
+                sinkTasks.isEmpty() ? com.baize.flux.api.sink.CommitScope.TASK_LOCAL
+                        : sinkTasks.get(0).getCommitScope(),
+                new ArrayList<String>(advice));
     }
 
     private void cancelAll(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/ExecutionOutcome.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/ExecutionOutcome.java
@@ -1,0 +1,15 @@
+package com.baize.flux.framework.execution;
+
+import com.baize.flux.framework.job.CommitSummary;
+
+/** Result returned by the coordinator, including the sink durability outcome. */
+public final class ExecutionOutcome {
+    private final Throwable failure;
+    private final CommitSummary commitSummary;
+    public ExecutionOutcome(Throwable failure, CommitSummary commitSummary) {
+        this.failure = failure;
+        this.commitSummary = commitSummary;
+    }
+    public Throwable getFailure() { return failure; }
+    public CommitSummary getCommitSummary() { return commitSummary; }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
@@ -13,6 +13,7 @@ import com.baize.flux.framework.execution.task.ExecutionTask;
 import com.baize.flux.framework.execution.task.SinkTask;
 import com.baize.flux.framework.execution.task.SourceTask;
 import com.baize.flux.framework.job.JobResult;
+import com.baize.flux.framework.job.CommitSummary;
 import com.baize.flux.framework.job.JobStatus;
 import com.baize.flux.framework.metrics.JobMetrics;
 import com.baize.flux.framework.planner.ExecutionPlan;
@@ -75,6 +76,7 @@ public final class JobExecution {
                         DataChannel<RecordEnvelope<FluxRow>>>();
 
         Throwable failure = null;
+        CommitSummary commitSummary = CommitSummary.empty();
 
         try {
             int sourceTaskCount =
@@ -92,7 +94,7 @@ public final class JobExecution {
                     sourceTaskCount,
                     sinkTaskCount);
 
-            List<ExecutionTask> sinkTasks =
+            List<SinkTask> sinkTasks =
                     createSinkTasks(channels);
 
             List<ExecutionTask> sourceTasks =
@@ -123,10 +125,9 @@ public final class JobExecution {
                                     }
                                 });
 
-                failure =
-                        coordinator.execute(
-                                sinkTasks,
-                                sourceTasks);
+                ExecutionOutcome outcome = coordinator.execute(sinkTasks, sourceTasks);
+                failure = outcome.getFailure();
+                commitSummary = outcome.getCommitSummary();
             }
 
         } catch (Throwable throwable) {
@@ -145,7 +146,7 @@ public final class JobExecution {
 
         JobStatus status;
 
-        if (failure != null) {
+        if (failure != null || commitSummary.isPartialCommit()) {
             status = JobStatus.FAILED;
         } else if (cancellationToken.isCancelled()) {
             status = JobStatus.CANCELED;
@@ -159,7 +160,8 @@ public final class JobExecution {
                 startTime,
                 System.currentTimeMillis(),
                 jobMetrics,
-                failure);
+                failure,
+                commitSummary);
     }
 
     public void cancel() {
@@ -192,7 +194,7 @@ public final class JobExecution {
         }
     }
 
-    private List<ExecutionTask> createSinkTasks(
+    private List<SinkTask> createSinkTasks(
             List<DataChannel<RecordEnvelope<FluxRow>>>
                     channels) {
 
@@ -204,8 +206,8 @@ public final class JobExecution {
                     "Sink task count does not match channel count");
         }
 
-        List<ExecutionTask> tasks =
-                new ArrayList<ExecutionTask>(
+        List<SinkTask> tasks =
+                new ArrayList<SinkTask>(
                         plans.size());
 
         for (int i = 0; i < plans.size(); i++) {

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
@@ -1,6 +1,7 @@
 package com.baize.flux.framework.execution.task;
 
 import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.sink.CommitScope;
 import com.baize.flux.api.table.type.FluxRow;
 import com.baize.flux.framework.channel.InputGate;
 import com.baize.flux.framework.channel.RecordEnvelope;
@@ -21,6 +22,10 @@ public final class SinkTask
 
     private final InputGate<RecordEnvelope<FluxRow>>
             inputGate;
+
+    private volatile boolean committed;
+    private volatile String retryAdvice;
+    private volatile CommitScope commitScope = CommitScope.TASK_LOCAL;
 
     public SinkTask(
             SinkTaskPlan plan,
@@ -52,12 +57,12 @@ public final class SinkTask
 
         Throwable failure = null;
 
-        boolean committed = false;
-
         try {
             writer =
                     plan.getPreparedSink()
                             .getWriter();
+            commitScope = writer.getCommitScope();
+            retryAdvice = writer.getRetryAdvice();
 
             writer.open();
 
@@ -123,6 +128,7 @@ public final class SinkTask
             }
 
             long commitStart = System.nanoTime();
+            writer.prepareCommit();
             writer.commit();
             context.getMetrics().addDatabaseCommitNanos(System.nanoTime() - commitStart);
 
@@ -133,7 +139,9 @@ public final class SinkTask
 
             if (writer != null) {
                 try {
-                    writer.rollback();
+                    if (!committed) {
+                        writer.abort();
+                    }
                 } catch (Throwable rollbackFailure) {
                     throwable.addSuppressed(
                             rollbackFailure);
@@ -155,8 +163,8 @@ public final class SinkTask
                         /*
                          * 事务尚未提交时，关闭异常需要让任务失败。
                          */
-                        throw propagate(
-                                closeFailure);
+                        failure = closeFailure;
+                        throw propagate(closeFailure);
                     }
 
                     /*
@@ -167,6 +175,12 @@ public final class SinkTask
             }
         }
     }
+
+    public boolean isCommitted() { return committed; }
+
+    public CommitScope getCommitScope() { return commitScope; }
+
+    public String getRetryAdvice() { return retryAdvice; }
 
     private static RuntimeException propagate(
             Throwable throwable)

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/CommitSummary.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/CommitSummary.java
@@ -1,0 +1,48 @@
+package com.baize.flux.framework.job;
+
+import com.baize.flux.api.sink.CommitScope;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Aggregated durability outcome for all SinkTasks in a job. */
+public final class CommitSummary {
+
+    private final int committedTaskCount;
+    private final int failedOrUncommittedTaskCount;
+    private final boolean partialCommit;
+    private final CommitScope commitScope;
+    private final List<String> retryAdvice;
+
+    public CommitSummary(int committedTaskCount, int failedOrUncommittedTaskCount,
+                         CommitScope commitScope, List<String> retryAdvice) {
+        if (committedTaskCount < 0 || failedOrUncommittedTaskCount < 0) {
+            throw new IllegalArgumentException("commit task counts must not be negative");
+        }
+        this.committedTaskCount = committedTaskCount;
+        this.failedOrUncommittedTaskCount = failedOrUncommittedTaskCount;
+        this.partialCommit = committedTaskCount > 0 && failedOrUncommittedTaskCount > 0;
+        this.commitScope = Objects.requireNonNull(commitScope, "commitScope must not be null");
+        this.retryAdvice = Collections.unmodifiableList(new ArrayList<String>(
+                Objects.requireNonNull(retryAdvice, "retryAdvice must not be null")));
+    }
+
+    public static CommitSummary empty() {
+        return new CommitSummary(0, 0, CommitScope.TASK_LOCAL, Collections.<String>emptyList());
+    }
+    public int getCommittedTaskCount() { return committedTaskCount; }
+    public int getFailedOrUncommittedTaskCount() { return failedOrUncommittedTaskCount; }
+    public boolean isPartialCommit() { return partialCommit; }
+    public CommitScope getCommitScope() { return commitScope; }
+    public List<String> getRetryAdvice() { return retryAdvice; }
+
+    /** Explicitly states why a partial result must not be treated as a global rollback. */
+    public String getWarning() {
+        return partialCommit
+                ? "Some SinkTasks committed while others failed or remained uncommitted. "
+                + "The Job is FAILED; TASK_LOCAL commits do not provide Job-level atomicity or a global rollback."
+                : null;
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobResult.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobResult.java
@@ -21,6 +21,8 @@ public final class JobResult {
 
     private final Throwable failure;
 
+    private final CommitSummary commitSummary;
+
     public JobResult(
             String jobName,
             JobStatus status,
@@ -28,6 +30,11 @@ public final class JobResult {
             long endTimeMillis,
             JobMetrics metrics,
             Throwable failure) {
+        this(jobName, status, startTimeMillis, endTimeMillis, metrics, failure, CommitSummary.empty());
+    }
+
+    public JobResult(String jobName, JobStatus status, long startTimeMillis, long endTimeMillis,
+                     JobMetrics metrics, Throwable failure, CommitSummary commitSummary) {
 
         this.jobName =
                 Objects.requireNonNull(
@@ -48,6 +55,7 @@ public final class JobResult {
                         "metrics must not be null");
 
         this.failure = failure;
+        this.commitSummary = Objects.requireNonNull(commitSummary, "commitSummary must not be null");
     }
 
     public void throwIfFailed() throws Exception {
@@ -95,6 +103,8 @@ public final class JobResult {
     public Throwable getFailure() {
         return failure;
     }
+
+    public CommitSummary getCommitSummary() { return commitSummary; }
 
     public boolean isSuccess() {
         return status == JobStatus.SUCCEEDED;

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java
@@ -4,6 +4,7 @@ import com.baize.flux.framework.metrics.ChannelMetrics;
 import com.baize.flux.framework.metrics.JobMetrics;
 import com.baize.flux.framework.metrics.TaskMetrics;
 import com.baize.flux.framework.job.JobResult;
+import com.baize.flux.framework.job.CommitSummary;
 
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -27,6 +28,18 @@ public final class JobResultPrinter {
         line(output, "作业名称", result.getJobName());
         line(output, "执行状态", result.getStatus());
         line(output, "执行耗时（毫秒）", result.getDurationMillis());
+        CommitSummary commits = result.getCommitSummary();
+        output.println("  提交结果：");
+        line(output, "提交语义", commits.getCommitScope());
+        line(output, "成功提交 SinkTask 数", commits.getCommittedTaskCount());
+        line(output, "失败或未提交 SinkTask 数", commits.getFailedOrUncommittedTaskCount());
+        line(output, "部分提交", commits.isPartialCommit());
+        if (commits.isPartialCommit()) {
+            line(output, "警告", commits.getWarning());
+        }
+        for (String advice : commits.getRetryAdvice()) {
+            line(output, "安全重跑建议", advice);
+        }
 
         output.println("  汇总指标：");
         output.println("    数据源：");


### PR DESCRIPTION
### Motivation
- Make sink commit semantics explicit so connectors and users understand that ordinary JDBC sinks commit per task and do not provide Job-level atomicity. 
- Record per-Task commit outcomes during execution and surface an aggregated summary to callers and logs to improve post-failure guidance. 
- Provide connector-level guidance for safe reruns based on save mode (APPEND/UPSERT/DROP/CUSTOM) instead of implying unsupported coordinated commits.

### Description
- Add `CommitScope` enum and extend `SinkWriter` with an explicit lifecycle including `prepareCommit`, `commit`, `abort` (plus deprecated `rollback`), `getCommitScope`, and `getRetryAdvice`, with default `TASK_LOCAL` semantics and a user-facing retry hint. 
- Update `JdbcSinkWriter` to keep its `JdbcSinkConfig`, implement `abort`, report `CommitScope.TASK_LOCAL`, and return per-save-mode rerun advice (distinct handling for `UPSERT`, `APPEND_DATA`, `DROP_DATA`, `CUSTOM_PROCESSING`, etc.).
- Change `SinkTask` to call `prepareCommit` before `commit`, call `abort` on uncommitted failures, capture `committed` state, `commitScope`, and `retryAdvice`, and preserve original exceptions while treating post-commit `close` failures as non-fatal to avoid triggering upstream duplicate writes. 
- Add `CommitSummary` to aggregate per-sink-task committed vs uncommitted counts, `partialCommit` flag, commit scope and collected retry advice; add `ExecutionOutcome` from the coordinator and thread these into `JobExecution` and `JobResult`. 
- Update `ExecutionCoordinator` to return an `ExecutionOutcome` and to build a `CommitSummary` from `SinkTask` outcomes, and update `JobResultPrinter` to print commit summary, partial-commit warning, and rerun suggestions.

### Testing
- Ran `git diff --check` which passed and validated the working tree changes. 
- Attempted `mvn test -pl baize-flux-framework,baize-flux-connectors/baize-flux-connector-jdbc,baize-flux-launcher -am` but the build failed during plugin resolution due to Maven Central returning HTTP 403, so unit tests could not run. 
- Attempted offline build `mvn -o test -pl ...` which also failed because the required `maven-resources-plugin` artifact was not cached locally, so automated test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6301c05cd88326a99df5cb9eb83e05)