### PR TITLE
Add isolated connector plugin loading

### DIFF
--- a/baize-flux-api/src/main/java/com/baize/flux/api/connector/ConnectorDescriptor.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/connector/ConnectorDescriptor.java
@@ -1,0 +1,44 @@
+package com.baize.flux.api.connector;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Small, transport-neutral description of a connector artifact.
+ * Capability strings deliberately remain opaque: the framework does not register or interpret
+ * capabilities that it does not consume.
+ */
+public final class ConnectorDescriptor {
+    private final String identifier;
+    private final String version;
+    private final String apiVersion;
+    private final Set<ConnectorType> types;
+    private final Set<String> requiredCapabilities;
+    private final String pluginPath;
+
+    public ConnectorDescriptor(String identifier, String version, String apiVersion,
+            Set<ConnectorType> types, Set<String> requiredCapabilities, String pluginPath) {
+        this.identifier = required(identifier, "identifier");
+        this.version = required(version, "version");
+        this.apiVersion = required(apiVersion, "apiVersion");
+        this.types = Collections.unmodifiableSet(types == null || types.isEmpty()
+                ? EnumSet.noneOf(ConnectorType.class) : EnumSet.copyOf(types));
+        this.requiredCapabilities = Collections.unmodifiableSet(requiredCapabilities == null
+                ? new LinkedHashSet<String>() : new LinkedHashSet<String>(requiredCapabilities));
+        this.pluginPath = pluginPath;
+    }
+    public String getIdentifier() { return identifier; }
+    public String getVersion() { return version; }
+    public String getApiVersion() { return apiVersion; }
+    public Set<ConnectorType> getTypes() { return types; }
+    public Set<String> getRequiredCapabilities() { return requiredCapabilities; }
+    public String getPluginPath() { return pluginPath; }
+    private static String required(String value, String name) {
+        Objects.requireNonNull(value, name + " must not be null");
+        if (value.trim().isEmpty()) throw new IllegalArgumentException(name + " must not be blank");
+        return value;
+    }
+}

