### PR TITLE
Add task-local sink commit semantics, commit summaries and JDBC retry guidance

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/CommitScope.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/CommitScope.java
@@ -1,0 +1,12 @@
+package com.baize.flux.api.sink;
+
+/**
+ * Scope at which a sink can make data durable.
+ *
+ * <p>{@link #TASK_LOCAL} means each SinkTask commits independently. It does not
+ * provide Job-wide atomicity or a global rollback guarantee.
+ */
+public enum CommitScope {
+
+    TASK_LOCAL
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkWriter.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/sink/SinkWriter.java
@@ -12,7 +12,8 @@ import com.baize.flux.api.table.catalog.CatalogTable;
  * open
  *   -> write
  *   -> write
- *   -> commit / rollback
+ *   -> prepareCommit
+ *   -> commit / abort
  *   -> close
  * </pre>
  */
@@ -37,16 +38,39 @@ public interface SinkWriter<T> extends AutoCloseable {
             CatalogTable sourceTable)
             throws Exception;
 
-    /**
-     * 当前 SinkTask 全部数据写入成功后提交。
-     */
+    /** Validates that this task is ready to commit; no coordinator is implied. */
+    default void prepareCommit() throws Exception {
+    }
+
+    /** Commits this SinkTask only. */
     default void commit() throws Exception {
     }
 
+    /** Aborts uncommitted work for this SinkTask only. */
+    default void abort() throws Exception {
+        rollback();
+    }
+
     /**
-     * 当前 SinkTask 执行失败时回滚。
+     * @deprecated Implement {@link #abort()} instead.
      */
+    @Deprecated
     default void rollback() throws Exception {
+    }
+
+    /**
+     * The durability boundary supplied by this writer.
+     *
+     * <p>Ordinary JDBC writers are {@link CommitScope#TASK_LOCAL}; they never
+     * claim Job-level atomicity.
+     */
+    default CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    /** Human-readable retry guidance to surface when this task has committed. */
+    default String getRetryAdvice() {
+        return "This sink commits per task; verify already committed targets before retrying.";
     }
 
     /**

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfig.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/config/JdbcSinkConfig.java
@@ -23,6 +23,8 @@ import java.util.Objects;
  * 3. commit；
  * 4. 失败时 rollback。
  * <p>
+ * 每个 SinkTask 独立提交；普通 JDBC Sink 不提供 Job 级原子性或全局回滚。
+ * <p>
  * 因此不再对外暴露 auto_commit、XA、Exactly Once 等配置。
  */
 @Getter

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkWriter.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/sink/JdbcSinkWriter.java
@@ -1,6 +1,7 @@
 package com.baize.flux.connector.jdbc.sink;
 
 import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.sink.CommitScope;
 import com.baize.flux.api.sink.PreparedSinkMetadata;
 import com.baize.flux.api.source.RecordBatch;
 import com.baize.flux.api.table.catalog.CatalogTable;
@@ -21,17 +22,18 @@ public final class JdbcSinkWriter
 
     private final JdbcOutputFormat outputFormat;
 
+    private final JdbcSinkConfig config;
+
     public JdbcSinkWriter(
             JdbcSinkConfig config,
             PreparedSinkMetadata metadata) {
 
+        this.config = Objects.requireNonNull(config, "config must not be null");
         this.outputFormat =
                 new JdbcOutputFormatBuilder()
                         .withMetadata(Objects.requireNonNull(metadata, "metadata must not be null"))
                         .withConfig(
-                                Objects.requireNonNull(
-                                        config,
-                                        "config must not be null"))
+                                this.config)
                         .build();
     }
 
@@ -63,8 +65,30 @@ public final class JdbcSinkWriter
     }
 
     @Override
