### PR TITLE
Add dynamic local split assignment

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/source/SourceReader.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/source/SourceReader.java
@@ -14,7 +14,26 @@ public interface SourceReader<T, SplitT extends SourceSplit>
     /**
      * 打开 Reader，并设置当前 Reader 负责的分片。
      */
-    void open(List<SplitT> splits) throws Exception;
+    default void open(List<SplitT> splits) throws Exception {
+        throw new UnsupportedOperationException(
+                "This SourceReader does not support opening a split list");
+    }
+
+    /** Opens task-scoped resources before individual splits are processed. */
+    default void open() throws Exception {
+        // Optional for legacy readers.
+    }
+
+    /** Opens resources for exactly one split. */
+    default void openSplit(SplitT split) throws Exception {
+        throw new UnsupportedOperationException(
+                "This SourceReader does not support single-split reading");
+    }
+
+    /** Closes resources associated with the current split. */
+    default void closeSplit() throws Exception {
+        // Optional for legacy readers.
+    }
 
     /**
      * 读取下一批数据。

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceReader.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceReader.java
@@ -94,6 +94,25 @@ public final class JdbcSourceReader
     }
 
     @Override
+    public void open() throws Exception {
+        if (opened) throw new IllegalStateException("JdbcSourceReader has already been opened");
+        inputFormat.openInputFormat();
+        opened = true;
+        finished = false;
+    }
+
+    @Override
+    public void openSplit(JdbcSourceSplit split) throws Exception {
+        checkOpened();
+        if (currentSplit != null) throw new IllegalStateException("A JDBC split is already open");
+        currentSplit = java.util.Objects.requireNonNull(split, "split must not be null");
+        inputFormat.open(currentSplit);
+    }
+
+    @Override
+    public void closeSplit() throws Exception { closeCurrentSplit(); }
+
+    @Override
     public RecordBatch<FluxRow> readBatch()
             throws Exception {
 

--- a/baize-flux-dist/src/main/dist/config/baize-flux.yaml
+++ b/baize-flux-dist/src/main/dist/config/baize-flux.yaml
@@ -1,7 +1,7 @@
 # HOCON job configuration. The .yaml extension is retained for deployment conventions.
 # Copy this file, store credentials in a secret manager, and pass the copy with -c.
 job.name = "jdbc-sync"
-env { source-parallelism = 1, sink-parallelism = 1, channel-capacity = 256 }
+env { source-parallelism = 1, sink-parallelism = 1, channel-capacity = 256, split-assignment-mode = STATIC_ROUND_ROBIN }
 source {
   type = "jdbc"
   batch-size = 500

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/CancellationToken.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/CancellationToken.java
@@ -3,6 +3,7 @@ package com.baize.flux.framework.execution;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Job 级取消信号。
@@ -14,6 +15,7 @@ public final class CancellationToken {
 
     private final AtomicReference<Throwable> cause =
             new AtomicReference<Throwable>();
+    private final CopyOnWriteArrayList<Runnable> listeners = new CopyOnWriteArrayList<Runnable>();
 
     public boolean cancel(Throwable cancellationCause) {
         if (cancellationCause != null) {
@@ -22,9 +24,17 @@ public final class CancellationToken {
                     cancellationCause);
         }
 
-        return cancelled.compareAndSet(
+        boolean changed = cancelled.compareAndSet(
                 false,
                 true);
+        if (changed) for (Runnable listener : listeners) listener.run();
+        return changed;
+    }
+
+    /** Registers a wake-up action for components blocked on job cancellation. */
+    public void onCancel(Runnable listener) {
+        listeners.add(java.util.Objects.requireNonNull(listener, "listener must not be null"));
+        if (isCancelled()) listener.run();
     }
 
     public boolean isCancelled() {

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
@@ -77,6 +77,7 @@ public final class JobExecution {
         Throwable failure = null;
 
         try {
+            registerSplitMetrics();
             int sourceTaskCount =
                     executionPlan
                             .getSourceTaskPlans()
@@ -116,6 +117,7 @@ public final class JobExecution {
                                 new Runnable() {
                                     @Override
                                     public void run() {
+                                        cancelSplitQueues();
                                         failChannels(
                                                 channels,
                                                 cancellationToken
@@ -162,10 +164,29 @@ public final class JobExecution {
                 failure);
     }
 
+    private void registerSplitMetrics() {
+        long total = 0L;
+        for (SourceTaskPlan<?> plan : executionPlan.getSourceTaskPlans()) {
+            total += plan.getSplits().size();
+            if (plan.getSplitQueue() != null) {
+                jobMetrics.registerSplitQueue(plan.getSplitQueue());
+                return;
+            }
+        }
+        jobMetrics.setStaticTotalSplitCount(total);
+    }
+
     public void cancel() {
         cancellationToken.cancel(
                 new java.util.concurrent.CancellationException(
-                        "Job was cancelled by caller"));
+                "Job was cancelled by caller"));
+        cancelSplitQueues();
+    }
+
+    private void cancelSplitQueues() {
+        for (SourceTaskPlan<?> plan : executionPlan.getSourceTaskPlans()) {
+            if (plan.getSplitQueue() != null) plan.getSplitQueue().cancel(cancellationToken.getCause());
+        }
     }
 
     private void createChannels(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/split/LocalSplitQueue.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/split/LocalSplitQueue.java
@@ -1,0 +1,110 @@
+package com.baize.flux.framework.execution.split;
+
+import com.baize.flux.api.source.SourceSplit;
+import com.baize.flux.framework.execution.CancellationToken;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+
+/** Thread-safe, in-process provider for dynamically assigned source splits. */
+public final class LocalSplitQueue<SplitT extends SourceSplit> {
+
+    private enum State { PENDING, RUNNING, COMPLETED, FAILED }
+
+    private final ArrayDeque<SplitT> pending = new ArrayDeque<SplitT>();
+    private final Map<String, State> states = new HashMap<String, State>();
+    private boolean cancelled;
+    private Throwable cancellationCause;
+
+    public LocalSplitQueue(Collection<SplitT> splits) {
+        Objects.requireNonNull(splits, "splits must not be null");
+        for (SplitT split : splits) {
+            Objects.requireNonNull(split, "split must not be null");
+            String id = Objects.requireNonNull(split.splitId(), "splitId must not be null");
+            if (states.put(id, State.PENDING) != null) {
+                throw new IllegalArgumentException("Duplicate split id: " + id);
+            }
+            pending.addLast(split);
+        }
+    }
+
+    /** Waits for a split, returning null only after all splits have completed. */
+    public synchronized SplitT acquire(CancellationToken token) throws InterruptedException {
+        Objects.requireNonNull(token, "token must not be null");
+        token.onCancel(new Runnable() {
+            @Override public void run() { wakeWaiters(); }
+        });
+        while (pending.isEmpty() && hasRunningSplits() && !isStopped(token)) {
+            wait();
+        }
+        throwIfStopped(token);
+        if (pending.isEmpty()) return null;
+        SplitT split = pending.removeFirst();
+        states.put(split.splitId(), State.RUNNING);
+        return split;
+    }
+
+    private synchronized void wakeWaiters() { notifyAll(); }
+
+    public synchronized void complete(SplitT split) {
+        transition(split, State.RUNNING, State.COMPLETED, false);
+    }
+
+    public synchronized void returnSplit(SplitT split) {
+        transition(split, State.RUNNING, State.PENDING, true);
+    }
+
+    /** Marks the split failed and wakes every waiting worker. */
+    public synchronized void fail(SplitT split, Throwable cause) {
+        transition(split, State.RUNNING, State.FAILED, false);
+        cancel(cause);
+    }
+
+    public synchronized void cancel(Throwable cause) {
+        if (!cancelled) {
+            cancelled = true;
+            cancellationCause = cause;
+        }
+        notifyAll();
+    }
+
+    public synchronized long getTotalSplitCount() { return states.size(); }
+    public synchronized long getPendingSplitCount() { return count(State.PENDING); }
+    public synchronized long getRunningSplitCount() { return count(State.RUNNING); }
+    public synchronized long getCompletedSplitCount() { return count(State.COMPLETED); }
+    public synchronized long getFailedSplitCount() { return count(State.FAILED); }
+
+    private void transition(SplitT split, State from, State to, boolean requeue) {
+        Objects.requireNonNull(split, "split must not be null");
+        String id = split.splitId();
+        if (states.get(id) != from) {
+            throw new IllegalStateException("Split " + id + " is not " + from);
+        }
+        states.put(id, to);
+        if (requeue) pending.addLast(split);
+        notifyAll();
+    }
+
+    private boolean hasRunningSplits() { return count(State.RUNNING) > 0; }
+    private long count(State state) {
+        long count = 0;
+        for (State value : states.values()) if (value == state) count++;
+        return count;
+    }
+    private boolean isStopped(CancellationToken token) {
+        return cancelled || token.isCancelled() || Thread.currentThread().isInterrupted();
+    }
+    private void throwIfStopped(CancellationToken token) {
+        if (Thread.currentThread().isInterrupted()) throw new CancellationException("Split acquisition was interrupted");
+        if (cancelled || token.isCancelled()) {
+            CancellationException exception = new CancellationException("Split acquisition was cancelled");
+            Throwable cause = cancellationCause != null ? cancellationCause : token.getCause();
+            if (cause != null) exception.initCause(cause);
+            throw exception;
+        }
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java
@@ -11,6 +11,7 @@ import com.baize.flux.framework.channel.RecordEnvelope;
 import com.baize.flux.framework.connector.PreparedSource;
 import com.baize.flux.framework.execution.TaskContext;
 import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.execution.split.LocalSplitQueue;
 import com.baize.flux.framework.planner.SourceTaskPlan;
 
 import java.util.Map;
@@ -74,51 +75,19 @@ public final class SourceTask<
                         "Source returned a null reader");
             }
 
-            reader.open(plan.getSplits());
-
-            while (!context
-                    .getCancellationToken()
-                    .isCancelled()) {
-
-                RecordBatch<FluxRow> batch =
-                        reader.readBatch();
-
-                if (batch == null) {
-                    throw new IllegalStateException(
-                            "SourceReader returned a null RecordBatch");
-                }
-
-                /*
-                 * 兼容现有 SourceReader API。
-                 * endOfInput 不再发送到 Channel。
-                 */
-                if (batch.isEndOfInput()) {
-                    for (SplitT split : plan.getSplits()) {
-                        context.getMetrics().markSplitCompleted(split.splitId());
-                    }
-                    break;
-                }
-
-                context.getMetrics().setCurrentPosition(batch.getDataSetId(), batch.getSplitId());
-
-                RecordEnvelope<FluxRow> envelope =
-                        createEnvelope(
-                                batch,
-                                preparedSource.getTables());
-
-                context.getMetrics()
-                        .incrementBatchCount();
-
-                context.getMetrics()
-                        .addSourceReadRecords(
-                                batch.getRecords().size());
-
-                outputGate.write(envelope);
+            if (plan.isDynamicSplitAssignment()) {
+                executeDynamically(reader, preparedSource, context);
+            } else {
+                executeStatically(reader, preparedSource, context);
             }
 
         } catch (Throwable throwable) {
             failure = throwable;
 
+            if (plan.getSplitQueue() != null) {
+                plan.getSplitQueue().cancel(throwable);
+            }
+            context.getCancellationToken().cancel(throwable);
             outputGate.fail(throwable);
 
             throw propagate(throwable);
@@ -140,24 +109,95 @@ public final class SourceTask<
                 if (closeFailure == null) {
                     closeFailure = throwable;
                 } else {
-                    closeFailure.addSuppressed(
-                            throwable);
+                    closeFailure.addSuppressed(throwable);
                 }
             }
 
-            if (failure != null
-                    && closeFailure != null) {
+            if (failure != null && closeFailure != null) failure.addSuppressed(closeFailure);
+            else if (failure == null && closeFailure != null) throw propagate(closeFailure);
+        }
+    }
 
-                failure.addSuppressed(
-                        closeFailure);
+    private void executeStatically(SourceReader<FluxRow, SplitT> reader,
+            PreparedSource<SplitT> preparedSource, TaskContext context) throws Exception {
+        reader.open(plan.getSplits());
+        while (!context.getCancellationToken().isCancelled()) {
 
-            } else if (failure == null
-                    && closeFailure != null) {
+                RecordBatch<FluxRow> batch =
+                        reader.readBatch();
 
-                throw propagate(
-                        closeFailure);
+                if (batch == null) {
+                    throw new IllegalStateException(
+                            "SourceReader returned a null RecordBatch");
+                }
+
+                /*
+                 * 兼容现有 SourceReader API。
+                 * endOfInput 不再发送到 Channel。
+                 */
+                if (batch.isEndOfInput()) {
+                for (SplitT split : plan.getSplits()) context.getMetrics().markSplitCompleted(split.splitId());
+                break;
+                }
+
+                context.getMetrics().setCurrentPosition(batch.getDataSetId(), batch.getSplitId());
+
+                RecordEnvelope<FluxRow> envelope =
+                        createEnvelope(
+                                batch,
+                                preparedSource.getTables());
+
+                context.getMetrics()
+                        .incrementBatchCount();
+
+                context.getMetrics()
+                        .addSourceReadRecords(
+                                batch.getRecords().size());
+
+                outputGate.write(envelope);
+        }
+    }
+
+    private void executeDynamically(SourceReader<FluxRow, SplitT> reader,
+            PreparedSource<SplitT> preparedSource, TaskContext context) throws Exception {
+        LocalSplitQueue<SplitT> queue = plan.getSplitQueue();
+        reader.open();
+        while (true) {
+            SplitT split = queue.acquire(context.getCancellationToken());
+            if (split == null) return;
+            boolean splitOpen = false;
+            try {
+                reader.openSplit(split);
+                splitOpen = true;
+                while (true) {
+                    RecordBatch<FluxRow> batch = reader.readBatch();
+                    if (batch == null) throw new IllegalStateException("SourceReader returned a null RecordBatch");
+                    if (batch.isEndOfInput()) break;
+                    writeBatch(batch, preparedSource, context);
+                }
+                try {
+                    reader.closeSplit();
+                } finally {
+                    splitOpen = false;
+                }
+                queue.complete(split);
+                context.getMetrics().markSplitCompleted(split.splitId());
+            } catch (Throwable failure) {
+                queue.fail(split, failure);
+                throw failure;
+            } finally {
+                if (splitOpen) reader.closeSplit();
             }
         }
+    }
+
+    private void writeBatch(RecordBatch<FluxRow> batch, PreparedSource<SplitT> preparedSource,
+            TaskContext context) throws Exception {
+        context.getMetrics().setCurrentPosition(batch.getDataSetId(), batch.getSplitId());
+        RecordEnvelope<FluxRow> envelope = createEnvelope(batch, preparedSource.getTables());
+        context.getMetrics().incrementBatchCount();
+        context.getMetrics().addSourceReadRecords(batch.getRecords().size());
+        outputGate.write(envelope);
     }
 
     private RecordEnvelope<FluxRow> createEnvelope(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/ExecutionConfig.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/ExecutionConfig.java
@@ -5,6 +5,8 @@ package com.baize.flux.framework.job;
  */
 public final class ExecutionConfig {
 
+    public enum SplitAssignmentMode { STATIC_ROUND_ROBIN, DYNAMIC }
+
     public static final int DEFAULT_BATCH_SIZE = 1_000;
 
     public static final int DEFAULT_SOURCE_PARALLELISM = 1;
@@ -20,12 +22,19 @@ public final class ExecutionConfig {
     private final int sinkParallelism;
 
     private final int channelCapacity;
+    private final SplitAssignmentMode splitAssignmentMode;
 
     public ExecutionConfig(
             int batchSize,
             int sourceParallelism,
             int sinkParallelism,
             int channelCapacity) {
+        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity,
+                SplitAssignmentMode.STATIC_ROUND_ROBIN);
+    }
+
+    public ExecutionConfig(int batchSize, int sourceParallelism, int sinkParallelism,
+            int channelCapacity, SplitAssignmentMode splitAssignmentMode) {
 
         if (batchSize <= 0) {
             throw new IllegalArgumentException(
@@ -51,6 +60,8 @@ public final class ExecutionConfig {
         this.sourceParallelism = sourceParallelism;
         this.sinkParallelism = sinkParallelism;
         this.channelCapacity = channelCapacity;
+        this.splitAssignmentMode = java.util.Objects.requireNonNull(
+                splitAssignmentMode, "splitAssignmentMode must not be null");
     }
 
     public int getBatchSize() {
@@ -68,4 +79,5 @@ public final class ExecutionConfig {
     public int getChannelCapacity() {
         return channelCapacity;
     }
+    public SplitAssignmentMode getSplitAssignmentMode() { return splitAssignmentMode; }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobConfigParser.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobConfigParser.java
@@ -70,6 +70,12 @@ public final class JobConfigParser {
                         ? root.getInt("env.channel-capacity")
                         : ExecutionConfig.DEFAULT_CHANNEL_CAPACITY;
 
+        ExecutionConfig.SplitAssignmentMode splitAssignmentMode =
+                root.hasPath("env.split-assignment-mode")
+                        ? ExecutionConfig.SplitAssignmentMode.valueOf(root.getString(
+                                "env.split-assignment-mode").trim().toUpperCase(java.util.Locale.ROOT))
+                        : ExecutionConfig.SplitAssignmentMode.STATIC_ROUND_ROBIN;
+
         Config sourceConnectorConfig =
                 sourceConfig
                         .withoutPath("type")
@@ -95,7 +101,8 @@ public final class JobConfigParser {
                         batchSize,
                         sourceParallelism,
                         sinkParallelism,
-                        channelCapacity);
+                        channelCapacity,
+                        splitAssignmentMode);
 
         return new JobDefinition(
                 jobName,

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/JobMetrics.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/JobMetrics.java
@@ -1,6 +1,7 @@
 package com.baize.flux.framework.metrics;
 
 import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.execution.split.LocalSplitQueue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -20,6 +21,8 @@ public final class JobMetrics {
 
     private final List<ChannelMetrics> channelMetrics =
             new CopyOnWriteArrayList<ChannelMetrics>();
+    private volatile LocalSplitQueue<?> splitQueue;
+    private volatile long staticTotalSplitCount;
 
     public TaskMetrics registerTask(TaskId taskId) {
         TaskMetrics created =
@@ -79,6 +82,12 @@ public final class JobMetrics {
     public long getSourceReadBytes() { return sumMetric("source", Metric.SOURCE_BYTES); }
     public long getSinkWrittenBytes() { return sumMetric("sink", Metric.SINK_BYTES); }
     public long getCompletedSplitCount() { return sumMetric("source", Metric.COMPLETED_SPLITS); }
+    public void registerSplitQueue(LocalSplitQueue<?> queue) { splitQueue = queue; }
+    public void setStaticTotalSplitCount(long count) { staticTotalSplitCount = count; }
+    public long getTotalSplitCount() { return splitQueue == null ? staticTotalSplitCount : splitQueue.getTotalSplitCount(); }
+    public long getPendingSplitCount() { return splitQueue == null ? Math.max(0L, staticTotalSplitCount - getCompletedSplitCount()) : splitQueue.getPendingSplitCount(); }
+    public long getRunningSplitCount() { return splitQueue == null ? 0L : splitQueue.getRunningSplitCount(); }
+    public long getFailedSplitCount() { return splitQueue == null ? 0L : splitQueue.getFailedSplitCount(); }
     public long getBatchRetryCount() { return sumMetric(null, Metric.BATCH_RETRIES); }
     public long getDatabaseCommitMillis() { return sumMetric("sink", Metric.COMMIT_MILLIS); }
     public long getSqlExecutionMillis() { return sumMetric(null, Metric.SQL_MILLIS); }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
@@ -6,6 +6,7 @@ import com.baize.flux.framework.connector.PreparedJob;
 import com.baize.flux.framework.connector.PreparedSink;
 import com.baize.flux.framework.connector.PreparedSource;
 import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.execution.split.LocalSplitQueue;
 import com.baize.flux.framework.job.ExecutionConfig;
 
 import java.util.ArrayList;
@@ -65,10 +66,13 @@ public final class JobPlanner {
                     "Source returned null splits");
         }
 
-        List<List<SplitT>> assignments =
-                splitAssigner.assign(
-                        splits,
-                        config.getSourceParallelism());
+        boolean dynamic = config.getSplitAssignmentMode()
+                == ExecutionConfig.SplitAssignmentMode.DYNAMIC;
+        List<List<SplitT>> assignments = dynamic
+                ? dynamicAssignments(splits, config.getSourceParallelism())
+                : splitAssigner.assign(splits, config.getSourceParallelism());
+        LocalSplitQueue<SplitT> splitQueue = dynamic
+                ? new LocalSplitQueue<SplitT>(splits) : null;
 
         List<SourceTaskPlan<?>> sourcePlans =
                 new ArrayList<SourceTaskPlan<?>>();
@@ -88,7 +92,8 @@ public final class JobPlanner {
                             taskId,
                             preparedSource,
                             assignments.get(i),
-                            config.getBatchSize()));
+                            config.getBatchSize(),
+                            splitQueue));
         }
 
         List<SinkTaskPlan> sinkPlans =
@@ -122,5 +127,13 @@ public final class JobPlanner {
                 config,
                 sourcePlans,
                 sinkPlans);
+    }
+
+    private static <SplitT extends SourceSplit> List<List<SplitT>> dynamicAssignments(
+            List<SplitT> splits, int parallelism) {
+        List<List<SplitT>> assignments = new ArrayList<List<SplitT>>();
+        int taskCount = Math.min(splits.size(), parallelism);
+        for (int i = 0; i < taskCount; i++) assignments.add(new ArrayList<SplitT>());
+        return assignments;
     }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/SourceTaskPlan.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/SourceTaskPlan.java
@@ -3,6 +3,7 @@ package com.baize.flux.framework.planner;
 import com.baize.flux.api.source.SourceSplit;
 import com.baize.flux.framework.connector.PreparedSource;
 import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.execution.split.LocalSplitQueue;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,12 +23,18 @@ public final class SourceTaskPlan<
     private final List<SplitT> splits;
 
     private final int batchSize;
+    private final LocalSplitQueue<SplitT> splitQueue;
 
     public SourceTaskPlan(
             TaskId taskId,
             PreparedSource<SplitT> preparedSource,
             List<SplitT> splits,
             int batchSize) {
+        this(taskId, preparedSource, splits, batchSize, null);
+    }
+
+    public SourceTaskPlan(TaskId taskId, PreparedSource<SplitT> preparedSource,
+            List<SplitT> splits, int batchSize, LocalSplitQueue<SplitT> splitQueue) {
 
         if (batchSize <= 0) {
             throw new IllegalArgumentException(
@@ -52,6 +59,7 @@ public final class SourceTaskPlan<
                                         "splits must not be null")));
 
         this.batchSize = batchSize;
+        this.splitQueue = splitQueue;
     }
 
     public TaskId getTaskId() {
@@ -69,4 +77,8 @@ public final class SourceTaskPlan<
     public int getBatchSize() {
         return batchSize;
     }
+
+    public LocalSplitQueue<SplitT> getSplitQueue() { return splitQueue; }
+
+    public boolean isDynamicSplitAssignment() { return splitQueue != null; }
 }

--- a/baize-flux-framework/src/test/java/com/baize/flux/framework/execution/split/LocalSplitQueueTest.java
+++ b/baize-flux-framework/src/test/java/com/baize/flux/framework/execution/split/LocalSplitQueueTest.java
@@ -1,0 +1,66 @@
+package com.baize.flux.framework.execution.split;
+
+import com.baize.flux.api.source.SourceSplit;
+import com.baize.flux.framework.execution.CancellationToken;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LocalSplitQueueTest {
+
+    @Test
+    public void acquiresEachSplitOnlyOnceAcrossWorkers() throws Exception {
+        final LocalSplitQueue<TestSplit> queue = new LocalSplitQueue<TestSplit>(Arrays.asList(
+                new TestSplit("a"), new TestSplit("b"), new TestSplit("c"), new TestSplit("d")));
+        final Set<String> acquired = Collections.synchronizedSet(new HashSet<String>());
+        Runnable worker = new Runnable() {
+            @Override public void run() {
+                try {
+                    TestSplit split;
+                    while ((split = queue.acquire(new CancellationToken())) != null) {
+                        assertTrue(acquired.add(split.splitId()));
+                        queue.complete(split);
+                    }
+                } catch (Exception e) { throw new AssertionError(e); }
+            }
+        };
+        Thread first = new Thread(worker);
+        Thread second = new Thread(worker);
+        first.start(); second.start(); first.join(); second.join();
+        assertEquals(4, acquired.size());
+        assertEquals(4, queue.getCompletedSplitCount());
+    }
+
+    @Test
+    public void cancellationWakesBlockedAcquire() throws Exception {
+        final LocalSplitQueue<TestSplit> queue = new LocalSplitQueue<TestSplit>(Arrays.asList(new TestSplit("a")));
+        final CancellationToken token = new CancellationToken();
+        final TestSplit split = queue.acquire(token);
+        final CountDownLatch stopped = new CountDownLatch(1);
+        Thread waiter = new Thread(new Runnable() {
+            @Override public void run() {
+                try { queue.acquire(token); } catch (RuntimeException expected) { stopped.countDown(); }
+                catch (InterruptedException e) { throw new AssertionError(e); }
+            }
+        });
+        waiter.start();
+        Thread.sleep(50L);
+        token.cancel(new RuntimeException("cancelled"));
+        assertTrue(stopped.await(2L, TimeUnit.SECONDS));
+        queue.returnSplit(split);
+    }
+
+    private static final class TestSplit implements SourceSplit {
+        private final String id;
+        private TestSplit(String id) { this.id = id; }
+        @Override public String splitId() { return id; }
+    }
+}


### PR DESCRIPTION
### Motivation

- Enable a DYNAMIC split assignment mode so SourceTasks can fetch splits on demand instead of holding a static list. 
- Provide a thread-safe, in-process split provider that supports blocking `acquire` and immediate wake-up when a job is cancelled or fails. 
- Evolve the `SourceReader` lifecycle so readers can open per-task and per-split resources, allowing connectors (e.g. JDBC) to reuse task-local resources while opening and closing ResultSets per split. 
- Surface split-level job metrics (total / pending / running / completed / failed) for observability of dynamic assignment.

### Description

- Added `LocalSplitQueue<SplitT>` implementing a thread-safe split provider with `acquire`, `complete`, `returnSplit`, `fail`, `cancel` and state counters, and cancellation-aware wakeups (`baize-flux-framework/src/main/java/com/baize/flux/framework/execution/split/LocalSplitQueue.java`).
- Added `ExecutionConfig.SplitAssignmentMode` with values `STATIC_ROUND_ROBIN` and `DYNAMIC`, preserved default `STATIC_ROUND_ROBIN`, and plumbed the new option through `JobConfigParser` and `ExecutionConfig` (`.../ExecutionConfig.java`, `.../JobConfigParser.java`).
- Updated `JobPlanner` to create a shared `LocalSplitQueue` in `DYNAMIC` mode and to produce SourceTask plans that reference the shared queue (`.../JobPlanner.java`, `.../SourceTaskPlan.java`).
- Reworked `SourceTask` to support two flows: `executeStatically` (legacy: `open(List<SplitT>)` and process) and `executeDynamically` (loop: `acquire` -> `openSplit` -> `readBatch` -> `closeSplit` -> `complete`), cancelling the shared queue and job on failure (`.../execution/task/SourceTask.java`).
- Evolved `SourceReader` interface with default methods `open()`, `openSplit(SplitT)`, and `closeSplit()` while keeping `open(List<SplitT>)` as a default for legacy readers (`baize-flux-api/src/main/java/com/baize/flux/api/source/SourceReader.java`).
- Implemented the new single-split lifecycle in `JdbcSourceReader` by reusing task-private `JdbcInputFormat` while opening/closing each `ResultSet` per split (`.../connector/jdbc/source/JdbcSourceReader.java`).
- Extended `JobMetrics` to expose split totals and live counts and to allow registering a `LocalSplitQueue` for dynamic metrics; `JobExecution` registers split metrics at startup (`.../metrics/JobMetrics.java`, `.../execution/JobExecution.java`).
- Made `CancellationToken` notify registered listeners to wake blocked components on cancel, used by `LocalSplitQueue` to wake blocked acquirers (`.../execution/CancellationToken.java`).
- Added unit tests `LocalSplitQueueTest` verifying concurrent non-duplicated acquisition and cancellation wake-up behavior (`baize-flux-framework/src/test/java/com/baize/flux/framework/execution/split/LocalSplitQueueTest.java`).
- Updated default distribution config to include `env.split-assignment-mode = STATIC_ROUND_ROBIN` to retain backward-compatible behavior (`baize-flux-dist/src/main/dist/config/baize-flux.yaml`).

### Testing

- Ran `git diff --check` which reported no issues. 
- Added `LocalSplitQueueTest` unit tests but full Maven test execution failed due to build-time plugin resolution errors against Maven Central (HTTP 403) so tests could not be executed in this environment. 
- Attempted `mvn -o -q -pl baize-flux-framework -am test` and `mvn test -q -DskipTests`, both failed because the required Maven plugin (`maven-resources-plugin:3.3.1`) could not be resolved from the remote repository in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6301ec864883269ab220789fbc7963)