### PR TITLE
feat(server): define single-node offline worker protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ bin/link-up.sh --config config/link-up.yaml
 The configuration file has a `.yaml` deployment-friendly name but uses HOCON syntax. Do not commit real JDBC
 credentials. See the [deployment and operations guide](docs/deployment.md) for packaging, CI, Docker, JVM options,
 Log4j2, security, rollback, and production guidance.
+
+## Offline Worker protocol
+
+`link-up-server` is a single-node, offline-only execution Worker. Its lifecycle is:
+
+```text
+CREATED -> SUBMITTED -> QUEUED -> RUNNING
+                                  -> SUCCEEDED / FAILED / CANCELED / LOST
+```
+
+The JSON submit protocol supports control-plane `externalExecutionId`, `idempotencyKey`, definition versioning,
+auditable state transitions, worker instance identity and deterministic duplicate submission handling. The previous
+HOCON body submission remains available for CLI and compatibility use.
+
+See [the single-node offline Worker protocol](docs/worker-protocol.md) for the complete API and state ownership contract.

--- a/docs/worker-protocol.md
+++ b/docs/worker-protocol.md
@@ -1,0 +1,81 @@
+# Link-Up 单节点离线 Worker 执行协议
+
+Link-Up Server 是一个只执行离线批量同步任务的单节点 Worker。Yak Ops 等控制面负责任务定义、调度、执行历史、重试和告警；Link-Up 负责接收一次执行命令、排队、运行、取消并返回最终结果。
+
+## Worker 身份
+
+```http
+GET /api/v1/node
+```
+
+响应包含稳定的 `nodeId`、每次启动变化的 `instanceId`、容量、负载和完整生命周期。控制面必须保存提交时的 `workerInstanceId`。如果同一 `nodeId` 返回了新的 `instanceId`，控制面应将旧实例中仍处于非终态的任务标记为 `LOST`。
+
+## 状态机
+
+```text
+CREATED
+   ↓
+SUBMITTED
+   ↓
+QUEUED
+   ↓
+RUNNING
+   ├── SUCCEEDED
+   ├── FAILED
+   ├── CANCELED
+   └── LOST
+```
+
+终态不可再次转换。每次状态转换都会增加 `stateVersion`，并记录在 `transitions` 中。取消请求不会引入额外的 `CANCELLING` 业务状态；`cancellationRequested=true` 表示取消意图已被接收，实际状态仍保持 `QUEUED` 或 `RUNNING`，直到进入终态。
+
+## JSON 提交协议
+
+```http
+POST /api/v1/jobs
+Content-Type: application/json
+```
+
+```json
+{
+  "externalExecutionId": "yak-execution-10086",
+  "idempotencyKey": "60af452d-813c-4e51-87d9-4b00b5e2b53f",
+  "definitionVersion": 3,
+  "hocon": "job { ... }"
+}
+```
+
+Worker 会计算配置摘要。相同 `externalExecutionId`、`idempotencyKey`、`definitionVersion` 和配置摘要的重复请求返回同一个 `jobId`；复用相同标识但提交不同内容时返回 HTTP `409` 和错误码 `FLUX-JOB-IDEMPOTENCY-CONFLICT`。
+
+旧版 `application/hocon` 和 `text/plain` 提交仍然保留，但只用于 CLI 或过渡期调用，不适合控制面可靠重试。
+
+## 查询与取消
+
+```http
+GET /api/v1/jobs/{jobId}
+GET /api/v1/jobs/external/{externalExecutionId}
+GET /api/v1/jobs?externalExecutionId={externalExecutionId}
+GET /api/v1/jobs?status=RUNNING&page=1&pageSize=20
+GET /api/v1/jobs/{jobId}/pipelines
+GET /api/v1/jobs/{jobId}/tasks
+GET /api/v1/jobs/{jobId}/metrics
+DELETE /api/v1/jobs/{jobId}
+```
+
+提交请求超时后，控制面应优先使用 `externalExecutionId` 查询，不能直接生成新执行实例重复提交。
+
+## LOST 处理
+
+`LOST` 表示最终结果未知，不等价于失败或取消：
+
+1. Worker 优雅关闭时先请求取消。
+2. 在关闭超时内完成的任务进入实际终态。
+3. 关闭超时后仍未完成的任务进入 `LOST`。
+4. 如果进程被直接杀死，控制面通过 `workerInstanceId` 变化或节点失联超时，将旧实例的非终态任务标记为 `LOST`。
+5. 对 `LOST` 的重试必须创建新的控制面执行实例和新的 `externalExecutionId`，不能修改原执行记录。
+
+## 控制面轮询建议
+
+- `SUBMITTED`、`QUEUED`：每 2～3 秒查询。
+- `RUNNING`：每 3～5 秒查询，长任务可退避到 15～30 秒。
+- 终态：停止轮询。
+- 更新前比较 `stateVersion`，只接受更高版本的状态。

--- a/link-up-server/src/main/java/com/link/up/server/FluxServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/FluxServer.java
@@ -9,6 +9,7 @@ import com.link.up.server.runtime.JobRepository;
 import com.link.up.server.runtime.LocalJobExecutor;
 import com.link.up.server.runtime.LocalJobIdGenerator;
 import com.link.up.server.runtime.LocalJobManager;
+import com.link.up.server.runtime.WorkerIdentity;
 import com.link.up.server.service.JobRestService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Link-Up REST Server 启动入口。
+ * Link-Up 单节点离线同步 Worker 启动入口。
  */
 public final class FluxServer {
 
@@ -31,8 +32,7 @@ public final class FluxServer {
     }
 
     private static final Logger LOG =
-            LogManager.getLogger(
-                    FluxServer.class);
+            LogManager.getLogger(FluxServer.class);
 
     private FluxServer() {
     }
@@ -51,14 +51,11 @@ public final class FluxServer {
                         Thread.currentThread()
                                 .getContextClassLoader(),
                         pluginDirectories.toArray(
-                                new Path[
-                                        pluginDirectories
-                                                .size()]));
+                                new Path[pluginDirectories.size()]));
 
         JobRepository repository =
                 new InMemoryJobRepository(
                         config.getHistoryLimit());
-
         JobIdGenerator jobIdGenerator =
                 new LocalJobIdGenerator();
 
@@ -71,23 +68,28 @@ public final class FluxServer {
                         repository,
                         jobIdGenerator);
 
+        WorkerIdentity workerIdentity =
+                new WorkerIdentity(
+                        config.getNodeId(),
+                        config.getNodeName(),
+                        WorkerIdentity.implementationVersion());
+
         JobRestService service =
-                new JobRestService(manager);
+                new JobRestService(
+                        manager,
+                        workerIdentity,
+                        config.getJobThreads(),
+                        config.getMaxQueuedJobs());
 
         final JettyServer server =
