### PR TITLE
Add JDBC source read consistency controls

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/source/Source.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/source/Source.java
@@ -44,6 +44,17 @@ public interface Source<SplitT extends SourceSplit>
     }
 
     /**
+     * Validates execution reader parallelism before source tasks are created.
+     * Connectors may override this to reject unsupported execution modes.
+     */
+    default void validateParallelism(int parallelism) {
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException(
+                    "parallelism must be greater than 0");
+        }
+    }
+
+    /**
      * 创建 SourceReader。
      * <p>
      * 每个执行任务必须使用独立 Reader，

--- a/baize-flux-connectors/baize-flux-connector-jdbc/README.md
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/README.md
@@ -41,7 +41,8 @@ INSERT/UPSERT SQL for the resolved target and ignores `custom_sql`/`query`.
 | `username` | no | empty | JDBC user name. |
 | `password` | no | empty | JDBC password. |
 | `driver` | no | — | JDBC driver class to load before connecting. |
-| `fetch-size` | no | `1000` | Maximum number of rows emitted in one batch. |
+| `fetch_size` | no | `1000` | JDBC fetch size used while reading. |
+| `read_consistency` | no | `BEST_EFFORT` | Read consistency: `BEST_EFFORT`, `SINGLE_CONNECTION_SNAPSHOT`, or a dialect-provided `DATABASE_SNAPSHOT`. |
 
 The result columns retain their query order and use JDBC column labels as the
 `FluxRow` field names.
@@ -60,5 +61,13 @@ env {
 ```
 
 The launcher creates at most `parallelism` source readers and assigns every split to one reader exactly once. JDBC uses this value while planning range splits, so an unspecified `partition_num` produces no more than this many chunks per table. Batches from different tables or ranges can be read concurrently, while the local sink remains single-threaded because the current `SinkWriter` owns one transactional JDBC connection and is not safe to share across writers.
+
+### Read consistency
+
+`BEST_EFFORT` is the default and preserves the existing parallel reader behavior. With more than one source reader, separate JDBC connections can observe different database snapshots; the connector emits a preparation-time warning without connection credentials or tokens.
+
+`SINGLE_CONNECTION_SNAPSHOT` requires `env.parallelism = 1`. The reader configures its JDBC connection as read-only, disables auto-commit, and requests repeatable-read isolation before reading. It is available only when the selected JDBC dialect declares support.
+
+`DATABASE_SNAPSHOT` is reserved for dialects that can coordinate one database snapshot across multiple readers. The built-in MySQL dialect does not implement it yet, so preparation fails before any source task is created.
 
 For string keys, configure a fixed-width ASCII column using a binary/ASCII-compatible database collation. Locale-aware and variable-width strings are not safe range keys.

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSourceConfig.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSourceConfig.java
@@ -44,6 +44,9 @@ public final class JdbcSourceConfig
      */
     private final int fetchSize;
 
+    /** Requested consistency for the source read. */
+    private final ReadConsistency readConsistency;
+
     /**
      * MySQL 整数类型缩小策略。
      */
@@ -60,6 +63,7 @@ public final class JdbcSourceConfig
             List<JdbcSourceTableConfig> tableConfigs,
             String whereCondition,
             int fetchSize,
+            ReadConsistency readConsistency,
             boolean intTypeNarrowing,
             MultiTableFailurePolicy
                     multiTableFailurePolicy) {
@@ -82,6 +86,8 @@ public final class JdbcSourceConfig
         }
 
         this.fetchSize = fetchSize;
+        this.readConsistency = Objects.requireNonNull(
+                readConsistency, "readConsistency must not be null");
         this.intTypeNarrowing =
                 intTypeNarrowing;
 
@@ -112,6 +118,8 @@ public final class JdbcSourceConfig
                         .orElse(null),
                 config.get(
                         JdbcSourceOptions.FETCH_SIZE),
+                config.get(
+                        JdbcSourceOptions.READ_CONSISTENCY),
                 config.get(
                         JdbcCommonOptions
                                 .INT_TYPE_NARROWING),
@@ -231,6 +239,10 @@ public final class JdbcSourceConfig
         return fetchSize;
     }
 
