### PR TITLE
Add isolated connector plugin loading with ConnectorClassLoader and ClassLoaderScope

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/connector/ConnectorDescriptor.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/connector/ConnectorDescriptor.java
@@ -1,0 +1,35 @@
+package com.baize.flux.api.connector;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable metadata used to identify a connector plugin. */
+public final class ConnectorDescriptor {
+    public enum Type { SOURCE, SINK }
+    private final String identifier;
+    private final String version;
+    private final String apiVersion;
+    private final Set<Type> types;
+    private final Set<String> requiredCapabilities;
+    private final String pluginPath;
+
+    public ConnectorDescriptor(String identifier, String version, String apiVersion,
+            Set<Type> types, Set<String> requiredCapabilities, String pluginPath) {
+        this.identifier = require(identifier, "identifier");
+        this.version = require(version, "version");
+        this.apiVersion = require(apiVersion, "apiVersion");
+        this.types = Collections.unmodifiableSet(new LinkedHashSet<Type>(Objects.requireNonNull(types, "types")));
+        this.requiredCapabilities = Collections.unmodifiableSet(new LinkedHashSet<String>(Objects.requireNonNull(requiredCapabilities, "requiredCapabilities")));
+        this.pluginPath = pluginPath;
+    }
+    private static String require(String value, String name) { if (value == null || value.trim().isEmpty()) throw new IllegalArgumentException(name + " must not be blank"); return value; }
+    public String getIdentifier() { return identifier; }
+    public String getVersion() { return version; }
+    public String getApiVersion() { return apiVersion; }
+    public Set<Type> getTypes() { return types; }
+    public Set<String> getRequiredCapabilities() { return requiredCapabilities; }
+    public String getPluginPath() { return pluginPath; }
+    public ConnectorDescriptor withPluginPath(String path) { return new ConnectorDescriptor(identifier, version, apiVersion, types, requiredCapabilities, path); }
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/factory/Factory.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/factory/Factory.java
@@ -1,5 +1,9 @@
 package com.baize.flux.api.factory;
 
+import com.baize.flux.api.connector.ConnectorDescriptor;
+
+import java.util.Collections;
+
 /**
  * Flux 插件工厂基础接口。
  * <p>
@@ -13,4 +17,11 @@ public interface Factory {
      * 例如：jdbc、mysql-cdc、file。
      */
     String factoryIdentifier();
+
+    /** Metadata for diagnostics and plugin discovery. */
+    default ConnectorDescriptor connectorDescriptor() {
+        return new ConnectorDescriptor(factoryIdentifier(), "unknown", "1",
+                Collections.<ConnectorDescriptor.Type>emptySet(),
+                Collections.<String>emptySet(), null);
+    }
 }

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkFactory.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkFactory.java
@@ -1,6 +1,7 @@
 package com.baize.flux.connector.jdbc.sink;
 
 import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.connector.ConnectorDescriptor;
 import com.baize.flux.api.configuration.util.OptionRule;
 import com.baize.flux.api.factory.SinkFactory;
 import com.baize.flux.api.sink.SinkWriter;
