### PR TITLE
Add dynamic local split assignment

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/source/SourceReader.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/source/SourceReader.java
@@ -16,6 +16,15 @@ public interface SourceReader<T, SplitT extends SourceSplit>
      */
     void open(List<SplitT> splits) throws Exception;
 
+    /** Opens task-local resources for single-split processing. */
+    default void open() throws Exception { open(java.util.Collections.<SplitT>emptyList()); }
+
+    /** Opens one split. Implementations supporting dynamic assignment must override this method. */
+    default void openSplit(SplitT split) throws Exception { throw new UnsupportedOperationException("Single-split lifecycle is not supported"); }
+
+    /** Closes the currently opened split while keeping task-local resources open. */
+    default void closeSplit() throws Exception { }
+
     /**
      * 读取下一批数据。
      * <p>

--- a/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceReader.java
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/src/main/java/com/baize/flux/connector/jdbc/source/JdbcSourceReader.java
@@ -94,6 +94,22 @@ public final class JdbcSourceReader
     }
 
     @Override
+    public void open() throws Exception {
+        open(Collections.<JdbcSourceSplit>emptyList());
+    }
+
+    @Override
+    public void openSplit(JdbcSourceSplit split) throws Exception {
+        checkOpened();
+        if (currentSplit != null) throw new IllegalStateException("A split is already open");
+        currentSplit = java.util.Objects.requireNonNull(split, "split must not be null");
+        inputFormat.open(currentSplit);
+    }
+
+    @Override
+    public void closeSplit() throws Exception { closeCurrentSplit(); }
+
+    @Override
     public RecordBatch<FluxRow> readBatch()
             throws Exception {
 

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
@@ -19,6 +19,7 @@ import com.baize.flux.framework.metrics.JobMetrics;
 import com.baize.flux.framework.planner.ExecutionPlan;
 import com.baize.flux.framework.planner.SinkTaskPlan;
 import com.baize.flux.framework.planner.SourceTaskPlan;
+import com.baize.flux.framework.execution.split.SplitProvider;
 import com.baize.flux.framework.routing.Partitioner;
 import com.baize.flux.framework.routing.SinkPartitioner;
 
@@ -100,6 +101,10 @@ public final class JobExecution {
             List<ExecutionTask> sourceTasks =
                     createSourceTasks(channels);
 
+            for (SourceTaskPlan<?> plan : executionPlan.getSourceTaskPlans()) {
+                jobMetrics.registerSplitProvider(plan.getSplitProvider());
+            }
+
             int totalTaskCount =
                     sinkTasks.size()
                             + sourceTasks.size();
@@ -118,10 +123,8 @@ public final class JobExecution {
                                 new Runnable() {
                                     @Override
                                     public void run() {
-                                        failChannels(
-                                                channels,
-                                                cancellationToken
-                                                        .getCause());
+                                        failChannels(channels, cancellationToken.getCause());
+                                        cancelSplitProviders(executionPlan.getSourceTaskPlans(), cancellationToken.getCause());
                                     }
                                 });
 
@@ -174,6 +177,12 @@ public final class JobExecution {
         cancellationToken.cancel(
                 new java.util.concurrent.CancellationException(
                         "Job was cancelled by caller"));
+    }
+
+    private static void cancelSplitProviders(List<SourceTaskPlan<?>> plans, Throwable cause) {
+        java.util.HashSet<SplitProvider<?>> providers = new java.util.HashSet<SplitProvider<?>>();
+        for (SourceTaskPlan<?> plan : plans) if (plan.getSplitProvider() != null) providers.add(plan.getSplitProvider());
+        for (SplitProvider<?> provider : providers) provider.cancel(cause);
     }
 
     private void createChannels(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/split/LocalSplitQueue.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/split/LocalSplitQueue.java
@@ -1,0 +1,51 @@
+package com.baize.flux.framework.execution.split;
+
+import com.baize.flux.api.source.SourceSplit;
+import com.baize.flux.framework.execution.CancellationToken;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Local blocking split provider. A split has exactly one terminal completion. */
+public final class LocalSplitQueue<SplitT extends SourceSplit> implements SplitProvider<SplitT> {
+    private enum State { PENDING, RUNNING, COMPLETED, FAILED }
+    private final ArrayDeque<SplitT> pending = new ArrayDeque<SplitT>();
+    private final Map<String, State> states = new HashMap<String, State>();
+    private boolean cancelled;
+
+    public LocalSplitQueue(Collection<SplitT> splits) {
+        Objects.requireNonNull(splits, "splits must not be null");
+        for (SplitT split : splits) {
+            if (split == null || split.splitId() == null || states.put(split.splitId(), State.PENDING) != null) {
+                throw new IllegalArgumentException("splits must have unique non-null IDs");
+            }
+            pending.add(split);
+        }
+    }
+    @Override public synchronized SplitT acquire(CancellationToken token) throws InterruptedException {
+        while (pending.isEmpty() && !isTerminal() && !cancelled && !token.isCancelled()) wait();
+        if (cancelled || token.isCancelled() || Thread.currentThread().isInterrupted()) return null;
+        SplitT split = pending.poll();
+        if (split != null) states.put(split.splitId(), State.RUNNING);
+        return split;
+    }
+    @Override public synchronized void complete(SplitT split) { transition(split, State.COMPLETED); }
+    @Override public synchronized void fail(SplitT split, Throwable cause) { transition(split, State.FAILED); }
+    @Override public synchronized void returnSplit(SplitT split) {
+        requireRunning(split); states.put(split.splitId(), State.PENDING); pending.addFirst(split); notifyAll();
+    }
+    @Override public synchronized void cancel(Throwable cause) { cancelled = true; notifyAll(); }
+    private void transition(SplitT split, State target) { requireRunning(split); states.put(split.splitId(), target); notifyAll(); }
+    private void requireRunning(SplitT split) {
+        if (split == null || states.get(split.splitId()) != State.RUNNING) throw new IllegalStateException("Split is not running: " + (split == null ? null : split.splitId()));
+    }
+    private boolean isTerminal() { for (State state : states.values()) if (state == State.PENDING || state == State.RUNNING) return false; return true; }
+    @Override public synchronized long getTotalSplitCount() { return states.size(); }
+    @Override public synchronized long getPendingSplitCount() { return count(State.PENDING); }
+    @Override public synchronized long getRunningSplitCount() { return count(State.RUNNING); }
+    @Override public synchronized long getCompletedSplitCount() { return count(State.COMPLETED); }
+    @Override public synchronized long getFailedSplitCount() { return count(State.FAILED); }
+    private long count(State state) { long n=0; for (State value: states.values()) if(value==state)n++; return n; }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/split/SplitProvider.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/split/SplitProvider.java
@@ -1,0 +1,18 @@
+package com.baize.flux.framework.execution.split;
+
+import com.baize.flux.api.source.SourceSplit;
+import com.baize.flux.framework.execution.CancellationToken;
+
+/** Thread-safe ownership lifecycle for source splits. */
+public interface SplitProvider<SplitT extends SourceSplit> {
+    SplitT acquire(CancellationToken cancellationToken) throws InterruptedException;
+    void complete(SplitT split);
+    void returnSplit(SplitT split);
+    void fail(SplitT split, Throwable cause);
+    void cancel(Throwable cause);
+    long getTotalSplitCount();
+    long getPendingSplitCount();
+    long getRunningSplitCount();
+    long getCompletedSplitCount();
+    long getFailedSplitCount();
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java
@@ -12,6 +12,7 @@ import com.baize.flux.framework.connector.PreparedSource;
 import com.baize.flux.framework.execution.TaskContext;
 import com.baize.flux.framework.execution.TaskId;
 import com.baize.flux.framework.planner.SourceTaskPlan;
+import com.baize.flux.framework.execution.split.SplitProvider;
 
 import java.util.Map;
 import java.util.Objects;
@@ -74,14 +75,17 @@ public final class SourceTask<
                         "Source returned a null reader");
             }
 