+    public ReadConsistency getReadConsistency() {
+        return readConsistency;
+    }
+
     public boolean isIntTypeNarrowing() {
         return intTypeNarrowing;
     }
@@ -343,6 +355,8 @@ public final class JdbcSourceConfig
                 + '\''
                 + ", fetchSize="
                 + fetchSize
+                + ", readConsistency="
+                + readConsistency
                 + ", intTypeNarrowing="
                 + intTypeNarrowing
                 + ", multiTableFailurePolicy="

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSourceOptions.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSourceOptions.java
@@ -63,6 +63,15 @@ public final class JdbcSourceOptions
                     .noDefaultValue()
                     .withDescription("公共查询过滤条件，不需要包含 where");
 
+    /**
+     * Requested consistency for the source read.
+     */
+    public static final Option<ReadConsistency> READ_CONSISTENCY =
+            Options.key("read_consistency")
+                    .enumType(ReadConsistency.class)
+                    .defaultValue(ReadConsistency.BEST_EFFORT)
+                    .withDescription("JDBC Source 读取一致性");
+
     public static final Option<Integer> FETCH_SIZE =
             Options.key("fetch_size")
                     .intType()

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/ReadConsistency.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/ReadConsistency.java
@@ -1,0 +1,23 @@
+package com.baize.flux.connector.jdbc.config;
+
+/**
+ * Consistency guarantee requested for a bounded JDBC source read.
+ */
+public enum ReadConsistency {
+
+    /**
+     * Preserve independent reader connections and existing parallel behaviour.
+     * A parallel read is not guaranteed to observe one database snapshot.
+     */
+    BEST_EFFORT,
+
+    /**
+     * Read through one read-only transaction. This requires one source reader.
+     */
+    SINGLE_CONNECTION_SNAPSHOT,
+
+    /**
+     * Ask the database dialect to coordinate a snapshot across readers.
+     */
+    DATABASE_SNAPSHOT
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/dialect/JdbcDialect.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/dialect/JdbcDialect.java
@@ -4,6 +4,7 @@ import com.baize.flux.api.table.catalog.Catalog;
 import com.baize.flux.api.table.catalog.Column;
 import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.connector.jdbc.config.JdbcConnectionConfig;
+import com.baize.flux.connector.jdbc.config.ReadConsistency;
 import com.baize.flux.connector.jdbc.core.converter.JdbcRowConverter;
 import com.baize.flux.connector.jdbc.core.split.StringRangeSplitDecision;
 import com.baize.flux.connector.jdbc.source.JdbcSourceTable;
@@ -91,6 +92,33 @@ public interface JdbcDialect extends Serializable {
      * JDBC 行读取和写入转换器。
      */
     JdbcRowConverter rowConverter();
+
+    /**
+     * Returns the read consistency modes implemented by this dialect.
+     */
+    default Set<ReadConsistency> supportedReadConsistencies() {
+        return Collections.singleton(ReadConsistency.BEST_EFFORT);
+    }
+
+    /**
+     * Configures a connection for a requested snapshot read. Dialects that
+     * support database-coordinated snapshots should override this method.
+     */
+    default void configureSnapshotConnection(
+            Connection connection,
+            ReadConsistency consistency) throws SQLException {
+
+        if (connection == null) {
+            throw new IllegalArgumentException("connection must not be null");
+        }
+        if (consistency != ReadConsistency.SINGLE_CONNECTION_SNAPSHOT) {
+            throw new UnsupportedOperationException(
+                    "Read consistency is not supported by dialect " + name());
+        }
+        connection.setReadOnly(true);
+        connection.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+        connection.setAutoCommit(false);
+    }
 
     /**
      * 解析配置中的表路径。

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/dialect/mysql/MySqlDialect.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/core/dialect/mysql/MySqlDialect.java
@@ -6,6 +6,7 @@ import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.connector.jdbc.catalog.JdbcCatalogConfig;
 import com.baize.flux.connector.jdbc.catalog.mysql.MySqlCatalog;
 import com.baize.flux.connector.jdbc.config.JdbcConnectionConfig;
+import com.baize.flux.connector.jdbc.config.ReadConsistency;
 import com.baize.flux.connector.jdbc.core.converter.JdbcRowConverter;
 import com.baize.flux.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
@@ -71,6 +72,13 @@ public final class MySqlDialect
     @Override
     public JdbcRowConverter rowConverter() {
         return new MySqlJdbcRowConverter();
+    }
+
+    @Override
+    public Set<ReadConsistency> supportedReadConsistencies() {
+        return EnumSet.of(
+                ReadConsistency.BEST_EFFORT,
+                ReadConsistency.SINGLE_CONNECTION_SNAPSHOT);
     }
 
     @Override

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/internal/JdbcInputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/internal/JdbcInputFormat.java
@@ -4,6 +4,7 @@ import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.api.table.type.FluxRow;
 import com.baize.flux.connector.jdbc.config.JdbcSourceConfig;
+import com.baize.flux.connector.jdbc.config.ReadConsistency;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
 import com.baize.flux.connector.jdbc.core.dialect.JdbcDialectLoader;
 import com.baize.flux.connector.jdbc.source.JdbcSourceSplit;
@@ -38,6 +39,12 @@ public final class JdbcInputFormat {
 
     public void openInputFormat() throws Exception {
         connection = connectionProvider.getOrEstablishConnection();
+        if (config.getReadConsistency()
+                != ReadConsistency.BEST_EFFORT) {
+            dialect.configureSnapshotConnection(
+                    connection,
+                    config.getReadConsistency());
+        }
     }
 
     public void open(JdbcSourceSplit split) throws Exception {

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSource.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSource.java
@@ -6,6 +6,11 @@ import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.api.table.type.FluxRow;
 import com.baize.flux.connector.jdbc.config.JdbcSourceConfig;
+import com.baize.flux.connector.jdbc.config.ReadConsistency;
+import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
+import com.baize.flux.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -21,6 +26,9 @@ public final class JdbcSource
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger LOG =
+            LoggerFactory.getLogger(JdbcSource.class);
+
     private final JdbcSourceConfig config;
 
     public JdbcSource(JdbcSourceConfig config) {
@@ -35,6 +43,32 @@ public final class JdbcSource
             throws Exception {
 
         return createSplits(tables, 1);
+    }
+
+    @Override
+    public void validateParallelism(int parallelism) {
+        Source.super.validateParallelism(parallelism);
+
+        ReadConsistency consistency = config.getReadConsistency();
+        if (consistency == ReadConsistency.BEST_EFFORT) {
+            if (parallelism > 1) {
+                LOG.warn("JDBC read_consistency=BEST_EFFORT with source parallelism {} does not guarantee a single snapshot across readers", parallelism);
+            }
+            return;
+        }
+
+        if (consistency == ReadConsistency.SINGLE_CONNECTION_SNAPSHOT
+                && parallelism != 1) {
+            throw new IllegalArgumentException(
+                    "read_consistency=SINGLE_CONNECTION_SNAPSHOT requires source parallelism=1");
+        }
+
+        JdbcDialect dialect = JdbcDialectLoader.load(config.getConnectionConfig());
+        if (!dialect.supportedReadConsistencies().contains(consistency)) {
+            throw new IllegalArgumentException(
+                    "JDBC dialect '" + dialect.name()
+                            + "' does not support read_consistency=" + consistency);
+        }
     }
 
     @Override

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceFactory.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceFactory.java
@@ -96,6 +96,7 @@ public final class JdbcSourceFactory
                         JdbcSourceOptions.QUERY,
                         JdbcSourceOptions.WHERE_CONDITION,
                         JdbcSourceOptions.FETCH_SIZE,
+                        JdbcSourceOptions.READ_CONSISTENCY,
                         JdbcSourceOptions.PARTITION_COLUMN,
                         JdbcSourceOptions.PARTITION_LOWER_BOUND,
                         JdbcSourceOptions.PARTITION_UPPER_BOUND,

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/source/JdbcReadConsistencyTest.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/test/java/com/baize/flux/connector/jdbc/source/JdbcReadConsistencyTest.java
@@ -1,0 +1,107 @@
+package com.baize.flux.connector.jdbc.source;
+
+import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.connector.jdbc.config.JdbcSourceConfig;
+import com.baize.flux.connector.jdbc.config.ReadConsistency;
+import com.baize.flux.connector.jdbc.core.dialect.JdbcDialect;
+import com.baize.flux.connector.jdbc.core.dialect.JdbcDialectLoader;
+import com.typesafe.config.ConfigFactory;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class JdbcReadConsistencyTest {
+
+    @Test
+    public void shouldDefaultToBestEffortAndAllowParallelReaders() {
+        JdbcSourceConfig config = config("");
+
+        assertEquals(ReadConsistency.BEST_EFFORT, config.getReadConsistency());
+        new JdbcSource(config).validateParallelism(4);
+    }
+
+    @Test
+    public void shouldAllowSingleConnectionSnapshotWithOneReader() {
+        new JdbcSource(config("read_consistency = SINGLE_CONNECTION_SNAPSHOT"))
+                .validateParallelism(1);
+    }
+
+    @Test
+    public void shouldConfigureSingleConnectionAsReadOnlyRepeatableReadTransaction()
+            throws Exception {
+        JdbcSourceConfig config = config(
+                "read_consistency = SINGLE_CONNECTION_SNAPSHOT");
+        JdbcDialect dialect = JdbcDialectLoader.load(config.getConnectionConfig());
+        final List<String> calls = new ArrayList<String>();
+        Connection connection = (Connection) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[] {Connection.class},
+                (proxy, method, args) -> {
+                    if ("setReadOnly".equals(method.getName())) {
+                        calls.add("readOnly=" + args[0]);
+                    } else if ("setTransactionIsolation".equals(method.getName())) {
+                        calls.add("isolation=" + args[0]);
+                    } else if ("setAutoCommit".equals(method.getName())) {
+                        calls.add("autoCommit=" + args[0]);
+                    }
+                    return null;
+                });
+
+        dialect.configureSnapshotConnection(
+                connection, ReadConsistency.SINGLE_CONNECTION_SNAPSHOT);
+
+        assertTrue(calls.contains("readOnly=true"));
+        assertTrue(calls.contains(
+                "isolation=" + Connection.TRANSACTION_REPEATABLE_READ));
+        assertTrue(calls.contains("autoCommit=false"));
+    }
+
+    @Test
+    public void shouldRejectSingleConnectionSnapshotWithParallelReaders() {
+        assertFailureWithoutSecrets(
+                "read_consistency = SINGLE_CONNECTION_SNAPSHOT",
+                2,
+                "SINGLE_CONNECTION_SNAPSHOT");
+    }
+
+    @Test
+    public void shouldRejectUnsupportedDatabaseSnapshotBeforeReadersExist() {
+        assertFailureWithoutSecrets(
+                "read_consistency = DATABASE_SNAPSHOT",
+                1,
+                "DATABASE_SNAPSHOT");
+    }
+
+    private void assertFailureWithoutSecrets(
+            String consistency,
+            int parallelism,
+            String expectedText) {
+        try {
+            new JdbcSource(config(consistency)).validateParallelism(parallelism);
+            fail("Expected consistency validation to fail");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains(expectedText));
+            assertFalse(expected.getMessage().contains("super-secret-password"));
+            assertFalse(expected.getMessage().contains("super-secret-token"));
+        }
+    }
+
+    private JdbcSourceConfig config(String consistency) {
+        return JdbcSourceConfig.of(ReadonlyConfig.fromConfig(
+                ConfigFactory.parseString(
+                        "url = \"jdbc:mysql://localhost:3306/flux_test\"\n"
+                                + "driver = \"com.mysql.cj.jdbc.Driver\"\n"
+                                + "password = \"super-secret-password\"\n"
+                                + "properties { token = \"super-secret-token\" }\n"
+                                + "table_path = \"flux_test.orders\"\n"
+                                + consistency)));
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
@@ -60,7 +60,9 @@ public final class ConnectorPreparer {
 
         PreparedSource<?> source =
                 prepareSource(
-                        definition.getSource());
+                        definition.getSource(),
+                        definition.getExecutionConfig()
+                                .getSourceParallelism());
 
         List<PreparedSink> sinks =
                 prepareSinks(
@@ -76,7 +78,8 @@ public final class ConnectorPreparer {
     }
 
     private PreparedSource<?> prepareSource(
-            SourceDefinition definition) throws Exception {
+            SourceDefinition definition,
+            int sourceParallelism) throws Exception {
 
         TableSourceFactory<?> factory =
                 registry.getSourceFactory(
@@ -95,14 +98,16 @@ public final class ConnectorPreparer {
         return createPreparedSource(
                 definition.getType(),
                 factory,
-                context);
+                context,
+                sourceParallelism);
     }
 
     private <SplitT extends SourceSplit>
     PreparedSource<SplitT> createPreparedSource(
             String identifier,
             TableSourceFactory<SplitT> factory,
-            SourceFactoryContext context) throws Exception {
+            SourceFactoryContext context,
+            int sourceParallelism) throws Exception {
 
         Source<SplitT> source =
                 factory.createSource(context);
@@ -113,6 +118,8 @@ public final class ConnectorPreparer {
                             + identifier
                             + "' returned a null source");
         }
+
+        source.validateParallelism(sourceParallelism);
 
         List<CatalogTable> catalogTables =
                 factory.discoverTableSchemas(context);


### PR DESCRIPTION
### Motivation
- Provide a configurable read consistency for the JDBC bounded source so callers can request BEST_EFFORT, a single-connection snapshot, or a dialect-coordinated database snapshot. 
- Ensure consistency-related validation happens before any SourceTask is created so illegal parallelism is rejected early. 
- Extend dialect APIs so drivers can opt in to snapshot modes and configure JDBC connections for snapshot reads without coupling to framework scheduling. 
- Prevent accidental leakage of sensitive connection data when reporting preparation-time failures or warnings. 

### Description
- Add a `ReadConsistency` enum and expose `read_consistency` as an option with default `BEST_EFFORT` in `JdbcSourceOptions` and `JdbcSourceConfig`. 
- Add `supportedReadConsistencies()` and `configureSnapshotConnection(Connection, ReadConsistency)` extension points to `JdbcDialect`, and implement `supportedReadConsistencies()` in `MySqlDialect` to include `BEST_EFFORT` and `SINGLE_CONNECTION_SNAPSHOT`. 
- Validate consistency vs execution parallelism in `JdbcSource.validateParallelism(int)`, logging a non-sensitive warning for `BEST_EFFORT` with multiple readers and rejecting illegal/unsupported modes (e.g. `SINGLE_CONNECTION_SNAPSHOT` with parallelism != 1 or unsupported `DATABASE_SNAPSHOT`). 
- Pass source parallelism into the connector preparation boundary (`ConnectorPreparer`) so `Source.validateParallelism` runs before any `SourceTask` creation and table discovery. 
- Configure the JDBC connection for snapshot modes in `JdbcInputFormat.openInputFormat()` by invoking the dialect `configureSnapshotConnection` after the connection is established. 
- Update JDBC README to document the `read_consistency` option and the expected semantics for `BEST_EFFORT`, `SINGLE_CONNECTION_SNAPSHOT`, and `DATABASE_SNAPSHOT`. 
- Add unit tests `JdbcReadConsistencyTest` to cover default behavior, parallelism validation, single-connection transaction setup, unsupported snapshot rejection, and that failure messages do not contain configured passwords or tokens. 

### Testing
- Ran `git diff --check` to verify whitespace and simple diff checks passed. 
- Attempted to run `./mvnw -q -pl baize-flux-connectors/baize-flux-connector-jdbc -am test -DskipTests` but the Maven wrapper files were not present in the environment so it could not run. 
- Attempted to run `mvn -q -pl baize-flux-connectors/baize-flux-connector-jdbc -am test -DskipTests` but dependency/plugin resolution failed due to network/registry (Maven Central) access returning HTTP 403, preventing a local test run in this environment. 
- Unit tests covering read consistency were added under the JDBC connector and should be exercised by CI where Maven dependencies and the wrapper are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6301eb9048832696297413f3d7765d)