@@ -15,6 +16,13 @@ import com.google.auto.service.AutoService;
  */
 @AutoService(SinkFactory.class)
 public final class JdbcSinkFactory implements SinkFactory {
+    @Override
+    public ConnectorDescriptor connectorDescriptor() {
+        return new ConnectorDescriptor("jdbc", "1.0.0", "1",
+                java.util.Collections.singleton(ConnectorDescriptor.Type.SINK),
+                java.util.Collections.<String>emptySet(), null);
+    }
+
     @Override
     public String factoryIdentifier() {
         return "jdbc";

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceFactory.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceFactory.java
@@ -1,6 +1,7 @@
 package com.baize.flux.connector.jdbc.source;
 
 import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.connector.ConnectorDescriptor;
 import com.baize.flux.api.configuration.util.OptionRule;
 import com.baize.flux.api.source.SourceFactoryContext;
 import com.baize.flux.api.table.catalog.CatalogTable;
@@ -33,6 +34,13 @@ public final class JdbcSourceFactory
         implements TableSourceFactory<JdbcSourceSplit> {
 
     private static final String IDENTIFIER = "jdbc";
+
+    @Override
+    public ConnectorDescriptor connectorDescriptor() {
+        return new ConnectorDescriptor("jdbc", "1.0.0", "1",
+                java.util.Collections.singleton(ConnectorDescriptor.Type.SOURCE),
+                java.util.Collections.<String>emptySet(), null);
+    }
 
     @Override
     public String factoryIdentifier() {

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
@@ -9,6 +9,7 @@ import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.api.table.factory.TableSourceFactory;
 import com.baize.flux.framework.job.JobDefinition;
+import com.baize.flux.framework.plugin.ClassLoaderScope;
 import com.baize.flux.framework.job.SinkDefinition;
 import com.baize.flux.framework.job.SourceDefinition;
 
@@ -104,8 +105,10 @@ public final class ConnectorPreparer {
             TableSourceFactory<SplitT> factory,
             SourceFactoryContext context) throws Exception {
 
-        Source<SplitT> source =
-                factory.createSource(context);
+        Source<SplitT> source;
+        try (ClassLoaderScope ignored = ClassLoaderScope.open(factory.getClass().getClassLoader())) {
+            source = factory.createSource(context);
+        }
 
         if (source == null) {
             throw new ConnectorException(
@@ -114,8 +117,10 @@ public final class ConnectorPreparer {
                             + "' returned a null source");
         }
 
-        List<CatalogTable> catalogTables =
-                factory.discoverTableSchemas(context);
+        List<CatalogTable> catalogTables;
+        try (ClassLoaderScope ignored = ClassLoaderScope.open(factory.getClass().getClassLoader())) {
+            catalogTables = factory.discoverTableSchemas(context);
+        }
 
         Map<TablePath, CatalogTable> tableMap =
                 buildTableMap(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/FactoryRegistry.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/FactoryRegistry.java
@@ -1,197 +1,68 @@
 package com.baize.flux.framework.connector;
 
+import com.baize.flux.api.connector.ConnectorDescriptor;
 import com.baize.flux.api.factory.Factory;
 import com.baize.flux.api.factory.SinkFactory;
 import com.baize.flux.api.table.factory.TableSourceFactory;
+import com.baize.flux.framework.plugin.ConnectorClassLoader;
 
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
-/**
- * Connector Factory 注册中心。
- *
- * <p>统一负责 SourceFactory 和 SinkFactory 的 SPI 发现。
- */
-public final class FactoryRegistry {
+/** Discovers application-classpath and isolated connector-directory factories. */
+public final class FactoryRegistry implements AutoCloseable {
+    private final Map<String, TableSourceFactory<?>> sourceFactories;
+    private final Map<String, SinkFactory> sinkFactories;
+    private final List<ConnectorClassLoader> pluginLoaders;
 
-    private final Map<String, TableSourceFactory<?>>
-            sourceFactories;
-
-    private final Map<String, SinkFactory>
-            sinkFactories;
-
-    public FactoryRegistry(ClassLoader classLoader) {
-        Objects.requireNonNull(
-                classLoader,
-                "classLoader must not be null");
-
-        this.sourceFactories =
-                discoverSourceFactories(classLoader);
-
-        this.sinkFactories =
-                discoverSinkFactories(classLoader);
-    }
-
-    public static FactoryRegistry discover(
-            ClassLoader classLoader) {
-
-        ClassLoader effectiveClassLoader =
-                classLoader == null
-                        ? Thread.currentThread()
-                        .getContextClassLoader()
-                        : classLoader;
-
-        return new FactoryRegistry(
-                effectiveClassLoader);
-    }
-
-    public TableSourceFactory<?> getSourceFactory(
-            String identifier) {
-
-        String normalized = normalize(identifier);
-
-        TableSourceFactory<?> factory =
-                sourceFactories.get(normalized);
-
-        if (factory == null) {
-            throw new ConnectorException(
-                    "Could not find source factory for identifier '"
-                            + identifier
-                            + "'. Available identifiers: "
-                            + sourceFactories.keySet());
+    public FactoryRegistry(ClassLoader classLoader) { this(classLoader, Collections.<Path>emptyList()); }
+    public FactoryRegistry(ClassLoader classLoader, Path... pluginDirectories) { this(classLoader, paths(pluginDirectories)); }
+    public FactoryRegistry(ClassLoader classLoader, Iterable<Path> pluginDirectories) {
+        Objects.requireNonNull(classLoader, "classLoader must not be null");
+        Map<String, TableSourceFactory<?>> sources = new LinkedHashMap<String, TableSourceFactory<?>>();
+        Map<String, SinkFactory> sinks = new LinkedHashMap<String, SinkFactory>();
+        pluginLoaders = new ArrayList<ConnectorClassLoader>();
+        discover(classLoader, null, false, sources, sinks);
+        for (Path directory : pluginDirectories) {
+            String path = directory.toAbsolutePath().toString();
+            try {
+                ConnectorClassLoader loader = new ConnectorClassLoader(pluginUrls(directory), classLoader);
+                pluginLoaders.add(loader);
+                discover(loader, path, true, sources, sinks);
+            } catch (ConnectorException e) { close(); throw e; }
+            catch (Throwable e) { close(); throw new ConnectorException("Could not load connector plugin at " + path, e); }
         }
-
-        return factory;
+        sourceFactories = Collections.unmodifiableMap(sources); sinkFactories = Collections.unmodifiableMap(sinks);
     }
-
-    public SinkFactory getSinkFactory(
-            String identifier) {
-
-        String normalized = normalize(identifier);
-
-        SinkFactory factory =
-                sinkFactories.get(normalized);
-
-        if (factory == null) {
-            throw new ConnectorException(
-                    "Could not find sink factory for identifier '"
-                            + identifier
-                            + "'. Available identifiers: "
-                            + sinkFactories.keySet());
-        }
-
-        return factory;
-    }
-
-    private Map<String, TableSourceFactory<?>>
-    discoverSourceFactories(
-            ClassLoader classLoader) {
-
-        Map<String, TableSourceFactory<?>> result =
-                new LinkedHashMap<
-                        String,
-                        TableSourceFactory<?>>();
-
+    public static FactoryRegistry discover(ClassLoader loader) { return new FactoryRegistry(loader == null ? Thread.currentThread().getContextClassLoader() : loader); }
+    public static FactoryRegistry discover(ClassLoader loader, Path... directories) { return new FactoryRegistry(loader == null ? Thread.currentThread().getContextClassLoader() : loader, directories); }
+    public TableSourceFactory<?> getSourceFactory(String identifier) { TableSourceFactory<?> f=sourceFactories.get(normalize(identifier)); if(f==null) throw new ConnectorException("Could not find source factory for identifier '"+identifier+"'. Available identifiers: "+sourceFactories.keySet()); return f; }
+    public SinkFactory getSinkFactory(String identifier) { SinkFactory f=sinkFactories.get(normalize(identifier)); if(f==null) throw new ConnectorException("Could not find sink factory for identifier '"+identifier+"'. Available identifiers: "+sinkFactories.keySet()); return f; }
+    private void discover(ClassLoader loader, String path, boolean pluginOnly, Map<String, TableSourceFactory<?>> sources, Map<String, SinkFactory> sinks) {
         try {
-            ServiceLoader<TableSourceFactory> loader =
-                    ServiceLoader.load(
-                            TableSourceFactory.class,
-                            classLoader);
-
-            for (TableSourceFactory<?> factory : loader) {
-                putFactory(
-                        result,
-                        factory.factoryIdentifier(),
-                        factory,
-                        "source");
-            }
-
-            return Collections.unmodifiableMap(result);
-
-        } catch (ServiceConfigurationError error) {
-            throw new ConnectorException(
-                    "Could not load source factories",
-                    error);
-        }
+            for (TableSourceFactory<?> f : ServiceLoader.load(TableSourceFactory.class, loader)) if (!pluginOnly || f.getClass().getClassLoader() == loader) put(sources, f, "source", path);
+            for (SinkFactory f : ServiceLoader.load(SinkFactory.class, loader)) if (!pluginOnly || f.getClass().getClassLoader() == loader) put(sinks, f, "sink", path);
+        } catch (ServiceConfigurationError e) { throw new ConnectorException("Could not load connector factories" + (path == null ? "" : " from plugin " + path), e); }
     }
-
-    private Map<String, SinkFactory>
-    discoverSinkFactories(
-            ClassLoader classLoader) {
-
-        Map<String, SinkFactory> result =
-                new LinkedHashMap<String, SinkFactory>();
-
-        try {
-            ServiceLoader<SinkFactory> loader =
-                    ServiceLoader.load(
-                            SinkFactory.class,
-                            classLoader);
-
-            for (SinkFactory factory : loader) {
-                putFactory(
-                        result,
-                        factory.factoryIdentifier(),
-                        factory,
-                        "sink");
-            }
-
-            return Collections.unmodifiableMap(result);
-
-        } catch (ServiceConfigurationError error) {
-            throw new ConnectorException(
-                    "Could not load sink factories",
-                    error);
-        }
+    private static <T extends Factory> void put(Map<String,T> target, T factory, String kind, String path) {
+        String key=normalize(factory.factoryIdentifier()); T previous=target.put(key, factory);
+        if(previous != null) { target.put(key, previous); throw new ConnectorException("Duplicated "+kind+" factory identifier '"+factory.factoryIdentifier()+"': "+describe(previous)+" conflicts with "+describe(factory, path)); }
     }
-
-    private static <T extends Factory> void putFactory(
-            Map<String, T> factories,
-            String identifier,
-            T factory,
-            String kind) {
-
-        String normalized = normalize(identifier);
-
-        T previous =
-                factories.put(
-                        normalized,
-                        factory);
-
-        if (previous != null) {
-            throw new ConnectorException(
-                    "Duplicated "
-                            + kind
-                            + " factory identifier '"
-                            + identifier
-                            + "': "
-                            + previous.getClass().getName()
-                            + ", "
-                            + factory.getClass().getName());
-        }
-    }
-
-    private static String normalize(
-            String identifier) {
-
-        Objects.requireNonNull(
-                identifier,
-                "factory identifier must not be null");
-
-        String normalized =
-                identifier.trim()
-                        .toLowerCase(Locale.ROOT);
-
-        if (normalized.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "factory identifier must not be blank");
-        }
-
-        return normalized;
-    }
+    private static String describe(Factory f) { return describe(f, f.connectorDescriptor().getPluginPath()); }
+    private static String describe(Factory f, String discoveredPath) { ConnectorDescriptor d=f.connectorDescriptor(); String path=discoveredPath == null ? d.getPluginPath() : discoveredPath; return f.getClass().getName()+" (version "+d.getVersion()+", plugin "+(path == null ? "classpath" : path)+")"; }
+    private static URL[] pluginUrls(Path directory) throws IOException { if (!Files.isDirectory(directory)) throw new IOException("Plugin directory does not exist or is not a directory: " + directory); List<URL> urls=new ArrayList<URL>(); urls.add(directory.toUri().toURL()); try (java.util.stream.Stream<Path> stream=Files.list(directory)) { for (Path p : (Iterable<Path>)stream.filter(p -> p.getFileName().toString().endsWith(".jar"))::iterator) urls.add(p.toUri().toURL()); } return urls.toArray(new URL[urls.size()]); }
+    private static List<Path> paths(Path... dirs) { List<Path> result=new ArrayList<Path>(); if(dirs != null) Collections.addAll(result, dirs); return result; }
+    private static String normalize(String id) { Objects.requireNonNull(id,"factory identifier must not be null"); String n=id.trim().toLowerCase(Locale.ROOT); if(n.isEmpty()) throw new IllegalArgumentException("factory identifier must not be blank"); return n; }
+    @Override public void close() { for (ConnectorClassLoader loader : pluginLoaders) try { loader.close(); } catch (IOException ignored) { } pluginLoaders.clear(); }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSink.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSink.java
@@ -4,6 +4,7 @@ import com.baize.flux.api.configuration.ReadonlyConfig;
 import com.baize.flux.api.factory.SinkFactory;
 import com.baize.flux.api.sink.SinkWriter;
 import com.baize.flux.api.table.type.FluxRow;
+import com.baize.flux.framework.plugin.ClassLoaderScope;
 
 import java.util.Objects;
 
@@ -40,8 +41,9 @@ public final class PreparedSink {
                         factory,
                         "factory must not be null");
 
-        this.writer =
-                nonNullFactory.createSink(options);
+        try (ClassLoaderScope ignored = ClassLoaderScope.open(nonNullFactory.getClass().getClassLoader())) {
+            this.writer = nonNullFactory.createSink(options);
+        }
 
         if (this.writer == null) {
             throw new ConnectorException(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/LocalFluxEngine.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/LocalFluxEngine.java
@@ -9,6 +9,7 @@ import com.baize.flux.framework.planner.ExecutionPlan;
 import com.baize.flux.framework.planner.JobPlanner;
 
 import java.util.Objects;
+import java.nio.file.Path;
 
 /**
  * 本地离线 Flux 执行引擎。
@@ -20,12 +21,15 @@ public final class LocalFluxEngine
 
     private final ConnectorPreparer connectorPreparer;
 
+    private final FactoryRegistry registry;
+
     private final JobPlanner jobPlanner;
 
     public LocalFluxEngine(
             ClassLoader classLoader,
             ConnectorPreparer connectorPreparer,
-            JobPlanner jobPlanner) {
+            JobPlanner jobPlanner,
+            FactoryRegistry registry) {
 
         this.classLoader =
                 Objects.requireNonNull(
@@ -37,6 +41,8 @@ public final class LocalFluxEngine
                         connectorPreparer,
                         "connectorPreparer must not be null");
 
+        this.registry = Objects.requireNonNull(registry, "registry must not be null");
+
         this.jobPlanner =
                 Objects.requireNonNull(
                         jobPlanner,
@@ -45,6 +51,10 @@ public final class LocalFluxEngine
 
     public static LocalFluxEngine create(
             ClassLoader classLoader) {
+        return create(classLoader, new Path[0]);
+    }
+
+    public static LocalFluxEngine create(ClassLoader classLoader, Path... pluginDirectories) {
 
         ClassLoader effectiveClassLoader =
                 classLoader == null
@@ -54,7 +64,7 @@ public final class LocalFluxEngine
 
         FactoryRegistry registry =
                 FactoryRegistry.discover(
-                        effectiveClassLoader);
+                        effectiveClassLoader, pluginDirectories);
 
         ConnectorPreparer preparer =
                 new ConnectorPreparer(
@@ -67,7 +77,8 @@ public final class LocalFluxEngine
         return new LocalFluxEngine(
                 effectiveClassLoader,
                 preparer,
-                planner);
+                planner,
+                registry);
     }
 
     @Override
@@ -75,27 +86,17 @@ public final class LocalFluxEngine
             JobDefinition definition)
             throws Exception {
 
-        PreparedJob preparedJob =
-                connectorPreparer.prepare(
-                        definition);
-
-        ExecutionPlan executionPlan =
-                jobPlanner.plan(
-                        preparedJob);
-
-        JobExecution jobExecution =
-                new JobExecution(
-                        executionPlan,
-                        classLoader);
-
-        return jobExecution.execute();
+        try {
+            PreparedJob preparedJob = connectorPreparer.prepare(definition);
+            ExecutionPlan executionPlan = jobPlanner.plan(preparedJob);
+            return new JobExecution(executionPlan, classLoader).execute();
+        } finally {
+            registry.close();
+        }
     }
 
     @Override
     public void close() {
-        /*
-         * 当前 Engine 不持有长生命周期线程池。
-         * 后续支持多 Job 并发时，可在这里关闭资源。
-         */
+        registry.close();
     }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
@@ -6,6 +6,7 @@ import com.baize.flux.framework.channel.InputGate;
 import com.baize.flux.framework.channel.RecordEnvelope;
 import com.baize.flux.framework.execution.TaskContext;
 import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.plugin.ClassLoaderScope;
 import com.baize.flux.framework.planner.SinkTaskPlan;
 
 import java.util.Objects;
@@ -54,7 +55,7 @@ public final class SinkTask
 
         boolean committed = false;
 
-        try {
+        try (ClassLoaderScope ignored = ClassLoaderScope.open(plan.getPreparedSink().getWriter().getClass().getClassLoader())) {
             writer =
                     plan.getPreparedSink()
                             .getWriter();

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java
@@ -11,6 +11,7 @@ import com.baize.flux.framework.channel.RecordEnvelope;
 import com.baize.flux.framework.connector.PreparedSource;
 import com.baize.flux.framework.execution.TaskContext;
 import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.plugin.ClassLoaderScope;
 import com.baize.flux.framework.planner.SourceTaskPlan;
 
 import java.util.Map;
@@ -61,7 +62,7 @@ public final class SourceTask<
 
         Throwable failure = null;
 
-        try {
+        try (ClassLoaderScope ignored = ClassLoaderScope.open(preparedSource.getSource().getClass().getClassLoader())) {
             reader =
                     preparedSource
                             .getSource()

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/plugin/ClassLoaderScope.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/plugin/ClassLoaderScope.java
@@ -1,0 +1,10 @@
+package com.baize.flux.framework.plugin;
+
+import java.util.Objects;
+/** Temporarily installs a connector loader as the thread context class loader. */
+public final class ClassLoaderScope implements AutoCloseable {
+    private final Thread thread; private final ClassLoader previous;
+    private ClassLoaderScope(ClassLoader loader) { thread = Thread.currentThread(); previous = thread.getContextClassLoader(); thread.setContextClassLoader(Objects.requireNonNull(loader, "loader")); }
+    public static ClassLoaderScope open(ClassLoader loader) { return new ClassLoaderScope(loader); }
+    @Override public void close() { thread.setContextClassLoader(previous); }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/plugin/ConnectorClassLoader.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/plugin/ConnectorClassLoader.java
@@ -1,0 +1,27 @@
+package com.baize.flux.framework.plugin;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/** Isolates connector implementation dependencies while sharing Flux API classes. */
+public final class ConnectorClassLoader extends URLClassLoader {
+    static { registerAsParallelCapable(); }
+    public ConnectorClassLoader(URL[] urls, ClassLoader parent) { super(urls, parent); }
+    @Override protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> loaded = findLoadedClass(name);
+            if (loaded == null) {
+                if (parentFirst(name)) loaded = getParent().loadClass(name);
+                else try { loaded = findClass(name); } catch (ClassNotFoundException absent) { loaded = getParent().loadClass(name); }
+            }
+            if (resolve) resolveClass(loaded);
+            return loaded;
+        }
+    }
+    private static boolean parentFirst(String name) {
+        return name.startsWith("java.") || name.startsWith("javax.") || name.startsWith("jdk.")
+                || name.startsWith("sun.") || name.startsWith("com.baize.flux.api.")
+                || name.startsWith("org.slf4j.") || name.startsWith("org.apache.logging.")
+                || name.startsWith("org.apache.log4j.");
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide a minimal immutable `ConnectorDescriptor` to identify connector plugins (identifier, version, API version, types, capabilities, plugin path) for diagnostics and discovery. 
- Allow connectors to bring private dependency versions without contaminating the application classpath by introducing an isolated, closeable plugin `ClassLoader`. 
- Ensure connector factory creation, schema discovery, reader/writer execution and JDBC driver loading run with the connector's class loader as the thread context class loader and that the context is restored afterwards. 
- Bind plugin ClassLoader lifecycle to the Job/Engine and close plugin loaders after job completion to avoid long-lived leaked class loaders.

### Description

- Add `ConnectorDescriptor` in `baize-flux-api` and a default `connectorDescriptor()` to the `Factory` API to supply basic plugin metadata via `ConnectorDescriptor`. 
- Add `ConnectorClassLoader` (extends `URLClassLoader`) implementing a clear parent-first / child-first policy so `java.*`, Flux API and logging facades load parent-first while connector private classes prefer child-first. 
- Add `ClassLoaderScope` utility to temporarily set the thread context class loader and restore it in a `finally`/`AutoCloseable` style. 
- Extend `FactoryRegistry` to discover factories from the application classpath and zero-or-more plugin directories, creating a `ConnectorClassLoader` per plugin directory, isolating ServiceLoader discovery per loader, and producing detailed duplicate/loader-failure diagnostics that include the conflicting factory, version and plugin path; the registry implements `AutoCloseable` and closes plugin loaders on `close()`. 
- Use `ClassLoaderScope` when invoking `factory.createSource()` and `factory.discoverTableSchemas()` in `ConnectorPreparer`, and when creating sink writers (`PreparedSink`) and when executing `SourceTask`/`SinkTask` to ensure connector code runs with its class loader. 
- Make `LocalFluxEngine.create(...)` accept optional plugin directories, instantiate a `FactoryRegistry` with plugin directories, and ensure `FactoryRegistry.close()` is invoked after job execution and on engine `close()` so plugin loaders are released. 
- Provide concrete `ConnectorDescriptor` values for the built-in JDBC `Source` and `Sink` factories so classpath-discovered connectors advertise expected metadata. 

### Testing

- Ran `git diff --check` to validate whitespace/format sanity and it succeeded. 
- Attempted `./mvnw -pl baize-flux-framework -am test -DskipTests` but the wrapper invocation failed because the repository does not contain the Maven wrapper files (`.mvn/wrapper/*`). 
- Ran `mvn -pl baize-flux-framework -am test -DskipTests` and the build/test run was blocked by Maven Central returning HTTP 403 while resolving `maven-resources-plugin:3.3.1`, so no module unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6301ef35208326a15202ad984cecb8)