+            SplitProvider<SplitT> provider = plan.getSplitProvider();
+            if (provider != null) {
+                executeDynamically(reader, provider, context, preparedSource);
+                return;
+            }
+
+            context.getMetrics().setTotalSplitCount(plan.getSplits().size());
             reader.open(plan.getSplits());
 
-            while (!context
-                    .getCancellationToken()
-                    .isCancelled()) {
-
-                RecordBatch<FluxRow> batch =
-                        reader.readBatch();
+            while (!context.getCancellationToken().isCancelled()) {
+                RecordBatch<FluxRow> batch = reader.readBatch();
 
                 if (batch == null) {
                     throw new IllegalStateException(
@@ -156,6 +160,49 @@ public final class SourceTask<
 
                 throw propagate(
                         closeFailure);
+            }
+        }
+    }
+
+    private void executeDynamically(SourceReader<FluxRow, SplitT> reader, SplitProvider<SplitT> provider,
+            TaskContext context, PreparedSource<SplitT> preparedSource) throws Exception {
+        reader.open();
+        while (!context.getCancellationToken().isCancelled()) {
+            SplitT split = provider.acquire(context.getCancellationToken());
+            if (split == null) return;
+            context.getMetrics().markSplitRunning();
+            boolean completed = false;
+            try {
+                reader.openSplit(split);
+                while (!context.getCancellationToken().isCancelled()) {
+                    RecordBatch<FluxRow> batch = reader.readBatch();
+                    if (batch == null) throw new IllegalStateException("SourceReader returned a null RecordBatch");
+                    if (batch.isEndOfInput()) { completed = true; break; }
+                    context.getMetrics().setCurrentPosition(batch.getDataSetId(), batch.getSplitId());
+                    context.getMetrics().incrementBatchCount();
+                    context.getMetrics().addSourceReadRecords(batch.getRecords().size());
+                    outputGate.write(createEnvelope(batch, preparedSource.getTables()));
+                }
+            } catch (Throwable failure) {
+                provider.fail(split, failure);
+                context.getMetrics().markSplitFailed();
+                try {
+                    reader.closeSplit();
+                } catch (Throwable closeFailure) {
+                    failure.addSuppressed(closeFailure);
+                }
+                throw failure;
+            } finally {
+                if (completed) reader.closeSplit();
+            }
+            if (completed) {
+                provider.complete(split);
+                context.getMetrics().markSplitFinished();
+                context.getMetrics().markSplitCompleted(split.splitId());
+            } else {
+                provider.returnSplit(split);
+                context.getMetrics().markSplitFinished();
+                return;
             }
         }
     }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/ExecutionConfig.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/ExecutionConfig.java
@@ -23,46 +23,37 @@ public final class ExecutionConfig {
 
     private final SinkPartitionStrategy sinkPartitionStrategy;
 
+    private final SplitAssignmentMode splitAssignmentMode;
+
     public ExecutionConfig(
             int batchSize,
             int sourceParallelism,
             int sinkParallelism,
             int channelCapacity) {
-        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, SinkPartitionStrategy.TABLE_AFFINITY);
+        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, SinkPartitionStrategy.TABLE_AFFINITY, SplitAssignmentMode.STATIC_ROUND_ROBIN);
     }
 
     public ExecutionConfig(
-            int batchSize,
-            int sourceParallelism,
-            int sinkParallelism,
-            int channelCapacity,
+            int batchSize, int sourceParallelism, int sinkParallelism, int channelCapacity,
             SinkPartitionStrategy sinkPartitionStrategy) {
+        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, sinkPartitionStrategy, SplitAssignmentMode.STATIC_ROUND_ROBIN);
+    }
 