-                new JettyServer(
-                        config,
-                        service);
-
+                new JettyServer(config, service);
         final AtomicBoolean shutdown =
                 new AtomicBoolean(false);
 
         final Runnable shutdownAction =
                 new Runnable() {
                     public void run() {
-                        if (!shutdown.compareAndSet(
-                                false,
-                                true)) {
+                        if (!shutdown.compareAndSet(false, true)) {
                             return;
                         }
 
@@ -108,15 +110,15 @@ public final class FluxServer {
                         shutdownAction,
                         "link-up-shutdown");
 
-        Runtime.getRuntime()
-                .addShutdownHook(
-                        shutdownHook);
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
 
         try {
             server.start();
 
             LOG.info(
-                    "Link-Up Server started, host={}, port={}, jobThreads={}, pluginDirectories={}",
+                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, host={}, port={}, jobThreads={}, pluginDirectories={}",
+                    workerIdentity.getNodeId(),
+                    workerIdentity.getInstanceId(),
                     config.getHost(),
                     server.getLocalPort(),
                     config.getJobThreads(),
@@ -128,37 +130,24 @@ public final class FluxServer {
 
             try {
                 Runtime.getRuntime()
-                        .removeShutdownHook(
-                                shutdownHook);
+                        .removeShutdownHook(shutdownHook);
             } catch (IllegalStateException ignored) {
                 // JVM 已经进入关闭流程。
             }
         }
     }
 
-    /**
-     * IDEA 直接启动 Server 时也提供稳定的默认日志文件。
-     *
-     * <p>显式 JVM 参数或 LOGFILE 环境变量优先级更高。
-     */
     private static void configureDefaultLogFile() {
-        if (hasText(
-                System.getProperty(
-                        LOG_FILE_PROPERTY))
-                || hasText(
-                System.getenv(
-                        "LOGFILE"))) {
+        if (hasText(System.getProperty(LOG_FILE_PROPERTY))
+                || hasText(System.getenv("LOGFILE"))) {
             return;
         }
 
         String logDirectory =
-                System.getProperty(
-                        "link.up.log.dir");
+                System.getProperty("link.up.log.dir");
 
         if (!hasText(logDirectory)) {
-            logDirectory =
-                    System.getenv(
-                            "LINK_UP_LOG_DIR");
+            logDirectory = System.getenv("LINK_UP_LOG_DIR");
         }
 
         if (!hasText(logDirectory)) {
@@ -174,7 +163,6 @@ public final class FluxServer {
     }
 
     private static boolean hasText(String value) {
-        return value != null
-                && !value.trim().isEmpty();
+        return value != null && !value.trim().isEmpty();
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/config/FluxServerConfig.java
+++ b/link-up-server/src/main/java/com/link/up/server/config/FluxServerConfig.java
@@ -18,6 +18,8 @@ public final class FluxServerConfig {
     public static final int DEFAULT_HISTORY_LIMIT = 1_000;
     public static final int DEFAULT_MAX_REQUEST_BYTES = 1024 * 1024;
     public static final long DEFAULT_SHUTDOWN_TIMEOUT_MILLIS = 10_000L;
+    public static final String DEFAULT_NODE_ID = "link-up-node-1";
+    public static final String DEFAULT_NODE_NAME = "Link-Up Offline Worker";
 
     private final String host;
     private final int port;
@@ -28,6 +30,8 @@ public final class FluxServerConfig {
     private final int maxRequestBytes;
     private final long shutdownTimeoutMillis;
     private final List<Path> pluginDirectories;
+    private final String nodeId;
+    private final String nodeName;
 
     public FluxServerConfig(
             String host,
@@ -40,38 +44,40 @@ public final class FluxServerConfig {
             long shutdownTimeoutMillis,
             List<Path> pluginDirectories) {
 
+        this(
+                host,
+                port,
+                jobThreads,
+                httpThreads,
+                maxQueuedJobs,
+                historyLimit,
+                maxRequestBytes,
+                shutdownTimeoutMillis,
+                pluginDirectories,
+                DEFAULT_NODE_ID,
+                DEFAULT_NODE_NAME);
+    }
+
+    public FluxServerConfig(
+            String host,
+            int port,
+            int jobThreads,
+            int httpThreads,
+            int maxQueuedJobs,
+            int historyLimit,
+            int maxRequestBytes,
+            long shutdownTimeoutMillis,
+            List<Path> pluginDirectories,
+            String nodeId,
+            String nodeName) {
+
         this.host = requireText(host, "host");
         this.port = requireRange(port, 1, 65535, "port");
-        this.jobThreads =
-                requireRange(
-                        jobThreads,
-                        1,
-                        Integer.MAX_VALUE,
-                        "jobThreads");
-        this.httpThreads =
-                requireRange(
-                        httpThreads,
-                        4,
-                        Integer.MAX_VALUE,
-                        "httpThreads");
-        this.maxQueuedJobs =
-                requireRange(
-                        maxQueuedJobs,
-                        1,
-                        Integer.MAX_VALUE,
-                        "maxQueuedJobs");
-        this.historyLimit =
-                requireRange(
-                        historyLimit,
-                        1,
-                        Integer.MAX_VALUE,
-                        "historyLimit");
-        this.maxRequestBytes =
-                requireRange(
-                        maxRequestBytes,
-                        1,
-                        Integer.MAX_VALUE,
-                        "maxRequestBytes");
+        this.jobThreads = requireRange(jobThreads, 1, Integer.MAX_VALUE, "jobThreads");
+        this.httpThreads = requireRange(httpThreads, 4, Integer.MAX_VALUE, "httpThreads");
+        this.maxQueuedJobs = requireRange(maxQueuedJobs, 1, Integer.MAX_VALUE, "maxQueuedJobs");
+        this.historyLimit = requireRange(historyLimit, 1, Integer.MAX_VALUE, "historyLimit");
+        this.maxRequestBytes = requireRange(maxRequestBytes, 1, Integer.MAX_VALUE, "maxRequestBytes");
 
         if (shutdownTimeoutMillis < 0L) {
             throw new IllegalArgumentException(
@@ -88,12 +94,12 @@ public final class FluxServerConfig {
         this.pluginDirectories =
                 Collections.unmodifiableList(
                         new ArrayList<Path>(directories));
+        this.nodeId = requireText(nodeId, "nodeId");
+        this.nodeName = requireText(nodeName, "nodeName");
     }
 
     public static FluxServerConfig defaults() {
-        int processors =
-                Runtime.getRuntime()
-                        .availableProcessors();
+        int processors = Runtime.getRuntime().availableProcessors();
 
         return new FluxServerConfig(
                 DEFAULT_HOST,
@@ -104,7 +110,9 @@ public final class FluxServerConfig {
                 DEFAULT_HISTORY_LIMIT,
                 DEFAULT_MAX_REQUEST_BYTES,
                 DEFAULT_SHUTDOWN_TIMEOUT_MILLIS,
-                Collections.<Path>emptyList());
+                Collections.<Path>emptyList(),
+                DEFAULT_NODE_ID,
+                DEFAULT_NODE_NAME);
     }
 
     public static FluxServerConfig fromArgs(String[] args) {
@@ -117,38 +125,27 @@ public final class FluxServerConfig {
         int maxQueuedJobs = defaults.getMaxQueuedJobs();
         int historyLimit = defaults.getHistoryLimit();
         int maxRequestBytes = defaults.getMaxRequestBytes();
-        long shutdownTimeout =
-                defaults.getShutdownTimeoutMillis();
+        long shutdownTimeout = defaults.getShutdownTimeoutMillis();
+        String nodeId = defaults.getNodeId();
+        String nodeName = defaults.getNodeName();
 
-        List<Path> pluginDirectories =
-                new ArrayList<Path>();
+        List<Path> pluginDirectories = new ArrayList<Path>();
 
-        for (int index = 0;
-             index < args.length;
-             index++) {
-
+        for (int index = 0; index < args.length; index++) {
             String argument = args[index];
 
-            if (argument == null
-                    || !argument.startsWith("--")) {
+            if (argument == null || !argument.startsWith("--")) {
                 throw new IllegalArgumentException(
                         "Unknown argument: " + argument);
             }
 
             String option;
             String value;
-
-            int equalIndex =
-                    argument.indexOf('=');
+            int equalIndex = argument.indexOf('=');
 
             if (equalIndex > 0) {
-                option =
-                        argument.substring(
-                                0,
-                                equalIndex);
-                value =
-                        argument.substring(
-                                equalIndex + 1);
+                option = argument.substring(0, equalIndex);
+                value = argument.substring(equalIndex + 1);
             } else {
                 option = argument;
 
@@ -175,12 +172,13 @@ public final class FluxServerConfig {
             } else if ("--max-request-bytes".equals(option)) {
                 maxRequestBytes = parseInt(option, value);
             } else if ("--shutdown-timeout-millis".equals(option)) {
-                shutdownTimeout =
-                        parseLong(option, value);
+                shutdownTimeout = parseLong(option, value);
             } else if ("--plugin-dir".equals(option)) {
-                addPluginDirectories(
-                        pluginDirectories,
-                        value);
+                addPluginDirectories(pluginDirectories, value);
+            } else if ("--node-id".equals(option)) {
+                nodeId = value;
+            } else if ("--node-name".equals(option)) {
+                nodeName = value;
             } else {
                 throw new IllegalArgumentException(
                         "Unknown option: " + option);
@@ -196,21 +194,21 @@ public final class FluxServerConfig {
                 historyLimit,
                 maxRequestBytes,
                 shutdownTimeout,
-                pluginDirectories);
+                pluginDirectories,
+                nodeId,
+                nodeName);
     }
 
     private static void addPluginDirectories(
             List<Path> directories,
             String value) {
 
-        if (value == null
-                || value.trim().isEmpty()) {
+        if (value == null || value.trim().isEmpty()) {
             throw new IllegalArgumentException(
                     "plugin directory must not be blank");
         }
 
-        String[] paths =
-                value.split(",");
+        String[] paths = value.split(",");
 
         for (String path : paths) {
             String normalized = path.trim();
@@ -224,40 +222,26 @@ public final class FluxServerConfig {
         }
     }
 
-    private static int parseInt(
-            String option,
-            String value) {
-
+    private static int parseInt(String option, String value) {
         try {
             return Integer.parseInt(value);
         } catch (NumberFormatException exception) {
             throw new IllegalArgumentException(
-                    option
-                            + " must be an integer: "
-                            + value);
+                    option + " must be an integer: " + value);
         }
     }
 
-    private static long parseLong(
-            String option,
-            String value) {
-
+    private static long parseLong(String option, String value) {
         try {
             return Long.parseLong(value);
         } catch (NumberFormatException exception) {
             throw new IllegalArgumentException(
-                    option
-                            + " must be a long integer: "
-                            + value);
+                    option + " must be a long integer: " + value);
         }
     }
 
-    private static String requireText(
-            String value,
-            String name) {
-
-        if (value == null
-                || value.trim().isEmpty()) {
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
             throw new IllegalArgumentException(
                     name + " must not be blank");
         }
@@ -271,52 +255,23 @@ public final class FluxServerConfig {
             int maximum,
             String name) {
 
-        if (value < minimum
-                || value > maximum) {
+        if (value < minimum || value > maximum) {
             throw new IllegalArgumentException(
-                    name
-                            + " must be between "
-                            + minimum
-                            + " and "
-                            + maximum);
+                    name + " must be between " + minimum + " and " + maximum);
         }
 
         return value;
     }
 
-    public String getHost() {
-        return host;
-    }
-
-    public int getPort() {
-        return port;
-    }
-
-    public int getJobThreads() {
-        return jobThreads;
-    }
-
-    public int getHttpThreads() {
-        return httpThreads;
-    }
-
-    public int getMaxQueuedJobs() {
-        return maxQueuedJobs;
-    }
-
-    public int getHistoryLimit() {
-        return historyLimit;
-    }
-
-    public int getMaxRequestBytes() {
-        return maxRequestBytes;
-    }
-
-    public long getShutdownTimeoutMillis() {
-        return shutdownTimeoutMillis;
-    }
-
-    public List<Path> getPluginDirectories() {
-        return pluginDirectories;
-    }
+    public String getHost() { return host; }
+    public int getPort() { return port; }
+    public int getJobThreads() { return jobThreads; }
+    public int getHttpThreads() { return httpThreads; }
+    public int getMaxQueuedJobs() { return maxQueuedJobs; }
+    public int getHistoryLimit() { return historyLimit; }
+    public int getMaxRequestBytes() { return maxRequestBytes; }
+    public long getShutdownTimeoutMillis() { return shutdownTimeoutMillis; }
+    public List<Path> getPluginDirectories() { return pluginDirectories; }
+    public String getNodeId() { return nodeId; }
+    public String getNodeName() { return nodeName; }
 }

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobResponse.java
@@ -1,0 +1,138 @@
+package com.link.up.server.dto;
+
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobStateTransition;
+import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.WorkerIdentity;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 对控制面稳定输出的离线作业协议视图。
+ */
+public final class JobResponse {
+
+    private final JobSnapshot snapshot;
+    private final JobExecutionMetadata metadata;
+    private final WorkerIdentity worker;
+
+    public JobResponse(
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata,
+            WorkerIdentity worker) {
+
+        this.snapshot = snapshot;
+        this.metadata = metadata;
+        this.worker = worker;
+    }
+
+    public JobSnapshot.Summary toSummary() {
+        return snapshot.toSummary();
+    }
+
+    public String getJobId() {
+        return snapshot.getJobId();
+    }
+
+    public String getExternalExecutionId() {
+        return metadata == null
+                ? null
+                : metadata.getExternalExecutionId();
+    }
+
+    public String getIdempotencyKey() {
+        return metadata == null
+                ? null
+                : metadata.getIdempotencyKey();
+    }
+
+    public String getJobName() {
+        return snapshot.getJobName();
+    }
+
+    public int getDefinitionVersion() {
+        return metadata == null
+                ? 1
+                : metadata.getDefinitionVersion();
+    }
+
+    public String getWorkerNodeId() {
+        return worker.getNodeId();
+    }
+
+    public String getWorkerInstanceId() {
+        return worker.getInstanceId();
+    }
+
+    public ServerJobStatus getStatus() {
+        return snapshot.getStatus();
+    }
+
+    public long getStateVersion() {
+        return metadata == null
+                ? 0L
+                : metadata.getStateVersion();
+    }
+
+    public boolean isCancellationRequested() {
+        return metadata != null
+                && metadata.isCancellationRequested();
+    }
+
+    public long getCreateTimeMillis() {
+        return snapshot.getCreateTimeMillis();
+    }
+
+    public long getSubmittedTimeMillis() {
+        return metadata == null
+                ? 0L
+                : metadata.getSubmittedTimeMillis();
+    }
+
+    public long getQueuedTimeMillis() {
+        return metadata == null
+                ? 0L
+                : metadata.getQueuedTimeMillis();
+    }
+
+    public long getStartTimeMillis() {
+        return snapshot.getStartTimeMillis();
+    }
+
+    public long getEndTimeMillis() {
+        return snapshot.getEndTimeMillis();
+    }
+
+    public long getDurationMillis() {
+        return snapshot.getDurationMillis();
+    }
+
+    public JobSnapshot.Metrics getMetrics() {
+        return snapshot.getMetrics();
+    }
+
+    public JobSnapshot.Commit getCommitSummary() {
+        return snapshot.getCommitSummary();
+    }
+
+    public List<JobSnapshot.Pipeline> getPipelines() {
+        return snapshot.getPipelines();
+    }
+
+    public List<JobStateTransition> getTransitions() {
+        return metadata == null
+                ? Collections
+                .<JobStateTransition>emptyList()
+                : metadata.getTransitions();
+    }
+
+    public String getErrorCode() {
+        return snapshot.getErrorCode();
+    }
+
+    public String getErrorMessage() {
+        return snapshot.getErrorMessage();
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobSubmitRequest.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobSubmitRequest.java
@@ -1,0 +1,50 @@
+package com.link.up.server.dto;
+
+/**
+ * Link-Up Worker JSON 提交协议。
+ */
+public final class JobSubmitRequest {
+
+    private String externalExecutionId;
+    private String idempotencyKey;
+    private Integer definitionVersion;
+    private String hocon;
+
+    public JobSubmitRequest() {
+    }
+
+    public String getExternalExecutionId() {
+        return externalExecutionId;
+    }
+
+    public void setExternalExecutionId(
+            String externalExecutionId) {
+        this.externalExecutionId = externalExecutionId;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public void setIdempotencyKey(
+            String idempotencyKey) {
+        this.idempotencyKey = idempotencyKey;
+    }
+
+    public Integer getDefinitionVersion() {
+        return definitionVersion;
+    }
+
+    public void setDefinitionVersion(
+            Integer definitionVersion) {
+        this.definitionVersion = definitionVersion;
+    }
+
+    public String getHocon() {
+        return hocon;
+    }
+
+    public void setHocon(String hocon) {
+        this.hocon = hocon;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/dto/WorkerNodeResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/WorkerNodeResponse.java
@@ -1,0 +1,118 @@
+package com.link.up.server.dto;
+
+import com.link.up.server.runtime.JobManager;
+import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.WorkerIdentity;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 单节点离线 Worker 信息。
+ */
+public final class WorkerNodeResponse {
+
+    private final String nodeId;
+    private final String nodeName;
+    private final String instanceId;
+    private final String version;
+    private final String status;
+    private final long startedAtMillis;
+    private final boolean offlineOnly;
+    private final int maxConcurrentJobs;
+    private final int maxQueuedJobs;
+    private final int runningJobs;
+    private final int queuedJobs;
+    private final int activeJobs;
+    private final List<ServerJobStatus> lifecycle;
+
+    public WorkerNodeResponse(
+            WorkerIdentity identity,
+            JobManager manager,
+            int maxConcurrentJobs,
+            int maxQueuedJobs) {
+
+        this.nodeId = identity.getNodeId();
+        this.nodeName = identity.getNodeName();
+        this.instanceId = identity.getInstanceId();
+        this.version = identity.getVersion();
+        this.status = manager.isClosed()
+                ? "DOWN"
+                : "UP";
+        this.startedAtMillis =
+                identity.getStartedAtMillis();
+        this.offlineOnly = true;
+        this.maxConcurrentJobs = maxConcurrentJobs;
+        this.maxQueuedJobs = maxQueuedJobs;
+        this.runningJobs =
+                manager.getRunningJobCount();
+        this.queuedJobs =
+                manager.getQueuedJobCount();
+        this.activeJobs =
+                manager.getActiveJobCount();
+        this.lifecycle =
+                Collections.unmodifiableList(
+                        Arrays.asList(
+                                ServerJobStatus.CREATED,
+                                ServerJobStatus.SUBMITTED,
+                                ServerJobStatus.QUEUED,
+                                ServerJobStatus.RUNNING,
+                                ServerJobStatus.SUCCEEDED,
+                                ServerJobStatus.FAILED,
+                                ServerJobStatus.CANCELED,
+                                ServerJobStatus.LOST));
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public String getNodeName() {
+        return nodeName;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public long getStartedAtMillis() {
+        return startedAtMillis;
+    }
+
+    public boolean isOfflineOnly() {
+        return offlineOnly;
+    }
+
+    public int getMaxConcurrentJobs() {
+        return maxConcurrentJobs;
+    }
+
+    public int getMaxQueuedJobs() {
+        return maxQueuedJobs;
+    }
+
+    public int getRunningJobs() {
+        return runningJobs;
+    }
+
+    public int getQueuedJobs() {
+        return queuedJobs;
+    }
+
+    public int getActiveJobs() {
+        return activeJobs;
+    }
+
+    public List<ServerJobStatus> getLifecycle() {
+        return lifecycle;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/http/ExceptionHandlingFilter.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/ExceptionHandlingFilter.java
@@ -3,6 +3,7 @@ package com.link.up.server.http;
 import com.link.up.server.dto.ErrorResponse;
 import com.link.up.server.runtime.JobNotFoundException;
 import com.link.up.server.runtime.JobStateConflictException;
+import com.link.up.server.runtime.JobSubmissionConflictException;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -25,14 +26,12 @@ public final class ExceptionHandlingFilter
         implements Filter {
 
     public static final String REQUEST_ID_ATTRIBUTE =
-            ExceptionHandlingFilter.class
-                    .getName()
+            ExceptionHandlingFilter.class.getName()
                     + ".requestId";
 
     private static final Logger LOG =
             Logger.getLogger(
-                    ExceptionHandlingFilter.class
-                            .getName());
+                    ExceptionHandlingFilter.class.getName());
 
     public void init(FilterConfig filterConfig) {
     }
@@ -45,35 +44,24 @@ public final class ExceptionHandlingFilter
 
         HttpServletRequest request =
                 (HttpServletRequest) servletRequest;
-
         HttpServletResponse response =
                 (HttpServletResponse) servletResponse;
-
-        String requestId =
-                requestId(request);
+        String requestId = requestId(request);
 
         request.setAttribute(
                 REQUEST_ID_ATTRIBUTE,
                 requestId);
-
-        response.setHeader(
-                "X-Request-Id",
-                requestId);
+        response.setHeader("X-Request-Id", requestId);
 
         try {
-            chain.doFilter(
-                    request,
-                    response);
+            chain.doFilter(request, response);
         } catch (Exception exception) {
-            Throwable failure =
-                    unwrap(exception);
+            Throwable failure = unwrap(exception);
 
             if (response.isCommitted()) {
                 LOG.log(
                         Level.SEVERE,
-                        logMessage(
-                                request,
-                                requestId),
+                        logMessage(request, requestId),
                         failure);
 
                 throw exception instanceof ServletException
@@ -81,18 +69,14 @@ public final class ExceptionHandlingFilter
                         : new ServletException(exception);
             }
 
-            ErrorMapping mapping =
-                    map(failure);
+            ErrorMapping mapping = map(failure);
 
             response.resetBuffer();
-            response.setStatus(
-                    mapping.httpStatus);
+            response.setStatus(mapping.httpStatus);
             response.setCharacterEncoding("UTF-8");
             response.setContentType(
                     "application/json;charset=UTF-8");
-            response.setHeader(
-                    "Cache-Control",
-                    "no-store");
+            response.setHeader("Cache-Control", "no-store");
 
             JsonSupport.mapper()
                     .writeValue(
@@ -109,9 +93,7 @@ public final class ExceptionHandlingFilter
 
             LOG.log(
                     level,
-                    logMessage(
-                            request,
-                            requestId),
+                    logMessage(request, requestId),
                     failure);
         }
     }
@@ -119,9 +101,7 @@ public final class ExceptionHandlingFilter
     public void destroy() {
     }
 
-    private static ErrorMapping map(
-            Throwable failure) {
-
+    private static ErrorMapping map(Throwable failure) {
         if (failure instanceof RestException) {
             RestException exception =
                     (RestException) failure;
@@ -132,40 +112,42 @@ public final class ExceptionHandlingFilter
                     exception.getMessage());
         }
 
-        if (failure
-                instanceof JobNotFoundException) {
+        if (failure instanceof JobNotFoundException) {
             return new ErrorMapping(
                     404,
                     "FLUX-JOB-NOT-FOUND",
                     failure.getMessage());
         }
 
-        if (failure
-                instanceof JobStateConflictException) {
+        if (failure instanceof JobStateConflictException) {
             return new ErrorMapping(
                     409,
                     "FLUX-JOB-STATE-CONFLICT",
                     failure.getMessage());
         }
 
-        if (failure
-                instanceof IllegalArgumentException) {
+        if (failure instanceof JobSubmissionConflictException) {
+            return new ErrorMapping(
+                    409,
+                    "FLUX-JOB-IDEMPOTENCY-CONFLICT",
+                    failure.getMessage());
+        }
+
+        if (failure instanceof IllegalArgumentException) {
             return new ErrorMapping(
                     400,
                     "FLUX-REST-400",
                     safeMessage(failure));
         }
 
-        if (failure
-                instanceof RejectedExecutionException) {
+        if (failure instanceof RejectedExecutionException) {
             return new ErrorMapping(
                     503,
                     "FLUX-SERVER-BUSY",
                     "Job queue is full");
         }
 
-        if (failure
-                instanceof IllegalStateException) {
+        if (failure instanceof IllegalStateException) {
             return new ErrorMapping(
                     409,
                     "FLUX-REST-409",
@@ -178,15 +160,11 @@ public final class ExceptionHandlingFilter
                 "Internal server error");
     }
 
-    private static Throwable unwrap(
-            Throwable failure) {
-
+    private static Throwable unwrap(Throwable failure) {
         Throwable current = failure;
 
-        while (current
-                instanceof ServletException
+        while (current instanceof ServletException
                 && current.getCause() != null) {
-
             current = current.getCause();
         }
 
@@ -196,32 +174,22 @@ public final class ExceptionHandlingFilter
     private static String requestId(
             HttpServletRequest request) {
 
-        String provided =
-                request.getHeader(
-                        "X-Request-Id");
+        String provided = request.getHeader("X-Request-Id");
 
         if (provided != null
                 && provided.length() <= 128
-                && provided.matches(
-                "[A-Za-z0-9._-]+")) {
-
+                && provided.matches("[A-Za-z0-9._-]+")) {
             return provided;
         }
 
-        return UUID.randomUUID()
-                .toString();
+        return UUID.randomUUID().toString();
     }
 
-    private static String safeMessage(
-            Throwable failure) {
+    private static String safeMessage(Throwable failure) {
+        String message = failure.getMessage();
 
-        String message =
-                failure.getMessage();
-
-        return message == null
-                || message.trim().isEmpty()
-                ? failure.getClass()
-                .getSimpleName()
+        return message == null || message.trim().isEmpty()
+                ? failure.getClass().getSimpleName()
                 : message;
     }
 
@@ -230,16 +198,12 @@ public final class ExceptionHandlingFilter
             String requestId) {
 
         return "REST request failed"
-                + ", requestId="
-                + requestId
-                + ", method="
-                + request.getMethod()
-                + ", uri="
-                + request.getRequestURI();
+                + ", requestId=" + requestId
+                + ", method=" + request.getMethod()
+                + ", uri=" + request.getRequestURI();
     }
 
     private static final class ErrorMapping {
-
         private final int httpStatus;
         private final String code;
         private final String message;
@@ -248,7 +212,6 @@ public final class ExceptionHandlingFilter
                 int httpStatus,
                 String code,
                 String message) {
-
             this.httpStatus = httpStatus;
             this.code = code;
             this.message = message;

--- a/link-up-server/src/main/java/com/link/up/server/http/JettyServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/JettyServer.java
@@ -4,6 +4,7 @@ import com.link.up.server.config.FluxServerConfig;
 import com.link.up.server.http.servlet.HealthServlet;
 import com.link.up.server.http.servlet.JobResourceServlet;
 import com.link.up.server.http.servlet.JobsServlet;
+import com.link.up.server.http.servlet.NodeServlet;
 import com.link.up.server.http.servlet.NotFoundServlet;
 import com.link.up.server.service.JobRestService;
 import org.eclipse.jetty.server.Server;
@@ -33,9 +34,7 @@ public final class JettyServer
             JobRestService service) {
 
         int minimumThreads =
-                Math.min(
-                        4,
-                        config.getHttpThreads());
+                Math.min(4, config.getHttpThreads());
 
         QueuedThreadPool threadPool =
                 new QueuedThreadPool(
@@ -43,27 +42,17 @@ public final class JettyServer
                         minimumThreads,
                         60_000);
 
-        threadPool.setName(
-                "link-up-http");
+        threadPool.setName("link-up-http");
 
-        this.server =
-                new Server(threadPool);
-
+        this.server = new Server(threadPool);
         this.server.setStopTimeout(
                 config.getShutdownTimeoutMillis());
 
-        this.connector =
-                new ServerConnector(server);
-
-        connector.setHost(
-                config.getHost());
-        connector.setPort(
-                config.getPort());
-        connector.setIdleTimeout(
-                30_000L);
-        connector.setAcceptQueueSize(
-                128);
-
+        this.connector = new ServerConnector(server);
+        connector.setHost(config.getHost());
+        connector.setPort(config.getPort());
+        connector.setIdleTimeout(30_000L);
+        connector.setAcceptQueueSize(128);
         server.addConnector(connector);
 
         ServletContextHandler context =
@@ -76,60 +65,38 @@ public final class JettyServer
                 new FilterHolder(
                         new ExceptionHandlingFilter()),
                 "/*",
-                EnumSet.of(
-                        DispatcherType.REQUEST));
+                EnumSet.of(DispatcherType.REQUEST));
 
         context.addServlet(
-                new ServletHolder(
-                        new HealthServlet()),
+                new ServletHolder(new HealthServlet()),
                 RestConstants.HEALTH);
-
+        context.addServlet(
+                new ServletHolder(new NodeServlet(service)),
+                RestConstants.NODE);
         context.addServlet(
                 new ServletHolder(
                         new JobsServlet(
                                 service,
                                 config.getMaxRequestBytes())),
                 RestConstants.JOBS);
-
         context.addServlet(
                 new ServletHolder(
                         new JobResourceServlet(service)),
                 RestConstants.JOBS + "/*");
-
-        /*
-         * 默认路由最后注册，统一返回 JSON 404。
-         */
         context.addServlet(
-                new ServletHolder(
-                        new NotFoundServlet()),
+                new ServletHolder(new NotFoundServlet()),
                 "/");
 
         server.setHandler(context);
     }
 
-    public void start() throws Exception {
-        server.start();
-    }
-
-    public void join()
-            throws InterruptedException {
-
-        server.join();
-    }
-
-    public int getLocalPort() {
-        return connector.getLocalPort();
-    }
-
-    public boolean isStarted() {
-        return server.isStarted();
-    }
+    public void start() throws Exception { server.start(); }
+    public void join() throws InterruptedException { server.join(); }
+    public int getLocalPort() { return connector.getLocalPort(); }
+    public boolean isStarted() { return server.isStarted(); }
 
     public void stop() throws Exception {
-        if (closed.compareAndSet(
-                false,
-                true)) {
-
+        if (closed.compareAndSet(false, true)) {
             server.stop();
         }
     }

--- a/link-up-server/src/main/java/com/link/up/server/http/RestConstants.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/RestConstants.java
@@ -8,6 +8,9 @@ public final class RestConstants {
     public static final String HEALTH =
             API_PREFIX + "/health";
 
+    public static final String NODE =
+            API_PREFIX + "/node";
+
     public static final String JOBS =
             API_PREFIX + "/jobs";
 

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/JobResourceServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/JobResourceServlet.java
@@ -10,24 +10,14 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * 处理以下资源：
- *
- * <pre>
- * GET    /api/v1/jobs/{jobId}
- * DELETE /api/v1/jobs/{jobId}
- * GET    /api/v1/jobs/{jobId}/pipelines
- * GET    /api/v1/jobs/{jobId}/tasks
- * GET    /api/v1/jobs/{jobId}/metrics
- * </pre>
+ * 处理单个离线作业资源和运行明细。
  */
 public final class JobResourceServlet
         extends FluxServlet {
 
     private final JobRestService service;
 
-    public JobResourceServlet(
-            JobRestService service) {
-
+    public JobResourceServlet(JobRestService service) {
         this.service = service;
     }
 
@@ -36,45 +26,43 @@ public final class JobResourceServlet
             HttpServletResponse response)
             throws IOException {
 
-        List<String> segments =
-                pathSegments(request);
+        List<String> segments = pathSegments(request);
 
         if (segments.size() == 1) {
             write(
                     response,
                     200,
-                    service.job(segments.get(0)));
+                    service.jobResponse(segments.get(0)));
+            return;
+        }
+
+        if (segments.size() == 2
+                && "external".equals(segments.get(0))) {
+
+            write(
+                    response,
+                    200,
+                    service.jobByExternalExecutionId(
+                            segments.get(1)));
             return;
         }
 
         if (segments.size() == 2) {
-            String jobId =
-                    segments.get(0);
-
-            String resource =
-                    segments.get(1);
+            String jobId = segments.get(0);
+            String resource = segments.get(1);
 
             if ("pipelines".equals(resource)) {
-                write(
-                        response,
-                        200,
-                        service.pipelines(jobId));
+                write(response, 200, service.pipelines(jobId));
                 return;
             }
 
             if ("tasks".equals(resource)) {
-                write(
-                        response,
-                        200,
-                        service.tasks(jobId));
+                write(response, 200, service.tasks(jobId));
                 return;
             }
 
             if ("metrics".equals(resource)) {
-                write(
-                        response,
-                        200,
-                        service.metrics(jobId));
+                write(response, 200, service.metrics(jobId));
                 return;
             }
         }
@@ -88,8 +76,7 @@ public final class JobResourceServlet
             HttpServletResponse response)
             throws IOException {
 
-        List<String> segments =
-                pathSegments(request);
+        List<String> segments = pathSegments(request);
 
         if (segments.size() != 1) {
             throw new JobNotFoundException(
@@ -99,6 +86,6 @@ public final class JobResourceServlet
         write(
                 response,
                 202,
-                service.cancel(segments.get(0)));
+                service.cancelResponse(segments.get(0)));
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/JobsServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/JobsServlet.java
@@ -1,11 +1,15 @@
 package com.link.up.server.http.servlet;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.link.up.server.dto.JobSubmitRequest;
 import com.link.up.server.http.FluxServlet;
+import com.link.up.server.http.JsonSupport;
 import com.link.up.server.service.JobRestService;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Locale;
 
 /**
  * /api/v1/jobs 集合资源。
@@ -31,39 +35,79 @@ public final class JobsServlet
 
         validateSubmitContentType(request);
 
-        write(
-                response,
-                202,
-                service.submit(
-                        requestBody(
-                                request,
-                                maxRequestBytes)));
-    }
+        String body =
+                requestBody(
+                        request,
+                        maxRequestBytes);
 
+        Object result;
+
+        if (isJson(request)) {
+            try {
+                JobSubmitRequest submitRequest =
+                        JsonSupport.mapper()
+                                .readValue(
+                                        body,
+                                        JobSubmitRequest.class);
+
+                result = service.submit(submitRequest);
+            } catch (JsonProcessingException exception) {
+                throw new IllegalArgumentException(
+                        "Invalid JSON submit request");
+            }
+        } else {
+            result = service.submitLegacyResponse(body);
+        }
+
+        write(response, 202, result);
+    }
 
     protected void doGet(
             HttpServletRequest request,
             HttpServletResponse response)
             throws IOException {
 
-        int page =
-                intParameter(
-                        request,
-                        "page",
-                        1);
+        String externalExecutionId =
+                request.getParameter("externalExecutionId");
 
-        int pageSize =
-                intParameter(
-                        request,
-                        "pageSize",
-                        20);
+        if (externalExecutionId != null
+                && !externalExecutionId.trim().isEmpty()) {
+
+            write(
+                    response,
+                    200,
+                    service.jobByExternalExecutionId(
+                            externalExecutionId));
+            return;
+        }
+
+        int page = intParameter(request, "page", 1);
+        int pageSize = intParameter(request, "pageSize", 20);
 
         write(
                 response,
                 200,
-                service.jobs(
+                service.executionPage(
                         request.getParameter("status"),
                         page,
                         pageSize));
+    }
+
+    private boolean isJson(HttpServletRequest request) {
+        String contentType = request.getContentType();
+
+        if (contentType == null) {
+            return false;
+        }
+
+        int separator = contentType.indexOf(';');
+        String mediaType =
+                separator >= 0
+                        ? contentType.substring(0, separator)
+                        : contentType;
+
+        return "application/json".equals(
+                mediaType.trim()
+                        .toLowerCase(Locale.ROOT));
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/NodeServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/NodeServlet.java
@@ -1,0 +1,29 @@
+package com.link.up.server.http.servlet;
+
+import com.link.up.server.http.FluxServlet;
+import com.link.up.server.service.JobRestService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * 单节点离线 Worker 身份、容量和实例信息。
+ */
+public final class NodeServlet
+        extends FluxServlet {
+
+    private final JobRestService service;
+
+    public NodeServlet(JobRestService service) {
+        this.service = service;
+    }
+
+    protected void doGet(
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws IOException {
+
+        write(response, 200, service.node());
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/InMemoryJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/InMemoryJobRepository.java
@@ -20,6 +20,10 @@ public final class InMemoryJobRepository
             snapshots =
             new ConcurrentHashMap<String, JobSnapshot>();
 
+    private final ConcurrentMap<String, JobExecutionMetadata>
+            metadata =
+            new ConcurrentHashMap<String, JobExecutionMetadata>();
+
     private final ConcurrentLinkedDeque<String>
             orderedJobIds =
             new ConcurrentLinkedDeque<String>();
@@ -34,10 +38,23 @@ public final class InMemoryJobRepository
     }
 
     public void save(JobSnapshot snapshot) {
+        save(snapshot, null);
+    }
+
+    public void save(
+            JobSnapshot snapshot,
+            JobExecutionMetadata executionMetadata) {
+
         JobSnapshot previous =
                 snapshots.put(
                         snapshot.getJobId(),
                         snapshot);
+
+        if (executionMetadata != null) {
+            metadata.put(
+                    snapshot.getJobId(),
+                    executionMetadata);
+        }
 
         if (previous == null) {
             orderedJobIds.addFirst(
@@ -49,6 +66,11 @@ public final class InMemoryJobRepository
 
     public JobSnapshot get(String jobId) {
         return snapshots.get(jobId);
+    }
+
+    public JobExecutionMetadata getMetadata(
+            String jobId) {
+        return metadata.get(jobId);
     }
 
     public List<JobSnapshot> list() {
@@ -90,6 +112,7 @@ public final class InMemoryJobRepository
             }
 
             snapshots.remove(oldestJobId);
+            metadata.remove(oldestJobId);
         }
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionHandle.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionHandle.java
@@ -4,6 +4,8 @@ import com.link.up.framework.execution.JobExecution;
 import com.link.up.framework.job.JobDefinition;
 import com.link.up.framework.job.JobResult;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.Future;
 
@@ -11,7 +13,7 @@ import java.util.concurrent.Future;
  * Server 内部使用的可变作业执行句柄。
  *
  * <p>所有状态转换均通过 synchronized 方法完成，
- * 避免提交、开始执行、取消和完成之间发生状态覆盖。
+ * 避免提交、入队、开始执行、取消和完成之间发生状态覆盖。
  */
 final class JobExecutionHandle {
 
@@ -22,15 +24,21 @@ final class JobExecutionHandle {
     }
 
     private final String jobId;
-    private final JobDefinition definition;
+    private final JobSubmission submission;
     private final long createTimeMillis;
+    private final List<JobStateTransition> transitions =
+            new ArrayList<JobStateTransition>();
 
+    private volatile long submittedTimeMillis;
+    private volatile long queuedTimeMillis;
     private volatile long startTimeMillis;
     private volatile long endTimeMillis;
+    private volatile long stateVersion;
 
     private volatile ServerJobStatus status =
-            ServerJobStatus.SUBMITTED;
+            ServerJobStatus.CREATED;
 
+    private volatile boolean cancellationRequested;
     private volatile JobExecution execution;
     private volatile Future<?> future;
     private volatile JobResult result;
@@ -38,20 +46,46 @@ final class JobExecutionHandle {
 
     JobExecutionHandle(
             String jobId,
-            JobDefinition definition) {
+            JobSubmission submission) {
 
         this.jobId =
                 Objects.requireNonNull(
                         jobId,
                         "jobId must not be null");
 
-        this.definition =
+        this.submission =
                 Objects.requireNonNull(
-                        definition,
-                        "definition must not be null");
+                        submission,
+                        "submission must not be null");
 
         this.createTimeMillis =
                 System.currentTimeMillis();
+
+        transitions.add(
+                new JobStateTransition(
+                        stateVersion,
+                        null,
+                        ServerJobStatus.CREATED,
+                        createTimeMillis,
+                        "job-created"));
+    }
+
+    synchronized void markSubmitted() {
+        submittedTimeMillis =
+                System.currentTimeMillis();
+
+        transition(
+                ServerJobStatus.SUBMITTED,
+                "submission-accepted");
+    }
+
+    synchronized void markQueued() {
+        queuedTimeMillis =
+                System.currentTimeMillis();
+
+        transition(
+                ServerJobStatus.QUEUED,
+                "worker-queue-accepted");
     }
 
     synchronized void bindFuture(Future<?> future) {
@@ -60,21 +94,24 @@ final class JobExecutionHandle {
                         future,
                         "future must not be null");
 
-        if (status == ServerJobStatus.CANCELLING
-                || status == ServerJobStatus.CANCELED) {
+        if (cancellationRequested) {
             future.cancel(true);
         }
     }
 
     synchronized boolean markRunning() {
-        if (status != ServerJobStatus.SUBMITTED) {
+        if (status != ServerJobStatus.QUEUED
+                || cancellationRequested) {
             return false;
         }
 
         startTimeMillis =
                 System.currentTimeMillis();
 
-        status = ServerJobStatus.RUNNING;
+        transition(
+                ServerJobStatus.RUNNING,
+                "execution-started");
+
         return true;
     }
 
@@ -86,8 +123,7 @@ final class JobExecutionHandle {
                         execution,
                         "execution must not be null");
 
-        if (status == ServerJobStatus.CANCELLING
-                || status == ServerJobStatus.CANCELED) {
+        if (cancellationRequested) {
             execution.cancel();
         }
     }
@@ -99,14 +135,14 @@ final class JobExecutionHandle {
                     status);
         }
 
-        if (status == ServerJobStatus.CANCELLING) {
+        if (cancellationRequested) {
             return CancelResult.ALREADY_REQUESTED;
         }
 
-        boolean beforeStart =
-                startTimeMillis == 0L;
+        cancellationRequested = true;
 
-        status = ServerJobStatus.CANCELLING;
+        boolean beforeStart =
+                status != ServerJobStatus.RUNNING;
 
         JobExecution currentExecution =
                 execution;
@@ -146,7 +182,12 @@ final class JobExecutionHandle {
         this.failure = failure;
         this.endTimeMillis =
                 System.currentTimeMillis();
-        this.status = finalStatus;
+
+        transition(
+                finalStatus,
+                terminalReason(
+                        finalStatus,
+                        failure));
 
         execution = null;
         future = null;
@@ -154,9 +195,66 @@ final class JobExecutionHandle {
         return true;
     }
 
+    private void transition(
+            ServerJobStatus target,
+            String reason) {
+
+        ServerJobStatus previous = status;
+
+        JobStateMachine.requireTransition(
+                previous,
+                target);
+
+        stateVersion++;
+        status = target;
+
+        transitions.add(
+                new JobStateTransition(
+                        stateVersion,
+                        previous,
+                        target,
+                        System.currentTimeMillis(),
+                        reason));
+    }
+
+    private static String terminalReason(
+            ServerJobStatus status,
+            Throwable failure) {
+
+        if (status == ServerJobStatus.SUCCEEDED) {
+            return "execution-succeeded";
+        }
+
+        if (status == ServerJobStatus.CANCELED) {
+            return "cancellation-completed";
+        }
+
+        if (status == ServerJobStatus.LOST) {
+            return "worker-lost-execution";
+        }
+
+        return failure == null
+                ? "execution-failed"
+                : "execution-failed:"
+                + failure.getClass()
+                .getSimpleName();
+    }
+
+    synchronized JobExecutionMetadata metadata() {
+        return new JobExecutionMetadata(
+                submission.getExternalExecutionId(),
+                submission.getIdempotencyKey(),
+                submission.getDefinitionVersion(),
+                submission.getConfigDigest(),
+                submittedTimeMillis,
+                queuedTimeMillis,
+                stateVersion,
+                cancellationRequested,
+                transitions);
+    }
+
     boolean isCancellationRequested() {
-        return status == ServerJobStatus.CANCELLING
-                || status == ServerJobStatus.CANCELED;
+        return cancellationRequested;
     }
 
     String getJobId() {
@@ -164,11 +262,12 @@ final class JobExecutionHandle {
     }
 
     String getJobName() {
-        return definition.getName();
+        return submission.getDefinition()
+                .getName();
     }
 
     JobDefinition getDefinition() {
-        return definition;
+        return submission.getDefinition();
     }
 
     long getCreateTimeMillis() {

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionMetadata.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionMetadata.java
@@ -1,0 +1,82 @@
+package com.link.up.server.runtime;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 作业协议元数据和状态机快照。
+ */
+public final class JobExecutionMetadata {
+
+    private final String externalExecutionId;
+    private final String idempotencyKey;
+    private final int definitionVersion;
+    private final String configDigest;
+    private final long submittedTimeMillis;
+    private final long queuedTimeMillis;
+    private final long stateVersion;
+    private final boolean cancellationRequested;
+    private final List<JobStateTransition> transitions;
+
+    public JobExecutionMetadata(
+            String externalExecutionId,
+            String idempotencyKey,
+            int definitionVersion,
+            String configDigest,
+            long submittedTimeMillis,
+            long queuedTimeMillis,
+            long stateVersion,
+            boolean cancellationRequested,
+            List<JobStateTransition> transitions) {
+
+        this.externalExecutionId = externalExecutionId;
+        this.idempotencyKey = idempotencyKey;
+        this.definitionVersion = definitionVersion;
+        this.configDigest = configDigest;
+        this.submittedTimeMillis = submittedTimeMillis;
+        this.queuedTimeMillis = queuedTimeMillis;
+        this.stateVersion = stateVersion;
+        this.cancellationRequested = cancellationRequested;
+        this.transitions =
+                Collections.unmodifiableList(
+                        new ArrayList<JobStateTransition>(
+                                transitions));
+    }
+
+    public String getExternalExecutionId() {
+        return externalExecutionId;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public int getDefinitionVersion() {
+        return definitionVersion;
+    }
+
+    public String getConfigDigest() {
+        return configDigest;
+    }
+
+    public long getSubmittedTimeMillis() {
+        return submittedTimeMillis;
+    }
+
+    public long getQueuedTimeMillis() {
+        return queuedTimeMillis;
+    }
+
+    public long getStateVersion() {
+        return stateVersion;
+    }
+
+    public boolean isCancellationRequested() {
+        return cancellationRequested;
+    }
+
+    public List<JobStateTransition> getTransitions() {
+        return transitions;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobManager.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobManager.java
@@ -9,11 +9,40 @@ public interface JobManager
 
     JobSnapshot submit(JobDefinition definition);
 
+    default JobSnapshot submit(
+            JobSubmission submission) {
+        return submit(submission.getDefinition());
+    }
+
     JobSnapshot getJob(String jobId);
+
+    default JobSnapshot getJobByExternalExecutionId(
+            String externalExecutionId) {
+        throw new JobNotFoundException(
+                externalExecutionId);
+    }
+
+    default JobExecutionMetadata getMetadata(
+            String jobId) {
+        return null;
+    }
 
     List<JobSnapshot> listJobs();
 
     JobSnapshot cancel(String jobId);
+
+    default int getRunningJobCount() {
+        return 0;
+    }
+
+    default int getQueuedJobCount() {
+        return 0;
+    }
+
+    default int getActiveJobCount() {
+        return getRunningJobCount()
+                + getQueuedJobCount();
+    }
 
     boolean isClosed();
 

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobRepository.java
@@ -6,7 +6,18 @@ public interface JobRepository {
 
     void save(JobSnapshot snapshot);
 
+    default void save(
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata) {
+        save(snapshot);
+    }
+
     JobSnapshot get(String jobId);
+
+    default JobExecutionMetadata getMetadata(
+            String jobId) {
+        return null;
+    }
 
     List<JobSnapshot> list();
 }

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobStateMachine.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobStateMachine.java
@@ -1,0 +1,71 @@
+package com.link.up.server.runtime;
+
+import java.util.EnumSet;
+
+/**
+ * Link-Up 单节点离线作业状态机。
+ */
+public final class JobStateMachine {
+
+    private JobStateMachine() {
+    }
+
+    public static boolean canTransition(
+            ServerJobStatus from,
+            ServerJobStatus to) {
+
+        if (from == null || to == null || from == to) {
+            return false;
+        }
+
+        if (from.isTerminal()) {
+            return false;
+        }
+
+        switch (from) {
+            case CREATED:
+                return EnumSet.of(
+                                ServerJobStatus.SUBMITTED,
+                                ServerJobStatus.CANCELED,
+                                ServerJobStatus.FAILED,
+                                ServerJobStatus.LOST)
+                        .contains(to);
+            case SUBMITTED:
+                return EnumSet.of(
+                                ServerJobStatus.QUEUED,
+                                ServerJobStatus.CANCELED,
+                                ServerJobStatus.FAILED,
+                                ServerJobStatus.LOST)
+                        .contains(to);
+            case QUEUED:
+                return EnumSet.of(
+                                ServerJobStatus.RUNNING,
+                                ServerJobStatus.CANCELED,
+                                ServerJobStatus.FAILED,
+                                ServerJobStatus.LOST)
+                        .contains(to);
+            case RUNNING:
+                return EnumSet.of(
+                                ServerJobStatus.SUCCEEDED,
+                                ServerJobStatus.FAILED,
+                                ServerJobStatus.CANCELED,
+                                ServerJobStatus.LOST)
+                        .contains(to);
+            default:
+                return false;
+        }
+    }
+
+    public static void requireTransition(
+            ServerJobStatus from,
+            ServerJobStatus to) {
+
+        if (!canTransition(from, to)) {
+            throw new IllegalStateException(
+                    "Illegal job state transition: "
+                            + from
+                            + " -> "
+                            + to);
+        }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobStateTransition.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobStateTransition.java
@@ -1,0 +1,47 @@
+package com.link.up.server.runtime;
+
+/**
+ * 一次可审计的作业状态转换。
+ */
+public final class JobStateTransition {
+
+    private final long version;
+    private final ServerJobStatus fromStatus;
+    private final ServerJobStatus toStatus;
+    private final long transitionTimeMillis;
+    private final String reason;
+
+    public JobStateTransition(
+            long version,
+            ServerJobStatus fromStatus,
+            ServerJobStatus toStatus,
+            long transitionTimeMillis,
+            String reason) {
+
+        this.version = version;
+        this.fromStatus = fromStatus;
+        this.toStatus = toStatus;
+        this.transitionTimeMillis = transitionTimeMillis;
+        this.reason = reason;
+    }
+
+    public long getVersion() {
+        return version;
+    }
+
+    public ServerJobStatus getFromStatus() {
+        return fromStatus;
+    }
+
+    public ServerJobStatus getToStatus() {
+        return toStatus;
+    }
+
+    public long getTransitionTimeMillis() {
+        return transitionTimeMillis;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobSubmission.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobSubmission.java
@@ -1,0 +1,98 @@
+package com.link.up.server.runtime;
+
+import com.link.up.framework.job.JobDefinition;
+
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * 控制面提交给 Link-Up Worker 的一次离线执行命令。
+ */
+public final class JobSubmission {
+
+    private final String externalExecutionId;
+    private final String idempotencyKey;
+    private final int definitionVersion;
+    private final String configDigest;
+    private final JobDefinition definition;
+
+    public JobSubmission(
+            String externalExecutionId,
+            String idempotencyKey,
+            int definitionVersion,
+            String configDigest,
+            JobDefinition definition) {
+
+        this.externalExecutionId =
+                requireText(
+                        externalExecutionId,
+                        "externalExecutionId");
+        this.idempotencyKey =
+                requireText(
+                        idempotencyKey,
+                        "idempotencyKey");
+
+        if (definitionVersion <= 0) {
+            throw new IllegalArgumentException(
+                    "definitionVersion must be greater than 0");
+        }
+
+        this.definitionVersion = definitionVersion;
+        this.configDigest =
+                requireText(
+                        configDigest,
+                        "configDigest");
+        this.definition =
+                Objects.requireNonNull(
+                        definition,
+                        "definition must not be null");
+    }
+
+    public static JobSubmission legacy(
+            JobDefinition definition) {
+
+        String token =
+                UUID.randomUUID()
+                        .toString();
+
+        return new JobSubmission(
+                "legacy-" + token,
+                token,
+                1,
+                "legacy-" + token,
+                definition);
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null
+                || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+
+        return value.trim();
+    }
+
+    public String getExternalExecutionId() {
+        return externalExecutionId;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public int getDefinitionVersion() {
+        return definitionVersion;
+    }
+
+    public String getConfigDigest() {
+        return configDigest;
+    }
+
+    public JobDefinition getDefinition() {
+        return definition;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobSubmissionConflictException.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobSubmissionConflictException.java
@@ -1,0 +1,13 @@
+package com.link.up.server.runtime;
+
+/**
+ * 相同幂等键或外部执行 ID 被用于不同提交内容。
+ */
+public final class JobSubmissionConflictException
+        extends RuntimeException {
+
+    public JobSubmissionConflictException(
+            String message) {
+        super(message);
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/LocalJobManager.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/LocalJobManager.java
@@ -24,7 +24,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * 单机异步作业协调器。
+ * 单节点离线作业 Worker 协调器。
+ *
+ * <p>负责幂等提交、显式队列状态、执行取消和终态归档。
  */
 public final class LocalJobManager
         implements JobManager {
@@ -40,6 +42,18 @@ public final class LocalJobManager
             new java.util.concurrent.ConcurrentHashMap<
                     String,
                     JobExecutionHandle>();
+
+    private final Map<String, String>
+            jobIdsByIdempotencyKey =
+            new java.util.concurrent.ConcurrentHashMap<
+                    String,
+                    String>();
+
+    private final Map<String, String>
+            jobIdsByExternalExecutionId =
+            new java.util.concurrent.ConcurrentHashMap<
+                    String,
+                    String>();
 
     private final AtomicBoolean closed =
             new AtomicBoolean(false);
@@ -83,9 +97,25 @@ public final class LocalJobManager
     }
 
     public JobSnapshot submit(
-            final JobDefinition definition) {
+            JobDefinition definition) {
+
+        return submit(
+                JobSubmission.legacy(
+                        definition));
+    }
+
+    public synchronized JobSnapshot submit(
+            final JobSubmission submission) {
 
         ensureOpen();
+
+        JobSnapshot existing =
+                findExistingSubmission(
+                        submission);
+
+        if (existing != null) {
+            return existing;
+        }
 
         final String jobId =
                 jobIdGenerator.nextId();
@@ -93,18 +123,7 @@ public final class LocalJobManager
         final JobExecutionHandle handle =
                 new JobExecutionHandle(
                         jobId,
-                        definition);
-
-        FutureTask<Void> task =
-                new FutureTask<Void>(
-                        new Callable<Void>() {
-                            public Void call() {
-                                executeJob(handle);
-                                return null;
-                            }
-                        });
-
-        handle.bindFuture(task);
+                        submission);
 
         JobExecutionHandle previous =
                 runningJobs.putIfAbsent(
@@ -117,28 +136,177 @@ public final class LocalJobManager
         }
 
         try {
-            executor.execute(task);
-        } catch (RejectedExecutionException exception) {
+            registerSubmission(
+                    jobId,
+                    submission);
+        } catch (RuntimeException exception) {
             runningJobs.remove(
                     jobId,
                     handle);
+            throw exception;
+        }
 
+        handle.markSubmitted();
+
+        FutureTask<Void> task =
+                new FutureTask<Void>(
+                        new Callable<Void>() {
+                            public Void call() {
+                                executeJob(handle);
+                                return null;
+                            }
+                        });
+
+        handle.bindFuture(task);
+        handle.markQueued();
+
+        try {
+            executor.execute(task);
+        } catch (RejectedExecutionException exception) {
             task.cancel(true);
+            runningJobs.remove(
+                    jobId,
+                    handle);
+            unregisterSubmission(
+                    jobId,
+                    submission);
             throw exception;
         }
 
         return JobSnapshotFactory.create(handle);
     }
 
+    private JobSnapshot findExistingSubmission(
+            JobSubmission submission) {
+
+        String byIdempotency =
+                jobIdsByIdempotencyKey.get(
+                        submission.getIdempotencyKey());
+
+        String byExternal =
+                jobIdsByExternalExecutionId.get(
+                        submission.getExternalExecutionId());
+
+        if (byIdempotency == null
+                && byExternal == null) {
+            return null;
+        }
+
+        if (byIdempotency != null
+                && byExternal != null
+                && !byIdempotency.equals(byExternal)) {
+
+            throw new JobSubmissionConflictException(
+                    "idempotencyKey and externalExecutionId reference different jobs");
+        }
+
+        String jobId =
+                byIdempotency != null
+                        ? byIdempotency
+                        : byExternal;
+
+        JobSnapshot snapshot;
+
+        try {
+            snapshot = getJob(jobId);
+        } catch (JobNotFoundException exception) {
+            removeStaleIndexes(
+                    jobId,
+                    submission);
+            return null;
+        }
+
+        JobExecutionMetadata metadata =
+                getMetadata(jobId);
+
+        if (metadata == null
+                || !submission.getExternalExecutionId()
+                .equals(
+                        metadata.getExternalExecutionId())
+                || !submission.getIdempotencyKey()
+                .equals(
+                        metadata.getIdempotencyKey())
+                || submission.getDefinitionVersion()
+                != metadata.getDefinitionVersion()
+                || !submission.getConfigDigest()
+                .equals(
+                        metadata.getConfigDigest())) {
+
+            throw new JobSubmissionConflictException(
+                    "The idempotency key or external execution ID was reused with different content");
+        }
+
+        return snapshot;
+    }
+
+    private void registerSubmission(
+            String jobId,
+            JobSubmission submission) {
+
+        String existingByIdempotency =
+                jobIdsByIdempotencyKey.putIfAbsent(
+                        submission.getIdempotencyKey(),
+                        jobId);
+
+        if (existingByIdempotency != null) {
+            throw new JobSubmissionConflictException(
+                    "idempotencyKey already belongs to job "
+                            + existingByIdempotency);
+        }
+
+        String existingByExternal =
+                jobIdsByExternalExecutionId.putIfAbsent(
+                        submission.getExternalExecutionId(),
+                        jobId);
+
+        if (existingByExternal != null) {
+            jobIdsByIdempotencyKey.remove(
+                    submission.getIdempotencyKey(),
+                    jobId);
+
+            throw new JobSubmissionConflictException(
+                    "externalExecutionId already belongs to job "
+                            + existingByExternal);
+        }
+    }
+
+    private void unregisterSubmission(
+            String jobId,
+            JobSubmission submission) {
+
+        jobIdsByIdempotencyKey.remove(
+                submission.getIdempotencyKey(),
+                jobId);
+        jobIdsByExternalExecutionId.remove(
+                submission.getExternalExecutionId(),
+                jobId);
+    }
+
+    private void removeStaleIndexes(
+            String jobId,
+            JobSubmission submission) {
+
+        jobIdsByIdempotencyKey.remove(
+                submission.getIdempotencyKey(),
+                jobId);
+        jobIdsByExternalExecutionId.remove(
+                submission.getExternalExecutionId(),
+                jobId);
+    }
+
     private void executeJob(
             final JobExecutionHandle handle) {
 
         if (!handle.markRunning()) {
-            completeAndArchive(
-                    handle,
-                    ServerJobStatus.CANCELED,
-                    null,
-                    null);
+            if (!handle.getStatus().isTerminal()) {
+                completeAndArchive(
+                        handle,
+                        handle.isCancellationRequested()
+                                ? ServerJobStatus.CANCELED
+                                : ServerJobStatus.FAILED,
+                        null,
+                        null);
+            }
             return;
         }
 
@@ -237,7 +405,9 @@ public final class LocalJobManager
         JobSnapshot snapshot =
                 JobSnapshotFactory.create(handle);
 
-        repository.save(snapshot);
+        repository.save(
+                snapshot,
+                handle.metadata());
 
         runningJobs.remove(
                 handle.getJobId(),
@@ -263,6 +433,40 @@ public final class LocalJobManager
         }
 
         return finished;
+    }
+
+    public JobSnapshot getJobByExternalExecutionId(
+            String externalExecutionId) {
+
+        requireText(
+                externalExecutionId,
+                "externalExecutionId");
+
+        String jobId =
+                jobIdsByExternalExecutionId.get(
+                        externalExecutionId.trim());
+
+        if (jobId == null) {
+            throw new JobNotFoundException(
+                    externalExecutionId);
+        }
+
+        return getJob(jobId);
+    }
+
+    public JobExecutionMetadata getMetadata(
+            String jobId) {
+
+        requireJobId(jobId);
+
+        JobExecutionHandle running =
+                runningJobs.get(jobId);
+
+        if (running != null) {
+            return running.metadata();
+        }
+
+        return repository.getMetadata(jobId);
     }
 
     public List<JobSnapshot> listJobs() {
@@ -335,6 +539,8 @@ public final class LocalJobManager
                 == JobExecutionHandle.CancelResult
                 .CANCELLED_BEFORE_START) {
 
+            executor.purge();
+
             completeAndArchive(
                     handle,
                     ServerJobStatus.CANCELED,
@@ -343,6 +549,43 @@ public final class LocalJobManager
         }
 
         return getJob(jobId);
+    }
+
+    public int getRunningJobCount() {
+        int count = 0;
+
+        for (JobExecutionHandle handle :
+                runningJobs.values()) {
+            if (handle.getStatus()
+                    == ServerJobStatus.RUNNING) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    public int getQueuedJobCount() {
+        int count = 0;
+
+        for (JobExecutionHandle handle :
+                runningJobs.values()) {
+
+            ServerJobStatus status =
+                    handle.getStatus();
+
+            if (status == ServerJobStatus.CREATED
+                    || status == ServerJobStatus.SUBMITTED
+                    || status == ServerJobStatus.QUEUED) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    public int getActiveJobCount() {
+        return runningJobs.size();
     }
 
     public boolean isClosed() {
@@ -367,6 +610,8 @@ public final class LocalJobManager
                         == JobExecutionHandle.CancelResult
                         .CANCELLED_BEFORE_START) {
 
+                    executor.purge();
+
                     completeAndArchive(
                             handle,
                             ServerJobStatus.CANCELED,
@@ -390,15 +635,15 @@ public final class LocalJobManager
         }
 
         /*
-         * 超时仍未退出的 Job，在 Server 层标记为取消。
-         * 引擎线程已经收到中断和 CancellationToken。
+         * 关闭超时后仍未返回终态的作业，其真实结果已经无法确认，
+         * 必须标记为 LOST，而不是伪装成 CANCELED。
          */
         for (JobExecutionHandle handle :
                 runningJobs.values()) {
 
             completeAndArchive(
                     handle,
-                    ServerJobStatus.CANCELED,
+                    ServerJobStatus.LOST,
                     null,
                     null);
         }
@@ -414,10 +659,17 @@ public final class LocalJobManager
     private static void requireJobId(
             String jobId) {
 
-        if (jobId == null
-                || jobId.trim().isEmpty()) {
+        requireText(jobId, "jobId");
+    }
+
+    private static void requireText(
+            String value,
+            String name) {
+
+        if (value == null
+                || value.trim().isEmpty()) {
             throw new IllegalArgumentException(
-                    "jobId must not be blank");
+                    name + " must not be blank");
         }
     }
 

--- a/link-up-server/src/main/java/com/link/up/server/runtime/ServerJobStatus.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/ServerJobStatus.java
@@ -1,16 +1,22 @@
 package com.link.up.server.runtime;
 
 /**
- * REST Server 对外提供的异步作业状态。
+ * Link-Up 离线作业对外状态。
+ *
+ * <p>状态机固定为：
+ * CREATED -> SUBMITTED -> QUEUED -> RUNNING ->
+ * SUCCEEDED / FAILED / CANCELED / LOST。
  */
 public enum ServerJobStatus {
 
+    CREATED(false),
     SUBMITTED(false),
+    QUEUED(false),
     RUNNING(false),
-    CANCELLING(false),
-    CANCELED(true),
     SUCCEEDED(true),
-    FAILED(true);
+    FAILED(true),
+    CANCELED(true),
+    LOST(true);
 
     private final boolean terminal;
 
@@ -23,8 +29,6 @@ public enum ServerJobStatus {
     }
 
     public boolean canCancel() {
-        return this == SUBMITTED
-                || this == RUNNING
-                || this == CANCELLING;
+        return !terminal;
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/runtime/WorkerIdentity.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/WorkerIdentity.java
@@ -1,0 +1,83 @@
+package com.link.up.server.runtime;
+
+import java.util.UUID;
+
+/**
+ * 单个 Link-Up Worker 进程的稳定节点身份和易变实例身份。
+ */
+public final class WorkerIdentity {
+
+    private final String nodeId;
+    private final String nodeName;
+    private final String instanceId;
+    private final String version;
+    private final long startedAtMillis;
+
+    public WorkerIdentity(
+            String nodeId,
+            String nodeName,
+            String version) {
+
+        this.nodeId = requireText(nodeId, "nodeId");
+        this.nodeName = requireText(nodeName, "nodeName");
+        this.version = requireText(version, "version");
+        this.startedAtMillis = System.currentTimeMillis();
+        this.instanceId =
+                this.nodeId
+                        + "-"
+                        + startedAtMillis
+                        + "-"
+                        + UUID.randomUUID()
+                        .toString();
+    }
+
+    public static String implementationVersion() {
+        Package packageInfo =
+                WorkerIdentity.class
+                        .getPackage();
+
+        String value =
+                packageInfo == null
+                        ? null
+                        : packageInfo
+                        .getImplementationVersion();
+
+        return value == null
+                || value.trim().isEmpty()
+                ? "1.0.0"
+                : value.trim();
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null
+                || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+
+        return value.trim();
+    }
+
+    public String getNodeId() {
+        return nodeId;
+    }
+
+    public String getNodeName() {
+        return nodeName;
+    }
+
+    public String getInstanceId() {
+        return instanceId;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public long getStartedAtMillis() {
+        return startedAtMillis;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/service/JobRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobRestService.java
@@ -2,19 +2,29 @@ package com.link.up.server.service;
 
 import com.link.up.framework.job.JobConfigParser;
 import com.link.up.framework.job.JobDefinition;
+import com.link.up.server.dto.JobResponse;
+import com.link.up.server.dto.JobSubmitRequest;
 import com.link.up.server.dto.PageResponse;
+import com.link.up.server.dto.WorkerNodeResponse;
+import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobManager;
 import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobSubmission;
 import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.WorkerIdentity;
 import com.typesafe.config.ConfigException;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 
 /**
- * REST 输入与运行时领域服务之间的适配层。
+ * REST 输入与单节点离线 Worker 运行时之间的适配层。
  */
 public final class JobRestService {
 
@@ -22,66 +32,120 @@ public final class JobRestService {
 
     private final JobManager manager;
     private final JobConfigParser parser;
+    private final WorkerIdentity workerIdentity;
+    private final int maxConcurrentJobs;
+    private final int maxQueuedJobs;
 
     public JobRestService(JobManager manager) {
-        this.manager = manager;
-        this.parser = new JobConfigParser();
+        this(
+                manager,
+                new WorkerIdentity(
+                        "embedded-link-up-node",
+                        "Embedded Link-Up Offline Worker",
+                        WorkerIdentity.implementationVersion()),
+                1,
+                1);
     }
 
-    public JobSnapshot.Summary submit(
-            String hocon) {
+    public JobRestService(
+            JobManager manager,
+            WorkerIdentity workerIdentity,
+            int maxConcurrentJobs,
+            int maxQueuedJobs) {
 
-        if (hocon == null
-                || hocon.trim().isEmpty()) {
+        this.manager = manager;
+        this.parser = new JobConfigParser();
+        this.workerIdentity = workerIdentity;
+        this.maxConcurrentJobs = maxConcurrentJobs;
+        this.maxQueuedJobs = maxQueuedJobs;
+    }
+
+    public JobSnapshot.Summary submit(String hocon) {
+        return submitLegacyResponse(hocon)
+                .toSummary();
+    }
+
+    public JobResponse submitLegacyResponse(String hocon) {
+        String token = UUID.randomUUID().toString();
+
+        JobSubmitRequest request = new JobSubmitRequest();
+        request.setExternalExecutionId("legacy-" + token);
+        request.setIdempotencyKey(token);
+        request.setDefinitionVersion(1);
+        request.setHocon(hocon);
+
+        return submit(request);
+    }
+
+    public JobResponse submit(JobSubmitRequest request) {
+        if (request == null) {
             throw new IllegalArgumentException(
-                    "Job configuration is empty");
+                    "Submit request must not be null");
         }
 
-        JobDefinition definition;
+        String externalExecutionId =
+                requireText(
+                        request.getExternalExecutionId(),
+                        "externalExecutionId");
+        String idempotencyKey =
+                requireText(
+                        request.getIdempotencyKey(),
+                        "idempotencyKey");
+        Integer definitionVersion =
+                request.getDefinitionVersion();
 
-        try {
-            definition = parser.parse(hocon);
-        } catch (ConfigException exception) {
+        if (definitionVersion == null || definitionVersion <= 0) {
             throw new IllegalArgumentException(
-                    "Invalid HOCON job configuration");
+                    "definitionVersion must be greater than 0");
         }
 
-        return manager.submit(
-                definition).toSummary();
+        String hocon = requireText(request.getHocon(), "hocon");
+        JobDefinition definition = parse(hocon);
+
+        JobSubmission submission =
+                new JobSubmission(
+                        externalExecutionId,
+                        idempotencyKey,
+                        definitionVersion,
+                        sha256(hocon),
+                        definition);
+
+        return response(manager.submit(submission));
     }
 
     public JobSnapshot job(String jobId) {
         return manager.getJob(jobId);
     }
 
-    public List<JobSnapshot.Pipeline> pipelines(
-            String jobId) {
-
-        return manager.getJob(jobId)
-                .getPipelines();
+    public JobResponse jobResponse(String jobId) {
+        return response(manager.getJob(jobId));
     }
 
-    public List<JobSnapshot.Task> tasks(
-            String jobId) {
+    public JobResponse jobByExternalExecutionId(
+            String externalExecutionId) {
 
+        return response(
+                manager.getJobByExternalExecutionId(
+                        externalExecutionId));
+    }
+
+    public List<JobSnapshot.Pipeline> pipelines(String jobId) {
+        return manager.getJob(jobId).getPipelines();
+    }
+
+    public List<JobSnapshot.Task> tasks(String jobId) {
         List<JobSnapshot.Task> tasks =
                 new ArrayList<JobSnapshot.Task>();
 
-        for (JobSnapshot.Pipeline pipeline :
-                pipelines(jobId)) {
-
-            tasks.addAll(
-                    pipeline.getTasks());
+        for (JobSnapshot.Pipeline pipeline : pipelines(jobId)) {
+            tasks.addAll(pipeline.getTasks());
         }
 
         return Collections.unmodifiableList(tasks);
     }
 
-    public JobSnapshot.Metrics metrics(
-            String jobId) {
-
-        return manager.getJob(jobId)
-                .getMetrics();
+    public JobSnapshot.Metrics metrics(String jobId) {
+        return manager.getJob(jobId).getMetrics();
     }
 
     public PageResponse<JobSnapshot.Summary> jobs(
@@ -89,69 +153,116 @@ public final class JobRestService {
             int page,
             int pageSize) {
 
+        List<JobSnapshot.Summary> summaries =
+                new ArrayList<JobSnapshot.Summary>();
+
+        for (JobSnapshot snapshot : filtered(statusValue)) {
+            summaries.add(snapshot.toSummary());
+        }
+
+        return page(summaries, page, pageSize);
+    }
+
+    public PageResponse<JobResponse> executionPage(
+            String statusValue,
+            int page,
+            int pageSize) {
+
+        List<JobResponse> responses =
+                new ArrayList<JobResponse>();
+
+        for (JobSnapshot snapshot : filtered(statusValue)) {
+            responses.add(response(snapshot));
+        }
+
+        return page(responses, page, pageSize);
+    }
+
+    public JobSnapshot.Summary cancel(String jobId) {
+        return manager.cancel(jobId).toSummary();
+    }
+
+    public JobResponse cancelResponse(String jobId) {
+        return response(manager.cancel(jobId));
+    }
+
+    public WorkerNodeResponse node() {
+        return new WorkerNodeResponse(
+                workerIdentity,
+                manager,
+                maxConcurrentJobs,
+                maxQueuedJobs);
+    }
+
+    private JobDefinition parse(String hocon) {
+        try {
+            return parser.parse(hocon);
+        } catch (ConfigException exception) {
+            throw new IllegalArgumentException(
+                    "Invalid HOCON job configuration");
+        }
+    }
+
+    private List<JobSnapshot> filtered(String statusValue) {
+        ServerJobStatus status = parseStatus(statusValue);
+        List<JobSnapshot> result =
+                new ArrayList<JobSnapshot>();
+
+        for (JobSnapshot snapshot : manager.listJobs()) {
+            if (status == null || snapshot.getStatus() == status) {
+                result.add(snapshot);
+            }
+        }
+
+        return result;
+    }
+
+    private <T> PageResponse<T> page(
+            List<T> values,
+            int page,
+            int pageSize) {
+
+        validatePage(page, pageSize);
+
+        long startLong = (long) (page - 1) * pageSize;
+        int from =
+                startLong >= values.size()
+                        ? values.size()
+                        : (int) startLong;
+        int to = Math.min(values.size(), from + pageSize);
+
+        return new PageResponse<T>(
+                values.subList(from, to),
+                page,
+                pageSize,
+                values.size());
+    }
+
+    private void validatePage(int page, int pageSize) {
         if (page < 1) {
             throw new IllegalArgumentException(
                     "page must be greater than 0");
         }
 
-        if (pageSize < 1
-                || pageSize > MAX_PAGE_SIZE) {
-
+        if (pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
             throw new IllegalArgumentException(
                     "pageSize must be between 1 and "
                             + MAX_PAGE_SIZE);
         }
-
-        ServerJobStatus status =
-                parseStatus(statusValue);
-
-        List<JobSnapshot.Summary> filtered =
-                new ArrayList<JobSnapshot.Summary>();
-
-        for (JobSnapshot snapshot :
-                manager.listJobs()) {
-
-            if (status == null
-                    || snapshot.getStatus() == status) {
-
-                filtered.add(
-                        snapshot.toSummary());
-            }
-        }
-
-        long startLong =
-                (long) (page - 1)
-                        * pageSize;
-
-        int from =
-                startLong >= filtered.size()
-                        ? filtered.size()
-                        : (int) startLong;
-
-        int to =
-                Math.min(
-                        filtered.size(),
-                        from + pageSize);
-
-        return new PageResponse<JobSnapshot.Summary>(
-                filtered.subList(from, to),
-                page,
-                pageSize,
-                filtered.size());
     }
 
-    public JobSnapshot.Summary cancel(
-            String jobId) {
+    private JobResponse response(JobSnapshot snapshot) {
+        JobExecutionMetadata metadata =
+                manager.getMetadata(snapshot.getJobId());
 
-        return manager.cancel(jobId)
-                .toSummary();
+        return new JobResponse(
+                snapshot,
+                metadata,
+                workerIdentity);
     }
 
-    private ServerJobStatus parseStatus(
-            String statusValue) {
-
-        if (statusValue == null
-                || statusValue.trim().isEmpty()) {
+    private ServerJobStatus parseStatus(String statusValue) {
+        if (statusValue == null || statusValue.trim().isEmpty()) {
             return null;
         }
 
@@ -161,8 +272,42 @@ public final class JobRestService {
                             .toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException exception) {
             throw new IllegalArgumentException(
-                    "Unknown job status: "
-                            + statusValue);
+                    "Unknown job status: " + statusValue);
+        }
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+
+        return value.trim();
+    }
+
+    private static String sha256(String value) {
+        try {
+            MessageDigest digest =
+                    MessageDigest.getInstance("SHA-256");
+            byte[] bytes =
+                    digest.digest(
+                            value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder result =
+                    new StringBuilder(bytes.length * 2);
+
+            for (byte current : bytes) {
+                result.append(
+                        String.format(
+                                Locale.ROOT,
+                                "%02x",
+                                current & 0xff));
+            }
+
+            return result.toString();
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                    "SHA-256 is not available",
+                    exception);
         }
     }
 }

--- a/link-up-server/src/test/java/com/link/up/server/runtime/JobExecutionHandleTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/runtime/JobExecutionHandleTest.java
@@ -1,0 +1,70 @@
+package com.link.up.server.runtime;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.SinkDefinition;
+import com.link.up.framework.job.SourceDefinition;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobExecutionHandleTest {
+
+    @Test
+    public void shouldRecordCompleteLifecycleAndLostTerminalState() {
+        JobExecutionHandle handle =
+                new JobExecutionHandle(
+                        "job-1",
+                        submission("digest-1"));
+
+        handle.markSubmitted();
+        handle.markQueued();
+        assertTrue(handle.markRunning());
+        assertTrue(handle.complete(
+                ServerJobStatus.LOST,
+                null,
+                null));
+
+        JobExecutionMetadata metadata = handle.metadata();
+        List<JobStateTransition> transitions =
+                metadata.getTransitions();
+
+        assertEquals(5, transitions.size());
+        assertEquals(ServerJobStatus.CREATED,
+                transitions.get(0).getToStatus());
+        assertEquals(ServerJobStatus.SUBMITTED,
+                transitions.get(1).getToStatus());
+        assertEquals(ServerJobStatus.QUEUED,
+                transitions.get(2).getToStatus());
+        assertEquals(ServerJobStatus.RUNNING,
+                transitions.get(3).getToStatus());
+        assertEquals(ServerJobStatus.LOST,
+                transitions.get(4).getToStatus());
+        assertEquals(4L, metadata.getStateVersion());
+    }
+
+    private static JobSubmission submission(String digest) {
+        ReadonlyConfig options =
+                ReadonlyConfig.fromMap(
+                        Collections.<String, Object>emptyMap());
+
+        JobDefinition definition =
+                new JobDefinition(
+                        "protocol-test",
+                        new SourceDefinition("test-source", options),
+                        new SinkDefinition("test-sink", options),
+                        new ExecutionConfig(100, 1, 1, 1));
+
+        return new JobSubmission(
+                "execution-1",
+                "idempotency-1",
+                1,
+                digest,
+                definition);
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/runtime/JobStateMachineTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/runtime/JobStateMachineTest.java
@@ -1,0 +1,44 @@
+package com.link.up.server.runtime;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JobStateMachineTest {
+
+    @Test
+    public void shouldAllowOnlyOfflineWorkerLifecycle() {
+        assertTrue(JobStateMachine.canTransition(
+                ServerJobStatus.CREATED,
+                ServerJobStatus.SUBMITTED));
+        assertTrue(JobStateMachine.canTransition(
+                ServerJobStatus.SUBMITTED,
+                ServerJobStatus.QUEUED));
+        assertTrue(JobStateMachine.canTransition(
+                ServerJobStatus.QUEUED,
+                ServerJobStatus.RUNNING));
+        assertTrue(JobStateMachine.canTransition(
+                ServerJobStatus.RUNNING,
+                ServerJobStatus.SUCCEEDED));
+        assertTrue(JobStateMachine.canTransition(
+                ServerJobStatus.RUNNING,
+                ServerJobStatus.FAILED));
+        assertTrue(JobStateMachine.canTransition(
+                ServerJobStatus.RUNNING,
+                ServerJobStatus.CANCELED));
+        assertTrue(JobStateMachine.canTransition(
+                ServerJobStatus.RUNNING,
+                ServerJobStatus.LOST));
+
+        assertFalse(JobStateMachine.canTransition(
+                ServerJobStatus.CREATED,
+                ServerJobStatus.RUNNING));
+        assertFalse(JobStateMachine.canTransition(
+                ServerJobStatus.QUEUED,
+                ServerJobStatus.SUCCEEDED));
+        assertFalse(JobStateMachine.canTransition(
+                ServerJobStatus.SUCCEEDED,
+                ServerJobStatus.RUNNING));
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/runtime/LocalJobManagerProtocolTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/runtime/LocalJobManagerProtocolTest.java
@@ -1,0 +1,156 @@
+package com.link.up.server.runtime;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.framework.execution.JobExecutionListener;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.JobResult;
+import com.link.up.framework.job.JobStatus;
+import com.link.up.framework.job.SinkDefinition;
+import com.link.up.framework.job.SourceDefinition;
+import com.link.up.framework.metrics.JobMetrics;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class LocalJobManagerProtocolTest {
+
+    @Test
+    public void shouldReturnSameJobForSameIdempotentSubmission()
+            throws Exception {
+
+        LocalJobManager manager = manager();
+
+        try {
+            JobSubmission submission =
+                    submission(
+                            "external-100",
+                            "key-100",
+                            "digest-100");
+
+            JobSnapshot first = manager.submit(submission);
+            waitForTerminal(manager, first.getJobId());
+            JobSnapshot second = manager.submit(submission);
+
+            assertEquals(
+                    first.getJobId(),
+                    second.getJobId());
+            assertEquals(
+                    first.getJobId(),
+                    manager.getJobByExternalExecutionId(
+                            "external-100")
+                            .getJobId());
+        } finally {
+            manager.close();
+        }
+    }
+
+    @Test(expected = JobSubmissionConflictException.class)
+    public void shouldRejectReusedIdempotencyKeyWithDifferentContent()
+            throws Exception {
+
+        LocalJobManager manager = manager();
+
+        try {
+            JobSnapshot first =
+                    manager.submit(
+                            submission(
+                                    "external-200",
+                                    "key-200",
+                                    "digest-a"));
+
+            waitForTerminal(manager, first.getJobId());
+
+            manager.submit(
+                    submission(
+                            "external-200",
+                            "key-200",
+                            "digest-b"));
+        } finally {
+            manager.close();
+        }
+    }
+
+    private static LocalJobManager manager() {
+        final AtomicInteger ids = new AtomicInteger();
+
+        JobExecutor executor =
+                new JobExecutor() {
+                    public JobResult execute(
+                            JobDefinition definition,
+                            JobExecutionListener listener) {
+
+                        long now = System.currentTimeMillis();
+
+                        return new JobResult(
+                                definition.getName(),
+                                JobStatus.SUCCEEDED,
+                                now,
+                                now,
+                                new JobMetrics(),
+                                null);
+                    }
+                };
+
+        JobIdGenerator idGenerator =
+                new JobIdGenerator() {
+                    public String nextId() {
+                        return "job-" + ids.incrementAndGet();
+                    }
+                };
+
+        return new LocalJobManager(
+                1,
+                4,
+                1_000L,
+                executor,
+                new InMemoryJobRepository(20),
+                idGenerator);
+    }
+
+    private static JobSubmission submission(
+            String externalExecutionId,
+            String idempotencyKey,
+            String digest) {
+
+        ReadonlyConfig options =
+                ReadonlyConfig.fromMap(
+                        Collections.<String, Object>emptyMap());
+
+        JobDefinition definition =
+                new JobDefinition(
+                        "protocol-test",
+                        new SourceDefinition("test-source", options),
+                        new SinkDefinition("test-sink", options),
+                        new ExecutionConfig(100, 1, 1, 1));
+
+        return new JobSubmission(
+                externalExecutionId,
+                idempotencyKey,
+                1,
+                digest,
+                definition);
+    }
+
+    private static JobSnapshot waitForTerminal(
+            LocalJobManager manager,
+            String jobId)
+            throws InterruptedException {
+
+        for (int attempt = 0; attempt < 100; attempt++) {
+            JobSnapshot snapshot = manager.getJob(jobId);
+
+            if (snapshot.getStatus().isTerminal()) {
+                return snapshot;
+            }
+
+            Thread.sleep(10L);
+        }
+
+        throw new AssertionError(
+                "Job did not reach terminal state");
+    }
+}


### PR DESCRIPTION
## Summary

- define the exact offline execution lifecycle: `CREATED -> SUBMITTED -> QUEUED -> RUNNING -> SUCCEEDED / FAILED / CANCELED / LOST`
- add an idempotent JSON submit protocol with `externalExecutionId`, `idempotencyKey`, `definitionVersion`, and a configuration digest
- expose stable worker `nodeId`, per-process `instanceId`, queue capacity, running count, and queued count
- preserve legacy HOCON body submission for CLI and compatibility use
- add query-by-external-execution-ID support, state versions, cancellation intent, and auditable transition history
- model unknown shutdown outcomes as `LOST` instead of incorrectly reporting them as canceled
- document the Yak Ops control-plane / Link-Up offline-worker ownership boundary

## API changes

- `GET /api/v1/node`
- `POST /api/v1/jobs` with `application/json`
- `GET /api/v1/jobs/external/{externalExecutionId}`
- `GET /api/v1/jobs?externalExecutionId=...`
- existing job detail, pipeline, task, metrics, list, legacy HOCON submit, and cancel routes remain available

## Reliability behavior

- an identical idempotent retry returns the original `jobId`
- reusing an idempotency key or external execution ID with different content returns HTTP `409` with `FLUX-JOB-IDEMPOTENCY-CONFLICT`
- cancellation is represented by `cancellationRequested=true`; no extra realtime-style lifecycle state is introduced
- unresolved jobs after graceful shutdown timeout become `LOST`
- after a hard process restart, Yak Ops can identify stale executions from the changed `workerInstanceId`

## Validation

- added JUnit coverage for legal and illegal state transitions
- added lifecycle history coverage including the `LOST` terminal state
- added manager-level coverage for idempotent duplicate submission and conflict detection
- performed Java 8-compatible static compilation and a local protocol harness for lifecycle and idempotency behavior

Full Maven execution was not available in the execution environment because Maven is not installed; GitHub checks can validate the complete reactor after this draft PR is opened.

## Scope

Link-Up remains an **offline-only batch synchronization Worker**. This change does not introduce CDC, checkpoint, savepoint, streaming deployment, pause, or resume semantics.