### PR TITLE
feat: per-task log files (Log4j routing + SLF4J bridge)

### DIFF
--- a/baize-flux-api/pom.xml
+++ b/baize-flux-api/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.13</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/baize-flux-connectors/baize-flux-connector-jdbc/pom.xml
+++ b/baize-flux-connectors/baize-flux-connector-jdbc/pom.xml
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.13</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>

--- a/baize-flux-dist/src/main/dist/config/log4j2.xml
+++ b/baize-flux-dist/src/main/dist/config/log4j2.xml
@@ -17,11 +17,27 @@
             </Policies>
             <DefaultRolloverStrategy max="14"/>
         </RollingFile>
+        <Routing name="TaskFiles">
+            <Routes pattern="$${ctx:taskLogFile}">
+                <Route key="$${ctx:taskLogFile}">
+                    <RollingFile name="TaskFile-$${ctx:taskLogFile}"
+                                 fileName="${LOG_DIR}/$${ctx:taskLogFile}"
+                                 filePattern="${LOG_DIR}/$${ctx:taskLogFile}.%i.gz">
+                        <PatternLayout pattern="${PATTERN}"/>
+                        <Policies>
+                            <SizeBasedTriggeringPolicy size="100 MB"/>
+                        </Policies>
+                        <DefaultRolloverStrategy max="14"/>
+                    </RollingFile>
+                </Route>
+            </Routes>
+        </Routing>
     </Appenders>
     <Loggers>
         <Root level="INFO">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="File"/>
+            <AppenderRef ref="TaskFiles"/>
         </Root>
     </Loggers>
 </Configuration>

