### PR TITLE
Add multidimensional local channel backpressure

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/source/RecordBatch.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/source/RecordBatch.java
@@ -44,6 +44,8 @@ public final class RecordBatch<T> implements Serializable {
      */
     private final boolean endOfInput;
 
+    private final long estimatedBytes;
+
     private RecordBatch(
             String dataSetId,
             String splitId,
@@ -54,6 +56,7 @@ public final class RecordBatch<T> implements Serializable {
         this.splitId = splitId;
         this.records = records;
         this.endOfInput = endOfInput;
+        this.estimatedBytes = estimateRecords(records);
     }
 
     /**
@@ -97,6 +100,20 @@ public final class RecordBatch<T> implements Serializable {
 
     public List<T> getRecords() {
         return records;
+    }
+
+    /** Approximate bytes occupied by this batch's records. */
+    public long getEstimatedBytes() {
+        return estimatedBytes;
+    }
+
+    private static long estimateRecords(List<?> records) {
+        long total = 16L;
+        for (Object record : records) {
+            long size = RecordSizeEstimator.estimate(record);
+            total = total > Long.MAX_VALUE - size ? Long.MAX_VALUE : total + size;
+        }
+        return total;
     }
 
     public int size() {

--- a/baize-flux-api/src/main/java/com/baize/flux/api/source/RecordSizeEstimator.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/source/RecordSizeEstimator.java
@@ -1,0 +1,34 @@
+package com.baize.flux.api.source;
+
+import com.baize.flux.api.table.type.FluxRow;
+
+/**
+ * Stable, deliberately approximate record memory-size estimator.
+ *
+ * <p>The result is intended for backpressure accounting rather than exact JVM heap measurement.
+ */
+public interface RecordSizeEstimator<T> {
+
+    long UNKNOWN_RECORD_BYTES = 256L;
+
+    long estimateBytes(T record);
+
+    static long estimate(Object record) {
+        if (record == null) {
+            return 8L;
+        }
+        if (record instanceof FluxRow) {
+            return ((FluxRow) record).estimatedSizeBytes();
+        }
+        if (record instanceof byte[]) {
+            return 16L + ((byte[]) record).length;
+        }
+        if (record instanceof CharSequence) {
+            return 40L + 2L * ((CharSequence) record).length();
+        }
+        if (record instanceof Number || record instanceof Boolean || record instanceof Character) {
+            return 24L;
+        }
+        return UNKNOWN_RECORD_BYTES;
+    }
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/table/type/FluxRow.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/table/type/FluxRow.java
@@ -3,6 +3,9 @@ package com.baize.flux.api.table.type;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
+import java.math.BigDecimal;
+import java.time.temporal.TemporalAccessor;
+import java.util.Date;
 
 /**
  * Flux 离线数据行。
@@ -82,6 +85,30 @@ public final class FluxRow implements Serializable {
     /**
      * 复制完整数据行。
      */
+    /** Approximate bytes used by this row for channel backpressure accounting. */
+    public long estimatedSizeBytes() {
+        long total = 24L + 8L * fields.length;
+        for (Object field : fields) {
+            total = addSaturated(total, estimateFieldBytes(field));
+        }
+        return total;
+    }
+
+    private static long estimateFieldBytes(Object value) {
+        if (value == null) return 8L;
+        if (value instanceof byte[]) return 16L + ((byte[]) value).length;
+        if (value instanceof String || value instanceof Character) return 40L + 2L * value.toString().length();
+        if (value instanceof BigDecimal) return 48L + 2L * ((BigDecimal) value).precision();
+        if (value instanceof Boolean || value instanceof Byte || value instanceof Short
+                || value instanceof Integer || value instanceof Long || value instanceof Float || value instanceof Double) return 24L;
+        if (value instanceof Date || value instanceof TemporalAccessor) return 32L;
+        return 256L;
+    }
+
+    private static long addSaturated(long left, long right) {
+        return left > Long.MAX_VALUE - right ? Long.MAX_VALUE : left + right;
+    }
+
     public FluxRow copy() {
         return new FluxRow(fields, true);
     }

--- a/baize-flux-api/src/test/java/com/baize/flux/api/source/RecordSizeEstimatorTest.java
+++ b/baize-flux-api/src/test/java/com/baize/flux/api/source/RecordSizeEstimatorTest.java
@@ -1,0 +1,19 @@
+package com.baize.flux.api.source;
+
+import com.baize.flux.api.table.type.FluxRow;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RecordSizeEstimatorTest {
+    @Test public void estimatesSupportedFluxRowValuesAndBatch() {
+        FluxRow row = FluxRow.of(null, 1, true, "text", new byte[] {1, 2}, new BigDecimal("1.23"), Instant.now(), new Object());
+        long rowBytes = row.estimatedSizeBytes();
+        Assert.assertTrue(rowBytes > RecordSizeEstimator.UNKNOWN_RECORD_BYTES);
+        RecordBatch<FluxRow> batch = RecordBatch.of(split(), java.util.Collections.singletonList(row));
+        Assert.assertEquals(1, batch.size());
+        Assert.assertTrue(batch.getEstimatedBytes() >= rowBytes);
+    }
+    private static SourceSplit split() { return new SourceSplit() { public String splitId() { return "split"; } public String dataSetId() { return "data"; } }; }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/channel/LocalDataChannel.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/channel/LocalDataChannel.java
@@ -1,7 +1,8 @@
 package com.baize.flux.framework.channel;
 
+import com.baize.flux.api.source.RecordBatch;
+import com.baize.flux.api.source.RecordSizeEstimator;
 import com.baize.flux.framework.metrics.ChannelMetrics;
-
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Objects;
@@ -10,330 +11,42 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-/**
- * 基于内存的本地有界 Channel。
- *
- * <p>支持：
- *
- * <ul>
- *     <li>多个生产者</li>
- *     <li>单个消费者</li>
- *     <li>有界队列和背压</li>
- *     <li>生产者完成计数</li>
- *     <li>失败传播</li>
- *     <li>全局取消</li>
- * </ul>
- */
-public final class LocalDataChannel<T>
-        implements DataChannel<T> {
-
-    private final String channelId;
-
-    private final int capacity;
-
-    private final int expectedProducers;
-
-    private final Deque<T> buffer;
-
-    private final ReentrantLock lock;
-
-    private final Condition notEmpty;
-
-    private final Condition notFull;
-
-    private final ChannelMetrics metrics;
-
-    private int createdWriters;
-
-    private int remainingProducers;
-
-    private boolean readerOpened;
-
-    private boolean cancelled;
-
-    private Throwable failure;
-
-    public LocalDataChannel(
-            String channelId,
-            int capacity,
-            int expectedProducers) {
-
-        if (capacity <= 0) {
-            throw new IllegalArgumentException(
-                    "capacity must be greater than 0");
-        }
-
-        if (expectedProducers <= 0) {
-            throw new IllegalArgumentException(
-                    "expectedProducers must be greater than 0");
-        }
-
-        this.channelId =
-                Objects.requireNonNull(
-                        channelId,
-                        "channelId must not be null");
-
-        this.capacity = capacity;
-        this.expectedProducers = expectedProducers;
-        this.remainingProducers = expectedProducers;
-
-        this.buffer = new ArrayDeque<T>(capacity);
-        this.lock = new ReentrantLock();
-        this.notEmpty = lock.newCondition();
-        this.notFull = lock.newCondition();
-        this.metrics = new ChannelMetrics(channelId);
+/** In-memory local channel with atomic batch, record and byte backpressure. */
+public final class LocalDataChannel<T> implements DataChannel<T> {
+    private final String channelId; private final int maxBatches, expectedProducers;
+    private final long maxRecords, maxBytes, maxRecordsPerSecond, maxBytesPerSecond;
+    private final Deque<Entry<T>> buffer = new ArrayDeque<Entry<T>>();
+    private final ReentrantLock lock = new ReentrantLock(); private final Condition notEmpty=lock.newCondition(), notFull=lock.newCondition();
+    private final ChannelMetrics metrics; private int createdWriters, remainingProducers; private long bufferedRecords, bufferedBytes, nextRecordPermitNanos, nextBytePermitNanos;
+    private boolean readerOpened, cancelled; private Throwable failure;
+    public LocalDataChannel(String channelId, int capacity, int expectedProducers) { this(channelId, capacity, 0, 0, 0, 0, expectedProducers); }
+    public LocalDataChannel(String channelId, int maxBatches, long maxRecords, long maxBytes, long maxRecordsPerSecond, long maxBytesPerSecond, int expectedProducers) {
+        if (maxBatches<=0 && maxRecords<=0 && maxBytes<=0) throw new IllegalArgumentException("at least one buffer limit must be greater than 0");
+        if (expectedProducers<=0 || maxRecordsPerSecond<0 || maxBytesPerSecond<0) throw new IllegalArgumentException("invalid channel limits");
+        this.channelId=Objects.requireNonNull(channelId,"channelId must not be null"); this.maxBatches=maxBatches; this.maxRecords=maxRecords; this.maxBytes=maxBytes; this.maxRecordsPerSecond=maxRecordsPerSecond; this.maxBytesPerSecond=maxBytesPerSecond; this.expectedProducers=expectedProducers; remainingProducers=expectedProducers; metrics=new ChannelMetrics(channelId);
     }
-
-    @Override
-    public ChannelWriter<T> openWriter() {
-        lock.lock();
-
-        try {
-            ensureNotCancelledOrFailed();
-
-            if (createdWriters >= expectedProducers) {
-                throw new IllegalStateException(
-                        "Too many writers created for channel '"
-                                + channelId
-                                + "', expected="
-                                + expectedProducers);
-            }
-
-            createdWriters++;
-
-            return new LocalChannelWriter();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public ChannelReader<T> openReader() {
-        lock.lock();
-
-        try {
-            if (readerOpened) {
-                throw new IllegalStateException(
-                        "Channel '" + channelId
-                                + "' only supports one reader");
-            }
-
-            readerOpened = true;
-
-            return new LocalChannelReader();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public void fail(Throwable cause) {
-        Objects.requireNonNull(
-                cause,
-                "cause must not be null");
-
-        lock.lock();
-
-        try {
-            if (failure == null) {
-                failure = cause;
-            }
-
-            notEmpty.signalAll();
-            notFull.signalAll();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public void cancel() {
-        lock.lock();
-
-        try {
-            cancelled = true;
-
-            notEmpty.signalAll();
-            notFull.signalAll();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public ChannelMetrics getMetrics() {
-        return metrics;
-    }
-
-    @Override
-    public void close() {
-        cancel();
-    }
-
-    private void writeInternal(T value)
-            throws Exception {
-
-        Objects.requireNonNull(
-                value,
-                "channel value must not be null");
-
-        lock.lockInterruptibly();
-
-        try {
-            while (buffer.size() >= capacity
-                    && failure == null
-                    && !cancelled) {
-
-                long start = System.nanoTime();
-
-                try {
-                    notFull.await();
-                } finally {
-                    metrics.addWriteBlockedNanos(
-                            System.nanoTime() - start);
-                }
-            }
-
-            ensureNotCancelledOrFailed();
-
-            buffer.addLast(value);
-
-            metrics.recordEnqueued(buffer.size());
-
-            notEmpty.signal();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    private T readInternal()
-            throws Exception {
-
-        lock.lockInterruptibly();
-
-        try {
-            while (buffer.isEmpty()
-                    && remainingProducers > 0
-                    && failure == null
-                    && !cancelled) {
-
-                long start = System.nanoTime();
-
-                try {
-                    notEmpty.await();
-                } finally {
-                    metrics.addReadBlockedNanos(
-                            System.nanoTime() - start);
-                }
-            }
-
-            if (!buffer.isEmpty()) {
-                T value = buffer.removeFirst();
-
-                metrics.recordDequeued(buffer.size());
-
-                notFull.signal();
-
-                return value;
-            }
-
-            if (failure != null) {
-                throw new IllegalStateException(
-                        "Channel '" + channelId
-                                + "' execution failed",
-                        failure);
-            }
-
-            if (cancelled) {
-                throw new CancellationException(
-                        "Channel '" + channelId
-                                + "' has been cancelled");
-            }
-
-            /*
-             * 队列为空，并且所有生产者均已完成。
-             */
-            return null;
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    private void producerFinished() {
-        lock.lock();
-
-        try {
-            if (remainingProducers > 0) {
-                remainingProducers--;
-            }
-
-            if (remainingProducers == 0) {
-                notEmpty.signalAll();
-            }
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    private void ensureNotCancelledOrFailed() {
-        if (failure != null) {
-            throw new IllegalStateException(
-                    "Channel '" + channelId
-                            + "' execution failed",
-                    failure);
-        }
-
-        if (cancelled) {
-            throw new CancellationException(
-                    "Channel '" + channelId
-                            + "' has been cancelled");
-        }
-    }
-
-    private final class LocalChannelWriter
-            implements ChannelWriter<T> {
-
-        private final AtomicBoolean closed =
-                new AtomicBoolean(false);
-
-        @Override
-        public void write(T value)
-                throws Exception {
-
-            if (closed.get()) {
-                throw new IllegalStateException(
-                        "Channel writer has already been closed");
-            }
-
-            writeInternal(value);
-        }
-
-        @Override
-        public void fail(Throwable cause) {
-            LocalDataChannel.this.fail(cause);
-        }
-
-        @Override
-        public void close() {
-            if (closed.compareAndSet(false, true)) {
-                producerFinished();
-            }
-        }
-    }
-
-    private final class LocalChannelReader
-            implements ChannelReader<T> {
-
-        @Override
-        public T read() throws Exception {
-            return readInternal();
-        }
-    }
+    public ChannelWriter<T> openWriter(){ lock.lock(); try { ensureActive(); if(createdWriters>=expectedProducers) throw new IllegalStateException("Too many writers created for channel '"+channelId+"'"); createdWriters++; return new LocalChannelWriter(); } finally {lock.unlock();} }
+    public ChannelReader<T> openReader(){lock.lock();try {if(readerOpened) throw new IllegalStateException("Channel '"+channelId+"' only supports one reader");readerOpened=true;return new LocalChannelReader();}finally{lock.unlock();}}
+    public void fail(Throwable cause){Objects.requireNonNull(cause,"cause must not be null");lock.lock();try{if(failure==null)failure=cause;signalAll();}finally{lock.unlock();}}
+    public void cancel(){lock.lock();try{cancelled=true;signalAll();}finally{lock.unlock();}}
+    public ChannelMetrics getMetrics(){return metrics;} public void close(){cancel();}
+    private void writeInternal(T value) throws Exception { Objects.requireNonNull(value,"channel value must not be null"); Entry<T> entry=entry(value); lock.lockInterruptibly(); try {
+        boolean oversized=exceeds(entry) && buffer.isEmpty();
+        while (!canAccept(entry) && !oversized && failure==null && !cancelled) { long start=System.nanoTime(); try{notFull.await();}finally{metrics.addWriteBlockedNanos(System.nanoTime()-start);} oversized=exceeds(entry)&&buffer.isEmpty(); }
+        ensureActive(); if(oversized) metrics.recordOversizedBatch(); awaitRate(entry); ensureActive();
+        buffer.addLast(entry); bufferedRecords+=entry.records; bufferedBytes+=entry.bytes; metrics.recordEnqueued(buffer.size(), bufferedRecords, bufferedBytes); notEmpty.signal();
+    } finally {lock.unlock();} }
+    private void awaitRate(Entry<T> entry) throws InterruptedException { long now=System.nanoTime(); long due=Math.max(nextRecordPermitNanos,nextBytePermitNanos); while(due>now){ long start=System.nanoTime(); notFull.awaitNanos(due-now); metrics.addRateLimitWaitNanos(System.nanoTime()-start); ensureActive(); now=System.nanoTime(); due=Math.max(nextRecordPermitNanos,nextBytePermitNanos); }
+        now=System.nanoTime(); if(maxRecordsPerSecond>0) nextRecordPermitNanos=Math.max(now,nextRecordPermitNanos)+nanosFor(entry.records,maxRecordsPerSecond); if(maxBytesPerSecond>0) nextBytePermitNanos=Math.max(now,nextBytePermitNanos)+nanosFor(entry.bytes,maxBytesPerSecond); }
+    private static long nanosFor(long amount,long perSecond){ if(amount<=0)return 0; return amount>Long.MAX_VALUE/1_000_000_000L ? Long.MAX_VALUE : Math.max(1L, amount*1_000_000_000L/perSecond); }
+    private boolean canAccept(Entry<T> e){return (maxBatches<=0||buffer.size()+1<=maxBatches)&&(maxRecords<=0||bufferedRecords+e.records<=maxRecords)&&(maxBytes<=0||bufferedBytes+e.bytes<=maxBytes);}
+    private boolean exceeds(Entry<T> e){return (maxBatches>0&&1>maxBatches)||(maxRecords>0&&e.records>maxRecords)||(maxBytes>0&&e.bytes>maxBytes);}
+    private T readInternal() throws Exception {lock.lockInterruptibly();try{while(buffer.isEmpty()&&remainingProducers>0&&failure==null&&!cancelled){long s=System.nanoTime();try{notEmpty.await();}finally{metrics.addReadBlockedNanos(System.nanoTime()-s);}}if(!buffer.isEmpty()){Entry<T>e=buffer.removeFirst();bufferedRecords-=e.records;bufferedBytes-=e.bytes;metrics.recordDequeued(buffer.size(),bufferedRecords,bufferedBytes);notFull.signalAll();return e.value;}ensureActive();return null;}finally{lock.unlock();}}
+    private Entry<T> entry(T value){ if(value instanceof RecordEnvelope){RecordBatch<?> b=((RecordEnvelope<?>)value).getBatch();return new Entry<T>(value,b.size(),b.getEstimatedBytes());} if(value instanceof RecordBatch){RecordBatch<?>b=(RecordBatch<?>)value;return new Entry<T>(value,b.size(),b.getEstimatedBytes());}return new Entry<T>(value,1,RecordSizeEstimator.estimate(value));}
+    private void producerFinished(){lock.lock();try{if(remainingProducers>0)--remainingProducers;if(remainingProducers==0)notEmpty.signalAll();}finally{lock.unlock();}}
+    private void signalAll(){notEmpty.signalAll();notFull.signalAll();}
+    private void ensureActive(){if(failure!=null)throw new IllegalStateException("Channel '"+channelId+"' execution failed",failure);if(cancelled)throw new CancellationException("Channel '"+channelId+"' has been cancelled");}
+    private static final class Entry<E>{final E value;final long records,bytes;Entry(E value,long records,long bytes){this.value=value;this.records=records;this.bytes=bytes;}}
+    private final class LocalChannelWriter implements ChannelWriter<T>{private final AtomicBoolean closed=new AtomicBoolean();public void write(T value)throws Exception{if(closed.get())throw new IllegalStateException("Channel writer has already been closed");writeInternal(value);}public void fail(Throwable cause){LocalDataChannel.this.fail(cause);}public void close(){if(closed.compareAndSet(false,true))producerFinished();}}
+    private final class LocalChannelReader implements ChannelReader<T>{public T read()throws Exception{return readInternal();}}
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
@@ -182,7 +182,11 @@ public final class JobExecution {
                             "source-to-sink-" + i,
                             executionPlan
                                     .getExecutionConfig()
-                                    .getChannelCapacity(),
+                                    .getMaxBufferedBatches(),
+                            executionPlan.getExecutionConfig().getMaxBufferedRecords(),
+                            executionPlan.getExecutionConfig().getMaxBufferedBytes(),
+                            executionPlan.getExecutionConfig().getMaxRecordsPerSecond(),
+                            executionPlan.getExecutionConfig().getMaxBytesPerSecond(),
                             sourceTaskCount);
 
             channels.add(channel);

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/ExecutionConfig.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/ExecutionConfig.java
@@ -1,71 +1,25 @@
 package com.baize.flux.framework.job;
 
-/**
- * Framework 执行配置。
- */
+/** Framework execution configuration. A non-positive optional limit is disabled. */
 public final class ExecutionConfig {
-
     public static final int DEFAULT_BATCH_SIZE = 1_000;
-
     public static final int DEFAULT_SOURCE_PARALLELISM = 1;
-
     public static final int DEFAULT_SINK_PARALLELISM = 1;
-
     public static final int DEFAULT_CHANNEL_CAPACITY = 32;
-
-    private final int batchSize;
-
-    private final int sourceParallelism;
-
-    private final int sinkParallelism;
-
-    private final int channelCapacity;
-
-    public ExecutionConfig(
-            int batchSize,
-            int sourceParallelism,
-            int sinkParallelism,
-            int channelCapacity) {
-
-        if (batchSize <= 0) {
-            throw new IllegalArgumentException(
-                    "batchSize must be greater than 0");
-        }
-
-        if (sourceParallelism <= 0) {
-            throw new IllegalArgumentException(
-                    "sourceParallelism must be greater than 0");
-        }
-
-        if (sinkParallelism <= 0) {
-            throw new IllegalArgumentException(
-                    "sinkParallelism must be greater than 0");
-        }
-
-        if (channelCapacity <= 0) {
-            throw new IllegalArgumentException(
-                    "channelCapacity must be greater than 0");
-        }
-
-        this.batchSize = batchSize;
-        this.sourceParallelism = sourceParallelism;
-        this.sinkParallelism = sinkParallelism;
-        this.channelCapacity = channelCapacity;
+    private final int batchSize, sourceParallelism, sinkParallelism, maxBufferedBatches;
+    private final long maxBufferedRecords, maxBufferedBytes, maxRecordsPerSecond, maxBytesPerSecond;
+    public ExecutionConfig(int batchSize, int sourceParallelism, int sinkParallelism, int channelCapacity) {
+        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, 0, 0, 0, 0);
     }
-
-    public int getBatchSize() {
-        return batchSize;
+    public ExecutionConfig(int batchSize, int sourceParallelism, int sinkParallelism, int maxBufferedBatches, long maxBufferedRecords, long maxBufferedBytes, long maxRecordsPerSecond, long maxBytesPerSecond) {
+        if (batchSize <= 0 || sourceParallelism <= 0 || sinkParallelism <= 0) throw new IllegalArgumentException("batch size and parallelism must be greater than 0");
+        if (maxBufferedBatches <= 0 && maxBufferedRecords <= 0 && maxBufferedBytes <= 0) throw new IllegalArgumentException("at least one buffer limit must be greater than 0");
+        if (maxRecordsPerSecond < 0 || maxBytesPerSecond < 0) throw new IllegalArgumentException("rate limits must not be negative");
+        this.batchSize=batchSize; this.sourceParallelism=sourceParallelism; this.sinkParallelism=sinkParallelism; this.maxBufferedBatches=maxBufferedBatches;
+        this.maxBufferedRecords=maxBufferedRecords; this.maxBufferedBytes=maxBufferedBytes; this.maxRecordsPerSecond=maxRecordsPerSecond; this.maxBytesPerSecond=maxBytesPerSecond;
     }
-
-    public int getSourceParallelism() {
-        return sourceParallelism;
-    }
-
-    public int getSinkParallelism() {
-        return sinkParallelism;
-    }
-
-    public int getChannelCapacity() {
-        return channelCapacity;
-    }
+    public int getBatchSize(){return batchSize;} public int getSourceParallelism(){return sourceParallelism;} public int getSinkParallelism(){return sinkParallelism;}
+    /** Compatibility alias for max buffered batches. */ public int getChannelCapacity(){return maxBufferedBatches;}
+    public int getMaxBufferedBatches(){return maxBufferedBatches;} public long getMaxBufferedRecords(){return maxBufferedRecords;} public long getMaxBufferedBytes(){return maxBufferedBytes;}
+    public long getMaxRecordsPerSecond(){return maxRecordsPerSecond;} public long getMaxBytesPerSecond(){return maxBytesPerSecond;}
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobConfigParser.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobConfigParser.java
@@ -65,10 +65,13 @@ public final class JobConfigParser {
                         ? root.getInt("env.sink-parallelism")
                         : ExecutionConfig.DEFAULT_SINK_PARALLELISM;
 
-        int channelCapacity =
-                root.hasPath("env.channel-capacity")
-                        ? root.getInt("env.channel-capacity")
-                        : ExecutionConfig.DEFAULT_CHANNEL_CAPACITY;
+        int maxBufferedBatches = root.hasPath("env.max-buffered-batches")
+                ? root.getInt("env.max-buffered-batches")
+                : (root.hasPath("env.channel-capacity") ? root.getInt("env.channel-capacity") : ExecutionConfig.DEFAULT_CHANNEL_CAPACITY);
+        long maxBufferedRecords = readLong(root, "env.max-buffered-records");
+        long maxBufferedBytes = readLong(root, "env.max-buffered-bytes");
+        long maxRecordsPerSecond = readLong(root, "env.max-records-per-second");
+        long maxBytesPerSecond = readLong(root, "env.max-bytes-per-second");
 
         Config sourceConnectorConfig =
                 sourceConfig
@@ -95,13 +98,21 @@ public final class JobConfigParser {
                         batchSize,
                         sourceParallelism,
                         sinkParallelism,
-                        channelCapacity);
+                        maxBufferedBatches,
+                        maxBufferedRecords,
+                        maxBufferedBytes,
+                        maxRecordsPerSecond,
+                        maxBytesPerSecond);
 
         return new JobDefinition(
                 jobName,
                 source,
                 sink,
                 executionConfig);
+    }
+
+    private static long readLong(Config root, String path) {
+        return root.hasPath(path) ? root.getLong(path) : 0L;
     }
 
     private int readSourceParallelism(Config root) {

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/ChannelMetrics.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/ChannelMetrics.java
@@ -1,111 +1,57 @@
 package com.baize.flux.framework.metrics;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * Channel 运行指标。
- */
+/** Channel runtime metrics, including batch, record and byte backpressure accounting. */
 public final class ChannelMetrics {
-
     private final String channelId;
-
-    private final AtomicLong enqueuedCount =
-            new AtomicLong();
-
-    private final AtomicLong dequeuedCount =
-            new AtomicLong();
-
-    private final AtomicInteger currentSize =
-            new AtomicInteger();
-
-    private final AtomicInteger maximumSize =
-            new AtomicInteger();
-
-    private final AtomicLong writeBlockedNanos =
-            new AtomicLong();
-
-    private final AtomicLong readBlockedNanos =
-            new AtomicLong();
-
+    private final AtomicLong enqueuedCount = new AtomicLong();
+    private final AtomicLong dequeuedCount = new AtomicLong();
+    private final AtomicLong currentBatches = new AtomicLong();
+    private final AtomicLong currentRecords = new AtomicLong();
+    private final AtomicLong currentBytes = new AtomicLong();
+    private final AtomicLong maximumBatches = new AtomicLong();
+    private final AtomicLong maximumRecords = new AtomicLong();
+    private final AtomicLong maximumBytes = new AtomicLong();
+    private final AtomicLong writeBlockedNanos = new AtomicLong();
+    private final AtomicLong readBlockedNanos = new AtomicLong();
+    private final AtomicLong rateLimitWaitNanos = new AtomicLong();
+    private final AtomicLong oversizedBatches = new AtomicLong();
     private final long createdNanos = System.nanoTime();
 
-    public ChannelMetrics(String channelId) {
-        this.channelId =
-                Objects.requireNonNull(
-                        channelId,
-                        "channelId must not be null");
+    public ChannelMetrics(String channelId) { this.channelId = Objects.requireNonNull(channelId, "channelId must not be null"); }
+    public void recordEnqueued(long batches, long records, long bytes) {
+        enqueuedCount.incrementAndGet(); currentBatches.set(batches); currentRecords.set(records); currentBytes.set(bytes);
+        updateMaximum(maximumBatches, batches); updateMaximum(maximumRecords, records); updateMaximum(maximumBytes, bytes);
     }
-
-    public void recordEnqueued(int size) {
-        enqueuedCount.incrementAndGet();
-        currentSize.set(size);
-        updateMaximumSize(size);
+    public void recordDequeued(long batches, long records, long bytes) {
+        dequeuedCount.incrementAndGet(); currentBatches.set(batches); currentRecords.set(records); currentBytes.set(bytes);
     }
-
-    public void recordDequeued(int size) {
-        dequeuedCount.incrementAndGet();
-        currentSize.set(size);
-    }
-
-    public void addWriteBlockedNanos(long nanos) {
-        if (nanos > 0) {
-            writeBlockedNanos.addAndGet(nanos);
-        }
-    }
-
-    public void addReadBlockedNanos(long nanos) {
-        if (nanos > 0) {
-            readBlockedNanos.addAndGet(nanos);
-        }
-    }
-
-    private void updateMaximumSize(int size) {
-        int currentMaximum;
-
-        do {
-            currentMaximum = maximumSize.get();
-
-            if (size <= currentMaximum) {
-                return;
-            }
-        } while (!maximumSize.compareAndSet(
-                currentMaximum,
-                size));
-    }
-
-    public String getChannelId() {
-        return channelId;
-    }
-
-    public long getEnqueuedCount() {
-        return enqueuedCount.get();
-    }
-
-    public long getDequeuedCount() {
-        return dequeuedCount.get();
-    }
-
-    public int getCurrentSize() {
-        return currentSize.get();
-    }
-
-    public int getMaximumSize() {
-        return maximumSize.get();
-    }
-
-    public long getWriteBlockedMillis() {
-        return writeBlockedNanos.get() / 1_000_000L;
-    }
-
-    public long getReadBlockedMillis() {
-        return readBlockedNanos.get() / 1_000_000L;
-    }
-
-    /** Fraction of channel lifetime spent waiting on either side, capped at one. */
-    public double getBlockedRatio() {
-        long elapsed = Math.max(1L, System.nanoTime() - createdNanos);
-        return Math.min(1D, (writeBlockedNanos.get() + readBlockedNanos.get()) / (double) elapsed);
-    }
+    /** Compatibility method for old channel implementations. */
+    public void recordEnqueued(int size) { recordEnqueued(size, size, size); }
+    /** Compatibility method for old channel implementations. */
+    public void recordDequeued(int size) { recordDequeued(size, size, size); }
+    public void recordOversizedBatch() { oversizedBatches.incrementAndGet(); }
+    public void addWriteBlockedNanos(long nanos) { add(writeBlockedNanos, nanos); }
+    public void addReadBlockedNanos(long nanos) { add(readBlockedNanos, nanos); }
+    public void addRateLimitWaitNanos(long nanos) { add(rateLimitWaitNanos, nanos); }
+    private static void add(AtomicLong target, long nanos) { if (nanos > 0) target.addAndGet(nanos); }
+    private static void updateMaximum(AtomicLong maximum, long value) { long old; do { old = maximum.get(); if (value <= old) return; } while (!maximum.compareAndSet(old, value)); }
+    public String getChannelId() { return channelId; }
+    public long getEnqueuedCount() { return enqueuedCount.get(); }
+    public long getDequeuedCount() { return dequeuedCount.get(); }
+    public int getCurrentSize() { return (int) currentBatches.get(); }
+    public int getMaximumSize() { return (int) maximumBatches.get(); }
+    public long getCurrentBatches() { return currentBatches.get(); }
+    public long getCurrentRecords() { return currentRecords.get(); }
+    public long getCurrentBytes() { return currentBytes.get(); }
+    public long getMaximumBatches() { return maximumBatches.get(); }
+    public long getMaximumRecords() { return maximumRecords.get(); }
+    public long getMaximumBytes() { return maximumBytes.get(); }
+    public long getOversizedBatches() { return oversizedBatches.get(); }
+    public long getWriteBlockedMillis() { return writeBlockedNanos.get() / 1_000_000L; }
+    public long getReadBlockedMillis() { return readBlockedNanos.get() / 1_000_000L; }
+    public long getRateLimitWaitMillis() { return rateLimitWaitNanos.get() / 1_000_000L; }
+    public double getBlockedRatio() { long elapsed = Math.max(1L, System.nanoTime() - createdNanos); return Math.min(1D, (writeBlockedNanos.get() + readBlockedNanos.get()) / (double) elapsed); }
 }

--- a/baize-flux-framework/src/test/java/com/baize/flux/framework/channel/LocalDataChannelCapacityTest.java
+++ b/baize-flux-framework/src/test/java/com/baize/flux/framework/channel/LocalDataChannelCapacityTest.java
@@ -1,0 +1,32 @@
+package com.baize.flux.framework.channel;
+
+import com.baize.flux.api.source.RecordBatch;
+import com.baize.flux.api.source.SourceSplit;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LocalDataChannelCapacityTest {
+    @Test public void releasesRecordAndByteCapacityAfterRead() throws Exception {
+        RecordBatch<String> batch = RecordBatch.of(split(), Collections.singletonList("data"));
+        LocalDataChannel<RecordBatch<String>> channel = new LocalDataChannel<RecordBatch<String>>("test", 1, 1, batch.getEstimatedBytes(), 0, 0, 1);
+        ChannelWriter<RecordBatch<String>> writer = channel.openWriter();
+        ChannelReader<RecordBatch<String>> reader = channel.openReader();
+        writer.write(batch);
+        Assert.assertEquals(1, channel.getMetrics().getCurrentRecords());
+        Assert.assertEquals(batch.getEstimatedBytes(), channel.getMetrics().getCurrentBytes());
+        Assert.assertSame(batch, reader.read());
+        Assert.assertEquals(0, channel.getMetrics().getCurrentRecords());
+        Assert.assertEquals(0, channel.getMetrics().getCurrentBytes());
+        writer.close();
+    }
+    @Test public void permitsOversizedBatchOnlyWhenEmpty() throws Exception {
+        RecordBatch<String> batch = RecordBatch.of(split(), Collections.singletonList("too large"));
+        LocalDataChannel<RecordBatch<String>> channel = new LocalDataChannel<RecordBatch<String>>("test", 1, 0, 1, 0, 0, 1);
+        ChannelWriter<RecordBatch<String>> writer = channel.openWriter();
+        writer.write(batch);
+        Assert.assertEquals(1, channel.getMetrics().getOversizedBatches());
+        writer.close();
+    }
+    private static SourceSplit split() { return new SourceSplit() { public String splitId() { return "split"; } public String dataSetId() { return "data"; } }; }
+}


### PR DESCRIPTION
### Motivation

- Provide a stable, conservative record-size estimator for channel backpressure accounting so buffers can enforce byte-level limits without relying on exact JVM heap measurements. 
- Support finer-grained channel throttling and protection by adding record- and byte-level buffer limits and optional rate limits in addition to the existing batch-capacity semantics. 
- Avoid permanent blocking caused by extremely large single batches by allowing a well-defined oversized-batch admission policy and ensure accurate release of record/byte counters when batches are consumed. 

### Description

- Add `RecordSizeEstimator` (`baize-flux-api/src/main/java/com/baize/flux/api/source/RecordSizeEstimator.java`) and integrate conservative estimators for `FluxRow`, `byte[]`, `CharSequence`, numeric/boolean values, and a default unknown-size fallback. 
- Extend `FluxRow` with `estimatedSizeBytes()` and per-field heuristics covering `null`, numeric/boolean, `String`/`char`, `byte[]`, `BigDecimal`, and date/time types, and add saturated accumulation helpers. 
- Add approximate byte accounting to `RecordBatch` by storing `estimatedBytes` and exposing `getEstimatedBytes()`, computed using `RecordSizeEstimator.estimate(...)`. 
- Expand execution configuration in `ExecutionConfig` to accept `max-buffered-batches` (compatible with the legacy `env.channel-capacity`), `max-buffered-records`, `max-buffered-bytes`, `max-records-per-second`, and `max-bytes-per-second`, while keeping a compatibility alias `getChannelCapacity()`. 
- Rewrite `LocalDataChannel` to enforce atomic acceptance checks over batches, records and bytes, to compute and update `bufferedRecords`/`bufferedBytes`, to admit oversized batches only when the queue is empty, and to implement interruptible rate-limiting waits and prompt wake-up on `cancel()`/`fail()`; the channel now builds `Entry` objects (records/bytes) using `RecordBatch`/`RecordEnvelope` or `RecordSizeEstimator`. 
- Extend `ChannelMetrics` to report current and maximum batches/records/bytes, read/write blocked time, rate-limit wait time, oversized-batch counters, and provide compatibility shims for older APIs. 
- Add unit tests `RecordSizeEstimatorTest` and `LocalDataChannelCapacityTest` validating record/batch size estimation, capacity accounting, and oversized-batch admission behavior. 

### Testing

- `javac` focused compilation of the API and channel classes succeeded when compiling `RecordSizeEstimator`, `RecordBatch`, `FluxRow`, `ChannelMetrics`, channel interfaces and `LocalDataChannel`. 
- `git diff --check` produced no whitespace errors. 
- `mvn -q -pl baize-flux-framework -am test` could not complete because Maven dependency resolution failed against Maven Central (HTTP 403), so the new JUnit tests were added but not executed in the CI run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6301ef19348326b23516fa350a78e2)