### PR TITLE
Refactor Sink lifecycle for task-local writers

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/factory/SinkFactory.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/factory/SinkFactory.java
@@ -2,12 +2,34 @@ package com.baize.flux.api.factory;
 
 import com.baize.flux.api.configuration.ReadonlyConfig;
 import com.baize.flux.api.configuration.util.OptionRule;
+import com.baize.flux.api.sink.Sink;
+import com.baize.flux.api.sink.SinkFactoryContext;
 import com.baize.flux.api.sink.SinkWriter;
 import com.baize.flux.api.table.type.FluxRow;
 
+/** 创建 Job 级不可变 Sink 的 Connector Factory。 */
 public interface SinkFactory extends Factory {
-
     OptionRule optionRule();
+    /** 在 Job 准备阶段仅调用一次。 */
+    default Sink createSink(SinkFactoryContext context) {
+        final SinkWriter<FluxRow> legacyWriter = createSink(context.getOptions());
+        if (legacyWriter == null) {
+            return null;
+        }
+        return new Sink() {
+            @Override
+            public SinkWriter<FluxRow> createWriter(com.baize.flux.api.sink.SinkWriterContext writerContext) {
+                if (writerContext.getParallelism() != 1) {
+                    throw new IllegalStateException("Legacy SinkFactory only supports parallelism of 1");
+                }
+                return legacyWriter;
+            }
+        };
+    }
 
-    SinkWriter<FluxRow> createSink(ReadonlyConfig config);
+    /** 旧 Writer Factory 的短期兼容入口，新 Connector 不应实现此方法。 */
+    @Deprecated
+    default SinkWriter<FluxRow> createSink(ReadonlyConfig config) {
+        throw new UnsupportedOperationException("SinkFactory must implement createSink(SinkFactoryContext)");
+    }
 }

