### PR TITLE
fix: aggregate batch retry metrics

### DIFF
--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/JobMetrics.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/metrics/JobMetrics.java
@@ -72,6 +72,9 @@ public final class JobMetrics {
                     case 9:
                         n += m.getUnknownStateRecordCount();
                         break;
+                    case 10:
+                        n += m.getBatchRetryCount();
+                        break;
                 }
             }
         return n;
@@ -162,7 +165,7 @@ public final class JobMetrics {
     }
 
     public long getBatchRetryCount() {
-        return 0;
+        return sum(null, 10);
     }
 
     public long getDatabaseCommitMillis() {

--- a/baize-flux-framework/src/test/java/com/baize/flux/framework/metrics/TaskMetricsTest.java
+++ b/baize-flux-framework/src/test/java/com/baize/flux/framework/metrics/TaskMetricsTest.java
@@ -49,6 +49,9 @@ public class TaskMetricsTest {
         sink.addSinkWriteSuccessRecords(8);
         sink.addSinkWrittenBytes(80);
         sink.addDatabaseCommitNanos(3_000_000L);
+        source.incrementBatchRetryCount();
+        sink.incrementBatchRetryCount();
+        sink.incrementBatchRetryCount();
 
         assertEquals(10L, job.getSourceRecordCount());
         assertEquals(8L, job.getSinkRecordCount());
@@ -57,5 +60,6 @@ public class TaskMetricsTest {
         assertEquals(80L, job.getSinkWrittenBytes());
         assertEquals(1L, job.getCompletedSplitCount());
         assertEquals(3L, job.getDatabaseCommitMillis());
+        assertEquals(3L, job.getBatchRetryCount());
     }
 }


### PR DESCRIPTION
### Motivation
- 修复 `JobMetrics#getBatchRetryCount()` 始终返回 `0` 的问题，使作业级指标汇总各任务的重试次数。
- 增加回归测试以覆盖来自多个任务的批次重试计数的聚合行为。

### Description
- 在 `JobMetrics.sum(...)` 的 switch 中新增 `case 10`，将每个任务的 `getBatchRetryCount()` 纳入汇总计算。 
- 将 `JobMetrics#getBatchRetryCount()` 从返回常量 `0` 改为调用 `sum(null, 10)` 以返回所有任务的重试总和。 
- 在 `TaskMetricsTest.aggregatesSourceSinkAndDifference()` 中增加对 `incrementBatchRetryCount()` 的调用并断言 `job.getBatchRetryCount()` 的期望值，作为回归测试。

### Testing
- 运行 `git diff --check`，检查通过（无格式错误）。
- 尝试运行 `mvn -B test`，在线访问 Maven Central 时遇到 `403 Forbidden` 导致构建失败，因此无法在当前环境完整执行测试。 
- 尝试运行 `mvn -o -B -pl baize-flux-framework -am test`（离线模式）时失败，原因是本地未缓存所需的 `maven-resources-plugin:3.3.1`，因此模块测试无法在此环境通过执行。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63200dfdfc8326987eb388bcb4ed46)