-    public void rollback() throws Exception {
+    public void abort() throws Exception {
         outputFormat.rollback();
+    }
+
+    @Override
+    public CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    @Override
+    public String getRetryAdvice() {
+        if (config.getWriteMode() == com.baize.flux.connector.jdbc.config.JdbcWriteMode.UPSERT) {
+            return "JDBC UPSERT is usually safe to rerun when primary keys are stable, but safety depends on dialect semantics.";
+        }
+        switch (config.getDataSaveMode()) {
+            case APPEND_DATA:
+                return "JDBC APPEND may duplicate rows on retry; verify committed targets before rerunning.";
+            case DROP_DATA:
+                return "JDBC DROP_DATA may have cleared target data before failure; inspect and restore/reload as needed before rerunning.";
+            case CUSTOM_PROCESSING:
+                return "JDBC CUSTOM_PROCESSING retry safety is determined by the configured SQL; review its effects before rerunning.";
+            default:
+                return "JDBC retry safety depends on the configured save and write modes; verify committed targets before rerunning.";
+        }
     }
 
     @Override

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/ExecutionCoordinator.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/ExecutionCoordinator.java
@@ -1,6 +1,8 @@
 package com.baize.flux.framework.execution;
 
 import com.baize.flux.framework.execution.task.ExecutionTask;
+import com.baize.flux.framework.execution.task.SinkTask;
+import com.baize.flux.framework.job.CommitSummary;
 import com.baize.flux.framework.metrics.JobMetrics;
 import com.baize.flux.framework.metrics.TaskMetrics;
 
@@ -68,7 +70,7 @@ public final class ExecutionCoordinator {
                         "cancellationHook must not be null");
     }
 