--- a/baize-flux-api/src/main/java/com/baize/flux/api/connector/ConnectorType.java
+++ b/baize-flux-api/src/main/java/com/baize/flux/api/connector/ConnectorType.java
@@ -1,0 +1,4 @@
+package com.baize.flux.api.connector;
+
+/** The runtime roles implemented by a connector. */
+public enum ConnectorType { SOURCE, SINK }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/classloading/ClassLoaderScope.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/classloading/ClassLoaderScope.java
@@ -1,0 +1,19 @@
+package com.baize.flux.framework.classloading;
+
+import java.util.Objects;
+
+/** Temporarily installs a connector loader as the current thread context class loader. */
+public final class ClassLoaderScope implements AutoCloseable {
+    private final Thread thread;
+    private final ClassLoader previous;
+    private boolean closed;
+    private ClassLoaderScope(ClassLoader loader) {
+        this.thread = Thread.currentThread();
+        this.previous = thread.getContextClassLoader();
+        thread.setContextClassLoader(Objects.requireNonNull(loader, "loader must not be null"));
+    }
+    public static ClassLoaderScope open(ClassLoader loader) { return new ClassLoaderScope(loader); }
+    @Override public void close() {
+        if (!closed) { thread.setContextClassLoader(previous); closed = true; }
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/classloading/ConnectorClassLoader.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/classloading/ConnectorClassLoader.java
@@ -1,0 +1,29 @@
+package com.baize.flux.framework.classloading;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+/** Isolated connector loader: framework/API contracts come from the parent, connector libraries do not. */
+public final class ConnectorClassLoader extends URLClassLoader {
+    static { registerAsParallelCapable(); }
+    public ConnectorClassLoader(URL[] urls, ClassLoader parent) { super(urls, parent); }
+    @Override protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (getClassLoadingLock(name)) {
+            Class<?> loaded = findLoadedClass(name);
+            if (loaded == null && parentFirst(name)) {
+                try { loaded = getParent().loadClass(name); } catch (ClassNotFoundException ignored) { }
+            }
+            if (loaded == null) {
+                try { loaded = findClass(name); } catch (ClassNotFoundException ignored) { }
+            }
+            if (loaded == null) loaded = getParent().loadClass(name);
+            if (resolve) resolveClass(loaded);
+            return loaded;
+        }
+    }
+    private static boolean parentFirst(String name) {
+        return name.startsWith("java.") || name.startsWith("javax.") || name.startsWith("jdk.")
+                || name.startsWith("sun.") || name.startsWith("com.baize.flux.api.")
+                || name.startsWith("org.slf4j.") || name.startsWith("org.apache.logging.");
+    }
+}

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/ConnectorPreparer.java
@@ -11,6 +11,7 @@ import com.baize.flux.api.table.catalog.CatalogTable;
 import com.baize.flux.api.table.catalog.TablePath;
 import com.baize.flux.api.table.factory.TableSourceFactory;
 import com.baize.flux.framework.job.JobDefinition;
+import com.baize.flux.framework.classloading.ClassLoaderScope;
 import com.baize.flux.framework.job.SinkDefinition;
 import com.baize.flux.framework.job.SourceDefinition;
 
@@ -113,7 +114,7 @@ public final class ConnectorPreparer {
             int sourceParallelism) throws Exception {
 
         Source<SplitT> source =
-                factory.createSource(context);
+                createSourceInScope(factory, context);
 
         if (source == null) {
             throw new ConnectorException(
@@ -124,8 +125,10 @@ public final class ConnectorPreparer {
 
         source.validateParallelism(sourceParallelism);
 
-        List<CatalogTable> catalogTables =
-                factory.discoverTableSchemas(context);
+        List<CatalogTable> catalogTables;
+        try (ClassLoaderScope ignored = ClassLoaderScope.open(registry.getClassLoader(factory))) {
+            catalogTables = factory.discoverTableSchemas(context);
+        }
 
         Map<TablePath, CatalogTable> tableMap =
                 buildTableMap(
@@ -135,7 +138,8 @@ public final class ConnectorPreparer {
         return new PreparedSource<SplitT>(
                 identifier,
                 source,
-                tableMap);
+                tableMap,
+                registry.getClassLoader(factory));
     }
 
     private List<PreparedSink> prepareSinks(
@@ -152,8 +156,11 @@ public final class ConnectorPreparer {
                 .validate(
                         factory.optionRule());
 
-        PreparedSinkMetadata metadata = factory.createPreparer(definition.getOptions())
-                .prepare(new SinkPrepareContext(definition.getOptions(), sourceTables));
+        PreparedSinkMetadata metadata;
+        try (ClassLoaderScope ignored = ClassLoaderScope.open(registry.getClassLoader(factory))) {
+            metadata = factory.createPreparer(definition.getOptions())
+                    .prepare(new SinkPrepareContext(definition.getOptions(), sourceTables));
+        }
         if (metadata == null) {
             throw new ConnectorException("Sink factory '" + definition.getType() + "' returned null preparation metadata");
         }
@@ -168,10 +175,17 @@ public final class ConnectorPreparer {
                             definition.getType(),
                             factory,
                             definition.getOptions(),
-                            metadata));
+                            metadata,
+                            registry.getClassLoader(factory)));
         }
 
         return sinks;
+    }
+
+    private <SplitT extends SourceSplit> Source<SplitT> createSourceInScope(TableSourceFactory<SplitT> factory, SourceFactoryContext context) throws Exception {
+        try (ClassLoaderScope ignored = ClassLoaderScope.open(registry.getClassLoader(factory))) {
+            return factory.createSource(context);
+        }
     }
 
     private Map<TablePath, CatalogTable> buildTableMap(

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/FactoryRegistry.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/FactoryRegistry.java
@@ -3,195 +3,99 @@ package com.baize.flux.framework.connector;
 import com.baize.flux.api.factory.Factory;
 import com.baize.flux.api.factory.SinkFactory;
 import com.baize.flux.api.table.factory.TableSourceFactory;
+import com.baize.flux.framework.classloading.ConnectorClassLoader;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
-/**
- * Connector Factory 注册中心。
- *
- * <p>统一负责 SourceFactory 和 SinkFactory 的 SPI 发现。
- */
-public final class FactoryRegistry {
+/** Discovers application and isolated connector factories. */
+public final class FactoryRegistry implements AutoCloseable {
+    private final Map<String, TableSourceFactory<?>> sourceFactories = new LinkedHashMap<String, TableSourceFactory<?>>();
+    private final Map<String, SinkFactory> sinkFactories = new LinkedHashMap<String, SinkFactory>();
+    private final Map<Factory, FactoryOrigin> origins = new IdentityHashMap<Factory, FactoryOrigin>();
+    private final List<ConnectorClassLoader> pluginLoaders = new ArrayList<ConnectorClassLoader>();
 
-    private final Map<String, TableSourceFactory<?>>
-            sourceFactories;
-
-    private final Map<String, SinkFactory>
-            sinkFactories;
-
-    public FactoryRegistry(ClassLoader classLoader) {
-        Objects.requireNonNull(
-                classLoader,
-                "classLoader must not be null");
-
-        this.sourceFactories =
-                discoverSourceFactories(classLoader);
-
-        this.sinkFactories =
-                discoverSinkFactories(classLoader);
+    public FactoryRegistry(ClassLoader classLoader) { this(classLoader, Collections.<Path>emptyList()); }
+    public FactoryRegistry(ClassLoader classLoader, Iterable<Path> pluginDirectories) {
+        ClassLoader parent = Objects.requireNonNull(classLoader, "classLoader must not be null");
+        discoverFrom(parent, "application classpath");
+        for (Path directory : pluginDirectories) discoverPlugin(parent, Objects.requireNonNull(directory, "plugin directory must not be null"));
     }
-
-    public static FactoryRegistry discover(
-            ClassLoader classLoader) {
-
-        ClassLoader effectiveClassLoader =
-                classLoader == null
-                        ? Thread.currentThread()
-                        .getContextClassLoader()
-                        : classLoader;
-
-        return new FactoryRegistry(
-                effectiveClassLoader);
+    public static FactoryRegistry discover(ClassLoader classLoader) { return new FactoryRegistry(effective(classLoader)); }
+    public static FactoryRegistry discover(ClassLoader classLoader, Path... pluginDirectories) {
+        List<Path> paths = new ArrayList<Path>();
+        if (pluginDirectories != null) Collections.addAll(paths, pluginDirectories);
+        return new FactoryRegistry(effective(classLoader), paths);
     }
-
-    public TableSourceFactory<?> getSourceFactory(
-            String identifier) {
-
-        String normalized = normalize(identifier);
-
-        TableSourceFactory<?> factory =
-                sourceFactories.get(normalized);
-
-        if (factory == null) {
-            throw new ConnectorException(
-                    "Could not find source factory for identifier '"
-                            + identifier
-                            + "'. Available identifiers: "
-                            + sourceFactories.keySet());
+    public static FactoryRegistry discover(ClassLoader classLoader, Iterable<Path> pluginDirectories) {
+        return new FactoryRegistry(effective(classLoader), pluginDirectories);
+    }
+    public TableSourceFactory<?> getSourceFactory(String identifier) { return required(sourceFactories, identifier, "source"); }
+    public SinkFactory getSinkFactory(String identifier) { return required(sinkFactories, identifier, "sink"); }
+    public ClassLoader getClassLoader(Factory factory) {
+        FactoryOrigin origin = origins.get(factory);
+        return origin == null ? factory.getClass().getClassLoader() : origin.loader;
+    }
+    private void discoverPlugin(ClassLoader parent, Path directory) {
+        final URL[] urls;
+        try {
+            if (!Files.isDirectory(directory)) throw new ConnectorException("Plugin path is not a directory: " + directory);
+            List<URL> result = new ArrayList<URL>();
+            java.nio.file.DirectoryStream<Path> jars = Files.newDirectoryStream(directory, "*.jar");
+            try { for (Path jar : jars) result.add(jar.toUri().toURL()); } finally { jars.close(); }
+            urls = result.toArray(new URL[result.size()]);
+        } catch (IOException e) { throw new ConnectorException("Could not read plugin path '" + directory + "'", e); }
+        ConnectorClassLoader loader = new ConnectorClassLoader(urls, parent);
+        try { discoverFrom(loader, directory.toAbsolutePath().toString()); pluginLoaders.add(loader); }
+        catch (RuntimeException e) { try { loader.close(); } catch (IOException close) { e.addSuppressed(close); } throw e; }
+    }
+    private void discoverFrom(ClassLoader loader, String path) {
+        discoverSources(loader, path); discoverSinks(loader, path);
+    }
+    private void discoverSources(ClassLoader loader, String path) {
+        try { for (TableSourceFactory<?> factory : ServiceLoader.load(TableSourceFactory.class, loader)) put(sourceFactories, factory, "source", loader, path); }
+        catch (ServiceConfigurationError e) { throw new ConnectorException("Could not load source factories from plugin path '" + path + "'", e); }
+    }
+    private void discoverSinks(ClassLoader loader, String path) {
+        try { for (SinkFactory factory : ServiceLoader.load(SinkFactory.class, loader)) put(sinkFactories, factory, "sink", loader, path); }
+        catch (ServiceConfigurationError e) { throw new ConnectorException("Could not load sink factories from plugin path '" + path + "'", e); }
+    }
+    private <T extends Factory> void put(Map<String, T> factories, T factory, String kind, ClassLoader loader, String path) {
+        String id = normalize(factory.factoryIdentifier()); T prior = factories.get(id);
+        if (prior != null) {
+            FactoryOrigin previous = origins.get(prior);
+            throw new ConnectorException("Duplicated " + kind + " factory identifier '" + id + "': "
+                    + describe(prior, previous) + " conflicts with " + describe(factory, new FactoryOrigin(loader, path)));
         }
-
+        factories.put(id, factory); origins.put(factory, new FactoryOrigin(loader, path));
+    }
+    private static String describe(Factory factory, FactoryOrigin origin) {
+        Package p = factory.getClass().getPackage(); String version = p == null ? null : p.getImplementationVersion();
+        return factory.getClass().getName() + " (version=" + (version == null ? "unknown" : version) + ", pluginPath=" + origin.path + ")";
+    }
+    private static <T> T required(Map<String, T> map, String id, String kind) {
+        T factory = map.get(normalize(id));
+        if (factory == null) throw new ConnectorException("Could not find " + kind + " factory for identifier '" + id + "'. Available identifiers: " + map.keySet());
         return factory;
     }
-
-    public SinkFactory getSinkFactory(
-            String identifier) {
-
-        String normalized = normalize(identifier);
-
-        SinkFactory factory =
-                sinkFactories.get(normalized);
-
-        if (factory == null) {
-            throw new ConnectorException(
-                    "Could not find sink factory for identifier '"
-                            + identifier
-                            + "'. Available identifiers: "
-                            + sinkFactories.keySet());
-        }
-
-        return factory;
+    private static ClassLoader effective(ClassLoader loader) { return loader == null ? Thread.currentThread().getContextClassLoader() : loader; }
+    private static String normalize(String id) { Objects.requireNonNull(id, "factory identifier must not be null"); String value = id.trim().toLowerCase(Locale.ROOT); if (value.isEmpty()) throw new IllegalArgumentException("factory identifier must not be blank"); return value; }
+    @Override public void close() {
+        IOException failure = null; for (ConnectorClassLoader loader : pluginLoaders) try { loader.close(); } catch (IOException e) { if (failure == null) failure = e; else failure.addSuppressed(e); }
+        pluginLoaders.clear(); if (failure != null) throw new ConnectorException("Could not close connector class loaders", failure);
     }
-
-    private Map<String, TableSourceFactory<?>>
-    discoverSourceFactories(
-            ClassLoader classLoader) {
-
-        Map<String, TableSourceFactory<?>> result =
-                new LinkedHashMap<
-                        String,
-                        TableSourceFactory<?>>();
-
-        try {
-            ServiceLoader<TableSourceFactory> loader =
-                    ServiceLoader.load(
-                            TableSourceFactory.class,
-                            classLoader);
-
-            for (TableSourceFactory<?> factory : loader) {
-                putFactory(
-                        result,
-                        factory.factoryIdentifier(),
-                        factory,
-                        "source");
-            }
-
-            return Collections.unmodifiableMap(result);
-
-        } catch (ServiceConfigurationError error) {
-            throw new ConnectorException(
-                    "Could not load source factories",
-                    error);
-        }
-    }
-
-    private Map<String, SinkFactory>
-    discoverSinkFactories(
-            ClassLoader classLoader) {
-
-        Map<String, SinkFactory> result =
-                new LinkedHashMap<String, SinkFactory>();
-
-        try {
-            ServiceLoader<SinkFactory> loader =
-                    ServiceLoader.load(
-                            SinkFactory.class,
-                            classLoader);
-
-            for (SinkFactory factory : loader) {
-                putFactory(
-                        result,
-                        factory.factoryIdentifier(),
-                        factory,
-                        "sink");
-            }
-
-            return Collections.unmodifiableMap(result);
-
-        } catch (ServiceConfigurationError error) {
-            throw new ConnectorException(
-                    "Could not load sink factories",
-                    error);
-        }
-    }
-
-    private static <T extends Factory> void putFactory(
-            Map<String, T> factories,
-            String identifier,
-            T factory,
-            String kind) {
-
-        String normalized = normalize(identifier);
-
-        T previous =
-                factories.put(
-                        normalized,
-                        factory);
-
-        if (previous != null) {
-            throw new ConnectorException(
-                    "Duplicated "
-                            + kind
-                            + " factory identifier '"
-                            + identifier
-                            + "': "
-                            + previous.getClass().getName()
-                            + ", "
-                            + factory.getClass().getName());
-        }
-    }
-
-    private static String normalize(
-            String identifier) {
-
-        Objects.requireNonNull(
-                identifier,
-                "factory identifier must not be null");
-
-        String normalized =
-                identifier.trim()
-                        .toLowerCase(Locale.ROOT);
-
-        if (normalized.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "factory identifier must not be blank");
-        }
-
-        return normalized;
-    }
+    private static final class FactoryOrigin { private final ClassLoader loader; private final String path; private FactoryOrigin(ClassLoader loader, String path) { this.loader = loader; this.path = path; } }
 }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSink.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSink.java
@@ -14,17 +14,24 @@ public final class PreparedSink {
     private final SinkFactory factory;
     private final ReadonlyConfig options;
     private final PreparedSinkMetadata metadata;
+    private final ClassLoader classLoader;
     public PreparedSink(String factoryIdentifier, SinkFactory factory, ReadonlyConfig options, PreparedSinkMetadata metadata) {
+        this(factoryIdentifier, factory, options, metadata, factory.getClass().getClassLoader());
+    }
+    public PreparedSink(String factoryIdentifier, SinkFactory factory, ReadonlyConfig options, PreparedSinkMetadata metadata, ClassLoader classLoader) {
         this.factoryIdentifier = Objects.requireNonNull(factoryIdentifier, "factoryIdentifier must not be null");
         this.factory = Objects.requireNonNull(factory, "factory must not be null");
         this.options = Objects.requireNonNull(options, "options must not be null");
         this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
+        this.classLoader = Objects.requireNonNull(classLoader, "classLoader must not be null");
     }
     public SinkWriter<FluxRow> createWriter() {
-        SinkWriter<FluxRow> writer = factory.createSink(options, metadata);
+        SinkWriter<FluxRow> writer;
+        try (com.baize.flux.framework.classloading.ClassLoaderScope ignored = com.baize.flux.framework.classloading.ClassLoaderScope.open(classLoader)) { writer = factory.createSink(options, metadata); }
         if (writer == null) throw new ConnectorException("Sink factory '" + factoryIdentifier + "' returned a null writer");
         return writer;
     }
+    public ClassLoader getClassLoader() { return classLoader; }
     public String getFactoryIdentifier() { return factoryIdentifier; }
     public ReadonlyConfig getOptions() { return options; }
     public PreparedSinkMetadata getMetadata() { return metadata; }

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSource.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/connector/PreparedSource.java
@@ -22,10 +22,20 @@ public final class PreparedSource<
 
     private final Map<TablePath, CatalogTable> tables;
 
+    private final ClassLoader classLoader;
+
     public PreparedSource(
             String factoryIdentifier,
             Source<SplitT> source,
             Map<TablePath, CatalogTable> tables) {
+        this(factoryIdentifier, source, tables, source.getClass().getClassLoader());
+    }
+
+    public PreparedSource(
+            String factoryIdentifier,
+            Source<SplitT> source,
+            Map<TablePath, CatalogTable> tables,
+            ClassLoader classLoader) {
 
         this.factoryIdentifier =
                 Objects.requireNonNull(
@@ -45,6 +55,8 @@ public final class PreparedSource<
                                 Objects.requireNonNull(
                                         tables,
                                         "tables must not be null")));
+
+        this.classLoader = Objects.requireNonNull(classLoader, "classLoader must not be null");
     }
 
     public String getFactoryIdentifier() {
@@ -54,6 +66,8 @@ public final class PreparedSource<
     public Source<SplitT> getSource() {
         return source;
     }
+
+    public ClassLoader getClassLoader() { return classLoader; }
 
     public Map<TablePath, CatalogTable> getTables() {
         return tables;

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/LocalFluxEngine.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/LocalFluxEngine.java
@@ -9,6 +9,7 @@ import com.baize.flux.framework.planner.ExecutionPlan;
 import com.baize.flux.framework.planner.JobPlanner;
 
 import java.util.Objects;
+import java.nio.file.Path;
 
 /**
  * 本地离线 Flux 执行引擎。
@@ -22,10 +23,20 @@ public final class LocalFluxEngine
 
     private final JobPlanner jobPlanner;
 
+    private final FactoryRegistry registry;
+
     public LocalFluxEngine(
             ClassLoader classLoader,
             ConnectorPreparer connectorPreparer,
             JobPlanner jobPlanner) {
+        this(classLoader, connectorPreparer, jobPlanner, null);
+    }
+
+    private LocalFluxEngine(
+            ClassLoader classLoader,
+            ConnectorPreparer connectorPreparer,
+            JobPlanner jobPlanner,
+            FactoryRegistry registry) {
 
         this.classLoader =
                 Objects.requireNonNull(
@@ -41,6 +52,7 @@ public final class LocalFluxEngine
                 Objects.requireNonNull(
                         jobPlanner,
                         "jobPlanner must not be null");
+        this.registry = registry;
     }
 
     public static LocalFluxEngine create(
@@ -67,7 +79,14 @@ public final class LocalFluxEngine
         return new LocalFluxEngine(
                 effectiveClassLoader,
                 preparer,
-                planner);
+                planner,
+                registry);
+    }
+
+    public static LocalFluxEngine create(ClassLoader classLoader, Path... pluginDirectories) {
+        ClassLoader effectiveClassLoader = classLoader == null ? Thread.currentThread().getContextClassLoader() : classLoader;
+        FactoryRegistry registry = FactoryRegistry.discover(effectiveClassLoader, pluginDirectories);
+        return new LocalFluxEngine(effectiveClassLoader, new ConnectorPreparer(registry, effectiveClassLoader), new JobPlanner(), registry);
     }
 
     @Override
@@ -75,24 +94,20 @@ public final class LocalFluxEngine
             JobDefinition definition)
             throws Exception {
 
-        PreparedJob preparedJob =
-                connectorPreparer.prepare(
-                        definition);
-
-        ExecutionPlan executionPlan =
-                jobPlanner.plan(
-                        preparedJob);
-
-        JobExecution jobExecution =
-                new JobExecution(
-                        executionPlan,
-                        classLoader);
-
-        return jobExecution.execute();
+        try {
+            PreparedJob preparedJob = connectorPreparer.prepare(definition);
+            ExecutionPlan executionPlan = jobPlanner.plan(preparedJob);
+            JobExecution jobExecution = new JobExecution(executionPlan, classLoader);
+            return jobExecution.execute();
+        } finally {
+            // Plugin loaders are job resources; no open jar remains after a job completes or fails.
+            if (registry != null) registry.close();
+        }
     }
 
     @Override
     public void close() {
+        if (registry != null) registry.close();
         /*
          * 当前 Engine 不持有长生命周期线程池。
          * 后续支持多 Job 并发时，可在这里关闭资源。

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SinkTask.java
@@ -53,6 +53,8 @@ public final class SinkTask
             TaskContext context)
             throws Exception {
 
+        try (com.baize.flux.framework.classloading.ClassLoaderScope ignored =
+                com.baize.flux.framework.classloading.ClassLoaderScope.open(plan.getPreparedSink().getClassLoader())) {
         SinkWriter<FluxRow> writer = null;
 
         Throwable failure = null;
@@ -171,6 +173,7 @@ public final class SinkTask
                      */
                 }
             }
+        }
         }
     }
 

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/task/SourceTask.java
@@ -56,6 +56,8 @@ public final class SourceTask<
 
         PreparedSource<SplitT> preparedSource =
                 plan.getPreparedSource();
+        try (com.baize.flux.framework.classloading.ClassLoaderScope ignored =
+                com.baize.flux.framework.classloading.ClassLoaderScope.open(preparedSource.getClassLoader())) {
 
         SourceReader<FluxRow, SplitT> reader =
                 null;
@@ -161,6 +163,7 @@ public final class SourceTask<
                 throw propagate(
                         closeFailure);
             }
+        }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Introduce a minimal, transport-neutral `ConnectorDescriptor` to represent connector identity, API version, runtime roles, required capabilities and plugin path without adding a complex capability registry.
- Provide an isolated, child-first class loader strategy for connector jars while keeping Java/JDK, `com.baize.flux.api` and common logging packages parent-first to avoid class conflicts.
- Allow discovery of connector factories from both the application classpath and one or more plugin directories, and retain precise diagnostics when duplicates or corrupted plugins are found.
- Ensure connector class loader lifecycles are owned by the Job/Engine and that thread context class loader is switched during connector setup and runtime operations to ensure correct loading and isolation.

### Description
- Added API types `ConnectorDescriptor` and `ConnectorType` to `baize-flux-api` describing connector identifier, version, API version, roles, opaque required capabilities and plugin path (`baize-flux-api/src/main/java/com/baize/flux/api/connector/*`).
- Implemented `ConnectorClassLoader` (child-first with parent-first exceptions for JDK/API/logging) and a `ClassLoaderScope` helper to swap the thread context class loader (`baize-flux-framework/src/main/java/com/baize/flux/framework/classloading/*`).
- Reworked `FactoryRegistry` to discover SPI factories from the application classpath and zero or more plugin directories, retain per-factory origin information (loader + plugin path), produce rich duplicate/conflict errors including implementation version and plugin path, and close plugin loaders on `close()` (`baize-flux-framework/src/main/java/com/baize/flux/framework/connector/FactoryRegistry.java`).
- Scoped connector interactions to their owning class loaders by switching context class loader during: factory `createSource` and `discoverTableSchemas`, sink preparer invocation, and during `SourceTask`/`SinkTask` execution; extended `PreparedSource`/`PreparedSink` to carry the loader; and updated `ConnectorPreparer`, `SourceTask`, `SinkTask`, and `Prepared*` types accordingly (`baize-flux-framework/src/main/java/com/baize/flux/framework/connector/*`, `.../execution/task/*`).
- Made `LocalFluxEngine` create/discover `FactoryRegistry` with optional plugin directory paths and ensured plugin loaders are closed after a job completes or fails, making plugin loader lifecycle job-scoped (`baize-flux-framework/src/main/java/com/baize/flux/framework/execution/LocalFluxEngine.java`).

### Testing
- Successfully compiled the new connector API and classloading helpers with `javac -source 8 -target 8 -d /tmp/check baize-flux-api/src/main/java/com/baize/flux/api/connector/*.java baize-flux-framework/src/main/java/com/baize/flux/framework/classloading/*.java` (succeeded).
- Attempted to compile the entire API+framework sources; `javac -d /tmp/flux-classes` reported missing third-party dependencies (Jackson, Typesafe config, Lombok, etc.), which is expected in this environment (failed due to unresolved external deps).
- Attempted to run Maven tests with `mvn -q -pl baize-flux-api,baize-flux-framework -am test -DskipTests`, but Maven failed to resolve `maven-resources-plugin:3.3.1` from Maven Central (HTTP 403), so automated Maven test execution could not complete in this environment (failed due to repository access).
- Ran `git diff --check` and local quick compile checks for the newly added files during development (no whitespace errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63099a03d883269c474c5e26128e53)