### PR TITLE
fix: propagate servlet IO failures

### DIFF
--- a/baize-flux-server/src/main/java/com/baize/flux/server/http/servlet/HealthServlet.java
+++ b/baize-flux-server/src/main/java/com/baize/flux/server/http/servlet/HealthServlet.java
@@ -14,7 +14,7 @@ public final class HealthServlet
     protected void doGet(
             HttpServletRequest request,
             HttpServletResponse response)
-            {
+            throws IOException {
 
         Map<String, Object> result =
                 new LinkedHashMap<String, Object>();
@@ -27,13 +27,9 @@ public final class HealthServlet
                 "timestamp",
                 System.currentTimeMillis());
 
-                try {
-                    write(
-                            response,
-                            200,
-                            result);
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
+        write(
+                response,
+                200,
+                result);
+    }
 }

--- a/baize-flux-server/src/main/java/com/baize/flux/server/http/servlet/JobResourceServlet.java
+++ b/baize-flux-server/src/main/java/com/baize/flux/server/http/servlet/JobResourceServlet.java
@@ -33,21 +33,17 @@ public final class JobResourceServlet
 
     protected void doGet(
             HttpServletRequest request,
-            HttpServletResponse response) {
+            HttpServletResponse response)
+            throws IOException {
 
         List<String> segments =
                 pathSegments(request);
 
         if (segments.size() == 1) {
-            try {
-                write(
-                        response,
-                        200,
-                        service.job(
-                                segments.get(0)));
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+            write(
+                    response,
+                    200,
+                    service.job(segments.get(0)));
             return;
         }
 
@@ -59,38 +55,26 @@ public final class JobResourceServlet
                     segments.get(1);
 
             if ("pipelines".equals(resource)) {
-                try {
-                    write(
-                            response,
-                            200,
-                            service.pipelines(jobId));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+                write(
+                        response,
+                        200,
+                        service.pipelines(jobId));
                 return;
             }
 
             if ("tasks".equals(resource)) {
-                try {
-                    write(
-                            response,
-                            200,
-                            service.tasks(jobId));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+                write(
+                        response,
+                        200,
+                        service.tasks(jobId));
                 return;
             }
 
             if ("metrics".equals(resource)) {
-                try {
-                    write(
-                            response,
-                            200,
-                            service.metrics(jobId));
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
+                write(
+                        response,
+                        200,
+                        service.metrics(jobId));
                 return;
             }
         }
@@ -101,7 +85,8 @@ public final class JobResourceServlet
 
     protected void doDelete(
             HttpServletRequest request,
-            HttpServletResponse response) {
+            HttpServletResponse response)
+            throws IOException {
 
         List<String> segments =
                 pathSegments(request);
@@ -111,14 +96,9 @@ public final class JobResourceServlet
                     request.getRequestURI());
         }
 
-        try {
-            write(
-                    response,
-                    202,
-                    service.cancel(
-                            segments.get(0)));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        write(
+                response,
+                202,
+                service.cancel(segments.get(0)));
     }
 }

--- a/baize-flux-server/src/main/java/com/baize/flux/server/http/servlet/JobsServlet.java
+++ b/baize-flux-server/src/main/java/com/baize/flux/server/http/servlet/JobsServlet.java
@@ -27,28 +27,24 @@ public final class JobsServlet
     protected void doPost(
             HttpServletRequest request,
             HttpServletResponse response)
-             {
+            throws IOException {
 
         validateSubmitContentType(request);
 
-                 try {
-                     write(
-                             response,
-                             202,
-                             service.submit(
-                                     requestBody(
-                                             request,
-                                             maxRequestBytes)));
-                 } catch (IOException e) {
-                     e.printStackTrace();
-                 }
-             }
+        write(
+                response,
+                202,
+                service.submit(
+                        requestBody(
+                                request,
+                                maxRequestBytes)));
+    }
 
 
     protected void doGet(
             HttpServletRequest request,
             HttpServletResponse response)
-             {
+            throws IOException {
 
         int page =
                 intParameter(
@@ -62,17 +58,12 @@ public final class JobsServlet
                         "pageSize",
                         20);
 
-                 try {
-                     write(
-                             response,
-                             200,
-                             service.jobs(
-                                     request.getParameter(
-                                             "status"),
-                                     page,
-                                     pageSize));
-                 } catch (IOException e) {
-                     e.printStackTrace();
-                 }
-             }
+        write(
+                response,
+                200,
+                service.jobs(
+                        request.getParameter("status"),
+                        page,
+                        pageSize));
+    }
 }


### PR DESCRIPTION
### Motivation
- Several servlet handlers were swallowing `IOException` during response serialization by calling `printStackTrace()`, which can return a misleading successful HTTP status while the response body was never written. 
- The server should let the container / centralized `ExceptionHandlingFilter` observe write failures so errors are logged and correct HTTP error responses are returned.

### Description
- Updated `JobsServlet` to propagate I/O errors by adding `throws IOException` to `doPost` and `doGet` and removing local `try/catch` blocks so `write(...)` failures bubble up. 
- Updated `JobResourceServlet` to add `throws IOException` to `doGet`/`doDelete` and removed swallowing `IOException` around `write(...)` calls for job details, pipelines, tasks, metrics and cancel endpoints. 
- Updated `HealthServlet` to add `throws IOException` to `doGet` and to propagate `write(...)` failures instead of catching them. 
- The changes remove `printStackTrace()` error handling and normalize servlet implementations to rely on the central `ExceptionHandlingFilter` for mapping and logging failures; affected files: `baize-flux-server/src/main/java/com/baize/flux/server/http/servlet/JobsServlet.java`, `.../JobResourceServlet.java`, and `.../HealthServlet.java`.

### Testing
- Searched for remaining `printStackTrace` / `catch (IOException` occurrences with `rg` to confirm affected sites were updated, which succeeded. 
- Ran `git diff --check` to ensure no whitespace/merge artifacts, which passed. 
- Attempted to run module tests with `mvn -pl baize-flux-server -am test`, which failed due to dependency resolution error against Maven Central (`maven-resources-plugin:3.3.1` returned HTTP 403). 
- Attempted the Maven Wrapper (`./mvnw`) but the project does not include the wrapper files in this environment, so the wrapper run could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6334fcc9608326bfd8b9887f15d767)