### PR TITLE
Add record-aware channel backpressure controls and record size estimator

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/channel/FluxRowBatch.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/channel/FluxRowBatch.java
@@ -1,6 +1,7 @@
 package com.baize.flux.api.channel;
 
 import com.baize.flux.api.table.type.FluxRow;
+import com.baize.flux.api.source.RecordSizeEstimator;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -63,6 +64,14 @@ public final class FluxRowBatch implements Serializable {
 
     public int size() {
         return rows.size();
+    }
+
+    public long getEstimatedBytes() {
+        long total = 32L;
+        for (FluxRow row : rows) {
+            total += RecordSizeEstimator.estimateObjectSizeBytes(row);
+        }
+        return total;
     }
 
     public boolean isEndOfInput() {

--- a/baize-flux-api/src/main/java/com/baize/flux/api/source/RecordBatch.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/source/RecordBatch.java
@@ -103,6 +103,27 @@ public final class RecordBatch<T> implements Serializable {
         return records.size();
     }
 
+    /** Estimates this batch using the supplied stable record estimator. */
+    public long estimatedSizeBytes(RecordSizeEstimator<? super T> estimator) {
+        Objects.requireNonNull(estimator, "estimator must not be null");
+        long total = 32L;
+        for (T record : records) {
+            long estimate = estimator.estimateSizeBytes(record);
+            total += Math.max(0L, estimate);
+        }
+        return total;
+    }
+
+    /** Estimates bytes with the public conservative default estimator. */
+    public long getEstimatedBytes() {
+        return estimatedSizeBytes(new RecordSizeEstimator<T>() {
+            @Override
+            public long estimateSizeBytes(T record) {
+                return RecordSizeEstimator.estimateObjectSizeBytes(record);
+            }
+        });
+    }
+
     public boolean isEndOfInput() {
         return endOfInput;
     }

--- a/baize-flux-api/src/main/java/com/baize/flux/api/source/RecordSizeEstimator.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/source/RecordSizeEstimator.java
@@ -1,0 +1,42 @@
+package com.baize.flux.api.source;
+
+import com.baize.flux.api.table.type.FluxRow;
+
+import java.math.BigDecimal;
+import java.time.temporal.TemporalAccessor;
+import java.util.Date;
+
+/**
+ * A stable, deliberately approximate estimate of the memory occupied by a record.
+ *
+ * <p>The estimate is intended for channel backpressure, not for accounting or serialization.
+ */
+@FunctionalInterface
+public interface RecordSizeEstimator<T> {
+
+    long UNKNOWN_RECORD_BYTES = 256L;
+
+    long estimateSizeBytes(T record);
+
+    static RecordSizeEstimator<FluxRow> fluxRowEstimator() {
+        return FluxRow::estimatedSizeBytes;
+    }
+
+    /** Estimates common JVM values and uses a conservative value for unknown objects. */
+    static long estimateObjectSizeBytes(Object value) {
+        if (value == null) return 4L;
+        if (value instanceof Boolean || value instanceof Byte) return 16L;
+        if (value instanceof Character || value instanceof Short) return 16L;
+        if (value instanceof Integer || value instanceof Float) return 16L;
+        if (value instanceof Long || value instanceof Double) return 24L;
+        if (value instanceof String) return 40L + ((String) value).length() * 2L;
+        if (value instanceof byte[]) return 24L + ((byte[]) value).length;
+        if (value instanceof BigDecimal) {
+            BigDecimal decimal = (BigDecimal) value;
+            return 48L + Math.max(16L, decimal.unscaledValue().toByteArray().length);
+        }
+        if (value instanceof Date || value instanceof TemporalAccessor) return 32L;
+        if (value instanceof FluxRow) return ((FluxRow) value).estimatedSizeBytes();
+        return UNKNOWN_RECORD_BYTES;
+    }
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/table/type/FluxRow.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/table/type/FluxRow.java
@@ -1,5 +1,7 @@
 package com.baize.flux.api.table.type;
 
+import com.baize.flux.api.source.RecordSizeEstimator;
+
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
@@ -84,6 +86,15 @@ public final class FluxRow implements Serializable {
      */
     public FluxRow copy() {
         return new FluxRow(fields, true);
+    }
+
+    /** Returns a stable approximate size for backpressure accounting. */
+    public long estimatedSizeBytes() {
+        long size = 24L + 16L + fields.length * 8L;
+        for (Object field : fields) {
+            size += RecordSizeEstimator.estimateObjectSizeBytes(field);
+        }
+        return size;
     }
 
     /**

--- a/baize-flux-api/src/test/java/com/baize/flux/api/source/RecordSizeEstimatorTest.java
+++ b/baize-flux-api/src/test/java/com/baize/flux/api/source/RecordSizeEstimatorTest.java
@@ -1,0 +1,37 @@
+package com.baize.flux.api.source;
+
+import com.baize.flux.api.table.type.FluxRow;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+
+import static org.junit.Assert.assertTrue;
+
+public class RecordSizeEstimatorTest {
+
+    @Test
+    public void estimatesSupportedFluxRowValuesAndUnknownValues() {
+        FluxRow row = FluxRow.of(null, 42, true, "text", new byte[12],
+                new BigDecimal("12.34"), new Date(), Instant.now(), new Object());
+
+        assertTrue(row.estimatedSizeBytes() > RecordSizeEstimator.UNKNOWN_RECORD_BYTES);
+        assertTrue(RecordSizeEstimator.estimateObjectSizeBytes(new Object())
+                >= RecordSizeEstimator.UNKNOWN_RECORD_BYTES);
+    }
+
+    @Test
+    public void batchExposesEstimatedBytes() {
+        RecordBatch<FluxRow> batch = RecordBatch.of(new TestSplit(),
+                Arrays.asList(FluxRow.of("one"), FluxRow.of("two")));
+
+        assertTrue(batch.getEstimatedBytes() > 0L);
+        assertTrue(batch.estimatedSizeBytes(RecordSizeEstimator.fluxRowEstimator()) > 0L);
+    }
+
+    private static final class TestSplit implements SourceSplit {
+        @Override public String splitId() { return "split"; }
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/channel/LocalDataChannel.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/channel/LocalDataChannel.java
@@ -1,7 +1,9 @@
 package com.baize.flux.framework.channel;
 
+import com.baize.flux.api.channel.FluxRowBatch;
+import com.baize.flux.api.source.RecordBatch;
+import com.baize.flux.api.source.RecordSizeEstimator;
 import com.baize.flux.framework.metrics.ChannelMetrics;
-
 import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.Objects;
@@ -10,330 +12,39 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
-/**
- * 基于内存的本地有界 Channel。
- *
- * <p>支持：
- *
- * <ul>
- *     <li>多个生产者</li>
- *     <li>单个消费者</li>
- *     <li>有界队列和背压</li>
- *     <li>生产者完成计数</li>
- *     <li>失败传播</li>
- *     <li>全局取消</li>
- * </ul>
- */
-public final class LocalDataChannel<T>
-        implements DataChannel<T> {
-
-    private final String channelId;
-
-    private final int capacity;
-
-    private final int expectedProducers;
-
-    private final Deque<T> buffer;
-
-    private final ReentrantLock lock;
-
-    private final Condition notEmpty;
-
-    private final Condition notFull;
-
-    private final ChannelMetrics metrics;
-
-    private int createdWriters;
-
-    private int remainingProducers;
-
-    private boolean readerOpened;
-
-    private boolean cancelled;
-
-    private Throwable failure;
-
-    public LocalDataChannel(
-            String channelId,
-            int capacity,
-            int expectedProducers) {
-
-        if (capacity <= 0) {
-            throw new IllegalArgumentException(
-                    "capacity must be greater than 0");
-        }
-
-        if (expectedProducers <= 0) {
-            throw new IllegalArgumentException(
-                    "expectedProducers must be greater than 0");
-        }
-
-        this.channelId =
-                Objects.requireNonNull(
-                        channelId,
-                        "channelId must not be null");
-
-        this.capacity = capacity;
-        this.expectedProducers = expectedProducers;
-        this.remainingProducers = expectedProducers;
-
-        this.buffer = new ArrayDeque<T>(capacity);
-        this.lock = new ReentrantLock();
-        this.notEmpty = lock.newCondition();
-        this.notFull = lock.newCondition();
-        this.metrics = new ChannelMetrics(channelId);
+/** A local channel with atomic batch, record and byte backpressure. */
+public final class LocalDataChannel<T> implements DataChannel<T> {
+    private final String channelId; private final int maxBatches, expectedProducers; private final long maxRecords,maxBytes,maxRecordsPerSecond,maxBytesPerSecond;
+    private final Deque<Entry<T>> buffer=new ArrayDeque<Entry<T>>(); private final ReentrantLock lock=new ReentrantLock(); private final Condition notEmpty=lock.newCondition(), notFull=lock.newCondition(); private final ChannelMetrics metrics;
+    private int createdWriters,remainingProducers; private long bufferedRecords,bufferedBytes; private boolean readerOpened,cancelled; private Throwable failure;
+    private double recordTokens,byteTokens; private long lastRefillNanos=System.nanoTime();
+    public LocalDataChannel(String id,int capacity,int producers){this(id,capacity,-1,-1,-1,-1,producers);}
+    public LocalDataChannel(String id,int batches,long records,long bytes,long recordsPerSecond,long bytesPerSecond,int producers){
+        if(batches<=0&&records<=0&&bytes<=0)throw new IllegalArgumentException("at least one buffer limit must be greater than 0"); if(producers<=0)throw new IllegalArgumentException("expectedProducers must be greater than 0");
+        checkOptional(records,"maxRecords");checkOptional(bytes,"maxBytes");checkOptional(recordsPerSecond,"maxRecordsPerSecond");checkOptional(bytesPerSecond,"maxBytesPerSecond"); channelId=Objects.requireNonNull(id,"channelId must not be null");maxBatches=batches;maxRecords=records;maxBytes=bytes;maxRecordsPerSecond=recordsPerSecond;maxBytesPerSecond=bytesPerSecond;expectedProducers=producers;remainingProducers=producers;recordTokens=recordsPerSecond>0?recordsPerSecond:0;byteTokens=bytesPerSecond>0?bytesPerSecond:0;metrics=new ChannelMetrics(id);
     }
-
-    @Override
-    public ChannelWriter<T> openWriter() {
-        lock.lock();
-
-        try {
-            ensureNotCancelledOrFailed();
-
-            if (createdWriters >= expectedProducers) {
-                throw new IllegalStateException(
-                        "Too many writers created for channel '"
-                                + channelId
-                                + "', expected="
-                                + expectedProducers);
-            }
-
-            createdWriters++;
-
-            return new LocalChannelWriter();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public ChannelReader<T> openReader() {
-        lock.lock();
-
-        try {
-            if (readerOpened) {
-                throw new IllegalStateException(
-                        "Channel '" + channelId
-                                + "' only supports one reader");
-            }
-
-            readerOpened = true;
-
-            return new LocalChannelReader();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public void fail(Throwable cause) {
-        Objects.requireNonNull(
-                cause,
-                "cause must not be null");
-
-        lock.lock();
-
-        try {
-            if (failure == null) {
-                failure = cause;
-            }
-
-            notEmpty.signalAll();
-            notFull.signalAll();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public void cancel() {
-        lock.lock();
-
-        try {
-            cancelled = true;
-
-            notEmpty.signalAll();
-            notFull.signalAll();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    @Override
-    public ChannelMetrics getMetrics() {
-        return metrics;
-    }
-
-    @Override
-    public void close() {
-        cancel();
-    }
-
-    private void writeInternal(T value)
-            throws Exception {
-
-        Objects.requireNonNull(
-                value,
-                "channel value must not be null");
-
-        lock.lockInterruptibly();
-
-        try {
-            while (buffer.size() >= capacity
-                    && failure == null
-                    && !cancelled) {
-
-                long start = System.nanoTime();
-
-                try {
-                    notFull.await();
-                } finally {
-                    metrics.addWriteBlockedNanos(
-                            System.nanoTime() - start);
-                }
-            }
-
-            ensureNotCancelledOrFailed();
-
-            buffer.addLast(value);
-
-            metrics.recordEnqueued(buffer.size());
-
-            notEmpty.signal();
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    private T readInternal()
-            throws Exception {
-
-        lock.lockInterruptibly();
-
-        try {
-            while (buffer.isEmpty()
-                    && remainingProducers > 0
-                    && failure == null
-                    && !cancelled) {
-
-                long start = System.nanoTime();
-
-                try {
-                    notEmpty.await();
-                } finally {
-                    metrics.addReadBlockedNanos(
-                            System.nanoTime() - start);
-                }
-            }
-
-            if (!buffer.isEmpty()) {
-                T value = buffer.removeFirst();
-
-                metrics.recordDequeued(buffer.size());
-
-                notFull.signal();
-
-                return value;
-            }
-
-            if (failure != null) {
-                throw new IllegalStateException(
-                        "Channel '" + channelId
-                                + "' execution failed",
-                        failure);
-            }
-
-            if (cancelled) {
-                throw new CancellationException(
-                        "Channel '" + channelId
-                                + "' has been cancelled");
-            }
-
-            /*
-             * 队列为空，并且所有生产者均已完成。
-             */
-            return null;
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    private void producerFinished() {
-        lock.lock();
-
-        try {
-            if (remainingProducers > 0) {
-                remainingProducers--;
-            }
-
-            if (remainingProducers == 0) {
-                notEmpty.signalAll();
-            }
-
-        } finally {
-            lock.unlock();
-        }
-    }
-
-    private void ensureNotCancelledOrFailed() {
-        if (failure != null) {
-            throw new IllegalStateException(
-                    "Channel '" + channelId
-                            + "' execution failed",
-                    failure);
-        }
-
-        if (cancelled) {
-            throw new CancellationException(
-                    "Channel '" + channelId
-                            + "' has been cancelled");
-        }
-    }
-
-    private final class LocalChannelWriter
-            implements ChannelWriter<T> {
-
-        private final AtomicBoolean closed =
-                new AtomicBoolean(false);
-
-        @Override
-        public void write(T value)
-                throws Exception {
-
-            if (closed.get()) {
-                throw new IllegalStateException(
-                        "Channel writer has already been closed");
-            }
-
-            writeInternal(value);
-        }
-
-        @Override
-        public void fail(Throwable cause) {
-            LocalDataChannel.this.fail(cause);
-        }
-
-        @Override
-        public void close() {
-            if (closed.compareAndSet(false, true)) {
-                producerFinished();
-            }
-        }
-    }
-
-    private final class LocalChannelReader
-            implements ChannelReader<T> {
-
-        @Override
-        public T read() throws Exception {
-            return readInternal();
-        }
-    }
+    private static void checkOptional(long v,String n){if(v==0||v<-1)throw new IllegalArgumentException(n+" must be positive or -1");}
+    public ChannelWriter<T> openWriter(){lock.lock();try{ensureOpen();if(createdWriters>=expectedProducers)throw new IllegalStateException("Too many writers created for channel '"+channelId+"'");createdWriters++;return new Writer();}finally{lock.unlock();}}
+    public ChannelReader<T> openReader(){lock.lock();try{if(readerOpened)throw new IllegalStateException("Channel '"+channelId+"' only supports one reader");readerOpened=true;return new Reader();}finally{lock.unlock();}}
+    public void fail(Throwable cause){Objects.requireNonNull(cause,"cause must not be null");lock.lock();try{if(failure==null)failure=cause;signalAll();}finally{lock.unlock();}}
+    public void cancel(){lock.lock();try{cancelled=true;signalAll();}finally{lock.unlock();}} private void signalAll(){notEmpty.signalAll();notFull.signalAll();}
+    public ChannelMetrics getMetrics(){return metrics;} public void close(){cancel();}
+    private void writeInternal(T value)throws Exception {Objects.requireNonNull(value,"channel value must not be null"); Entry<T> entry=new Entry<T>(value,records(value),bytes(value));lock.lockInterruptibly();try{
+        boolean oversized=isOversized(entry);
+        while(!fits(entry,oversized)){long start=System.nanoTime();try{notFull.await();}finally{metrics.addWriteBlockedNanos(System.nanoTime()-start);}ensureOpen();}
+        if(oversized)metrics.recordOversizedBatch(); awaitRate(entry); ensureOpen(); buffer.addLast(entry);bufferedRecords+=entry.records;bufferedBytes+=entry.bytes;metrics.recordEnqueued(buffer.size(),bufferedRecords,bufferedBytes);notEmpty.signal();
+    }finally{lock.unlock();}}
+    private boolean fits(Entry<T> e,boolean oversized){if(failure!=null||cancelled)return true; if(maxBatches>0&&buffer.size()>=maxBatches)return false; if(oversized)return buffer.isEmpty(); return (maxRecords<=0||bufferedRecords+e.records<=maxRecords)&&(maxBytes<=0||bufferedBytes+e.bytes<=maxBytes);}
+    private boolean isOversized(Entry<T> e){return (maxRecords>0&&e.records>maxRecords)||(maxBytes>0&&e.bytes>maxBytes);}
+    private void awaitRate(Entry<T> e)throws InterruptedException {while(true){ensureOpen();refill();double recordDeficit=maxRecordsPerSecond>0&&e.records<=maxRecordsPerSecond?e.records-recordTokens:0, byteDeficit=maxBytesPerSecond>0&&e.bytes<=maxBytesPerSecond?e.bytes-byteTokens:0;if(recordDeficit<=0&&byteDeficit<=0){if(maxRecordsPerSecond>0&&e.records<=maxRecordsPerSecond)recordTokens-=e.records;if(maxBytesPerSecond>0&&e.bytes<=maxBytesPerSecond)byteTokens-=e.bytes;return;} long wait=Math.max(maxRecordsPerSecond>0?(long)Math.ceil(recordDeficit*1_000_000_000D/maxRecordsPerSecond):0,maxBytesPerSecond>0?(long)Math.ceil(byteDeficit*1_000_000_000D/maxBytesPerSecond):0);long start=System.nanoTime();notFull.awaitNanos(Math.max(1L,wait));metrics.addRateLimitedNanos(System.nanoTime()-start);}}
+    private void refill(){long now=System.nanoTime(), elapsed=now-lastRefillNanos;lastRefillNanos=now;if(maxRecordsPerSecond>0)recordTokens=Math.min(maxRecordsPerSecond,recordTokens+elapsed*(double)maxRecordsPerSecond/1_000_000_000D);if(maxBytesPerSecond>0)byteTokens=Math.min(maxBytesPerSecond,byteTokens+elapsed*(double)maxBytesPerSecond/1_000_000_000D);}
+    private T readInternal()throws Exception{lock.lockInterruptibly();try{while(buffer.isEmpty()&&remainingProducers>0&&failure==null&&!cancelled){long start=System.nanoTime();try{notEmpty.await();}finally{metrics.addReadBlockedNanos(System.nanoTime()-start);}}if(!buffer.isEmpty()){Entry<T> e=buffer.removeFirst();bufferedRecords-=e.records;bufferedBytes-=e.bytes;metrics.recordDequeued(buffer.size(),bufferedRecords,bufferedBytes);notFull.signalAll();return e.value;}ensureOpen();return null;}finally{lock.unlock();}}
+    private void producerFinished(){lock.lock();try{if(remainingProducers>0)remainingProducers--;if(remainingProducers==0)notEmpty.signalAll();}finally{lock.unlock();}}
+    private void ensureOpen(){if(failure!=null)throw new IllegalStateException("Channel '"+channelId+"' execution failed",failure);if(cancelled)throw new CancellationException("Channel '"+channelId+"' has been cancelled");}
+    private static long records(Object value){if(value instanceof RecordEnvelope)return ((RecordEnvelope<?>)value).getBatch().size();if(value instanceof RecordBatch)return ((RecordBatch<?>)value).size();if(value instanceof FluxRowBatch)return ((FluxRowBatch)value).size();return 1;}
+    private static long bytes(Object value){if(value instanceof RecordEnvelope)return batchBytes(((RecordEnvelope<?>)value).getBatch());if(value instanceof RecordBatch)return batchBytes((RecordBatch<?>)value);if(value instanceof FluxRowBatch){long n=32;for(Object row:((FluxRowBatch)value).getRows())n+=RecordSizeEstimator.estimateObjectSizeBytes(row);return n;}return RecordSizeEstimator.estimateObjectSizeBytes(value);}
+    private static long batchBytes(RecordBatch<?> batch){return batch.getEstimatedBytes();}
+    private static final class Entry<E>{final E value;final long records,bytes;Entry(E value,long records,long bytes){this.value=value;this.records=records;this.bytes=bytes;}}
+    private final class Writer implements ChannelWriter<T>{private final AtomicBoolean closed=new AtomicBoolean();public void write(T value)throws Exception{if(closed.get())throw new IllegalStateException("Channel writer has already been closed");writeInternal(value);}public void fail(Throwable cause){LocalDataChannel.this.fail(cause);}public void close(){if(closed.compareAndSet(false,true))producerFinished();}}
+    private final class Reader implements ChannelReader<T>{public T read()throws Exception{return readInternal();}}
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
@@ -199,7 +199,11 @@ public final class JobExecution {
                             "source-to-sink-" + i,
                             executionPlan
                                     .getExecutionConfig()
-                                    .getChannelCapacity(),
+                                    .getMaxBufferedBatches(),
+                            executionPlan.getExecutionConfig().getMaxBufferedRecords(),
+                            executionPlan.getExecutionConfig().getMaxBufferedBytes(),
+                            executionPlan.getExecutionConfig().getMaxRecordsPerSecond(),
+                            executionPlan.getExecutionConfig().getMaxBytesPerSecond(),
                             sourceTaskCount);
 
             channels.add(channel);

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/ExecutionConfig.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/ExecutionConfig.java
@@ -1,80 +1,47 @@
 package com.baize.flux.framework.job;
 
-/**
- * Framework 执行配置。
- */
+/** Framework execution configuration. A negative optional limit means disabled. */
 public final class ExecutionConfig {
-
     public static final int DEFAULT_BATCH_SIZE = 1_000;
-
     public static final int DEFAULT_SOURCE_PARALLELISM = 1;
-
     public static final int DEFAULT_SINK_PARALLELISM = 1;
-
     public static final int DEFAULT_CHANNEL_CAPACITY = 32;
 
-    private final int batchSize;
-
-    private final int sourceParallelism;
-
-    private final int sinkParallelism;
-
-    private final int channelCapacity;
-
+    private final int batchSize, sourceParallelism, sinkParallelism, maxBufferedBatches;
+    private final long maxBufferedRecords, maxBufferedBytes, maxRecordsPerSecond, maxBytesPerSecond;
     private final SinkPartitionStrategy sinkPartitionStrategy;
-
     private final SplitAssignmentMode splitAssignmentMode;
 
-    public ExecutionConfig(
-            int batchSize,
-            int sourceParallelism,
-            int sinkParallelism,
-            int channelCapacity) {
-        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, SinkPartitionStrategy.TABLE_AFFINITY, SplitAssignmentMode.STATIC_ROUND_ROBIN);
+    public ExecutionConfig(int batchSize, int sourceParallelism, int sinkParallelism, int channelCapacity) {
+        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, -1, -1, -1, -1,
+                SinkPartitionStrategy.TABLE_AFFINITY, SplitAssignmentMode.STATIC_ROUND_ROBIN);
     }
-
-    public ExecutionConfig(
-            int batchSize, int sourceParallelism, int sinkParallelism, int channelCapacity,
-            SinkPartitionStrategy sinkPartitionStrategy) {
-        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, sinkPartitionStrategy, SplitAssignmentMode.STATIC_ROUND_ROBIN);
+    public ExecutionConfig(int batchSize, int sourceParallelism, int sinkParallelism, int channelCapacity,
+            SinkPartitionStrategy strategy) {
+        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, -1, -1, -1, -1,
+                strategy, SplitAssignmentMode.STATIC_ROUND_ROBIN);
     }
-
-    public ExecutionConfig(
-            int batchSize, int sourceParallelism, int sinkParallelism, int channelCapacity,
-            SinkPartitionStrategy sinkPartitionStrategy, SplitAssignmentMode splitAssignmentMode) {
-
-        if (batchSize <= 0) { throw new IllegalArgumentException("batchSize must be greater than 0"); }
-        if (sourceParallelism <= 0) { throw new IllegalArgumentException("sourceParallelism must be greater than 0"); }
-        if (sinkParallelism <= 0) { throw new IllegalArgumentException("sinkParallelism must be greater than 0"); }
-        if (channelCapacity <= 0) { throw new IllegalArgumentException("channelCapacity must be greater than 0"); }
-
-        this.batchSize = batchSize;
-        this.sourceParallelism = sourceParallelism;
-        this.sinkParallelism = sinkParallelism;
-        this.channelCapacity = channelCapacity;
-        this.sinkPartitionStrategy = sinkPartitionStrategy == null ? SinkPartitionStrategy.TABLE_AFFINITY : sinkPartitionStrategy;
-        this.splitAssignmentMode = splitAssignmentMode == null ? SplitAssignmentMode.STATIC_ROUND_ROBIN : splitAssignmentMode;
+    public ExecutionConfig(int batchSize, int sourceParallelism, int sinkParallelism, int channelCapacity,
+            SinkPartitionStrategy strategy, SplitAssignmentMode mode) {
+        this(batchSize, sourceParallelism, sinkParallelism, channelCapacity, -1, -1, -1, -1, strategy, mode);
     }
-
-    public int getBatchSize() {
-        return batchSize;
+    public ExecutionConfig(int batchSize, int sourceParallelism, int sinkParallelism, int maxBufferedBatches,
+            long maxBufferedRecords, long maxBufferedBytes, long maxRecordsPerSecond, long maxBytesPerSecond,
+            SinkPartitionStrategy strategy, SplitAssignmentMode mode) {
+        if (batchSize <= 0 || sourceParallelism <= 0 || sinkParallelism <= 0) throw new IllegalArgumentException("batch size and parallelism must be greater than 0");
+        if (maxBufferedBatches <= 0 && maxBufferedRecords <= 0 && maxBufferedBytes <= 0) throw new IllegalArgumentException("at least one buffer limit must be greater than 0");
+        validateOptional(maxBufferedRecords, "maxBufferedRecords"); validateOptional(maxBufferedBytes, "maxBufferedBytes");
+        validateOptional(maxRecordsPerSecond, "maxRecordsPerSecond"); validateOptional(maxBytesPerSecond, "maxBytesPerSecond");
+        this.batchSize=batchSize; this.sourceParallelism=sourceParallelism; this.sinkParallelism=sinkParallelism;
+        this.maxBufferedBatches=maxBufferedBatches; this.maxBufferedRecords=maxBufferedRecords; this.maxBufferedBytes=maxBufferedBytes;
+        this.maxRecordsPerSecond=maxRecordsPerSecond; this.maxBytesPerSecond=maxBytesPerSecond;
+        this.sinkPartitionStrategy=strategy == null ? SinkPartitionStrategy.TABLE_AFFINITY : strategy;
+        this.splitAssignmentMode=mode == null ? SplitAssignmentMode.STATIC_ROUND_ROBIN : mode;
     }
-
-    public int getSourceParallelism() {
-        return sourceParallelism;
-    }
-
-    public int getSinkParallelism() {
-        return sinkParallelism;
-    }
-
-    public int getChannelCapacity() {
-        return channelCapacity;
-    }
-
-    public SplitAssignmentMode getSplitAssignmentMode() { return splitAssignmentMode; }
-
-    public SinkPartitionStrategy getSinkPartitionStrategy() {
-        return sinkPartitionStrategy;
-    }
+    private static void validateOptional(long value, String name) { if (value == 0 || value < -1) throw new IllegalArgumentException(name + " must be positive or -1"); }
+    public int getBatchSize(){return batchSize;} public int getSourceParallelism(){return sourceParallelism;} public int getSinkParallelism(){return sinkParallelism;}
+    /** Compatibility accessor for the historical channel-capacity setting. */ public int getChannelCapacity(){return maxBufferedBatches;}
+    public int getMaxBufferedBatches(){return maxBufferedBatches;} public long getMaxBufferedRecords(){return maxBufferedRecords;}
+    public long getMaxBufferedBytes(){return maxBufferedBytes;} public long getMaxRecordsPerSecond(){return maxRecordsPerSecond;} public long getMaxBytesPerSecond(){return maxBytesPerSecond;}
+    public SplitAssignmentMode getSplitAssignmentMode(){return splitAssignmentMode;} public SinkPartitionStrategy getSinkPartitionStrategy(){return sinkPartitionStrategy;}
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobConfigParser.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/job/JobConfigParser.java
@@ -66,10 +66,12 @@ public final class JobConfigParser {
                         ? root.getInt("env.sink-parallelism")
                         : ExecutionConfig.DEFAULT_SINK_PARALLELISM;
 
-        int channelCapacity =
-                root.hasPath("env.channel-capacity")
-                        ? root.getInt("env.channel-capacity")
-                        : ExecutionConfig.DEFAULT_CHANNEL_CAPACITY;
+        int channelCapacity = root.hasPath("env.max-buffered-batches") ? root.getInt("env.max-buffered-batches")
+                : root.hasPath("env.channel-capacity") ? root.getInt("env.channel-capacity") : ExecutionConfig.DEFAULT_CHANNEL_CAPACITY;
+        long maxBufferedRecords = readOptionalLong(root, "env.max-buffered-records");
+        long maxBufferedBytes = readOptionalLong(root, "env.max-buffered-bytes");
+        long maxRecordsPerSecond = readOptionalLong(root, "env.max-records-per-second");
+        long maxBytesPerSecond = readOptionalLong(root, "env.max-bytes-per-second");
 
         Config sourceConnectorConfig =
                 sourceConfig
@@ -100,7 +102,8 @@ public final class JobConfigParser {
                 : SplitAssignmentMode.STATIC_ROUND_ROBIN;
 
         ExecutionConfig executionConfig = new ExecutionConfig(batchSize, sourceParallelism, sinkParallelism,
-                channelCapacity, sinkPartitionStrategy, splitAssignmentMode);
+                channelCapacity, maxBufferedRecords, maxBufferedBytes, maxRecordsPerSecond, maxBytesPerSecond,
+                sinkPartitionStrategy, splitAssignmentMode);
 
         return new JobDefinition(
                 jobName,
@@ -124,6 +127,10 @@ public final class JobConfigParser {
         }
 
         return ExecutionConfig.DEFAULT_SOURCE_PARALLELISM;
+    }
+
+    private static long readOptionalLong(Config root, String path) {
+        return root.hasPath(path) ? root.getLong(path) : -1L;
     }
 
     private static void requireObject(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/ChannelMetrics.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/ChannelMetrics.java
@@ -1,111 +1,24 @@
 package com.baize.flux.framework.metrics;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-/**
- * Channel 运行指标。
- */
+/** Channel occupancy, backpressure and rate-limit metrics. */
 public final class ChannelMetrics {
-
-    private final String channelId;
-
-    private final AtomicLong enqueuedCount =
-            new AtomicLong();
-
-    private final AtomicLong dequeuedCount =
-            new AtomicLong();
-
-    private final AtomicInteger currentSize =
-            new AtomicInteger();
-
-    private final AtomicInteger maximumSize =
-            new AtomicInteger();
-
-    private final AtomicLong writeBlockedNanos =
-            new AtomicLong();
-
-    private final AtomicLong readBlockedNanos =
-            new AtomicLong();
-
-    private final long createdNanos = System.nanoTime();
-
-    public ChannelMetrics(String channelId) {
-        this.channelId =
-                Objects.requireNonNull(
-                        channelId,
-                        "channelId must not be null");
-    }
-
-    public void recordEnqueued(int size) {
-        enqueuedCount.incrementAndGet();
-        currentSize.set(size);
-        updateMaximumSize(size);
-    }
-
-    public void recordDequeued(int size) {
-        dequeuedCount.incrementAndGet();
-        currentSize.set(size);
-    }
-
-    public void addWriteBlockedNanos(long nanos) {
-        if (nanos > 0) {
-            writeBlockedNanos.addAndGet(nanos);
-        }
-    }
-
-    public void addReadBlockedNanos(long nanos) {
-        if (nanos > 0) {
-            readBlockedNanos.addAndGet(nanos);
-        }
-    }
-
-    private void updateMaximumSize(int size) {
-        int currentMaximum;
-
-        do {
-            currentMaximum = maximumSize.get();
-
-            if (size <= currentMaximum) {
-                return;
-            }
-        } while (!maximumSize.compareAndSet(
-                currentMaximum,
-                size));
-    }
-
-    public String getChannelId() {
-        return channelId;
-    }
-
-    public long getEnqueuedCount() {
-        return enqueuedCount.get();
-    }
-
-    public long getDequeuedCount() {
-        return dequeuedCount.get();
-    }
-
-    public int getCurrentSize() {
-        return currentSize.get();
-    }
-
-    public int getMaximumSize() {
-        return maximumSize.get();
-    }
-
-    public long getWriteBlockedMillis() {
-        return writeBlockedNanos.get() / 1_000_000L;
-    }
-
-    public long getReadBlockedMillis() {
-        return readBlockedNanos.get() / 1_000_000L;
-    }
-
-    /** Fraction of channel lifetime spent waiting on either side, capped at one. */
-    public double getBlockedRatio() {
-        long elapsed = Math.max(1L, System.nanoTime() - createdNanos);
-        return Math.min(1D, (writeBlockedNanos.get() + readBlockedNanos.get()) / (double) elapsed);
-    }
+    private final String channelId; private final AtomicLong enqueuedCount=new AtomicLong(), dequeuedCount=new AtomicLong();
+    private final AtomicLong currentBatches=new AtomicLong(), currentRecords=new AtomicLong(), currentBytes=new AtomicLong();
+    private final AtomicLong maximumBatches=new AtomicLong(), maximumRecords=new AtomicLong(), maximumBytes=new AtomicLong();
+    private final AtomicLong writeBlockedNanos=new AtomicLong(), readBlockedNanos=new AtomicLong(), rateLimitedNanos=new AtomicLong(), oversizedBatches=new AtomicLong();
+    private final long createdNanos=System.nanoTime();
+    public ChannelMetrics(String channelId){this.channelId=Objects.requireNonNull(channelId,"channelId must not be null");}
+    public void recordEnqueued(long batches,long records,long bytes){ enqueuedCount.incrementAndGet(); set(currentBatches,batches,maximumBatches); set(currentRecords,records,maximumRecords); set(currentBytes,bytes,maximumBytes); }
+    public void recordDequeued(long batches,long records,long bytes){ dequeuedCount.incrementAndGet(); currentBatches.set(batches); currentRecords.set(records); currentBytes.set(bytes); }
+    /** Legacy batch-only metric API. */ public void recordEnqueued(int size){recordEnqueued(size,0,0);} public void recordDequeued(int size){recordDequeued(size,0,0);}
+    private static void set(AtomicLong current,long value,AtomicLong max){current.set(value); long old; do {old=max.get(); if(value<=old)return;} while(!max.compareAndSet(old,value));}
+    public void addWriteBlockedNanos(long n){if(n>0)writeBlockedNanos.addAndGet(n);} public void addReadBlockedNanos(long n){if(n>0)readBlockedNanos.addAndGet(n);} public void addRateLimitedNanos(long n){if(n>0)rateLimitedNanos.addAndGet(n);} public void recordOversizedBatch(){oversizedBatches.incrementAndGet();}
+    public String getChannelId(){return channelId;} public long getEnqueuedCount(){return enqueuedCount.get();} public long getDequeuedCount(){return dequeuedCount.get();}
+    public int getCurrentSize(){return (int)currentBatches.get();} public int getMaximumSize(){return (int)maximumBatches.get();}
+    public long getCurrentBatches(){return currentBatches.get();} public long getCurrentRecords(){return currentRecords.get();} public long getCurrentBytes(){return currentBytes.get();} public long getMaximumBatches(){return maximumBatches.get();} public long getMaximumRecords(){return maximumRecords.get();} public long getMaximumBytes(){return maximumBytes.get();} public long getOversizedBatches(){return oversizedBatches.get();}
+    public long getWriteBlockedMillis(){return writeBlockedNanos.get()/1_000_000L;} public long getReadBlockedMillis(){return readBlockedNanos.get()/1_000_000L;} public long getRateLimitedMillis(){return rateLimitedNanos.get()/1_000_000L;}
+    public double getBlockedRatio(){long elapsed=Math.max(1,System.nanoTime()-createdNanos);return Math.min(1D,(writeBlockedNanos.get()+readBlockedNanos.get()+rateLimitedNanos.get())/(double)elapsed);}
 }


### PR DESCRIPTION
### Motivation

- Provide stable, conservative record-size estimates for channel backpressure so byte-aware limits and rate controls can be applied without relying on serialization sizes. 
- Extend channel buffering beyond simple batch-count to support limits by batches, records and bytes and to allow rate limiting by records/bytes per second. 
- Ensure practical behavior for oversized single batches and fast wake-up on cancel/fail while preserving compatibility with the historical `channel-capacity` setting.

### Description

- Add a public `RecordSizeEstimator` interface with a conservative `estimateObjectSizeBytes` helper and a `fluxRowEstimator`; implement `FluxRow.estimatedSizeBytes()` and expose batch/row byte estimators via `RecordBatch.estimatedSizeBytes`/`getEstimatedBytes` and `FluxRowBatch.getEstimatedBytes`.
- Extend `ExecutionConfig` to accept `max-buffered-batches` (compatible with old `channel-capacity`), `max-buffered-records`, `max-buffered-bytes`, `max-records-per-second` and `max-bytes-per-second`, with validation that at least one buffer limit is enabled.
- Update `JobConfigParser` to parse the new `env.*` entries and preserve `env.channel-capacity` as an alias for batch upper bound.
- Rework `LocalDataChannel` to perform atomic capacity checks across batches, records and bytes, release exact record/byte counts on dequeue, implement an "oversized batch" policy that allows a single oversized batch only if the queue is empty, and add interruptible rate-limiting waits that exit quickly on `cancel`/`fail`.
- Expand `ChannelMetrics` to record current/peak batches, records and bytes, read/write blocked time, rate-limit wait time, oversized-batch counts and maintain legacy batch-only API compatibility.
- Add unit test `RecordSizeEstimatorTest` to validate estimations and batch byte exposure.

### Testing

- Ran `git diff --check` with no reported issues.
- Compiled API sources with `javac` (API classes including `RecordSizeEstimator`, `FluxRow`, `RecordBatch`, `FluxRowBatch`) which succeeded as a smoke check of public API changes.
- Ran `mvn test -q -pl baize-flux-api,baize-flux-framework -am` but the Maven run could not complete due to plugin resolution failing against Maven Central (HTTP 403) in the environment, preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a630808b24c8326a95b73f161460a16)