-        if (batchSize <= 0) {
-            throw new IllegalArgumentException(
-                    "batchSize must be greater than 0");
-        }
+    public ExecutionConfig(
+            int batchSize, int sourceParallelism, int sinkParallelism, int channelCapacity,
+            SinkPartitionStrategy sinkPartitionStrategy, SplitAssignmentMode splitAssignmentMode) {
 
-        if (sourceParallelism <= 0) {
-            throw new IllegalArgumentException(
-                    "sourceParallelism must be greater than 0");
-        }
-
-        if (sinkParallelism <= 0) {
-            throw new IllegalArgumentException(
-                    "sinkParallelism must be greater than 0");
-        }
-
-        if (channelCapacity <= 0) {
-            throw new IllegalArgumentException(
-                    "channelCapacity must be greater than 0");
-        }
+        if (batchSize <= 0) { throw new IllegalArgumentException("batchSize must be greater than 0"); }
+        if (sourceParallelism <= 0) { throw new IllegalArgumentException("sourceParallelism must be greater than 0"); }
+        if (sinkParallelism <= 0) { throw new IllegalArgumentException("sinkParallelism must be greater than 0"); }
+        if (channelCapacity <= 0) { throw new IllegalArgumentException("channelCapacity must be greater than 0"); }
 
         this.batchSize = batchSize;
         this.sourceParallelism = sourceParallelism;
         this.sinkParallelism = sinkParallelism;
         this.channelCapacity = channelCapacity;
         this.sinkPartitionStrategy = sinkPartitionStrategy == null ? SinkPartitionStrategy.TABLE_AFFINITY : sinkPartitionStrategy;
+        this.splitAssignmentMode = splitAssignmentMode == null ? SplitAssignmentMode.STATIC_ROUND_ROBIN : splitAssignmentMode;
     }
 
     public int getBatchSize() {
@@ -80,6 +71,8 @@ public final class ExecutionConfig {
     public int getChannelCapacity() {
         return channelCapacity;
     }
+
+    public SplitAssignmentMode getSplitAssignmentMode() { return splitAssignmentMode; }
 
     public SinkPartitionStrategy getSinkPartitionStrategy() {
         return sinkPartitionStrategy;

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobConfigParser.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobConfigParser.java
@@ -2,6 +2,7 @@ package com.baize.flux.framework.job;
 
 import com.baize.flux.api.configuration.ReadonlyConfig;
 import com.typesafe.config.Config;
+import com.baize.flux.framework.job.SplitAssignmentMode;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigResolveOptions;
 
@@ -94,13 +95,12 @@ public final class JobConfigParser {
                 ? SinkPartitionStrategy.valueOf(root.getString("env.sink-partition-strategy").trim().toUpperCase(java.util.Locale.ROOT))
                 : SinkPartitionStrategy.TABLE_AFFINITY;
 
-        ExecutionConfig executionConfig =
-                new ExecutionConfig(
-                        batchSize,
-                        sourceParallelism,
-                        sinkParallelism,
-                        channelCapacity,
-                sinkPartitionStrategy);
+        SplitAssignmentMode splitAssignmentMode = root.hasPath("env.split-assignment-mode")
+                ? SplitAssignmentMode.valueOf(root.getString("env.split-assignment-mode").trim().toUpperCase(java.util.Locale.ROOT))
+                : SplitAssignmentMode.STATIC_ROUND_ROBIN;
+
+        ExecutionConfig executionConfig = new ExecutionConfig(batchSize, sourceParallelism, sinkParallelism,
+                channelCapacity, sinkPartitionStrategy, splitAssignmentMode);
 
         return new JobDefinition(
                 jobName,

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/SplitAssignmentMode.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/SplitAssignmentMode.java
@@ -1,0 +1,7 @@
+package com.baize.flux.framework.job;
+
+/** Source split assignment strategy. */
+public enum SplitAssignmentMode {
+    STATIC_ROUND_ROBIN,
+    DYNAMIC
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/JobMetrics.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/JobMetrics.java
@@ -1,6 +1,7 @@
 package com.baize.flux.framework.metrics;
 
 import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.execution.split.SplitProvider;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -18,6 +19,8 @@ public final class JobMetrics {
     private final Map<TaskId, TaskMetrics> taskMetrics =
             new ConcurrentHashMap<TaskId, TaskMetrics>();
 
+    private final List<SplitProvider<?>> splitProviders = new CopyOnWriteArrayList<SplitProvider<?>>();
+
     private final List<ChannelMetrics> channelMetrics =
             new CopyOnWriteArrayList<ChannelMetrics>();
 
@@ -34,6 +37,14 @@ public final class JobMetrics {
                 ? created
                 : previous;
     }
+
+    public void registerSplitProvider(SplitProvider<?> provider) { if (provider != null && !splitProviders.contains(provider)) splitProviders.add(provider); }
+    public long getTotalSplitCount() { return splitProviders.isEmpty() ? sumSplits(0) : splitCount(0); }
+    public long getPendingSplitCount() { return splitProviders.isEmpty() ? sumSplits(1) : splitCount(1); }
+    public long getRunningSplitCount() { return splitProviders.isEmpty() ? sumSplits(2) : splitCount(2); }
+    public long getFailedSplitCount() { return splitProviders.isEmpty() ? sumSplits(4) : splitCount(4); }
+    private long sumSplits(int type) { long total=0L; for (TaskMetrics m : taskMetrics.values()) { if (!"source".equals(m.getTaskId().getStageName())) continue; total += type == 0 ? m.getTotalSplitCount() : type == 1 ? m.getPendingSplitCount() : type == 2 ? m.getRunningSplitCount() : m.getFailedSplitCount(); } return total; }
+    private long splitCount(int type) { long total = 0L; for (SplitProvider<?> p : splitProviders) { total += type == 0 ? p.getTotalSplitCount() : type == 1 ? p.getPendingSplitCount() : type == 2 ? p.getRunningSplitCount() : p.getFailedSplitCount(); } return total; }
 
     public void registerChannel(
             ChannelMetrics metrics) {
@@ -78,7 +89,7 @@ public final class JobMetrics {
     public long getSkippedRecordCount() { return sumMetric(null, Metric.SKIPPED_RECORDS); }
     public long getSourceReadBytes() { return sumMetric("source", Metric.SOURCE_BYTES); }
     public long getSinkWrittenBytes() { return sumMetric("sink", Metric.SINK_BYTES); }
-    public long getCompletedSplitCount() { return sumMetric("source", Metric.COMPLETED_SPLITS); }
+    public long getCompletedSplitCount() { return splitProviders.isEmpty() ? sumMetric("source", Metric.COMPLETED_SPLITS) : splitCount(3); }
     public long getBatchRetryCount() { return sumMetric(null, Metric.BATCH_RETRIES); }
     public long getDatabaseCommitMillis() { return sumMetric("sink", Metric.COMMIT_MILLIS); }
     public long getSqlExecutionMillis() { return sumMetric(null, Metric.SQL_MILLIS); }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/TaskMetrics.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/TaskMetrics.java
@@ -36,6 +36,9 @@ public final class TaskMetrics {
     private final AtomicLong databaseCommitNanos = new AtomicLong();
     private final AtomicLong sqlExecutionNanos = new AtomicLong();
     private final AtomicLong completedSplitCount = new AtomicLong();
+    private final AtomicLong totalSplitCount = new AtomicLong();
+    private final AtomicLong runningSplitCount = new AtomicLong();
+    private final AtomicLong failedSplitCount = new AtomicLong();
     private final Set<String> completedSplits = ConcurrentHashMap.newKeySet();
 
     private volatile String currentTable;
@@ -97,6 +100,11 @@ public final class TaskMetrics {
         currentSplit = split;
     }
 
+    public void setTotalSplitCount(long count) { totalSplitCount.set(Math.max(0L, count)); }
+    public void markSplitRunning() { runningSplitCount.incrementAndGet(); }
+    public void markSplitFinished() { if (runningSplitCount.get() > 0L) runningSplitCount.decrementAndGet(); }
+    public void markSplitFailed() { markSplitFinished(); failedSplitCount.incrementAndGet(); }
+
     /** Marks a split completed once; repeated notifications are intentionally idempotent. */
     public void markSplitCompleted(String splitId) {
         if (splitId != null && completedSplits.add(splitId)) {
@@ -139,6 +147,10 @@ public final class TaskMetrics {
     public String getCurrentTable() { return currentTable; }
     public String getCurrentSplit() { return currentSplit; }
     public long getCompletedSplitCount() { return completedSplitCount.get(); }
+    public long getTotalSplitCount() { return totalSplitCount.get(); }
+    public long getPendingSplitCount() { return Math.max(0L, totalSplitCount.get() - runningSplitCount.get() - completedSplitCount.get() - failedSplitCount.get()); }
+    public long getRunningSplitCount() { return runningSplitCount.get(); }
+    public long getFailedSplitCount() { return failedSplitCount.get(); }
     public long getExpectedRecordCount() { return expectedRecordCount; }
 
     /** Rows per second since start, using source rows when available and sink rows otherwise. */

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/JobPlanner.java
@@ -7,6 +7,9 @@ import com.baize.flux.framework.connector.PreparedSink;
 import com.baize.flux.framework.connector.PreparedSource;
 import com.baize.flux.framework.execution.TaskId;
 import com.baize.flux.framework.job.ExecutionConfig;
+import com.baize.flux.framework.job.SplitAssignmentMode;
+import com.baize.flux.framework.execution.split.LocalSplitQueue;
+import com.baize.flux.framework.execution.split.SplitProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -66,9 +69,10 @@ public final class JobPlanner {
         }
 
         List<List<SplitT>> assignments =
-                splitAssigner.assign(
-                        splits,
-                        config.getSourceParallelism());
+                splitAssigner.assign(splits, config.getSourceParallelism());
+
+        SplitProvider<SplitT> sharedProvider = config.getSplitAssignmentMode() == SplitAssignmentMode.DYNAMIC
+                ? new LocalSplitQueue<SplitT>(splits) : null;
 
         List<SourceTaskPlan<?>> sourcePlans =
                 new ArrayList<SourceTaskPlan<?>>();
@@ -88,7 +92,8 @@ public final class JobPlanner {
                             taskId,
                             preparedSource,
                             assignments.get(i),
-                            config.getBatchSize()));
+                            config.getBatchSize(),
+                            sharedProvider));
         }
 
         List<SinkTaskPlan> sinkPlans =

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/SourceTaskPlan.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/planner/SourceTaskPlan.java
@@ -3,6 +3,7 @@ package com.baize.flux.framework.planner;
 import com.baize.flux.api.source.SourceSplit;
 import com.baize.flux.framework.connector.PreparedSource;
 import com.baize.flux.framework.execution.TaskId;
+import com.baize.flux.framework.execution.split.SplitProvider;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,11 +24,17 @@ public final class SourceTaskPlan<
 
     private final int batchSize;
 
+    private final SplitProvider<SplitT> splitProvider;
+
     public SourceTaskPlan(
             TaskId taskId,
             PreparedSource<SplitT> preparedSource,
             List<SplitT> splits,
             int batchSize) {
+        this(taskId, preparedSource, splits, batchSize, null);
+    }
+
+    public SourceTaskPlan(TaskId taskId, PreparedSource<SplitT> preparedSource, List<SplitT> splits, int batchSize, SplitProvider<SplitT> splitProvider) {
 
         if (batchSize <= 0) {
             throw new IllegalArgumentException(
@@ -52,6 +59,7 @@ public final class SourceTaskPlan<
                                         "splits must not be null")));
 
         this.batchSize = batchSize;
+        this.splitProvider = splitProvider;
     }
 
     public TaskId getTaskId() {
@@ -65,6 +73,8 @@ public final class SourceTaskPlan<
     public List<SplitT> getSplits() {
         return splits;
     }
+
+    public SplitProvider<SplitT> getSplitProvider() { return splitProvider; }
 
     public int getBatchSize() {
         return batchSize;


### PR DESCRIPTION
### Motivation
- Enable dynamic, thread-safe assignment of source splits so SourceTasks can claim and process splits concurrently rather than holding a static split list. 
- Preserve existing static round-robin behavior by default while making dynamic assignment configurable via runtime config. 
- Provide a single-split lifecycle for readers so connectors can reuse task-local resources while opening/closing per-split resources. 
- Expose split lifecycle counts in Task/Job metrics to observe pending/running/completed/failed split state.

### Description
- Add a `SplitProvider` interface and a `LocalSplitQueue` implementation implementing blocking `acquire`, `complete`, `returnSplit`, `fail`, `cancel` and lifecycle counters to ensure each split has exactly one terminal completion (`baize-flux-framework/src/main/java/com/baize/flux/framework/execution/split/`).
- Add `SplitAssignmentMode` and extend `ExecutionConfig` to include `split-assignment-mode` with default `STATIC_ROUND_ROBIN`, and parse `env.split-assignment-mode` in `JobConfigParser` (`baize-flux-framework/src/main/java/com/baize/flux/framework/job/`).
- Make `JobPlanner` create a shared `LocalSplitQueue` when `DYNAMIC` mode is selected and inject it into `SourceTaskPlan`s so tasks can share a provider (`baize-flux-framework/src/main/java/com/baize/flux/framework/planner/`).
- Evolve `SourceReader` with optional single-split lifecycle methods (`open()`, `openSplit(split)`, `closeSplit()`), adapt `JdbcSourceReader` to support per-split open/close while reusing task-local `InputFormat` and connections, and add `SourceTask` dynamic execution path that `acquire`s splits, processes them one-by-one, and reports lifecycle events (`baize-flux-api` and `baize-flux-connectors/baize-flux-connector-jdbc` and `baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java`).
- Extend `TaskMetrics` with split counters (`total`, `pending`, `running`, `completed`, `failed`) and update `JobMetrics` to aggregate either per-task metrics or directly from registered `SplitProvider`s, and register split providers from `JobExecution`; also cancel providers on job failure/cancel to wake waiting threads (`baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/` and `.../execution/JobExecution.java`).

### Testing
- `javac` compilation of the new split provider and dependent classes succeeded when compiling selected sources: `javac -d /tmp/flux-compile ... SplitProvider.java LocalSplitQueue.java CancellationToken.java SourceSplit.java` (success).
- Per-repo `git diff --check` and syntax checks were performed and local code formatting/compilation smoke checks passed (`git diff --check` returned no immediate errors).
- Full Maven build/verification was attempted but failed due to external dependency resolution being blocked by Maven Central returning HTTP 403, and offline Maven retry failed because the required plugin artifacts were not available in the local cache, so full integration tests were not executed (Maven plugin resolution error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63068f242c832696bd5a3d12d70c44)