--- a/baize-flux-framework/pom.xml
+++ b/baize-flux-framework/pom.xml
@@ -33,6 +33,11 @@
             <artifactId>config</artifactId>
             <version>${typesafe.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/JobExecution.java
@@ -42,7 +42,7 @@ public final class JobExecution {
                 for (final PipelinePlan p : executionPlan.getPipelinePlans())
                     submitted.add(cs.submit(new Callable<PipelineResult>() {
                         public PipelineResult call() {
-                            return new PipelineExecution(p, executionPlan.getExecutionConfig(), cancellationToken, jobMetrics, classLoader).execute();
+                            return new PipelineExecution(p, executionPlan.getExecutionConfig(), cancellationToken, jobMetrics, classLoader, executionPlan.getJobName(), start).execute();
                         }
                     }));
                 for (int i = 0; i < submitted.size(); i++) {

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/PipelineExecution.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/PipelineExecution.java
@@ -33,13 +33,17 @@ final class PipelineExecution {
     private final CancellationToken token;
     private final JobMetrics metrics;
     private final ClassLoader loader;
+    private final String jobName;
+    private final long runId;
 
-    PipelineExecution(PipelinePlan plan, com.baize.flux.framework.job.ExecutionConfig config, CancellationToken token, JobMetrics metrics, ClassLoader loader) {
+    PipelineExecution(PipelinePlan plan, com.baize.flux.framework.job.ExecutionConfig config, CancellationToken token, JobMetrics metrics, ClassLoader loader, String jobName, long runId) {
         this.plan = plan;
         this.config = config;
         this.token = token;
         this.metrics = metrics;
         this.loader = loader;
+        this.jobName = jobName;
+        this.runId = runId;
     }
 
     private static void fail(List<DataChannel<RecordEnvelope<FluxRow>>> channels, Throwable cause) {
@@ -63,7 +67,7 @@ final class PipelineExecution {
                 metrics.registerSplitProvider(source.getSplitProvider());
                 sources.add(createSource(source, channels));
             }
-            try (TaskExecutor executor = new TaskExecutor(sinks.size() + sources.size(), "baize-flux-" + plan.getPipelineId())) {
+            try (TaskExecutor executor = new TaskExecutor(sinks.size() + sources.size(), "baize-flux-" + plan.getPipelineId(), jobName, runId)) {
                 ExecutionCoordinator outcomeCoordinator = new ExecutionCoordinator(executor, token, metrics, loader, new Runnable() {
                     public void run() {
                         fail(channels, token.getCause());

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/TaskExecutor.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/TaskExecutor.java
@@ -2,6 +2,9 @@ package com.baize.flux.framework.execution;
 
 import com.baize.flux.framework.execution.task.ExecutionTask;
 import com.baize.flux.framework.metrics.TaskMetrics;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.ThreadContext;
 
 import java.util.Objects;
 import java.util.concurrent.*;
@@ -13,19 +16,40 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class TaskExecutor
         implements AutoCloseable {
 
+    private static final Logger LOG = LogManager.getLogger(TaskExecutor.class);
+
     private final ExecutorService executorService;
 
     private final ExecutorCompletionService<TaskResult>
             completionService;
 
+    private final String jobName;
+
+    private final long runId;
+
     public TaskExecutor(
             int threadCount,
             final String threadPrefix) {
+
+        this(threadCount, threadPrefix, "unnamed", System.currentTimeMillis());
+    }
+
+    public TaskExecutor(
+            int threadCount,
+            final String threadPrefix,
+            String jobName,
+            long runId) {
 
         if (threadCount <= 0) {
             throw new IllegalArgumentException(
                     "threadCount must be greater than 0");
         }
+
+        this.jobName = Objects.requireNonNull(jobName, "jobName must not be null");
+        if (runId < 0) {
+            throw new IllegalArgumentException("runId must not be negative");
+        }
+        this.runId = runId;
 
         final AtomicInteger sequence =
                 new AtomicInteger();
@@ -77,6 +101,9 @@ public final class TaskExecutor
                     @Override
                     public TaskResult call() {
 
+                        String taskLogFile = TaskLogFileName.create(jobName, task.getTaskId(), runId);
+                        ThreadContext.put("taskLogFile", taskLogFile);
+
                         TaskMetrics metrics =
                                 context.getMetrics();
 
@@ -87,6 +114,8 @@ public final class TaskExecutor
                             metrics.markFinished(
                                     TaskState.CANCELED);
 
+                            LOG.info("Task cancelled before execution: {}", task.getTaskId());
+                            ThreadContext.remove("taskLogFile");
                             return TaskResult.canceled(
                                     task.getTaskId(),
                                     context
@@ -95,6 +124,7 @@ public final class TaskExecutor
                         }
 
                         metrics.markStarted();
+                        LOG.info("Task started: {}", task.getTaskId());
 
                         try {
                             task.execute(context);
@@ -106,6 +136,7 @@ public final class TaskExecutor
                                 metrics.markFinished(
                                         TaskState.CANCELED);
 
+                                LOG.info("Task cancelled: {}", task.getTaskId());
                                 return TaskResult.canceled(
                                         task.getTaskId(),
                                         context
@@ -116,6 +147,7 @@ public final class TaskExecutor
                             metrics.markFinished(
                                     TaskState.FINISHED);
 
+                            LOG.info("Task finished: {}", task.getTaskId());
                             return TaskResult.finished(
                                     task.getTaskId());
 
@@ -132,6 +164,7 @@ public final class TaskExecutor
                                 metrics.markFinished(
                                         TaskState.CANCELED);
 
+                                LOG.info("Task cancelled: {}", task.getTaskId());
                                 return TaskResult.canceled(
                                         task.getTaskId(),
                                         throwable);
@@ -140,9 +173,13 @@ public final class TaskExecutor
                             metrics.markFinished(
                                     TaskState.FAILED);
 
+                            LOG.error("Task failed: " + task.getTaskId(), throwable);
+
                             return TaskResult.failed(
                                     task.getTaskId(),
                                     throwable);
+                        } finally {
+                            ThreadContext.remove("taskLogFile");
                         }
                     }
                 });

--- a/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/TaskLogFileName.java
+++ b/baize-flux-framework/src/main/java/com/baize/flux/framework/execution/TaskLogFileName.java
@@ -1,0 +1,30 @@
+package com.baize.flux.framework.execution;
+
+import java.util.Objects;
+
+/**
+ * Creates filesystem-safe, per-task log file names.
+ */
+public final class TaskLogFileName {
+
+    private TaskLogFileName() {
+    }
+
+    public static String create(String jobName, TaskId taskId, long runId) {
+        Objects.requireNonNull(jobName, "jobName must not be null");
+        Objects.requireNonNull(taskId, "taskId must not be null");
+        if (runId < 0) {
+            throw new IllegalArgumentException("runId must not be negative");
+        }
+        return "job-" + sanitize(jobName)
+                + "-" + sanitize(taskId.getPipelineId())
+                + "-" + taskId.getTaskType().name().toLowerCase()
+                + "-" + taskId.getSubtaskIndex()
+                + "-" + runId + ".log";
+    }
+
+    private static String sanitize(String value) {
+        String sanitized = value.trim().replaceAll("[^A-Za-z0-9._-]+", "_");
+        return sanitized.isEmpty() ? "unnamed" : sanitized;
+    }
+}

--- a/baize-flux-framework/src/test/java/com/baize/flux/framework/execution/TaskLogFileNameTest.java
+++ b/baize-flux-framework/src/test/java/com/baize/flux/framework/execution/TaskLogFileNameTest.java
@@ -1,0 +1,15 @@
+package com.baize.flux.framework.execution;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class TaskLogFileNameTest {
+
+    @Test
+    public void createsSafePerTaskFileName() {
+        assertEquals(
+                "job-orders_sync-pipeline_source.orders-source-0-128392984.log",
+                TaskLogFileName.create("orders sync", new TaskId("pipeline/source.orders", TaskType.SOURCE, 0, 1), 128392984L));
+    }
+}

--- a/baize-flux-launcher/pom.xml
+++ b/baize-flux-launcher/pom.xml
@@ -39,10 +39,10 @@
             <artifactId>log4j-core</artifactId>
             <version>${log4j2.version}</version>
         </dependency>
-<!--        <dependency>-->
-<!--            <groupId>org.apache.logging.log4j</groupId>-->
-<!--            <artifactId>log4j-slf4j2-impl</artifactId>-->
-<!--            <version>${log4j2.version}</version>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -42,7 +42,7 @@ Git。可通过 `BAIZE_FLUX_CONF_DIR`、`BAIZE_FLUX_LOG_DIR`、`BAIZE_FLUX_HOME`
 BAIZE_FLUX_JAVA_OPTS='-XX:+UseG1GC -XX:MaxRAMPercentage=70.0' bin/baize-flux.sh -c config/orders-prod.yaml
 ```
 
-`config/log4j2.xml` 同时输出控制台和 `${BAIZE_FLUX_LOG_DIR:-logs}/baize-flux.log`。日志按日或 100 MB 滚动，最多保留 14 个归档。对容器运行，优先采集
+`config/log4j2.xml` 同时输出控制台和 `${BAIZE_FLUX_LOG_DIR:-logs}/baize-flux.log`。日志按日或 100 MB 滚动，最多保留 14 个归档。每次作业执行还会为每个 Source/Sink Task 创建独立日志，命名为 `job-<job-name>-<pipeline>-<task-type>-<subtask>-<run-id>.log`（例如 `job-orders_sync-pipeline_source.orders-source-0-128392984.log`）。文件名中的不安全字符会替换为下划线；同一作业运行的 `run-id` 相同，便于按批次检索。Task 日志同样按 100 MB 滚动，最多保留 14 个归档。对容器运行，优先采集
 stdout；需要落盘时挂载日志目录。
 
 ## Docker、上线与回滚

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <lombok.version>1.18.42</lombok.version>
         <typesafe.version>1.4.3</typesafe.version>
         <log4j2.version>2.17.2</log4j2.version>
+        <slf4j.version>2.0.13</slf4j.version>
         <jsqlparser.version>4.9</jsqlparser.version>
 
 


### PR DESCRIPTION
### Motivation
- Provide one log file per Source/Sink task so task-level diagnostics and connector logs are easy to inspect and correlate to a job run.
- Produce filesystem-safe, searchable filenames and group logs by a per-run identifier to simplify batch forensics and retries.
- Ensure logs from SLF4J-using connectors are captured into the same per-task files via a Log4j-SLF4J bridge.

### Description
- Add `TaskLogFileName.create(jobName, taskId, runId)` to generate safe per-task filenames in the form `job-<job>-<pipeline>-<type>-<subtask>-<run-id>.log` with unsafe characters replaced by underscores (`baize-flux-framework/src/main/java/.../TaskLogFileName.java`).
- Propagate `jobName` and `runId` from `JobExecution` into `PipelineExecution` and construct `TaskExecutor` with these values so all tasks in the same job run share the same run id (`baize-flux-framework/src/main/java/.../JobExecution.java`, `PipelineExecution.java`).
- Have `TaskExecutor` set a Log4j `ThreadContext` key (`taskLogFile`) and emit lifecycle logs (start/finish/cancel/fail) so per-task events are routed to the corresponding file and connector logs become includable (`baize-flux-framework/src/main/java/.../TaskExecutor.java`).
- Extend the packaged Log4j2 configuration to add a `Routing` appender that writes `taskLogFile`-scoped events into individual rolling files (100 MB, retain 14) and add the Log4j SLF4J binding and API to POMs so SLF4J logs go to Log4j (`baize-flux-dist/src/main/dist/config/log4j2.xml`, `pom.xml`, `baize-flux-launcher/pom.xml`, `baize-flux-framework/pom.xml`).
- Add a unit test for filename generation (`TaskLogFileNameTest`) and update deployment docs to describe naming and retention (`docs/deployment.md`, `baize-flux-framework/src/test/...`).

### Testing
- Code checks via `git diff --cached --check` passed in the environment where the patch was prepared.
- Running the module tests with the wrapper (`bash mvnw -pl baize-flux-framework -am test`) failed because the repository lacks the Maven Wrapper files required to run the wrapper locally.
- Running `mvn -pl baize-flux-framework -am test` failed due to external dependency resolution (Maven Central returned HTTP 403 for `maven-resources-plugin:3.3.1`), so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63235fd48883268128802e916471c7)