-    public Throwable execute(
+    public ExecutionOutcome execute(
             List<ExecutionTask> sinkTasks,
             List<ExecutionTask> sourceTasks) {
 
@@ -90,7 +92,7 @@ public final class ExecutionCoordinator {
         allTasks.addAll(sourceTasks);
 
         if (allTasks.isEmpty()) {
-            return null;
+            return new ExecutionOutcome(null, CommitSummary.empty());
         }
 
         List<Future<TaskResult>> futures =
@@ -175,7 +177,36 @@ public final class ExecutionCoordinator {
                     throwable);
         }
 
-        return firstFailure;
+        return new ExecutionOutcome(firstFailure, summarizeCommits(sinkTasks));
+    }
+
+    private CommitSummary summarizeCommits(List<ExecutionTask> sinkTasks) {
+        int committed = 0;
+        String retryAdvice = "This sink commits per task; verify already committed targets before retrying.";
+        com.baize.flux.api.sink.CommitScope scope = com.baize.flux.api.sink.CommitScope.TASK_LOCAL;
+        for (ExecutionTask task : sinkTasks) {
+            if (task instanceof SinkTask) {
+                SinkTask sinkTask = (SinkTask) task;
+                if (sinkTask.isCommitted()) committed++;
+                scope = sinkTask.getCommitScope();
+                retryAdvice = sinkTask.getRetryAdvice();
+            }
+        }
+        return new CommitSummary(committed, sinkTasks.size() - committed, scope, retryAdvice);
+    }
+
+    /** Result of task coordination, including local sink commit observations. */
+    public static final class ExecutionOutcome {
+        private final Throwable failure;
+        private final CommitSummary commitSummary;
+
+        private ExecutionOutcome(Throwable failure, CommitSummary commitSummary) {
+            this.failure = failure;
+            this.commitSummary = commitSummary;
+        }
+
+        public Throwable getFailure() { return failure; }
+        public CommitSummary getCommitSummary() { return commitSummary; }
     }
 
     private void cancelAll(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
@@ -14,6 +14,7 @@ import com.baize.flux.framework.execution.task.SinkTask;
 import com.baize.flux.framework.execution.task.SourceTask;
 import com.baize.flux.framework.job.JobResult;
 import com.baize.flux.framework.job.JobStatus;
+import com.baize.flux.framework.job.CommitSummary;
 import com.baize.flux.framework.metrics.JobMetrics;
 import com.baize.flux.framework.planner.ExecutionPlan;
 import com.baize.flux.framework.planner.SinkTaskPlan;
@@ -75,6 +76,7 @@ public final class JobExecution {
                         DataChannel<RecordEnvelope<FluxRow>>>();
 
         Throwable failure = null;
+        CommitSummary commitSummary = CommitSummary.empty();
 
         try {
             int sourceTaskCount =
@@ -123,10 +125,9 @@ public final class JobExecution {
                                     }
                                 });
 
-                failure =
-                        coordinator.execute(
-                                sinkTasks,
-                                sourceTasks);
+                ExecutionCoordinator.ExecutionOutcome outcome = coordinator.execute(sinkTasks, sourceTasks);
+                failure = outcome.getFailure();
+                commitSummary = outcome.getCommitSummary();
             }
 
         } catch (Throwable throwable) {
@@ -145,7 +146,13 @@ public final class JobExecution {
 
         JobStatus status;
 
-        if (failure != null) {
+        if (commitSummary.isPartialCommit()) {
+            /* A partial task-local commit must never be presented as a successful or canceled Job. */
+            status = JobStatus.FAILED;
+            if (failure == null) {
+                failure = new IllegalStateException(commitSummary.getWarning());
+            }
+        } else if (failure != null) {
             status = JobStatus.FAILED;
         } else if (cancellationToken.isCancelled()) {
             status = JobStatus.CANCELED;
@@ -159,7 +166,8 @@ public final class JobExecution {
                 startTime,
                 System.currentTimeMillis(),
                 jobMetrics,
-                failure);
+                failure,
+                commitSummary);
     }
 
     public void cancel() {

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
@@ -1,6 +1,7 @@
 package com.baize.flux.framework.execution.task;
 
 import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.sink.CommitScope;
 import com.baize.flux.api.table.type.FluxRow;
 import com.baize.flux.framework.channel.InputGate;
 import com.baize.flux.framework.channel.RecordEnvelope;
@@ -21,6 +22,10 @@ public final class SinkTask
 
     private final InputGate<RecordEnvelope<FluxRow>>
             inputGate;
+
+    private volatile boolean committed;
+    private volatile CommitScope commitScope = CommitScope.TASK_LOCAL;
+    private volatile String retryAdvice = "This sink commits per task; verify already committed targets before retrying.";
 
     public SinkTask(
             SinkTaskPlan plan,
@@ -52,14 +57,14 @@ public final class SinkTask
 
         Throwable failure = null;
 
-        boolean committed = false;
-
         try {
             writer =
                     plan.getPreparedSink()
                             .createWriter();
 
             writer.open();
+            commitScope = writer.getCommitScope();
+            retryAdvice = writer.getRetryAdvice();
 
             while (true) {
                 /*
@@ -123,6 +128,7 @@ public final class SinkTask
             }
 
             long commitStart = System.nanoTime();
+            writer.prepareCommit();
             writer.commit();
             context.getMetrics().addDatabaseCommitNanos(System.nanoTime() - commitStart);
 
@@ -133,7 +139,7 @@ public final class SinkTask
 
             if (writer != null) {
                 try {
-                    writer.rollback();
+                    writer.abort();
                 } catch (Throwable rollbackFailure) {
                     throwable.addSuppressed(
                             rollbackFailure);
@@ -167,6 +173,12 @@ public final class SinkTask
             }
         }
     }
+
+    public boolean isCommitted() { return committed; }
+
+    public CommitScope getCommitScope() { return commitScope; }
+
+    public String getRetryAdvice() { return retryAdvice; }
 
     private static RuntimeException propagate(
             Throwable throwable)

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/CommitSummary.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/CommitSummary.java
@@ -1,0 +1,41 @@
+package com.baize.flux.framework.job;
+
+import com.baize.flux.api.sink.CommitScope;
+
+import java.util.Objects;
+
+/** Immutable summary of independently committed sink tasks. */
+public final class CommitSummary {
+
+    private final int committedTaskCount;
+    private final int failedOrUncommittedTaskCount;
+    private final boolean partialCommit;
+    private final CommitScope commitScope;
+    private final String retryAdvice;
+
+    public CommitSummary(int committedTaskCount, int failedOrUncommittedTaskCount,
+                         CommitScope commitScope, String retryAdvice) {
+        this.committedTaskCount = committedTaskCount;
+        this.failedOrUncommittedTaskCount = failedOrUncommittedTaskCount;
+        this.partialCommit = committedTaskCount > 0 && failedOrUncommittedTaskCount > 0;
+        this.commitScope = Objects.requireNonNull(commitScope, "commitScope must not be null");
+        this.retryAdvice = Objects.requireNonNull(retryAdvice, "retryAdvice must not be null");
+    }
+
+    public static CommitSummary empty() {
+        return new CommitSummary(0, 0, CommitScope.TASK_LOCAL,
+                "No sink tasks were executed.");
+    }
+
+    public int getCommittedTaskCount() { return committedTaskCount; }
+    public int getFailedOrUncommittedTaskCount() { return failedOrUncommittedTaskCount; }
+    public boolean isPartialCommit() { return partialCommit; }
+    public CommitScope getCommitScope() { return commitScope; }
+    public String getRetryAdvice() { return retryAdvice; }
+
+    /** Explicitly states why a partial task-local commit cannot be rolled back globally. */
+    public String getWarning() {
+        if (!partialCommit) return "";
+        return "Partial task-local commit detected; ordinary JDBC sinks do not provide Job-level atomicity or global rollback.";
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobResult.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobResult.java
@@ -20,6 +20,7 @@ public final class JobResult {
     private final JobMetrics metrics;
 
     private final Throwable failure;
+    private final CommitSummary commitSummary;
 
     public JobResult(
             String jobName,
@@ -28,6 +29,12 @@ public final class JobResult {
             long endTimeMillis,
             JobMetrics metrics,
             Throwable failure) {
+        this(jobName, status, startTimeMillis, endTimeMillis, metrics, failure, CommitSummary.empty());
+    }
+
+    public JobResult(
+            String jobName, JobStatus status, long startTimeMillis, long endTimeMillis,
+            JobMetrics metrics, Throwable failure, CommitSummary commitSummary) {
 
         this.jobName =
                 Objects.requireNonNull(
@@ -48,6 +55,7 @@ public final class JobResult {
                         "metrics must not be null");
 
         this.failure = failure;
+        this.commitSummary = Objects.requireNonNull(commitSummary, "commitSummary must not be null");
     }
 
     public void throwIfFailed() throws Exception {
@@ -95,6 +103,8 @@ public final class JobResult {
     public Throwable getFailure() {
         return failure;
     }
+
+    public CommitSummary getCommitSummary() { return commitSummary; }
 
     public boolean isSuccess() {
         return status == JobStatus.SUCCEEDED;

--- a/baize-flux-framework/src/test/java/com/baize/flux/framework/execution/task/SinkTaskCommitLifecycleTest.java
+++ b/baize-flux-framework/src/test/java/com/baize/flux/framework/execution/task/SinkTaskCommitLifecycleTest.java
@@ -1,0 +1,119 @@
+package com.baize.flux.framework.execution.task;
+
+import com.baize.flux.api.configuration.ReadonlyConfig;
+import com.baize.flux.api.configuration.util.OptionRule;
+import com.baize.flux.api.factory.SinkFactory;
+import com.baize.flux.api.sink.PreparedSinkMetadata;
+import com.baize.flux.api.sink.SinkWriter;
+import com.baize.flux.api.source.RecordBatch;
+import com.baize.flux.api.table.catalog.CatalogTable;
+import com.baize.flux.api.table.type.FluxRow;
+import com.baize.flux.framework.channel.ChannelReader;
+import com.baize.flux.framework.channel.InputGate;
+import com.baize.flux.framework.channel.RecordEnvelope;
+import com.baize.flux.framework.connector.PreparedSink;
+import com.baize.flux.framework.execution.CancellationToken;
+import com.baize.flux.framework.execution.TaskContext;
+import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.metrics.TaskMetrics;
+import com.baize.flux.framework.planner.SinkTaskPlan;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Regression coverage for task-local sink commit and cleanup boundaries. */
+public class SinkTaskCommitLifecycleTest {
+
+    @Test
+    public void commitsOneTaskAfterPrepare() throws Exception {
+        RecordingWriter writer = new RecordingWriter();
+        SinkTask task = task(writer, new EndReader());
+        task.execute(context());
+        assertEquals(1, writer.prepareCount);
+        assertEquals(1, writer.commitCount);
+        assertTrue(task.isCommitted());
+    }
+
+    @Test
+    public void readFailureAbortsWithoutCommitting() throws Exception {
+        RecordingWriter writer = new RecordingWriter();
+        SinkTask task = task(writer, new FailingReader());
+        try {
+            task.execute(context());
+            fail("expected failure");
+        } catch (IllegalStateException expected) {
+            assertEquals("write failed", expected.getMessage());
+        }
+        assertEquals(1, writer.abortCount);
+        assertEquals(0, writer.commitCount);
+        assertFalse(task.isCommitted());
+    }
+
+    @Test
+    public void closeFailureAfterCommitDoesNotMakeTaskRetryable() throws Exception {
+        RecordingWriter writer = new RecordingWriter();
+        writer.closeFailure = true;
+        SinkTask task = task(writer, new EndReader());
+        task.execute(context());
+        assertTrue(task.isCommitted());
+        assertEquals(1, writer.commitCount);
+    }
+
+    @Test
+    public void closeFailureDoesNotHideOriginalFailure() throws Exception {
+        RecordingWriter writer = new RecordingWriter();
+        writer.closeFailure = true;
+        try {
+            task(writer, new FailingReader()).execute(context());
+            fail("expected failure");
+        } catch (IllegalStateException expected) {
+            assertEquals("write failed", expected.getMessage());
+            assertEquals(1, expected.getSuppressed().length);
+            assertEquals("close failed", expected.getSuppressed()[0].getMessage());
+        }
+    }
+
+    private static SinkTask task(final RecordingWriter writer, ChannelReader<RecordEnvelope<FluxRow>> reader) {
+        SinkFactory factory = new SinkFactory() {
+            @Override public String factoryIdentifier() { return "test"; }
+            @Override public OptionRule optionRule() { return OptionRule.builder().build(); }
+            @Override public SinkWriter<FluxRow> createSink(ReadonlyConfig config) { return writer; }
+        };
+        PreparedSink sink = new PreparedSink("test", factory,
+                ReadonlyConfig.fromMap(Collections.<String, Object>emptyMap()),
+                new PreparedSinkMetadata(Collections.emptyMap()));
+        TaskId id = new TaskId("sink", 0, 1);
+        return new SinkTask(new SinkTaskPlan(id, sink), new InputGate<RecordEnvelope<FluxRow>>(reader));
+    }
+
+    private static TaskContext context() {
+        TaskId id = new TaskId("sink", 0, 1);
+        return new TaskContext(id, new CancellationToken(), new TaskMetrics(id),
+                SinkTaskCommitLifecycleTest.class.getClassLoader());
+    }
+
+    private static final class EndReader implements ChannelReader<RecordEnvelope<FluxRow>> {
+        @Override public RecordEnvelope<FluxRow> read() { return null; }
+    }
+    private static final class FailingReader implements ChannelReader<RecordEnvelope<FluxRow>> {
+        @Override public RecordEnvelope<FluxRow> read() { throw new IllegalStateException("write failed"); }
+    }
+    private static final class RecordingWriter implements SinkWriter<FluxRow> {
+        int prepareCount;
+        int commitCount;
+        int abortCount;
+        boolean closeFailure;
+        @Override public void write(RecordBatch<FluxRow> batch, CatalogTable table) { }
+        @Override public void prepareCommit() { prepareCount++; }
+        @Override public void commit() { commitCount++; }
+        @Override public void abort() { abortCount++; }
+        @Override public void close() {
+            if (closeFailure) throw new IllegalStateException("close failed");
+        }
+    }
+}

--- a/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java
+++ b/baize-flux-launcher/src/main/java/com/baize/flux/launcher/JobResultPrinter.java
@@ -27,6 +27,14 @@ public final class JobResultPrinter {
         line(output, "作业名称", result.getJobName());
         line(output, "执行状态", result.getStatus());
         line(output, "执行耗时（毫秒）", result.getDurationMillis());
+        line(output, "提交语义", result.getCommitSummary().getCommitScope());
+        line(output, "成功提交 SinkTask 数", result.getCommitSummary().getCommittedTaskCount());
+        line(output, "失败或未提交 SinkTask 数", result.getCommitSummary().getFailedOrUncommittedTaskCount());
+        line(output, "是否部分提交", result.getCommitSummary().isPartialCommit());
+        if (result.getCommitSummary().isPartialCommit()) {
+            line(output, "警告", result.getCommitSummary().getWarning());
+        }
+        line(output, "安全重跑建议", result.getCommitSummary().getRetryAdvice());
 
         output.println("  汇总指标：");
         output.println("    数据源：");


### PR DESCRIPTION
### Motivation

- Provide an explicit, minimal commit semantic for sinks so connectors can state the durability boundary (e.g. `CommitScope.TASK_LOCAL`) and consumers understand that ordinary JDBC sinks do not provide Job-level atomicity. 
- Make the SinkWriter lifecycle and boundaries clearer by adding `prepareCommit` / `commit` / `abort` so implementations can separate validation, local commit and abort semantics. 
- Collect per-task commit observations and expose an aggregated summary so Job-level results can surface partial-commit warnings and actionable retry advice. 
- Add focused regression tests to validate single-task commit, abort-on-write-failure, preserving original failures when close also fails, and close-after-commit behavior.

### Description

- Added `CommitScope` enum with `TASK_LOCAL` to represent the durability boundary of a sink writer. 
- Extended `SinkWriter` API with `prepareCommit()`, `abort()` (keeps `rollback()` deprecated for compatibility), `getCommitScope()` and `getRetryAdvice()` to clarify lifecycle and provide human guidance. 
- Updated `JdbcSinkWriter` to implement the new contract, expose `CommitScope.TASK_LOCAL`, and return user-facing retry advice derived from `DataSaveMode` and `JdbcWriteMode` (APPEND/UPSERT/DROP_DATA/CUSTOM_PROCESSING). 
- Enhanced `SinkTask` to call `prepareCommit()` before `commit()`, to call `abort()` on failures, and to record whether the task actually committed and the writer-provided scope/advice. 
- Introduced `CommitSummary` (immutable) and aggregated committed/uncommitted counts, partial-commit flag, commit scope and retry advice; `ExecutionCoordinator` now returns an `ExecutionOutcome` with a `CommitSummary`, and `JobExecution` attaches the `CommitSummary` to `JobResult`. 
- Changed job result handling so that a detected partial task-local commit forces `JobStatus.FAILED` and surfaces an explicit warning that ordinary JDBC sinks do not guarantee global rollback. 
- Enhanced `JobResultPrinter` to print commit semantics, committed/uncommitted sink task counts, partial-commit indicator, warning and retry guidance. 
- Added `SinkTaskCommitLifecycleTest` with cases covering: normal single-task commit after `prepareCommit`, write/read failure causing `abort()` without commit, close failure after commit not marking the task retryable, and preserving the original failure when close also fails.

### Testing

- Ran `git diff --check` to ensure no whitespace or trivial diff issues (passed). 
- Added targeted unit tests under `baize-flux-framework` (`SinkTaskCommitLifecycleTest`) to cover commit/abort/close interactions, but these tests were not executed in CI within this run. 
- Attempted a Maven verification `mvn -q -pl baize-flux-api,baize-flux-framework,baize-flux-connectors/baize-flux-connector-jdbc -am test -DskipTests`, which failed due to external dependency resolution (Maven plugin download from central returned HTTP 403), so full module build/test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6304f4b7008326b1648c0720dd906d)