--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/Sink.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/Sink.java
@@ -1,0 +1,17 @@
+package com.baize.flux.api.sink;
+
+import com.baize.flux.api.table.type.FluxRow;
+
+/**
+ * 不可变的 Sink 定义。
+ *
+ * <p>一个 Job 只创建一个 Sink；每个 SinkTask 必须通过 {@link #createWriter(SinkWriterContext)}
+ * 创建自己的 Writer，不能在 Sink 中共享连接或可变写入状态。
+ */
+public interface Sink {
+
+    /**
+     * 为一个 SinkTask 创建线程封闭的 Writer。
+     */
+    SinkWriter<FluxRow> createWriter(SinkWriterContext context);
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkFactoryContext.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkFactoryContext.java
@@ -1,0 +1,41 @@
+package com.baize.flux.api.sink;
+
+import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.catalog.TablePath;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Sink Factory 的 Job 级创建上下文。
+ *
+ * <p>其中表元数据是准备阶段的稳定快照，Factory 可据此生成可被所有 Writer 共享的不可变准备结果。
+ */
+public final class SinkFactoryContext {
+    private final ReadonlyConfig options;
+    private final ClassLoader classLoader;
+    private final String jobName;
+    private final Map<TablePath, CatalogTable> sourceTables;
+    private final Map<TablePath, CatalogTable> preparedTargetTables;
+
+    public SinkFactoryContext(ReadonlyConfig options, ClassLoader classLoader, String jobName,
+            Map<TablePath, CatalogTable> sourceTables, Map<TablePath, CatalogTable> preparedTargetTables) {
+        this.options = Objects.requireNonNull(options, "options must not be null");
+        this.classLoader = Objects.requireNonNull(classLoader, "classLoader must not be null");
+        this.jobName = Objects.requireNonNull(jobName, "jobName must not be null");
+        this.sourceTables = immutableCopy(sourceTables, "sourceTables");
+        this.preparedTargetTables = immutableCopy(preparedTargetTables, "preparedTargetTables");
+    }
+    private static Map<TablePath, CatalogTable> immutableCopy(Map<TablePath, CatalogTable> value, String name) {
+        return Collections.unmodifiableMap(new LinkedHashMap<TablePath, CatalogTable>(Objects.requireNonNull(value, name + " must not be null")));
+    }
+    public ReadonlyConfig getOptions() { return options; }
+    public ClassLoader getClassLoader() { return classLoader; }
+    public String getJobName() { return jobName; }
+    /** 已发现的源表。 */
+    public Map<TablePath, CatalogTable> getSourceTables() { return sourceTables; }
+    /** 已准备完成、供 Writer 使用的目标表元数据。 */
+    public Map<TablePath, CatalogTable> getPreparedTargetTables() { return preparedTargetTables; }
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkWriterContext.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkWriterContext.java
@@ -1,0 +1,33 @@
+package com.baize.flux.api.sink;
+
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.catalog.TablePath;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Sink Writer 的 Task 级运行上下文。 */
+public final class SinkWriterContext {
+    private final TaskId taskId;
+    private final int subtaskIndex;
+    private final int parallelism;
+    private final ClassLoader classLoader;
+    private final SinkWriterMetrics metrics;
+    private final Map<TablePath, CatalogTable> preparedTargetTables;
+    public SinkWriterContext(TaskId taskId, int subtaskIndex, int parallelism, ClassLoader classLoader,
+            SinkWriterMetrics metrics, Map<TablePath, CatalogTable> preparedTargetTables) {
+        this.taskId = Objects.requireNonNull(taskId, "taskId must not be null");
+        if (subtaskIndex < 0 || subtaskIndex >= parallelism || parallelism <= 0) throw new IllegalArgumentException("invalid subtaskIndex or parallelism");
+        this.subtaskIndex = subtaskIndex; this.parallelism = parallelism;
+        this.classLoader = Objects.requireNonNull(classLoader, "classLoader must not be null");
+        this.metrics = Objects.requireNonNull(metrics, "metrics must not be null");
+        this.preparedTargetTables = Collections.unmodifiableMap(new LinkedHashMap<TablePath, CatalogTable>(Objects.requireNonNull(preparedTargetTables, "preparedTargetTables must not be null")));
+    }
+    public TaskId getTaskId() { return taskId; }
+    public int getSubtaskIndex() { return subtaskIndex; }
+    public int getParallelism() { return parallelism; }
+    public ClassLoader getClassLoader() { return classLoader; }
+    public SinkWriterMetrics getMetrics() { return metrics; }
+    public Map<TablePath, CatalogTable> getPreparedTargetTables() { return preparedTargetTables; }
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkWriterMetrics.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkWriterMetrics.java
@@ -1,0 +1,7 @@
+package com.baize.flux.api.sink;
+
+/** Sink Writer 可选使用的轻量指标入口。 */
+public interface SinkWriterMetrics {
+    void incrementWriteSuccessRecords(long count);
+    void addWrittenBytes(long count);
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/TaskId.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/TaskId.java
@@ -1,0 +1,32 @@
+package com.baize.flux.api.sink;
+
+import java.util.Objects;
+
+/** Sink 任务的唯一标识。 */
+public class TaskId {
+    private final String stageName;
+    private final int subtaskIndex;
+    private final int parallelism;
+
+    public TaskId(String stageName, int subtaskIndex, int parallelism) {
+        this.stageName = Objects.requireNonNull(stageName, "stageName must not be null");
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException("parallelism must be greater than 0");
+        }
+        if (subtaskIndex < 0 || subtaskIndex >= parallelism) {
+            throw new IllegalArgumentException("subtaskIndex must be in [0, parallelism)");
+        }
+        this.subtaskIndex = subtaskIndex;
+        this.parallelism = parallelism;
+    }
+    public String getStageName() { return stageName; }
+    public int getSubtaskIndex() { return subtaskIndex; }
+    public int getParallelism() { return parallelism; }
+    @Override public String toString() { return stageName + "-" + subtaskIndex + "/" + parallelism; }
+    @Override public boolean equals(Object object) {
+        if (!(object instanceof TaskId)) return false;
+        TaskId that = (TaskId) object;
+        return subtaskIndex == that.subtaskIndex && parallelism == that.parallelism && stageName.equals(that.stageName);
+    }
+    @Override public int hashCode() { return Objects.hash(stageName, subtaskIndex, parallelism); }
+}

--- a/baize-flux-api/src/test/java/com/baize/flux/api/sink/SinkWriterContextTest.java
+++ b/baize-flux-api/src/test/java/com/baize/flux/api/sink/SinkWriterContextTest.java
@@ -1,0 +1,29 @@
+package com.baize.flux.api.sink;
+
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.catalog.TablePath;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class SinkWriterContextTest {
+    @Test
+    public void exposesTaskIdentityParallelismAndClassLoader() {
+        ClassLoader loader = getClass().getClassLoader();
+        SinkWriterMetrics metrics = new SinkWriterMetrics() {
+            @Override public void incrementWriteSuccessRecords(long count) { }
+            @Override public void addWrittenBytes(long count) { }
+        };
+        Map<TablePath, CatalogTable> tables = Collections.emptyMap();
+        SinkWriterContext context = new SinkWriterContext(new TaskId("sink", 1, 3), 1, 3,
+                loader, metrics, tables);
+        assertEquals(1, context.getSubtaskIndex());
+        assertEquals(3, context.getParallelism());
+        assertEquals("sink", context.getTaskId().getStageName());
+        assertSame(loader, context.getClassLoader());
+        assertSame(metrics, context.getMetrics());
+        assertEquals(tables, context.getPreparedTargetTables());
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/internal/JdbcConnectionProvider.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/internal/JdbcConnectionProvider.java
@@ -25,16 +25,21 @@ public final class JdbcConnectionProvider implements AutoCloseable, Serializable
 
     private final JdbcConnectionConfig config;
     private final JdbcDialect dialect;
+    private final ClassLoader classLoader;
 
     private transient Driver loadedDriver;
     private transient Connection connection;
 
     public JdbcConnectionProvider(JdbcConnectionConfig config, JdbcDialect dialect) {
+        this(config, dialect, Thread.currentThread().getContextClassLoader());
+    }
+    public JdbcConnectionProvider(JdbcConnectionConfig config, JdbcDialect dialect, ClassLoader classLoader) {
         this.config = Objects.requireNonNull(config, "config must not be null");
         this.dialect = Objects.requireNonNull(dialect, "dialect must not be null");
+        this.classLoader = Objects.requireNonNull(classLoader, "classLoader must not be null");
     }
 
-    private static Driver loadDriver(String driverName) throws ClassNotFoundException, SQLException {
+    private static Driver loadDriver(String driverName, ClassLoader classLoader) throws ClassNotFoundException, SQLException {
         Enumeration<Driver> drivers = DriverManager.getDrivers();
         while (drivers.hasMoreElements()) {
             Driver driver = drivers.nextElement();
@@ -43,7 +48,7 @@ public final class JdbcConnectionProvider implements AutoCloseable, Serializable
             }
         }
 
-        Class<?> driverClass = Class.forName(driverName, true, Thread.currentThread().getContextClassLoader());
+        Class<?> driverClass = Class.forName(driverName, true, classLoader);
         if (!Driver.class.isAssignableFrom(driverClass)) {
             throw new SQLException("Configured JDBC driver does not implement java.sql.Driver: " + driverName);
         }
@@ -125,7 +130,7 @@ public final class JdbcConnectionProvider implements AutoCloseable, Serializable
 
     private Driver getLoadedDriver() throws ClassNotFoundException, SQLException {
         if (loadedDriver == null) {
-            loadedDriver = loadDriver(config.getDriverName());
+            loadedDriver = loadDriver(config.getDriverName(), classLoader);
         }
         return loadedDriver;
     }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormat.java
@@ -88,8 +88,11 @@ public final class JdbcOutputFormat
 
     private boolean closed;
 
-    JdbcOutputFormat(
-            JdbcSinkConfig config) {
+    JdbcOutputFormat(JdbcSinkConfig config) {
+        this(config, Thread.currentThread().getContextClassLoader());
+    }
+
+    JdbcOutputFormat(JdbcSinkConfig config, ClassLoader classLoader) {
 
         this.config =
                 Objects.requireNonNull(
@@ -102,8 +105,7 @@ public final class JdbcOutputFormat
 
         this.connectionProvider =
                 new JdbcConnectionProvider(
-                        config.getConnectionConfig(),
-                        dialect);
+                        config.getConnectionConfig(), dialect, classLoader);
     }
 
     /**

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormatBuilder.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcOutputFormatBuilder.java
@@ -9,14 +9,20 @@ import java.util.Objects;
  */
 public final class JdbcOutputFormatBuilder {
     private JdbcSinkConfig config;
+    private ClassLoader classLoader;
 
     public JdbcOutputFormatBuilder withConfig(JdbcSinkConfig config) {
         this.config = Objects.requireNonNull(config, "config must not be null");
         return this;
     }
 
+    public JdbcOutputFormatBuilder withClassLoader(ClassLoader classLoader) {
+        this.classLoader = Objects.requireNonNull(classLoader, "classLoader must not be null");
+        return this;
+    }
+
     public JdbcOutputFormat build() {
         if (config == null) throw new IllegalStateException("JdbcSinkConfig must be configured before build");
-        return new JdbcOutputFormat(config);
+        return new JdbcOutputFormat(config, classLoader == null ? Thread.currentThread().getContextClassLoader() : classLoader);
     }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSink.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSink.java
@@ -1,0 +1,23 @@
+package com.baize.flux.connector.jdbc.sink;
+
+import com.baize.flux.api.sink.Sink;
+import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.sink.SinkWriterContext;
+import com.baize.flux.api.table.type.FluxRow;
+import com.baize.flux.connector.jdbc.config.JdbcSinkConfig;
+import java.util.Objects;
+
+/**
+ * JDBC 的不可变 Job 级 Sink。
+ *
+ * <p>仅共享不可变配置；每次创建 Writer 都会创建独立的 OutputFormat、Connection 与 Statement 缓存。
+ */
+public final class JdbcSink implements Sink {
+    private final JdbcSinkConfig config;
+    public JdbcSink(JdbcSinkConfig config) { this.config = Objects.requireNonNull(config, "config must not be null"); }
+    @Override
+    public SinkWriter<FluxRow> createWriter(SinkWriterContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        return new JdbcSinkWriter(config, context.getClassLoader());
+    }
+}

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkFactory.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkFactory.java
@@ -1,10 +1,10 @@
 package com.baize.flux.connector.jdbc.sink;
 
-import com.baize.flux.api.configuration.ReadonlyConfig;
+
 import com.baize.flux.api.configuration.util.OptionRule;
 import com.baize.flux.api.factory.SinkFactory;
-import com.baize.flux.api.sink.SinkWriter;
-import com.baize.flux.api.table.type.FluxRow;
+import com.baize.flux.api.sink.Sink;
+import com.baize.flux.api.sink.SinkFactoryContext;
 import com.baize.flux.connector.jdbc.config.JdbcCommonOptions;
 import com.baize.flux.connector.jdbc.config.JdbcSinkConfig;
 import com.baize.flux.connector.jdbc.config.JdbcSinkOptions;
@@ -33,7 +33,7 @@ public final class JdbcSinkFactory implements SinkFactory {
     }
 
     @Override
-    public SinkWriter<FluxRow> createSink(ReadonlyConfig config) {
-        return new JdbcSinkWriter(JdbcSinkConfig.of(config));
+    public Sink createSink(SinkFactoryContext context) {
+        return new JdbcSink(JdbcSinkConfig.of(context.getOptions()));
     }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkWriter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkWriter.java
@@ -22,9 +22,13 @@ public final class JdbcSinkWriter
 
     public JdbcSinkWriter(
             JdbcSinkConfig config) {
+        this(config, Thread.currentThread().getContextClassLoader());
+    }
 
+    public JdbcSinkWriter(JdbcSinkConfig config, ClassLoader classLoader) {
         this.outputFormat =
                 new JdbcOutputFormatBuilder()
+                        .withClassLoader(classLoader)
                         .withConfig(
                                 Objects.requireNonNull(
                                         config,

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
@@ -3,6 +3,8 @@ package com.baize.flux.framework.connector;
 import com.baize.flux.api.configuration.util.ConfigValidator;
 import com.baize.flux.api.factory.SinkFactory;
 import com.baize.flux.api.source.Source;
+import com.baize.flux.api.sink.Sink;
+import com.baize.flux.api.sink.SinkFactoryContext;
 import com.baize.flux.api.source.SourceFactoryContext;
 import com.baize.flux.api.source.SourceSplit;
 import com.baize.flux.api.table.catalog.CatalogTable;
@@ -65,8 +67,8 @@ public final class ConnectorPreparer {
         List<PreparedSink> sinks =
                 prepareSinks(
                         definition.getSink(),
-                        definition.getExecutionConfig()
-                                .getSinkParallelism());
+                        definition.getName(),
+                        source.getTables());
 
         return new PreparedJob(
                 definition.getName(),
@@ -130,7 +132,8 @@ public final class ConnectorPreparer {
 
     private List<PreparedSink> prepareSinks(
             SinkDefinition definition,
-            int parallelism) {
+            String jobName,
+            Map<TablePath, CatalogTable> sourceTables) {
 
         SinkFactory factory =
                 registry.getSinkFactory(
@@ -141,19 +144,15 @@ public final class ConnectorPreparer {
                 .validate(
                         factory.optionRule());
 
-        List<PreparedSink> sinks =
-                new java.util.ArrayList<PreparedSink>(
-                        parallelism);
-
-        for (int i = 0; i < parallelism; i++) {
-            sinks.add(
-                    new PreparedSink(
-                            definition.getType(),
-                            factory,
-                            definition.getOptions()));
+        SinkFactoryContext context =
+                new SinkFactoryContext(
+                        definition.getOptions(), classLoader, jobName, sourceTables, sourceTables);
+        Sink sink = factory.createSink(context);
+        if (sink == null) {
+            throw new ConnectorException("Sink factory '" + definition.getType() + "' returned a null sink");
         }
-
-        return sinks;
+        return java.util.Collections.singletonList(
+                new PreparedSink(definition.getType(), definition.getOptions(), sink, sourceTables));
     }
 
     private Map<TablePath, CatalogTable> buildTableMap(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSink.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSink.java
@@ -1,65 +1,30 @@
 package com.baize.flux.framework.connector;
 
 import com.baize.flux.api.configuration.ReadonlyConfig;
-import com.baize.flux.api.factory.SinkFactory;
-import com.baize.flux.api.sink.SinkWriter;
-import com.baize.flux.api.table.type.FluxRow;
-
+import com.baize.flux.api.sink.Sink;
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.catalog.TablePath;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 
-/**
- * 已完成 Factory 发现、配置校验和 Writer 初始化的 Sink。
- *
- * <p>SinkWriter 在 Job Prepare 阶段创建，并在对应的 SinkTask 中执行。
- */
+/** 已完成 Job 级准备的不可变 Sink 及目标表元数据。 */
 public final class PreparedSink {
-
     private final String factoryIdentifier;
-
     private final ReadonlyConfig options;
-
-    private final SinkWriter<FluxRow> writer;
-
-    public PreparedSink(
-            String factoryIdentifier,
-            SinkFactory factory,
-            ReadonlyConfig options) {
-
-        this.factoryIdentifier =
-                Objects.requireNonNull(
-                        factoryIdentifier,
-                        "factoryIdentifier must not be null");
-
-        this.options =
-                Objects.requireNonNull(
-                        options,
-                        "options must not be null");
-
-        SinkFactory nonNullFactory =
-                Objects.requireNonNull(
-                        factory,
-                        "factory must not be null");
-
-        this.writer =
-                nonNullFactory.createSink(options);
-
-        if (this.writer == null) {
-            throw new ConnectorException(
-                    "Sink factory '"
-                            + factoryIdentifier
-                            + "' returned a null writer");
-        }
+    private final Sink sink;
+    private final Map<TablePath, CatalogTable> preparedTargetTables;
+    public PreparedSink(String factoryIdentifier, ReadonlyConfig options, Sink sink,
+            Map<TablePath, CatalogTable> preparedTargetTables) {
+        this.factoryIdentifier = Objects.requireNonNull(factoryIdentifier, "factoryIdentifier must not be null");
+        this.options = Objects.requireNonNull(options, "options must not be null");
+        this.sink = Objects.requireNonNull(sink, "sink must not be null");
+        this.preparedTargetTables = Collections.unmodifiableMap(new LinkedHashMap<TablePath, CatalogTable>(Objects.requireNonNull(preparedTargetTables, "preparedTargetTables must not be null")));
     }
-
-    public SinkWriter<FluxRow> getWriter() {
-        return writer;
-    }
-
-    public String getFactoryIdentifier() {
-        return factoryIdentifier;
-    }
-
-    public ReadonlyConfig getOptions() {
-        return options;
-    }
+    public String getFactoryIdentifier() { return factoryIdentifier; }
+    public ReadonlyConfig getOptions() { return options; }
+    /** 不可变 Sink；Writer 必须由 SinkTask 创建。 */
+    public Sink getSink() { return sink; }
+    public Map<TablePath, CatalogTable> getPreparedTargetTables() { return preparedTargetTables; }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/TaskId.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/TaskId.java
@@ -1,90 +1,11 @@
 package com.baize.flux.framework.execution;
 
-import java.util.Objects;
-
 /**
- * Task 唯一标识。
+ * @deprecated 请使用 API 的 {@link com.baize.flux.api.sink.TaskId}。
  */
-public final class TaskId {
-
-    private final String stageName;
-
-    private final int subtaskIndex;
-
-    private final int parallelism;
-
-    public TaskId(
-            String stageName,
-            int subtaskIndex,
-            int parallelism) {
-
-        if (subtaskIndex < 0) {
-            throw new IllegalArgumentException(
-                    "subtaskIndex must not be negative");
-        }
-
-        if (parallelism <= 0) {
-            throw new IllegalArgumentException(
-                    "parallelism must be greater than 0");
-        }
-
-        if (subtaskIndex >= parallelism) {
-            throw new IllegalArgumentException(
-                    "subtaskIndex must be less than parallelism");
-        }
-
-        this.stageName =
-                Objects.requireNonNull(
-                        stageName,
-                        "stageName must not be null");
-
-        this.subtaskIndex = subtaskIndex;
-        this.parallelism = parallelism;
-    }
-
-    public String getStageName() {
-        return stageName;
-    }
-
-    public int getSubtaskIndex() {
-        return subtaskIndex;
-    }
-
-    public int getParallelism() {
-        return parallelism;
-    }
-
-    @Override
-    public String toString() {
-        return stageName
-                + "-"
-                + subtaskIndex
-                + "/"
-                + parallelism;
-    }
-
-    @Override
-    public boolean equals(Object object) {
-        if (this == object) {
-            return true;
-        }
-
-        if (!(object instanceof TaskId)) {
-            return false;
-        }
-
-        TaskId that = (TaskId) object;
-
-        return subtaskIndex == that.subtaskIndex
-                && parallelism == that.parallelism
-                && stageName.equals(that.stageName);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                stageName,
-                subtaskIndex,
-                parallelism);
+@Deprecated
+public final class TaskId extends com.baize.flux.api.sink.TaskId {
+    public TaskId(String stageName, int subtaskIndex, int parallelism) {
+        super(stageName, subtaskIndex, parallelism);
     }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
@@ -1,6 +1,8 @@
 package com.baize.flux.framework.execution.task;
 
 import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.sink.SinkWriterContext;
+import com.baize.flux.api.sink.SinkWriterMetrics;
 import com.baize.flux.api.table.type.FluxRow;
 import com.baize.flux.framework.channel.InputGate;
 import com.baize.flux.framework.channel.RecordEnvelope;
@@ -55,9 +57,13 @@ public final class SinkTask
         boolean committed = false;
 
         try {
-            writer =
-                    plan.getPreparedSink()
-                            .getWriter();
+            writer = plan.getPreparedSink().getSink().createWriter(
+                    new SinkWriterContext(getTaskId(), getTaskId().getSubtaskIndex(), getTaskId().getParallelism(),
+                            context.getClassLoader(), new TaskMetricsAdapter(context),
+                            plan.getPreparedSink().getPreparedTargetTables()));
+            if (writer == null) {
+                throw new IllegalStateException("Sink returned a null writer for " + getTaskId());
+            }
 
             writer.open();
 
@@ -166,6 +172,14 @@ public final class SinkTask
                 }
             }
         }
+    }
+
+    /** 将框架指标以最小 API 暴露给 Connector。 */
+    private static final class TaskMetricsAdapter implements SinkWriterMetrics {
+        private final TaskContext context;
+        private TaskMetricsAdapter(TaskContext context) { this.context = context; }
+        @Override public void incrementWriteSuccessRecords(long count) { context.getMetrics().addSinkWriteSuccessRecords(count); }
+        @Override public void addWrittenBytes(long count) { context.getMetrics().addSinkWrittenBytes(count); }
     }
 
     private static RuntimeException propagate(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
@@ -101,9 +101,8 @@ public final class JobPlanner {
             List<PreparedSink> preparedSinks =
                     preparedJob.getSinks();
 
-            if (preparedSinks.size() != sinkParallelism) {
-                throw new IllegalStateException(
-                        "Prepared sink count does not match sink parallelism");
+            if (preparedSinks.size() != 1) {
+                throw new IllegalStateException("A job must contain exactly one prepared sink");
             }
 
             for (int i = 0; i < sinkParallelism; i++) {
@@ -113,7 +112,7 @@ public final class JobPlanner {
                                         "sink",
                                         i,
                                         sinkParallelism),
-                                preparedSinks.get(i)));
+                                preparedSinks.get(0)));
             }
         }
 

--- a/baize-flux-framework/src/test/java/com/baize/flux/framework/connector/PreparedSinkTest.java
+++ b/baize-flux-framework/src/test/java/com/baize/flux/framework/connector/PreparedSinkTest.java
@@ -1,74 +1,35 @@
 package com.baize.flux.framework.connector;
 
 import com.baize.flux.api.configuration.ReadonlyConfig;
-import com.baize.flux.api.configuration.util.OptionRule;
-import com.baize.flux.api.factory.SinkFactory;
+import com.baize.flux.api.sink.Sink;
 import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.sink.SinkWriterContext;
 import com.baize.flux.api.source.RecordBatch;
 import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.type.FluxRow;
 import org.junit.Test;
-
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
 
 public class PreparedSinkTest {
-
     @Test
-    public void initializesWriterDuringPreparation() {
-        AtomicInteger createCount = new AtomicInteger();
-        SinkWriter<FluxRow> writer = new NoOpSinkWriter();
-
-        PreparedSink preparedSink =
-                new PreparedSink(
-                        "test",
-                        new TestingSinkFactory(createCount, writer),
-                        ReadonlyConfig.fromMap(Collections.<String, Object>emptyMap()));
-
-        assertEquals(1, createCount.get());
-        assertSame(writer, preparedSink.getWriter());
+    public void storesSinkAndDoesNotCreateWriterDuringPreparation() {
+        AtomicInteger writerCreates = new AtomicInteger();
+        Sink sink = new Sink() {
+            @Override public SinkWriter<FluxRow> createWriter(SinkWriterContext context) {
+                writerCreates.incrementAndGet(); return new NoOpSinkWriter();
+            }
+        };
+        PreparedSink preparedSink = new PreparedSink("test",
+                ReadonlyConfig.fromMap(Collections.<String, Object>emptyMap()), sink,
+                Collections.emptyMap());
+        assertSame(sink, preparedSink.getSink());
+        assertEquals(0, writerCreates.get());
     }
-
-    private static final class TestingSinkFactory implements SinkFactory {
-
-        private final AtomicInteger createCount;
-        private final SinkWriter<FluxRow> writer;
-
-        private TestingSinkFactory(
-                AtomicInteger createCount,
-                SinkWriter<FluxRow> writer) {
-            this.createCount = createCount;
-            this.writer = writer;
-        }
-
-        @Override
-        public String factoryIdentifier() {
-            return "test";
-        }
-
-        @Override
-        public OptionRule optionRule() {
-            return OptionRule.builder().build();
-        }
-
-        @Override
-        public SinkWriter<FluxRow> createSink(ReadonlyConfig config) {
-            createCount.incrementAndGet();
-            return writer;
-        }
-    }
-
     private static final class NoOpSinkWriter implements SinkWriter<FluxRow> {
-
-        @Override
-        public void write(RecordBatch<FluxRow> batch, CatalogTable sourceTable) {
-        }
-
-        @Override
-        public void close() {
-        }
+        @Override public void write(RecordBatch<FluxRow> batch, CatalogTable sourceTable) { }
+        @Override public void close() { }
     }
 }


### PR DESCRIPTION
### Motivation
- 避免在 Job 准备阶段创建可变的共享 Writer，从而防止跨 Task 共享 JDBC 连接和可变写入状态导致的并发/资源冲突。 
- 将 Factory 的职责限定为创建不可变的 Job 级 `Sink` 实例，并在 Task 运行时由 `Sink` 创建线程封闭的 Writer，以便每个 Task 拥有独立连接与 PreparedStatement 缓存。 
- 提供清晰的 Job/Task 级上下文（包含只读配置、ClassLoader、Job 名称、源表与准备后的目标表元数据、`TaskId`、下标、并行度和轻量指标入口），方便 Connector 正确管理生命周期与资源。 

### Description
- 新增 API：添加不可变 `Sink`、`SinkFactoryContext`、`SinkWriterContext`、API 级 `TaskId` 与轻量 `SinkWriterMetrics`，并在类/方法上补中文注释说明生命周期约定。 
- 改造 `SinkFactory`：将工厂接口调整为在 Job 准备阶段仅调用一次的 `createSink(SinkFactoryContext)`，并保留受限的弃用兼容方法 `createSink(ReadonlyConfig)`，该默认适配器包装旧 `SinkWriter` 并限制并行度为 1。 
- 修改准备与调度：`ConnectorPreparer` 只创建一次 `Sink` 并准备好目标表元数据，`PreparedSink` 不再持有 Writer 而是保存不可变 `Sink` 与准备结果，`JobPlanner` 强制 Job 仅包含一个 `PreparedSink`（由该 Sink 按 Task 创建 Writer）。 
- 修改执行时行为：`SinkTask` 在自己的执行生命周期中通过 `Sink.createWriter(SinkWriterContext)` 创建唯一、线程封闭的 Writer，传入 ClassLoader、`TaskId`、subtask index、parallelism 与轻量指标适配器（框架指标到 `SinkWriterMetrics`）。 
- JDBC 迁移：新增不可变 `JdbcSink`，`JdbcSinkFactory` 创建 `JdbcSink`；`JdbcSinkWriter`/`JdbcOutputFormat` 与 `JdbcConnectionProvider` 改为支持传入 `ClassLoader`，每个 Writer 拥有独立的 `JdbcOutputFormat`、`Connection` 与 PreparedStatement 缓存，避免跨 Task 共享连接。 
- 测试调整与新增：更新 `PreparedSinkTest` 验证准备阶段不再创建 Writer，并新增 `SinkWriterContextTest` 覆盖 `SinkWriterContext` 行为。 

### Testing
- 已运行 `git diff --check`，变更通过检查（成功）。
- 尝试运行 `mvn test -q -DskipTests=false` 但在 CI 环境中被阻塞，Maven Central 返回 `403 Forbidden` 导致 `maven-resources-plugin` 无法下载（失败，环境限制）。
- 尝试离线测试 `mvn -o -q -pl baize-flux-api,baize-flux-framework -am test -DskipTests=false` 但因本地缓存缺失所需插件而失败（失败，环境限制）。
- 单元测试变更包含 `PreparedSinkTest` 的断言变更和新增 `SinkWriterContextTest`，这些测试已添加到仓库但在当前环境中无法完整执行（见上两项）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6301ed04ec832699359f8aefcc4dc1)