### PR TITLE
feat(connector): add schema foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ auditable state transitions, worker instance identity and deterministic duplicat
 HOCON body submission remains available for CLI and compatibility use.
 
 See [the single-node offline Worker protocol](docs/worker-protocol.md) for the complete API and state ownership contract.
+
+## Connector Schema
+
+Link-Up exports Connector options, types, defaults, validation rules, semantic metadata and capabilities through a
+stable machine-readable schema:
+
+```http
+GET /api/v1/connectors
+GET /api/v1/connectors/{connectorId}/schema?role=SOURCE
+GET /api/v1/connectors/{connectorId}/schema?role=SINK
+```
+
+The schema is execution-focused and frontend-framework neutral. Yak Ops can cache it and combine it with its own
+Presentation Profile to produce a product-oriented form without duplicating Connector validation rules.
+
+See [the Connector Schema protocol](docs/connector-schema.md) for the complete contract and phase-one boundaries.

--- a/docs/connector-schema.md
+++ b/docs/connector-schema.md
@@ -1,0 +1,188 @@
+# Link-Up Connector Schema 协议
+
+Connector Schema 是 Link-Up 向 Yak Ops 等控制面公开的机器可读能力模型。它描述 Connector 实际接受的参数、类型、默认值、规则和执行能力，不描述 Ant Design 控件、页面分组、字段顺序或高级配置折叠方式。
+
+## 职责边界
+
+```text
+Link-Up OptionRule
+        ↓
+ConnectorSchemaExporter
+        ↓
+Connector Schema REST API
+        ↓
+Yak Ops Schema Registry / Presentation Profile
+        ↓
+Yak Ops Dynamic Form
+```
+
+- Link-Up 是参数合法性、条件规则和能力的最终事实来源。
+- Yak Ops 后端可以缓存 Schema，并叠加自己的 Presentation Profile。
+- Yak Ops 前端只消费合并后的 Form Schema，不应直接依赖 Java 类名。
+- HOCON 仍然是当前 Job 配置编码，但不属于 Connector Schema 协议。
+
+## 接口
+
+### 查询全部 Schema
+
+```http
+GET /api/v1/connectors
+GET /api/v1/connectors?role=SOURCE
+GET /api/v1/connectors?role=SINK
+```
+
+当前第一阶段直接返回完整 Schema 列表。后续 Connector 数量较多时，可以增加独立的摘要接口而不破坏单个 Schema 契约。
+
+### 查询单个 Schema
+
+```http
+GET /api/v1/connectors/{connectorId}/schema?role=SOURCE
+GET /api/v1/connectors/{connectorId}/schema?role=SINK
+```
+
+`role` 必填，因为同一个标识可以同时提供 Source 和 Sink，例如 JDBC。
+
+## 响应示例
+
+```json
+{
+  "connectorId": "jdbc",
+  "role": "SOURCE",
+  "schemaVersion": "1",
+  "schemaFingerprint": "sha256:...",
+  "implementationClass": "com.link.up.connector.jdbc.source.JdbcSourceFactory",
+  "implementationVersion": "1.0.0",
+  "options": [
+    {
+      "key": "url",
+      "valueType": "STRING",
+      "javaType": "java.lang.String",
+      "elementJavaType": null,
+      "defaultValue": null,
+      "allowedValues": [],
+      "description": "JDBC 连接地址",
+      "fallbackKeys": [],
+      "required": true,
+      "sensitive": false,
+      "semanticType": "JDBC_URL",
+      "scope": "DATASOURCE"
+    },
+    {
+      "key": "password",
+      "valueType": "STRING",
+      "javaType": "java.lang.String",
+      "defaultValue": null,
+      "allowedValues": [],
+      "required": false,
+      "sensitive": true,
+      "semanticType": "PASSWORD",
+      "scope": "DATASOURCE"
+    }
+  ],
+  "rules": [
+    {
+      "type": "REQUIRED",
+      "optionKeys": ["url", "driver"],
+      "condition": null,
+      "nestedRules": []
+    },
+    {
+      "type": "CONSTRAINT",
+      "optionKeys": ["url"],
+      "condition": {
+        "optionKey": "url",
+        "operator": "EXTENSION",
+        "expectedValue": null,
+        "compareOptionKey": null,
+        "extensionDescription": "JDBC URL 必须以 jdbc: 开头",
+        "logicalOperator": null,
+        "next": null
+      },
+      "nestedRules": []
+    }
+  ],
+  "capabilities": [
+    "CUSTOM_SQL",
+    "MULTI_TABLE",
+    "PARTITION_SPLIT",
+    "TABLE_SCHEMA_DISCOVERY"
+  ]
+}
+```
+
+## Option 元数据
+
+### valueType
+
+`valueType` 是跨语言基础类型，不要求控制面理解 Java 泛型：
+
+- `BOOLEAN`
+- `INTEGER`
+- `LONG`
+- `DECIMAL`
+- `FLOAT`
+- `DOUBLE`
+- `STRING`
+- `DURATION`
+- `MAP`
+- `LIST`
+- `ENUM`
+- `OBJECT`
+- `UNKNOWN`
+
+`javaType` 和 `elementJavaType` 用于诊断、缓存兼容判断和复杂对象扩展，不应直接决定前端控件。
+
+### semanticType
+
+`semanticType` 是稳定业务语义，例如：
+
+- `JDBC_URL`
+- `USERNAME`
+- `PASSWORD`
+- `DRIVER_CLASS`
+- `SCHEMA_NAME`
+- `SQL`
+- `TABLE_PATH`
+
+未声明时为 `GENERIC`。Link-Up 只提供语义，最终显示名称和控件仍由 Yak Ops Presentation Profile 决定。
+
+### scope
+
+- `DATASOURCE`：通常由数据源中心提供，例如 URL、用户名和密码。
+- `TASK`：属于任务定义，例如表、SQL 和写入模式。
+- `RUNTIME`：属于执行调优，例如并行度、批次和超时。
+- `SYSTEM`：由 Worker 或平台注入，不应由普通用户填写。
+
+### sensitive
+
+`sensitive=true` 表示该值不得出现在日志、错误详情、页面明文回显或普通配置导出中。Schema 本身只公开字段定义，不返回实际配置值。
+
+## Rule 类型
+
+- `REQUIRED`：字段绝对必填。
+- `EXCLUSIVE`：字段组中只能选择一个。
+- `BUNDLED`：字段必须同时存在或同时不存在。
+- `REQUIRED_WHEN`：条件成立时字段必填。
+- `CONSTRAINT`：字段值必须满足条件。
+- `RULE_WHEN`：条件成立时应用一组子规则；`optionKeys` 表示该条件下启用的可选字段。
+
+条件链通过 `logicalOperator` 和 `next` 表示 AND / OR，不把 Java `Condition` 的字符串形式当作协议。
+
+## 版本与指纹
+
+- `schemaVersion` 由 Connector 作者维护，不兼容变化时应提升。
+- `schemaFingerprint` 根据 Connector ID、角色、Option、规则和能力生成 SHA-256。
+- 控制面保存任务版本时应同时保存 Connector ID、角色、Schema 版本和指纹。
+- 实现版本不会参与指纹，同一实现重新打包不会导致无意义的 Schema 变化。
+
+## 第一阶段非目标
+
+本阶段不包含：
+
+- 前端分组、排序、重要程度和控件定义。
+- 数据库、表和字段发现 Action API。
+- Connector 配置在线校验 API。
+- JSON JobSpec 或 HOCON 替换。
+- Yak Ops Presentation Profile。
+
+这些能力会在后续阶段建立在本 Schema 契约之上。

--- a/link-up-api/src/main/java/com/link/up/api/configuration/Option.java
+++ b/link-up-api/src/main/java/com/link/up/api/configuration/Option.java
@@ -1,6 +1,7 @@
 package com.link.up.api.configuration;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,18 +29,47 @@ public class Option<T> {
      * 默认值。
      */
     private final T defaultValue;
+
     /**
      * 兼容的旧配置键。
      */
-    private final List<String> fallbackKeys = new ArrayList<>();
+    private final List<String> fallbackKeys =
+            new ArrayList<String>();
+
     /**
      * 配置说明。
      */
     private String description = "";
 
-    public Option(String key, TypeReference<T> typeReference, T defaultValue) {
-        this.key = Objects.requireNonNull(key, "key");
-        this.typeReference = Objects.requireNonNull(typeReference, "typeReference");
+    /**
+     * 是否包含密码、Token 等敏感信息。
+     */
+    private boolean sensitive;
+
+    /**
+     * 稳定业务语义，例如 JDBC_URL、PASSWORD、SQL。
+     */
+    private String semanticType = "GENERIC";
+
+    /**
+     * 配置值通常由哪一层提供。
+     */
+    private ConnectorOptionScope scope =
+            ConnectorOptionScope.TASK;
+
+    public Option(
+            String key,
+            TypeReference<T> typeReference,
+            T defaultValue) {
+
+        this.key =
+                Objects.requireNonNull(
+                        key,
+                        "key");
+        this.typeReference =
+                Objects.requireNonNull(
+                        typeReference,
+                        "typeReference");
         this.defaultValue = defaultValue;
     }
 
@@ -60,26 +90,94 @@ public class Option<T> {
     }
 
     public List<String> getFallbackKeys() {
-        return Collections.unmodifiableList(fallbackKeys);
+        return Collections.unmodifiableList(
+                fallbackKeys);
     }
 
-    public Option<T> withDescription(String description) {
-        this.description = description == null ? "" : description;
+    public boolean isSensitive() {
+        return sensitive;
+    }
+
+    public String getSemanticType() {
+        return semanticType;
+    }
+
+    public ConnectorOptionScope getScope() {
+        return scope;
+    }
+
+    public Option<T> withDescription(
+            String description) {
+
+        this.description =
+                description == null
+                        ? ""
+                        : description;
         return this;
     }
 
-    public Option<T> withFallbackKeys(String... keys) {
+    public Option<T> withFallbackKeys(
+            String... keys) {
+
         if (keys == null) {
             return this;
         }
 
         for (String fallbackKey : keys) {
             if (fallbackKey != null
-                    && !fallbackKey.trim().isEmpty()
-                    && !fallbackKeys.contains(fallbackKey)) {
-                fallbackKeys.add(fallbackKey);
+                    && !fallbackKey
+                    .trim()
+                    .isEmpty()
+                    && !fallbackKeys
+                    .contains(
+                            fallbackKey)) {
+
+                fallbackKeys.add(
+                        fallbackKey);
             }
         }
+
+        return this;
+    }
+
+    public Option<T> sensitive() {
+        return withSensitive(true);
+    }
+
+    public Option<T> withSensitive(
+            boolean sensitive) {
+
+        this.sensitive = sensitive;
+        return this;
+    }
+
+    public Option<T> withSemanticType(
+            String semanticType) {
+
+        if (semanticType == null
+                || semanticType
+                .trim()
+                .isEmpty()) {
+
+            this.semanticType = "GENERIC";
+        } else {
+            this.semanticType =
+                    semanticType
+                            .trim()
+                            .toUpperCase(
+                                    java.util.Locale.ROOT);
+        }
+
+        return this;
+    }
+
+    public Option<T> withScope(
+            ConnectorOptionScope scope) {
+
+        this.scope =
+                Objects.requireNonNull(
+                        scope,
+                        "scope");
         return this;
     }
 
@@ -93,10 +191,20 @@ public class Option<T> {
         }
 
         Option<?> that = (Option<?>) obj;
-        return Objects.equals(key, that.key)
-                && Objects.equals(typeReference.getType(), that.typeReference.getType())
-                && Objects.equals(defaultValue, that.defaultValue)
-                && Objects.equals(fallbackKeys, that.fallbackKeys);
+
+        return Objects.equals(
+                key,
+                that.key)
+                && Objects.equals(
+                typeReference.getType(),
+                that.typeReference
+                        .getType())
+                && Objects.equals(
+                defaultValue,
+                that.defaultValue)
+                && Objects.equals(
+                fallbackKeys,
+                that.fallbackKeys);
     }
 
     @Override

--- a/link-up-api/src/main/java/com/link/up/api/configuration/SingleChoiceOption.java
+++ b/link-up-api/src/main/java/com/link/up/api/configuration/SingleChoiceOption.java
@@ -1,6 +1,7 @@
 package com.link.up.api.configuration;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -12,7 +13,8 @@ import java.util.Objects;
  *
  * @param <T> 配置值类型
  */
-public class SingleChoiceOption<T> extends Option<T> {
+public class SingleChoiceOption<T>
+        extends Option<T> {
 
     /**
      * 可选值列表。
@@ -25,11 +27,17 @@ public class SingleChoiceOption<T> extends Option<T> {
             List<T> optionValues,
             T defaultValue) {
 
-        super(key, typeReference, defaultValue);
+        super(
+                key,
+                typeReference,
+                defaultValue);
+
         this.optionValues =
                 Collections.unmodifiableList(
-                        new ArrayList<>(Objects.requireNonNull(optionValues, "optionValues")))
-        ;
+                        new ArrayList<T>(
+                                Objects.requireNonNull(
+                                        optionValues,
+                                        "optionValues")));
     }
 
     public List<T> getOptionValues() {
@@ -37,14 +45,50 @@ public class SingleChoiceOption<T> extends Option<T> {
     }
 
     @Override
-    public SingleChoiceOption<T> withDescription(String description) {
+    public SingleChoiceOption<T>
+    withDescription(String description) {
+
         super.withDescription(description);
         return this;
     }
 
     @Override
-    public SingleChoiceOption<T> withFallbackKeys(String... fallbackKeys) {
-        super.withFallbackKeys(fallbackKeys);
+    public SingleChoiceOption<T>
+    withFallbackKeys(String... fallbackKeys) {
+
+        super.withFallbackKeys(
+                fallbackKeys);
+        return this;
+    }
+
+    @Override
+    public SingleChoiceOption<T> sensitive() {
+        super.sensitive();
+        return this;
+    }
+
+    @Override
+    public SingleChoiceOption<T>
+    withSensitive(boolean sensitive) {
+
+        super.withSensitive(sensitive);
+        return this;
+    }
+
+    @Override
+    public SingleChoiceOption<T>
+    withSemanticType(String semanticType) {
+
+        super.withSemanticType(
+                semanticType);
+        return this;
+    }
+
+    @Override
+    public SingleChoiceOption<T>
+    withScope(ConnectorOptionScope scope) {
+
+        super.withScope(scope);
         return this;
     }
 }

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorCapability.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorCapability.java
@@ -1,0 +1,16 @@
+package com.link.up.api.connector.schema;
+
+/**
+ * Connector 可以向控制面公开的稳定能力标识。
+ *
+ * <p>这里只描述执行引擎实际支持的能力，不包含具体前端控件和页面布局。
+ */
+public enum ConnectorCapability {
+    TABLE_SCHEMA_DISCOVERY,
+    MULTI_TABLE,
+    CUSTOM_SQL,
+    PARTITION_SPLIT,
+    UPSERT,
+    AUTO_CREATE_TABLE,
+    DIRTY_DATA_HANDLING
+}

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorConditionSchema.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorConditionSchema.java
@@ -1,0 +1,64 @@
+package com.link.up.api.connector.schema;
+
+/**
+ * 可序列化的条件表达式节点。
+ *
+ * <p>{@code logicalOperator} 表示当前节点与 {@code next} 的连接关系，
+ * 仅允许 AND 或 OR；最后一个节点为空。
+ */
+public final class ConnectorConditionSchema {
+
+    private final String optionKey;
+    private final String operator;
+    private final Object expectedValue;
+    private final String compareOptionKey;
+    private final String extensionDescription;
+    private final String logicalOperator;
+    private final ConnectorConditionSchema next;
+
+    public ConnectorConditionSchema(
+            String optionKey,
+            String operator,
+            Object expectedValue,
+            String compareOptionKey,
+            String extensionDescription,
+            String logicalOperator,
+            ConnectorConditionSchema next) {
+
+        this.optionKey = optionKey;
+        this.operator = operator;
+        this.expectedValue = expectedValue;
+        this.compareOptionKey = compareOptionKey;
+        this.extensionDescription = extensionDescription;
+        this.logicalOperator = logicalOperator;
+        this.next = next;
+    }
+
+    public String getOptionKey() {
+        return optionKey;
+    }
+
+    public String getOperator() {
+        return operator;
+    }
+
+    public Object getExpectedValue() {
+        return expectedValue;
+    }
+
+    public String getCompareOptionKey() {
+        return compareOptionKey;
+    }
+
+    public String getExtensionDescription() {
+        return extensionDescription;
+    }
+
+    public String getLogicalOperator() {
+        return logicalOperator;
+    }
+
+    public ConnectorConditionSchema getNext() {
+        return next;
+    }
+}

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorOptionSchema.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorOptionSchema.java
@@ -1,0 +1,110 @@
+package com.link.up.api.connector.schema;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Connector Option 的稳定协议视图。
+ */
+public final class ConnectorOptionSchema {
+
+    private final String key;
+    private final ConnectorOptionValueType valueType;
+    private final String javaType;
+    private final String elementJavaType;
+    private final Object defaultValue;
+    private final List<Object> allowedValues;
+    private final String description;
+    private final List<String> fallbackKeys;
+    private final boolean required;
+    private final boolean sensitive;
+    private final String semanticType;
+    private final ConnectorOptionScope scope;
+
+    public ConnectorOptionSchema(
+            String key,
+            ConnectorOptionValueType valueType,
+            String javaType,
+            String elementJavaType,
+            Object defaultValue,
+            List<Object> allowedValues,
+            String description,
+            List<String> fallbackKeys,
+            boolean required,
+            boolean sensitive,
+            String semanticType,
+            ConnectorOptionScope scope) {
+
+        this.key = key;
+        this.valueType = valueType;
+        this.javaType = javaType;
+        this.elementJavaType = elementJavaType;
+        this.defaultValue = defaultValue;
+        this.allowedValues =
+                Collections.unmodifiableList(
+                        new ArrayList<Object>(
+                                allowedValues == null
+                                        ? Collections.emptyList()
+                                        : allowedValues));
+        this.description = description;
+        this.fallbackKeys =
+                Collections.unmodifiableList(
+                        new ArrayList<String>(
+                                fallbackKeys == null
+                                        ? Collections.<String>emptyList()
+                                        : fallbackKeys));
+        this.required = required;
+        this.sensitive = sensitive;
+        this.semanticType = semanticType;
+        this.scope = scope;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public ConnectorOptionValueType getValueType() {
+        return valueType;
+    }
+
+    public String getJavaType() {
+        return javaType;
+    }
+
+    public String getElementJavaType() {
+        return elementJavaType;
+    }
+
+    public Object getDefaultValue() {
+        return defaultValue;
+    }
+
+    public List<Object> getAllowedValues() {
+        return allowedValues;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public List<String> getFallbackKeys() {
+        return fallbackKeys;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public boolean isSensitive() {
+        return sensitive;
+    }
+
+    public String getSemanticType() {
+        return semanticType;
+    }
+
+    public ConnectorOptionScope getScope() {
+        return scope;
+    }
+}

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorOptionScope.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorOptionScope.java
@@ -1,0 +1,11 @@
+package com.link.up.api.connector.schema;
+
+/**
+ * Connector Option 的配置来源范围。
+ */
+public enum ConnectorOptionScope {
+    DATASOURCE,
+    TASK,
+    RUNTIME,
+    SYSTEM
+}

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorOptionValueType.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorOptionValueType.java
@@ -1,0 +1,20 @@
+package com.link.up.api.connector.schema;
+
+/**
+ * 跨语言、跨前端框架的 Option 基础值类型。
+ */
+public enum ConnectorOptionValueType {
+    BOOLEAN,
+    INTEGER,
+    LONG,
+    DECIMAL,
+    FLOAT,
+    DOUBLE,
+    STRING,
+    DURATION,
+    MAP,
+    LIST,
+    ENUM,
+    OBJECT,
+    UNKNOWN
+}

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorRole.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorRole.java
@@ -1,0 +1,9 @@
+package com.link.up.api.connector.schema;
+
+/**
+ * Connector 在离线作业中的角色。
+ */
+public enum ConnectorRole {
+    SOURCE,
+    SINK
+}

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorRuleSchema.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorRuleSchema.java
@@ -1,0 +1,61 @@
+package com.link.up.api.connector.schema;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 可供控制面消费的 Connector 配置规则。
+ */
+public final class ConnectorRuleSchema {
+
+    public static final String REQUIRED = "REQUIRED";
+    public static final String EXCLUSIVE = "EXCLUSIVE";
+    public static final String BUNDLED = "BUNDLED";
+    public static final String REQUIRED_WHEN = "REQUIRED_WHEN";
+    public static final String CONSTRAINT = "CONSTRAINT";
+    public static final String RULE_WHEN = "RULE_WHEN";
+
+    private final String type;
+    private final List<String> optionKeys;
+    private final ConnectorConditionSchema condition;
+    private final List<ConnectorRuleSchema> nestedRules;
+
+    public ConnectorRuleSchema(
+            String type,
+            List<String> optionKeys,
+            ConnectorConditionSchema condition,
+            List<ConnectorRuleSchema> nestedRules) {
+
+        this.type = type;
+        this.optionKeys =
+                Collections.unmodifiableList(
+                        new ArrayList<String>(
+                                optionKeys == null
+                                        ? Collections.<String>emptyList()
+                                        : optionKeys));
+        this.condition = condition;
+        this.nestedRules =
+                Collections.unmodifiableList(
+                        new ArrayList<ConnectorRuleSchema>(
+                                nestedRules == null
+                                        ? Collections.<ConnectorRuleSchema>emptyList()
+                                        : nestedRules));
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public List<String> getOptionKeys() {
+        return optionKeys;
+    }
+
+    public ConnectorConditionSchema getCondition() {
+        return condition;
+    }
+
+    public List<ConnectorRuleSchema> getNestedRules() {
+        return nestedRules;
+    }
+}

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorSchema.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorSchema.java
@@ -1,0 +1,85 @@
+package com.link.up.api.connector.schema;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Link-Up 对控制面公开的 Connector Schema。
+ */
+public final class ConnectorSchema {
+
+    private final String connectorId;
+    private final ConnectorRole role;
+    private final String schemaVersion;
+    private final String schemaFingerprint;
+    private final String implementationClass;
+    private final String implementationVersion;
+    private final List<ConnectorOptionSchema> options;
+    private final List<ConnectorRuleSchema> rules;
+    private final List<ConnectorCapability> capabilities;
+
+    public ConnectorSchema(
+            String connectorId,
+            ConnectorRole role,
+            String schemaVersion,
+            String schemaFingerprint,
+            String implementationClass,
+            String implementationVersion,
+            List<ConnectorOptionSchema> options,
+            List<ConnectorRuleSchema> rules,
+            List<ConnectorCapability> capabilities) {
+
+        this.connectorId = connectorId;
+        this.role = role;
+        this.schemaVersion = schemaVersion;
+        this.schemaFingerprint = schemaFingerprint;
+        this.implementationClass = implementationClass;
+        this.implementationVersion = implementationVersion;
+        this.options =
+                Collections.unmodifiableList(
+                        new ArrayList<ConnectorOptionSchema>(options));
+        this.rules =
+                Collections.unmodifiableList(
+                        new ArrayList<ConnectorRuleSchema>(rules));
+        this.capabilities =
+                Collections.unmodifiableList(
+                        new ArrayList<ConnectorCapability>(capabilities));
+    }
+
+    public String getConnectorId() {
+        return connectorId;
+    }
+
+    public ConnectorRole getRole() {
+        return role;
+    }
+
+    public String getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public String getSchemaFingerprint() {
+        return schemaFingerprint;
+    }
+
+    public String getImplementationClass() {
+        return implementationClass;
+    }
+
+    public String getImplementationVersion() {
+        return implementationVersion;
+    }
+
+    public List<ConnectorOptionSchema> getOptions() {
+        return options;
+    }
+
+    public List<ConnectorRuleSchema> getRules() {
+        return rules;
+    }
+
+    public List<ConnectorCapability> getCapabilities() {
+        return capabilities;
+    }
+}

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorSchemaExporter.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorSchemaExporter.java
@@ -1,0 +1,870 @@
+package com.link.up.api.connector.schema;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.SingleChoiceOption;
+import com.link.up.api.configuration.util.Condition;
+import com.link.up.api.configuration.util.ConditionRule;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.configuration.util.RequiredOption;
+import com.link.up.api.factory.Factory;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 将运行时 {@link OptionRule} 转换为稳定、可序列化的 Connector Schema。
+ */
+public final class ConnectorSchemaExporter {
+
+    public ConnectorSchema export(
+            Factory factory,
+            ConnectorRole role,
+            OptionRule optionRule) {
+
+        if (factory == null) {
+            throw new IllegalArgumentException(
+                    "factory must not be null");
+        }
+        if (role == null) {
+            throw new IllegalArgumentException(
+                    "role must not be null");
+        }
+        if (optionRule == null) {
+            throw new IllegalArgumentException(
+                    "optionRule must not be null");
+        }
+
+        Map<String, Option<?>> optionIndex =
+                new LinkedHashMap<String, Option<?>>();
+
+        collectOptions(
+                optionRule,
+                optionIndex,
+                Collections.newSetFromMap(
+                        new IdentityHashMap<OptionRule, Boolean>()));
+
+        Set<String> absolutelyRequired =
+                new java.util.LinkedHashSet<String>();
+
+        for (RequiredOption required :
+                optionRule.getRequiredOptions()) {
+            if (required
+                    instanceof RequiredOption
+                    .AbsolutelyRequiredOptions) {
+                absolutelyRequired.addAll(
+                        optionKeys(
+                                required.getOptions()));
+            }
+        }
+
+        List<ConnectorOptionSchema> options =
+                new ArrayList<ConnectorOptionSchema>();
+
+        for (Option<?> option :
+                optionIndex.values()) {
+            options.add(
+                    optionSchema(
+                            option,
+                            absolutelyRequired.contains(
+                                    option.key())));
+        }
+
+        Collections.sort(
+                options,
+                new Comparator<ConnectorOptionSchema>() {
+                    public int compare(
+                            ConnectorOptionSchema first,
+                            ConnectorOptionSchema second) {
+                        return first.getKey()
+                                .compareTo(
+                                        second.getKey());
+                    }
+                });
+
+        List<ConnectorRuleSchema> rules =
+                exportRules(optionRule);
+
+        List<ConnectorCapability> capabilities =
+                new ArrayList<ConnectorCapability>(
+                        factory.capabilities());
+
+        Collections.sort(
+                capabilities,
+                new Comparator<ConnectorCapability>() {
+                    public int compare(
+                            ConnectorCapability first,
+                            ConnectorCapability second) {
+                        return first.name()
+                                .compareTo(
+                                        second.name());
+                    }
+                });
+
+        String implementationVersion =
+                implementationVersion(
+                        factory.getClass());
+
+        String fingerprint =
+                fingerprint(
+                        factory.factoryIdentifier(),
+                        role,
+                        factory.schemaVersion(),
+                        options,
+                        rules,
+                        capabilities);
+
+        return new ConnectorSchema(
+                factory.factoryIdentifier(),
+                role,
+                factory.schemaVersion(),
+                fingerprint,
+                factory.getClass().getName(),
+                implementationVersion,
+                options,
+                rules,
+                capabilities);
+    }
+
+    private static void collectOptions(
+            OptionRule rule,
+            Map<String, Option<?>> optionIndex,
+            Set<OptionRule> visited) {
+
+        if (!visited.add(rule)) {
+            throw new IllegalArgumentException(
+                    "Circular OptionRule graph detected");
+        }
+
+        for (Option<?> option :
+                rule.getOptionalOptions()) {
+            putOption(optionIndex, option);
+        }
+
+        for (RequiredOption required :
+                rule.getRequiredOptions()) {
+
+            for (Option<?> option :
+                    required.getOptions()) {
+                putOption(optionIndex, option);
+            }
+
+            if (required
+                    instanceof RequiredOption
+                    .ConditionalRequiredOptions) {
+
+                collectConditionOptions(
+                        ((RequiredOption
+                                .ConditionalRequiredOptions)
+                                required)
+                                .getCondition(),
+                        optionIndex);
+            }
+        }
+
+        for (Condition<?> constraint :
+                rule.getValueConstraints()) {
+            collectConditionOptions(
+                    constraint,
+                    optionIndex);
+        }
+
+        for (ConditionRule conditionRule :
+                rule.getConditionRules()) {
+
+            collectConditionOptions(
+                    conditionRule.getCondition(),
+                    optionIndex);
+
+            collectOptions(
+                    conditionRule.getOptionRule(),
+                    optionIndex,
+                    visited);
+        }
+
+        visited.remove(rule);
+    }
+
+    private static void collectConditionOptions(
+            Condition<?> condition,
+            Map<String, Option<?>> optionIndex) {
+
+        Set<Condition<?>> visited =
+                Collections.newSetFromMap(
+                        new IdentityHashMap<Condition<?>, Boolean>());
+
+        Condition<?> current = condition;
+
+        while (current != null) {
+            if (!visited.add(current)) {
+                throw new IllegalArgumentException(
+                        "Circular condition chain detected");
+            }
+
+            putOption(
+                    optionIndex,
+                    current.getOption());
+
+            if (current.getCompareOption() != null) {
+                putOption(
+                        optionIndex,
+                        current.getCompareOption());
+            }
+
+            current = current.getNext();
+        }
+    }
+
+    private static void putOption(
+            Map<String, Option<?>> optionIndex,
+            Option<?> option) {
+
+        Option<?> existing =
+                optionIndex.get(option.key());
+
+        if (existing == null) {
+            optionIndex.put(
+                    option.key(),
+                    option);
+            return;
+        }
+
+        if (!existing.typeReference()
+                .getType()
+                .equals(
+                        option.typeReference()
+                                .getType())) {
+
+            throw new IllegalArgumentException(
+                    "Option key '"
+                            + option.key()
+                            + "' is declared with different types");
+        }
+    }
+
+    private static List<ConnectorRuleSchema>
+    exportRules(OptionRule rule) {
+
+        List<ConnectorRuleSchema> result =
+                new ArrayList<ConnectorRuleSchema>();
+
+        for (RequiredOption required :
+                rule.getRequiredOptions()) {
+
+            if (required
+                    instanceof RequiredOption
+                    .AbsolutelyRequiredOptions) {
+
+                result.add(
+                        new ConnectorRuleSchema(
+                                ConnectorRuleSchema.REQUIRED,
+                                optionKeys(
+                                        required.getOptions()),
+                                null,
+                                null));
+
+            } else if (required
+                    instanceof RequiredOption
+                    .ExclusiveRequiredOptions) {
+
+                result.add(
+                        new ConnectorRuleSchema(
+                                ConnectorRuleSchema.EXCLUSIVE,
+                                optionKeys(
+                                        required.getOptions()),
+                                null,
+                                null));
+
+            } else if (required
+                    instanceof RequiredOption
+                    .BundledRequiredOptions) {
+
+                result.add(
+                        new ConnectorRuleSchema(
+                                ConnectorRuleSchema.BUNDLED,
+                                optionKeys(
+                                        required.getOptions()),
+                                null,
+                                null));
+
+            } else if (required
+                    instanceof RequiredOption
+                    .ConditionalRequiredOptions) {
+
+                RequiredOption
+                        .ConditionalRequiredOptions
+                        conditional =
+                        (RequiredOption
+                                .ConditionalRequiredOptions)
+                                required;
+
+                result.add(
+                        new ConnectorRuleSchema(
+                                ConnectorRuleSchema.REQUIRED_WHEN,
+                                optionKeys(
+                                        conditional.getOptions()),
+                                conditionSchema(
+                                        conditional.getCondition()),
+                                null));
+            }
+        }
+
+        for (Condition<?> constraint :
+                rule.getValueConstraints()) {
+
+            result.add(
+                    new ConnectorRuleSchema(
+                            ConnectorRuleSchema.CONSTRAINT,
+                            Collections.singletonList(
+                                    constraint
+                                            .getOption()
+                                            .key()),
+                            conditionSchema(constraint),
+                            null));
+        }
+
+        for (ConditionRule conditionRule :
+                rule.getConditionRules()) {
+
+            OptionRule nested =
+                    conditionRule.getOptionRule();
+
+            result.add(
+                    new ConnectorRuleSchema(
+                            ConnectorRuleSchema.RULE_WHEN,
+                            optionKeys(
+                                    nested.getOptionalOptions()),
+                            conditionSchema(
+                                    conditionRule.getCondition()),
+                            exportRules(nested)));
+        }
+
+        return Collections.unmodifiableList(result);
+    }
+
+    private static ConnectorConditionSchema
+    conditionSchema(Condition<?> condition) {
+
+        if (condition == null) {
+            return null;
+        }
+
+        String logicalOperator = null;
+
+        if (condition.getNext() != null) {
+            logicalOperator =
+                    Boolean.TRUE.equals(
+                            condition.and())
+                            ? "AND"
+                            : "OR";
+        }
+
+        String extensionDescription =
+                condition.getExtension() == null
+                        ? null
+                        : condition.getExtension()
+                        .description();
+
+        return new ConnectorConditionSchema(
+                condition.getOption().key(),
+                condition.getOperator().name(),
+                jsonValue(
+                        condition.getExpectedValue()),
+                condition.getCompareOption() == null
+                        ? null
+                        : condition.getCompareOption()
+                        .key(),
+                extensionDescription,
+                logicalOperator,
+                conditionSchema(
+                        condition.getNext()));
+    }
+
+    private static ConnectorOptionSchema optionSchema(
+            Option<?> option,
+            boolean required) {
+
+        Type type =
+                option.typeReference()
+                        .getType();
+
+        ConnectorOptionValueType valueType =
+                valueType(type);
+
+        List<Object> allowedValues =
+                allowedValues(option, type);
+
+        return new ConnectorOptionSchema(
+                option.key(),
+                valueType,
+                type.getTypeName(),
+                elementJavaType(type),
+                jsonValue(
+                        option.defaultValue()),
+                allowedValues,
+                option.getDescription(),
+                option.getFallbackKeys(),
+                required,
+                option.isSensitive(),
+                option.getSemanticType(),
+                option.getScope());
+    }
+
+    private static List<Object> allowedValues(
+            Option<?> option,
+            Type type) {
+
+        List<Object> result =
+                new ArrayList<Object>();
+
+        if (option instanceof SingleChoiceOption) {
+            for (Object value :
+                    ((SingleChoiceOption<?>) option)
+                            .getOptionValues()) {
+                result.add(jsonValue(value));
+            }
+        } else if (type instanceof Class
+                && ((Class<?>) type).isEnum()) {
+
+            Object[] constants =
+                    ((Class<?>) type)
+                            .getEnumConstants();
+
+            if (constants != null) {
+                for (Object constant : constants) {
+                    result.add(
+                            jsonValue(constant));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static ConnectorOptionValueType
+    valueType(Type type) {
+
+        if (type == Boolean.class
+                || type == boolean.class) {
+            return ConnectorOptionValueType.BOOLEAN;
+        }
+        if (type == Integer.class
+                || type == int.class
+                || type == Short.class
+                || type == short.class
+                || type == Byte.class
+                || type == byte.class) {
+            return ConnectorOptionValueType.INTEGER;
+        }
+        if (type == Long.class
+                || type == long.class) {
+            return ConnectorOptionValueType.LONG;
+        }
+        if (type == BigDecimal.class) {
+            return ConnectorOptionValueType.DECIMAL;
+        }
+        if (type == Float.class
+                || type == float.class) {
+            return ConnectorOptionValueType.FLOAT;
+        }
+        if (type == Double.class
+                || type == double.class) {
+            return ConnectorOptionValueType.DOUBLE;
+        }
+        if (type == String.class
+                || type == Character.class
+                || type == char.class) {
+            return ConnectorOptionValueType.STRING;
+        }
+        if (type == Duration.class) {
+            return ConnectorOptionValueType.DURATION;
+        }
+        if (type instanceof Class
+                && ((Class<?>) type).isEnum()) {
+            return ConnectorOptionValueType.ENUM;
+        }
+
+        Class<?> rawType = rawType(type);
+
+        if (rawType != null
+                && Map.class.isAssignableFrom(
+                        rawType)) {
+            return ConnectorOptionValueType.MAP;
+        }
+        if (rawType != null
+                && Collection.class
+                .isAssignableFrom(rawType)) {
+            return ConnectorOptionValueType.LIST;
+        }
+        if (type instanceof Class) {
+            return ConnectorOptionValueType.OBJECT;
+        }
+
+        return ConnectorOptionValueType.UNKNOWN;
+    }
+
+    private static String elementJavaType(Type type) {
+        if (!(type instanceof ParameterizedType)) {
+            return null;
+        }
+
+        ParameterizedType parameterizedType =
+                (ParameterizedType) type;
+
+        Type raw =
+                parameterizedType.getRawType();
+
+        if (!(raw instanceof Class)
+                || !Collection.class
+                .isAssignableFrom(
+                        (Class<?>) raw)) {
+            return null;
+        }
+
+        Type[] arguments =
+                parameterizedType
+                        .getActualTypeArguments();
+
+        return arguments.length == 0
+                ? null
+                : arguments[0].getTypeName();
+    }
+
+    private static Class<?> rawType(Type type) {
+        if (type instanceof Class) {
+            return (Class<?>) type;
+        }
+        if (type instanceof ParameterizedType) {
+            Type raw =
+                    ((ParameterizedType) type)
+                            .getRawType();
+            return raw instanceof Class
+                    ? (Class<?>) raw
+                    : null;
+        }
+        return null;
+    }
+
+    private static List<String> optionKeys(
+            List<? extends Option<?>> options) {
+
+        List<String> result =
+                new ArrayList<String>();
+
+        for (Option<?> option : options) {
+            result.add(option.key());
+        }
+
+        return result;
+    }
+
+    private static Object jsonValue(Object value) {
+        if (value == null
+                || value instanceof String
+                || value instanceof Number
+                || value instanceof Boolean) {
+            return value;
+        }
+
+        if (value instanceof Enum) {
+            return ((Enum<?>) value).name();
+        }
+
+        if (value instanceof Duration) {
+            return value.toString();
+        }
+
+        if (value instanceof Map) {
+            Map<?, ?> source =
+                    (Map<?, ?>) value;
+
+            Map<String, Object> result =
+                    new java.util.TreeMap<String, Object>();
+
+            for (Map.Entry<?, ?> entry :
+                    source.entrySet()) {
+
+                result.put(
+                        String.valueOf(
+                                entry.getKey()),
+                        jsonValue(
+                                entry.getValue()));
+            }
+
+            return result;
+        }
+
+        if (value instanceof Collection) {
+            List<Object> result =
+                    new ArrayList<Object>();
+
+            for (Object item :
+                    (Collection<?>) value) {
+                result.add(
+                        jsonValue(item));
+            }
+
+            return result;
+        }
+
+        if (value.getClass().isArray()) {
+            int length =
+                    java.lang.reflect.Array
+                            .getLength(value);
+
+            List<Object> result =
+                    new ArrayList<Object>(
+                            length);
+
+            for (int index = 0;
+                 index < length;
+                 index++) {
+
+                result.add(
+                        jsonValue(
+                                java.lang.reflect.Array
+                                        .get(
+                                                value,
+                                                index)));
+            }
+
+            return result;
+        }
+
+        /*
+         * Connector 自定义对象不能直接泄漏到协议中，
+         * 否则会把插件 ClassLoader 和 Java 实现细节带给控制面。
+         */
+        return String.valueOf(value);
+    }
+
+    private static String implementationVersion(
+            Class<?> implementationClass) {
+
+        Package implementationPackage =
+                implementationClass.getPackage();
+
+        String version =
+                implementationPackage == null
+                        ? null
+                        : implementationPackage
+                        .getImplementationVersion();
+
+        return version == null
+                || version.trim().isEmpty()
+                ? "unknown"
+                : version;
+    }
+
+    private static String fingerprint(
+            String connectorId,
+            ConnectorRole role,
+            String schemaVersion,
+            List<ConnectorOptionSchema> options,
+            List<ConnectorRuleSchema> rules,
+            List<ConnectorCapability> capabilities) {
+
+        StringBuilder canonical =
+                new StringBuilder();
+
+        canonical.append(connectorId)
+                .append('|')
+                .append(role.name())
+                .append('|')
+                .append(schemaVersion);
+
+        for (ConnectorOptionSchema option :
+                options) {
+
+            canonical.append("\nO|")
+                    .append(option.getKey())
+                    .append('|')
+                    .append(option.getValueType())
+                    .append('|')
+                    .append(option.getJavaType())
+                    .append('|')
+                    .append(option.getElementJavaType())
+                    .append('|')
+                    .append(canonicalValue(
+                            option.getDefaultValue()))
+                    .append('|')
+                    .append(canonicalValue(
+                            option.getAllowedValues()))
+                    .append('|')
+                    .append(option.isRequired())
+                    .append('|')
+                    .append(option.isSensitive())
+                    .append('|')
+                    .append(option.getSemanticType())
+                    .append('|')
+                    .append(option.getScope())
+                    .append('|')
+                    .append(option.getDescription())
+                    .append('|')
+                    .append(option.getFallbackKeys());
+        }
+
+        for (ConnectorRuleSchema rule : rules) {
+            appendRule(canonical, rule);
+        }
+
+        for (ConnectorCapability capability :
+                capabilities) {
+            canonical.append("\nC|")
+                    .append(capability.name());
+        }
+
+        try {
+            MessageDigest digest =
+                    MessageDigest.getInstance(
+                            "SHA-256");
+
+            byte[] value =
+                    digest.digest(
+                            canonical.toString()
+                                    .getBytes(
+                                            StandardCharsets.UTF_8));
+
+            StringBuilder hexadecimal =
+                    new StringBuilder(
+                            value.length * 2);
+
+            for (byte current : value) {
+                hexadecimal.append(
+                        String.format(
+                                "%02x",
+                                current & 0xff));
+            }
+
+            return "sha256:"
+                    + hexadecimal.toString();
+
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException(
+                    "SHA-256 is not available",
+                    exception);
+        }
+    }
+
+    private static void appendRule(
+            StringBuilder canonical,
+            ConnectorRuleSchema rule) {
+
+        canonical.append("\nR|")
+                .append(rule.getType())
+                .append('|')
+                .append(rule.getOptionKeys());
+
+        appendCondition(
+                canonical,
+                rule.getCondition());
+
+        for (ConnectorRuleSchema nested :
+                rule.getNestedRules()) {
+            appendRule(canonical, nested);
+        }
+    }
+
+    private static void appendCondition(
+            StringBuilder canonical,
+            ConnectorConditionSchema condition) {
+
+        ConnectorConditionSchema current =
+                condition;
+
+        while (current != null) {
+            canonical.append("|Q:")
+                    .append(current.getOptionKey())
+                    .append(':')
+                    .append(current.getOperator())
+                    .append(':')
+                    .append(canonicalValue(
+                            current.getExpectedValue()))
+                    .append(':')
+                    .append(current.getCompareOptionKey())
+                    .append(':')
+                    .append(current.getExtensionDescription())
+                    .append(':')
+                    .append(current.getLogicalOperator());
+
+            current = current.getNext();
+        }
+    }
+
+    private static String canonicalValue(
+            Object value) {
+
+        if (value == null) {
+            return "null";
+        }
+
+        if (value instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) value;
+            List<String> entries =
+                    new ArrayList<String>();
+
+            for (Map.Entry<?, ?> entry :
+                    map.entrySet()) {
+                entries.add(
+                        canonicalValue(entry.getKey())
+                                + "="
+                                + canonicalValue(
+                                entry.getValue()));
+            }
+
+            Collections.sort(entries);
+            return entries.toString();
+        }
+
+        if (value instanceof Collection) {
+            List<String> values =
+                    new ArrayList<String>();
+
+            for (Object item :
+                    (Collection<?>) value) {
+                values.add(
+                        canonicalValue(item));
+            }
+
+            return values.toString();
+        }
+
+        if (value.getClass().isArray()) {
+            int length =
+                    java.lang.reflect.Array
+                            .getLength(value);
+
+            List<String> values =
+                    new ArrayList<String>(length);
+
+            for (int index = 0;
+                 index < length;
+                 index++) {
+                values.add(
+                        canonicalValue(
+                                java.lang.reflect.Array
+                                        .get(
+                                                value,
+                                                index)));
+            }
+
+            return values.toString();
+        }
+
+        return String.valueOf(
+                jsonValue(value));
+    }
+}

--- a/link-up-api/src/main/java/com/link/up/api/factory/Factory.java
+++ b/link-up-api/src/main/java/com/link/up/api/factory/Factory.java
@@ -1,16 +1,40 @@
 package com.link.up.api.factory;
 
+import com.link.up.api.connector.schema.ConnectorCapability;
+
+import java.util.Collections;
+import java.util.Set;
+
 /**
- * Flux 插件工厂基础接口。
- * <p>
- * Source、Sink 等插件工厂都需要实现该接口。
+ * Link-Up 插件工厂基础接口。
+ *
+ * <p>Source、Sink 等插件工厂都需要实现该接口。
  */
 public interface Factory {
 
     /**
      * 工厂唯一标识。
-     * <p>
-     * 例如：jdbc、mysql-cdc、file。
+     *
+     * <p>例如：jdbc、doris、http、file。
      */
     String factoryIdentifier();
+
+    /**
+     * Connector Schema 的人工版本。
+     *
+     * <p>字段和规则发生不兼容变化时应提升版本；控制面还应结合
+     * schemaFingerprint 判断精确变化。
+     */
+    default String schemaVersion() {
+        return "1";
+    }
+
+    /**
+     * Connector 实际支持的稳定能力集合。
+     *
+     * <p>这里不返回前端控件或页面布局信息。
+     */
+    default Set<ConnectorCapability> capabilities() {
+        return Collections.emptySet();
+    }
 }

--- a/link-up-api/src/test/java/com/link/up/api/connector/schema/ConnectorSchemaExporterTest.java
+++ b/link-up-api/src/test/java/com/link/up/api/connector/schema/ConnectorSchemaExporterTest.java
@@ -1,0 +1,265 @@
+package com.link.up.api.connector.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.configuration.util.Conditions;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.factory.SourceFactory;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectorSchemaExporterTest {
+
+    private static final Option<String> MODE =
+            Options.key("mode")
+                    .singleChoice(
+                            String.class,
+                            Arrays.asList(
+                                    "TABLE",
+                                    "SQL"))
+                    .defaultValue("TABLE")
+                    .withDescription("读取方式")
+                    .withSemanticType("READ_MODE");
+
+    private static final Option<String> TABLE =
+            Options.key("table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withSemanticType("TABLE_PATH");
+
+    private static final Option<String> QUERY =
+            Options.key("query")
+                    .stringType()
+                    .noDefaultValue()
+                    .withSemanticType("SQL");
+
+    private static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
+
+    private static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .noDefaultValue()
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE)
+                    .withSemanticType("PASSWORD")
+                    .sensitive();
+
+    private static final Option<Integer> PARALLELISM =
+            Options.key("parallelism")
+                    .intType()
+                    .defaultValue(1)
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
+
+    private static final OptionRule RULE =
+            OptionRule.builder()
+                    .required(MODE)
+                    .conditional(
+                            MODE,
+                            "TABLE",
+                            TABLE)
+                    .conditional(
+                            MODE,
+                            "SQL",
+                            QUERY)
+                    .bundled(
+                            USERNAME,
+                            PASSWORD)
+                    .required(
+                            PARALLELISM,
+                            Conditions.greaterOrEqual(
+                                    PARALLELISM,
+                                    1))
+                    .build();
+
+    @Test
+    public void shouldExportOptionsRulesCapabilitiesAndFingerprint()
+            throws Exception {
+
+        ConnectorSchema schema =
+                new ConnectorSchemaExporter()
+                        .export(
+                                new TestSourceFactory(),
+                                ConnectorRole.SOURCE,
+                                RULE);
+
+        assertEquals(
+                "test",
+                schema.getConnectorId());
+        assertEquals(
+                ConnectorRole.SOURCE,
+                schema.getRole());
+        assertEquals(
+                "2",
+                schema.getSchemaVersion());
+        assertTrue(
+                schema.getSchemaFingerprint()
+                        .startsWith("sha256:"));
+        assertEquals(
+                64 + "sha256:".length(),
+                schema.getSchemaFingerprint()
+                        .length());
+
+        ConnectorOptionSchema password =
+                option(
+                        schema,
+                        "password");
+
+        assertTrue(password.isSensitive());
+        assertEquals(
+                "PASSWORD",
+                password.getSemanticType());
+        assertEquals(
+                ConnectorOptionScope.DATASOURCE,
+                password.getScope());
+        assertFalse(password.isRequired());
+
+        ConnectorOptionSchema mode =
+                option(
+                        schema,
+                        "mode");
+
+        assertEquals(
+                Arrays.<Object>asList(
+                        "TABLE",
+                        "SQL"),
+                mode.getAllowedValues());
+        assertTrue(mode.isRequired());
+
+        assertTrue(
+                hasRule(
+                        schema,
+                        ConnectorRuleSchema.REQUIRED_WHEN));
+        assertTrue(
+                hasRule(
+                        schema,
+                        ConnectorRuleSchema.BUNDLED));
+        assertTrue(
+                hasRule(
+                        schema,
+                        ConnectorRuleSchema.CONSTRAINT));
+
+        assertTrue(
+                schema.getCapabilities()
+                        .contains(
+                                ConnectorCapability.CUSTOM_SQL));
+
+        JsonNode json =
+                new ObjectMapper()
+                        .valueToTree(schema);
+
+        assertEquals(
+                "SOURCE",
+                json.path("role")
+                        .asText());
+        assertEquals(
+                "READ_MODE",
+                json.path("options")
+                        .get(0)
+                        .path("semanticType")
+                        .asText());
+        assertNotNull(
+                json.path("rules"));
+    }
+
+    @Test
+    public void shouldGenerateStableFingerprint() {
+        ConnectorSchemaExporter exporter =
+                new ConnectorSchemaExporter();
+
+        String first =
+                exporter.export(
+                                new TestSourceFactory(),
+                                ConnectorRole.SOURCE,
+                                RULE)
+                        .getSchemaFingerprint();
+
+        String second =
+                exporter.export(
+                                new TestSourceFactory(),
+                                ConnectorRole.SOURCE,
+                                RULE)
+                        .getSchemaFingerprint();
+
+        assertEquals(
+                first,
+                second);
+    }
+
+    private ConnectorOptionSchema option(
+            ConnectorSchema schema,
+            String key) {
+
+        for (ConnectorOptionSchema option :
+                schema.getOptions()) {
+
+            if (key.equals(
+                    option.getKey())) {
+                return option;
+            }
+        }
+
+        throw new AssertionError(
+                "Option not found: "
+                        + key);
+    }
+
+    private boolean hasRule(
+            ConnectorSchema schema,
+            String type) {
+
+        for (ConnectorRuleSchema rule :
+                schema.getRules()) {
+
+            if (type.equals(
+                    rule.getType())) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static final class TestSourceFactory
+            implements SourceFactory {
+
+        @Override
+        public String factoryIdentifier() {
+            return "test";
+        }
+
+        @Override
+        public String schemaVersion() {
+            return "2";
+        }
+
+        @Override
+        public Set<ConnectorCapability> capabilities() {
+            return Collections.unmodifiableSet(
+                    EnumSet.of(
+                            ConnectorCapability.CUSTOM_SQL,
+                            ConnectorCapability.MULTI_TABLE));
+        }
+
+        @Override
+        public OptionRule optionRule() {
+            return RULE;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/config/JdbcCommonOptions.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/config/JdbcCommonOptions.java
@@ -6,53 +6,69 @@ import com.link.up.api.configuration.ReadonlyConfig;
 import com.link.up.api.configuration.util.ConditionExtension;
 import com.link.up.api.configuration.util.Conditions;
 import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
 
 import java.util.Map;
 
 /**
  * JDBC Source、Sink、Catalog 共用配置。
- * <p>
- * 这里只保留真正属于 JDBC 连接层的配置，
+ *
+ * <p>这里只保留真正属于 JDBC 连接层的配置，
  * 不放 Source 分片、Sink 批次或数据库专属能力。
  */
 public class JdbcCommonOptions {
-
 
     public static final Option<String> URL =
             Options.key("url")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("JDBC 连接地址");
+                    .withDescription("JDBC 连接地址")
+                    .withSemanticType("JDBC_URL")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
     public static final Option<String> DRIVER =
             Options.key("driver")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("JDBC Driver 类名");
+                    .withDescription("JDBC Driver 类名")
+                    .withSemanticType("DRIVER_CLASS")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
     public static final Option<String> USERNAME =
             Options.key("username")
                     .stringType()
                     .noDefaultValue()
                     .withFallbackKeys("user")
-                    .withDescription("数据库用户名");
+                    .withDescription("数据库用户名")
+                    .withSemanticType("USERNAME")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
     public static final Option<String> PASSWORD =
             Options.key("password")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("数据库密码");
+                    .withDescription("数据库密码")
+                    .withSemanticType("PASSWORD")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE)
+                    .sensitive();
 
     /**
      * 显式指定数据库方言。
-     * <p>
-     * 未配置时，可以根据 JDBC URL 自动识别。
+     *
+     * <p>未配置时，可以根据 JDBC URL 自动识别。
      */
     public static final Option<String> DIALECT =
             Options.key("dialect")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("数据库方言，例如 mysql、postgresql");
+                    .withDescription("数据库方言，例如 mysql、postgresql")
+                    .withSemanticType("DATABASE_DIALECT")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
     /**
      * OceanBase 等兼容多种数据库协议的数据库可使用该配置。
@@ -61,31 +77,43 @@ public class JdbcCommonOptions {
             Options.key("compatible_mode")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("数据库兼容模式");
+                    .withDescription("数据库兼容模式")
+                    .withSemanticType("COMPATIBLE_MODE")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
     /**
      * 默认 Schema。
-     * <p>
-     * MySQL 中通常不使用；
-     * PostgreSQL、Oracle 等数据库可能需要。
+     *
+     * <p>MySQL 中通常不使用；PostgreSQL、Oracle 等数据库可能需要。
      */
     public static final Option<String> SCHEMA =
             Options.key("schema")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("默认 Schema");
+                    .withDescription("默认 Schema")
+                    .withSemanticType("SCHEMA_NAME")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
-    public static final Option<Integer> CONNECTION_CHECK_TIMEOUT_SEC =
+    public static final Option<Integer>
+            CONNECTION_CHECK_TIMEOUT_SEC =
             Options.key("connection_check_timeout_sec")
                     .intType()
                     .defaultValue(30)
-                    .withDescription("连接校验超时时间，单位秒");
+                    .withDescription("连接校验超时时间，单位秒")
+                    .withSemanticType("TIMEOUT_SECONDS")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
     public static final Option<Integer> CONNECT_TIMEOUT_MS =
             Options.key("connect_timeout_ms")
                     .intType()
                     .defaultValue(30_000)
-                    .withDescription("建立 JDBC 连接的超时时间，单位毫秒");
+                    .withDescription("建立 JDBC 连接的超时时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
     /**
      * 0 表示由 JDBC Driver 决定，适合长时间离线读取。
@@ -94,18 +122,25 @@ public class JdbcCommonOptions {
             Options.key("socket_timeout_ms")
                     .intType()
                     .defaultValue(0)
-                    .withDescription("Socket 读取超时时间，0 表示不主动限制");
+                    .withDescription("Socket 读取超时时间，0 表示不主动限制")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE);
 
     public static final Option<Map<String, String>> PROPERTIES =
             Options.key("properties")
                     .mapType()
                     .noDefaultValue()
-                    .withDescription("附加 JDBC 连接参数");
+                    .withDescription("附加 JDBC 连接参数")
+                    .withSemanticType("CONNECTION_PROPERTIES")
+                    .withScope(
+                            ConnectorOptionScope.DATASOURCE)
+                    .sensitive();
 
     /**
      * MySQL 类型映射选项。
-     * <p>
-     * 该配置虽然不是连接参数，但 Source、Catalog 都可能使用，
+     *
+     * <p>该配置虽然不是连接参数，但 Source、Catalog 都可能使用，
      * 暂时放在 JDBC 公共选项中。
      */
     public static final Option<Boolean> INT_TYPE_NARROWING =
@@ -113,7 +148,10 @@ public class JdbcCommonOptions {
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(
-                            "是否缩小 MySQL 整数类型，例如将 tinyint 映射为 Byte");
+                            "是否缩小 MySQL 整数类型，例如将 tinyint 映射为 Byte")
+                    .withSemanticType("TYPE_MAPPING")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     /**
      * Source、Sink、Catalog 工厂都可以复用的基础规则。
@@ -141,8 +179,8 @@ public class JdbcCommonOptions {
 
     /**
      * 这里只做 JDBC URL 基础格式校验。
-     * <p>
-     * MySQL、Oracle 等数据库的精确格式由各自 Factory 校验。
+     *
+     * <p>MySQL、Oracle 等数据库的精确格式由各自 Factory 校验。
      */
     static final class JdbcUrlValidator
             implements ConditionExtension<String> {
@@ -158,7 +196,8 @@ public class JdbcCommonOptions {
                 String value) {
 
             return value != null
-                    && value.trim().startsWith("jdbc:");
+                    && value.trim()
+                    .startsWith("jdbc:");
         }
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/config/JdbcSinkOptions.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/config/JdbcSinkOptions.java
@@ -2,6 +2,7 @@ package com.link.up.connector.jdbc.config;
 
 import com.link.up.api.configuration.Option;
 import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
 import com.link.up.connector.jdbc.sink.DataSaveMode;
 import com.link.up.connector.jdbc.sink.DirtyDataOutputType;
 import com.link.up.connector.jdbc.sink.DirtyDataPolicy;
@@ -15,27 +16,19 @@ import java.util.List;
 public final class JdbcSinkOptions
         extends JdbcCommonOptions {
 
-
     /**
-     * 目标表路径。
-     * <p>
-     * 单表：
-     * <p>
-     * database.table
-     * <p>
-     * 多表可以不配置，默认沿用 Source 表路径。支持
-     * {@code ${schema_name}} 和 {@code ${table_name}} 占位符，例如
-     * {@code archive.${schema_name}_${table_name}}。
-     * <p>
-     * 配置目标表时优先使用自动生成的 INSERT/UPSERT SQL，忽略
-     * {@code custom_sql}（以及其 {@code query} 别名）。
+     * 目标表路径或多表目标模板。
      */
     public static final Option<String> TABLE_PATH =
             Options.key("table_path")
                     .stringType()
                     .noDefaultValue()
                     .withFallbackKeys("table")
-                    .withDescription("目标表路径或多表目标模板，支持 ${schema_name} 和 ${table_name}");
+                    .withDescription(
+                            "目标表路径或多表目标模板，支持 ${schema_name} 和 ${table_name}")
+                    .withSemanticType("TABLE_PATH")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     public static final Option<SchemaSaveMode>
             SCHEMA_SAVE_MODE =
@@ -45,7 +38,10 @@ public final class JdbcSinkOptions
                     .defaultValue(
                             SchemaSaveMode
                                     .CREATE_SCHEMA_WHEN_NOT_EXIST)
-                    .withDescription("目标表结构处理方式");
+                    .withDescription("目标表结构处理方式")
+                    .withSemanticType("SCHEMA_SAVE_MODE")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     public static final Option<DataSaveMode>
             DATA_SAVE_MODE =
@@ -54,7 +50,10 @@ public final class JdbcSinkOptions
                             DataSaveMode.class)
                     .defaultValue(
                             DataSaveMode.APPEND_DATA)
-                    .withDescription("目标表已有数据处理方式");
+                    .withDescription("目标表已有数据处理方式")
+                    .withSemanticType("DATA_SAVE_MODE")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     /**
      * 未配置时，由 JdbcDialect 自动生成 INSERT/UPSERT SQL。
@@ -64,7 +63,10 @@ public final class JdbcSinkOptions
                     .stringType()
                     .noDefaultValue()
                     .withFallbackKeys("query")
-                    .withDescription("自定义写入 SQL");
+                    .withDescription("自定义写入 SQL")
+                    .withSemanticType("SQL")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     public static final Option<JdbcWriteMode>
             WRITE_MODE =
@@ -73,82 +75,138 @@ public final class JdbcSinkOptions
                             JdbcWriteMode.class)
                     .defaultValue(
                             JdbcWriteMode.INSERT)
-                    .withDescription("INSERT 或 UPSERT");
+                    .withDescription("INSERT 或 UPSERT")
+                    .withSemanticType("WRITE_MODE")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     /**
      * 用户显式指定的主键。
-     * <p>
-     * 未配置时可以使用 CatalogTable 中发现的主键。
      */
     public static final Option<List<String>>
             PRIMARY_KEYS =
             Options.key("primary_keys")
                     .listType()
                     .noDefaultValue()
-                    .withDescription("UPSERT 使用的主键字段");
+                    .withDescription("UPSERT 使用的主键字段")
+                    .withSemanticType("FIELD_LIST")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     public static final Option<Integer> BATCH_SIZE =
             Options.key("batch_size")
                     .intType()
                     .defaultValue(1000)
-                    .withDescription("JDBC executeBatch 每批写入数量");
+                    .withDescription("JDBC executeBatch 每批写入数量")
+                    .withSemanticType("BATCH_SIZE")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
 
-    /**
-     * Number of write statements retained per SinkTask. The cache is bounded
-     * so dynamic multi-table routing cannot grow JDBC driver resources without limit.
-     */
-    public static final Option<Integer> PREPARED_STATEMENT_CACHE_SIZE =
+    public static final Option<Integer>
+            PREPARED_STATEMENT_CACHE_SIZE =
             Options.key("prepared_statement_cache_size")
                     .intType()
                     .defaultValue(32)
-                    .withDescription("每个 SinkTask 缓存的目标表 PreparedStatement 数量上限");
+                    .withDescription(
+                            "每个 SinkTask 缓存的目标表 PreparedStatement 数量上限")
+                    .withSemanticType("CACHE_SIZE")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
 
-    /**
-     * JDBC query timeout applied to every cached write statement. A value of
-     * {@code 0} leaves timeout handling to the JDBC driver.
-     */
-    public static final Option<Integer> QUERY_TIMEOUT_SEC =
+    public static final Option<Integer>
+            QUERY_TIMEOUT_SEC =
             Options.key("query_timeout_sec")
                     .intType()
                     .defaultValue(0)
-                    .withDescription("写入 PreparedStatement 的查询超时时间，单位秒，0 表示不主动限制");
+                    .withDescription(
+                            "写入 PreparedStatement 的查询超时时间，单位秒，0 表示不主动限制")
+                    .withSemanticType("TIMEOUT_SECONDS")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
 
     public static final Option<Integer> MAX_RETRIES =
             Options.key("max_retries")
                     .intType()
                     .defaultValue(3)
-                    .withDescription("批次写入失败后的最大重试次数");
+                    .withDescription("批次写入失败后的最大重试次数")
+                    .withSemanticType("RETRY_COUNT")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
 
-    /**
-     * 脏数据处理策略。SKIP 会使用 Savepoint 回滚失败批次，然后逐行定位并跳过
-     * 无法写入的记录；FAIL_FAST 保持事务失败即回滚的默认行为。
-     */
-    public static final Option<DirtyDataPolicy> DIRTY_DATA_POLICY =
+    public static final Option<DirtyDataPolicy>
+            DIRTY_DATA_POLICY =
             Options.key("dirty_data_policy")
-                    .enumType(DirtyDataPolicy.class)
-                    .defaultValue(DirtyDataPolicy.FAIL_FAST)
-                    .withDescription("脏数据处理策略：FAIL_FAST 或 SKIP");
+                    .enumType(
+                            DirtyDataPolicy.class)
+                    .defaultValue(
+                            DirtyDataPolicy.FAIL_FAST)
+                    .withDescription("脏数据处理策略：FAIL_FAST 或 SKIP")
+                    .withSemanticType("DIRTY_DATA_POLICY")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
-    public static final Option<DirtyDataOutputType> DIRTY_DATA_OUTPUT_TYPE =
-            Options.key("dirty_data_output_type").enumType(DirtyDataOutputType.class).defaultValue(DirtyDataOutputType.MEMORY).withDescription("脏数据样例输出类型：MEMORY、LOGGING 或 JSONL");
-    public static final Option<String> DIRTY_DATA_OUTPUT_PATH =
-            Options.key("dirty_data_output_path").stringType().noDefaultValue().withDescription("JSONL 脏数据输出文件路径");
-    public static final Option<Integer> DIRTY_DATA_MAX_SAMPLES =
-            Options.key("dirty_data_max_samples").intType().defaultValue(100).withDescription("内存保留的脏数据样例上限");
-    public static final Option<Integer> DIRTY_DATA_MAX_COUNT =
-            Options.key("dirty_data_max_count").intType().defaultValue(Integer.MAX_VALUE).withDescription("允许跳过的脏数据数量上限");
-    public static final Option<Double> DIRTY_DATA_MAX_PERCENTAGE =
-            Options.key("dirty_data_max_percentage").doubleType().defaultValue(1D).withDescription("允许跳过的脏数据比例上限；分母为已尝试写入记录数");
+    public static final Option<DirtyDataOutputType>
+            DIRTY_DATA_OUTPUT_TYPE =
+            Options.key("dirty_data_output_type")
+                    .enumType(
+                            DirtyDataOutputType.class)
+                    .defaultValue(
+                            DirtyDataOutputType.MEMORY)
+                    .withDescription(
+                            "脏数据样例输出类型：MEMORY、LOGGING 或 JSONL")
+                    .withSemanticType("DIRTY_DATA_OUTPUT")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
-    /**
-     * 自动创建目标表时是否创建主键。
-     * <p>
-     * 当前 Catalog 第一版只支持主键，不处理普通索引。
-     */
+    public static final Option<String>
+            DIRTY_DATA_OUTPUT_PATH =
+            Options.key("dirty_data_output_path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("JSONL 脏数据输出文件路径")
+                    .withSemanticType("FILE_PATH")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
+
+    public static final Option<Integer>
+            DIRTY_DATA_MAX_SAMPLES =
+            Options.key("dirty_data_max_samples")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("内存保留的脏数据样例上限")
+                    .withSemanticType("SAMPLE_SIZE")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer>
+            DIRTY_DATA_MAX_COUNT =
+            Options.key("dirty_data_max_count")
+                    .intType()
+                    .defaultValue(
+                            Integer.MAX_VALUE)
+                    .withDescription("允许跳过的脏数据数量上限")
+                    .withSemanticType("LIMIT_COUNT")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Double>
+            DIRTY_DATA_MAX_PERCENTAGE =
+            Options.key("dirty_data_max_percentage")
+                    .doubleType()
+                    .defaultValue(1D)
+                    .withDescription(
+                            "允许跳过的脏数据比例上限；分母为已尝试写入记录数")
+                    .withSemanticType("PERCENTAGE")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
+
     public static final Option<Boolean>
             CREATE_PRIMARY_KEY =
             Options.key("create_primary_key")
                     .booleanType()
                     .defaultValue(true)
-                    .withDescription("自动建表时是否创建主键");
+                    .withDescription("自动建表时是否创建主键")
+                    .withSemanticType("CREATE_PRIMARY_KEY")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/config/JdbcSourceOptions.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/config/JdbcSourceOptions.java
@@ -2,6 +2,7 @@ package com.link.up.connector.jdbc.config;
 
 import com.link.up.api.configuration.Option;
 import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
 
 import java.util.List;
 
@@ -13,29 +14,32 @@ public final class JdbcSourceOptions
 
     /**
      * 数据表路径。
-     * <p>
-     * 例如：
-     * <p>
-     * database.table
-     * database.schema.table
+     *
+     * <p>例如 database.table 或 database.schema.table。
      */
     public static final Option<String> TABLE_PATH =
             Options.key("table_path")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("源表完整路径");
+                    .withDescription("源表完整路径")
+                    .withSemanticType("TABLE_PATH")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     /**
      * 自定义查询 SQL。
-     * <p>
-     * 配置 query 时仍建议配置 table_path，
+     *
+     * <p>配置 query 时仍建议配置 table_path，
      * table_path 作为该查询结果的数据集标识。
      */
     public static final Option<String> QUERY =
             Options.key("query")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("自定义查询 SQL");
+                    .withDescription("自定义查询 SQL")
+                    .withSemanticType("SQL")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     /**
      * 多表读取配置。
@@ -46,88 +50,146 @@ public final class JdbcSourceOptions
                     .listType(
                             JdbcSourceTableConfig.class)
                     .noDefaultValue()
-                    .withDescription("多表读取配置");
+                    .withDescription("多表读取配置")
+                    .withSemanticType("TABLE_LIST")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     /**
-     * 公共过滤条件。
-     * <p>
-     * 推荐只配置条件主体：
-     * <p>
-     * id > 100
-     * <p>
-     * 不需要写 where。
+     * 公共过滤条件，不需要包含 where。
      */
     public static final Option<String> WHERE_CONDITION =
             Options.key("where_condition")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("公共查询过滤条件，不需要包含 where");
+                    .withDescription("公共查询过滤条件，不需要包含 where")
+                    .withSemanticType("SQL_PREDICATE")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     /**
      * Requested consistency for the source read.
      */
-    public static final Option<ReadConsistency> READ_CONSISTENCY =
+    public static final Option<ReadConsistency>
+            READ_CONSISTENCY =
             Options.key("read_consistency")
-                    .enumType(ReadConsistency.class)
-                    .defaultValue(ReadConsistency.BEST_EFFORT)
-                    .withDescription("JDBC Source 读取一致性");
+                    .enumType(
+                            ReadConsistency.class)
+                    .defaultValue(
+                            ReadConsistency.BEST_EFFORT)
+                    .withDescription("JDBC Source 读取一致性")
+                    .withSemanticType("READ_CONSISTENCY")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     public static final Option<Integer> FETCH_SIZE =
             Options.key("fetch_size")
                     .intType()
                     .defaultValue(1000)
-                    .withDescription("JDBC 每次从数据库获取的行数");
+                    .withDescription("JDBC 每次从数据库获取的行数")
+                    .withSemanticType("FETCH_SIZE")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
 
     /**
      * 是否启用字段范围分片读取。
-     * <p>
-     * 默认关闭，保证第一版行为简单、稳定。
      */
     public static final Option<Boolean>
             ENABLE_PARTITION_READ =
             Options.key("enable_partition_read")
                     .booleanType()
                     .defaultValue(false)
-                    .withDescription("是否启用分片并行读取");
+                    .withDescription("是否启用分片并行读取")
+                    .withSemanticType("PARTITION_ENABLED")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
 
-    public static final Option<SplitPlanningMode> SPLIT_PLANNING_MODE =
-            Options.key("split_planning_mode").enumType(SplitPlanningMode.class)
-                    .defaultValue(SplitPlanningMode.MANUAL).withDescription("分片边界规划模式");
-    public static final Option<Integer> STATISTICS_QUERY_TIMEOUT =
-            Options.key("statistics_query_timeout").intType().defaultValue(30)
-                    .withDescription("统计查询超时秒数");
+    public static final Option<SplitPlanningMode>
+            SPLIT_PLANNING_MODE =
+            Options.key("split_planning_mode")
+                    .enumType(
+                            SplitPlanningMode.class)
+                    .defaultValue(
+                            SplitPlanningMode.MANUAL)
+                    .withDescription("分片边界规划模式")
+                    .withSemanticType("SPLIT_PLANNING_MODE")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer>
+            STATISTICS_QUERY_TIMEOUT =
+            Options.key("statistics_query_timeout")
+                    .intType()
+                    .defaultValue(30)
+                    .withDescription("统计查询超时秒数")
+                    .withSemanticType("TIMEOUT_SECONDS")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
+
     public static final Option<Integer> SAMPLE_SIZE =
-            Options.key("sample_size").intType().defaultValue(1000).withDescription("统计样本大小");
-    public static final Option<Boolean> ALLOW_STATISTICS_FALLBACK =
-            Options.key("allow_statistics_fallback").booleanType().defaultValue(false)
-                    .withDescription("是否允许统计模式降级");
-    public static final Option<Boolean> NULL_PARTITION_SINGLE_SPLIT =
-            Options.key("null_partition_single_split").booleanType().defaultValue(false)
-                    .withDescription("分区列全 NULL 时是否返回单 split");
+            Options.key("sample_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("统计样本大小")
+                    .withSemanticType("SAMPLE_SIZE")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Boolean>
+            ALLOW_STATISTICS_FALLBACK =
+            Options.key("allow_statistics_fallback")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("是否允许统计模式降级")
+                    .withSemanticType("FALLBACK_POLICY")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Boolean>
+            NULL_PARTITION_SINGLE_SPLIT =
+            Options.key("null_partition_single_split")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("分区列全 NULL 时是否返回单 split")
+                    .withSemanticType("NULL_PARTITION_POLICY")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
 
     public static final Option<String> PARTITION_COLUMN =
             Options.key("partition_column")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("分片字段");
+                    .withDescription("分片字段")
+                    .withSemanticType("PARTITION_COLUMN")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     public static final Option<Integer> PARTITION_NUM =
             Options.key("partition_num")
                     .intType()
                     .defaultValue(4)
-                    .withDescription("分片数量");
+                    .withDescription("分片数量")
+                    .withSemanticType("PARTITION_COUNT")
+                    .withScope(
+                            ConnectorOptionScope.RUNTIME);
 
     public static final Option<String>
             PARTITION_LOWER_BOUND =
             Options.key("partition_lower_bound")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("分片字段下界");
+                    .withDescription("分片字段下界")
+                    .withSemanticType("PARTITION_BOUND")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 
     public static final Option<String>
             PARTITION_UPPER_BOUND =
             Options.key("partition_upper_bound")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("分片字段上界");
+                    .withDescription("分片字段上界")
+                    .withSemanticType("PARTITION_BOUND")
+                    .withScope(
+                            ConnectorOptionScope.TASK);
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkFactory.java
@@ -55,6 +55,11 @@ public final class JdbcSinkFactory
                         JdbcSinkOptions.QUERY_TIMEOUT_SEC,
                         JdbcSinkOptions.MAX_RETRIES,
                         JdbcSinkOptions.DIRTY_DATA_POLICY,
+                        JdbcSinkOptions.DIRTY_DATA_OUTPUT_TYPE,
+                        JdbcSinkOptions.DIRTY_DATA_OUTPUT_PATH,
+                        JdbcSinkOptions.DIRTY_DATA_MAX_SAMPLES,
+                        JdbcSinkOptions.DIRTY_DATA_MAX_COUNT,
+                        JdbcSinkOptions.DIRTY_DATA_MAX_PERCENTAGE,
                         JdbcSinkOptions.CREATE_PRIMARY_KEY)
                 .build();
     }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkFactory.java
@@ -1,7 +1,9 @@
 package com.link.up.connector.jdbc.sink;
 
+import com.google.auto.service.AutoService;
 import com.link.up.api.configuration.ReadonlyConfig;
 import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
 import com.link.up.api.factory.SinkFactory;
 import com.link.up.api.sink.PreparedSinkMetadata;
 import com.link.up.api.sink.SinkPreparer;
@@ -10,37 +12,70 @@ import com.link.up.api.table.type.FluxRow;
 import com.link.up.connector.jdbc.config.JdbcCommonOptions;
 import com.link.up.connector.jdbc.config.JdbcSinkConfig;
 import com.link.up.connector.jdbc.config.JdbcSinkOptions;
-import com.google.auto.service.AutoService;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * JDBC Sink SPI factory.
  */
 @AutoService(SinkFactory.class)
-public final class JdbcSinkFactory implements SinkFactory {
+public final class JdbcSinkFactory
+        implements SinkFactory {
+
     @Override
     public String factoryIdentifier() {
         return "jdbc";
     }
 
     @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(
+                        ConnectorCapability.MULTI_TABLE,
+                        ConnectorCapability.CUSTOM_SQL,
+                        ConnectorCapability.UPSERT,
+                        ConnectorCapability.AUTO_CREATE_TABLE,
+                        ConnectorCapability.DIRTY_DATA_HANDLING));
+    }
+
+    @Override
     public OptionRule optionRule() {
-        return JdbcCommonOptions.baseConnectionRule().optional(
-                JdbcSinkOptions.TABLE_PATH, JdbcSinkOptions.SCHEMA_SAVE_MODE,
-                JdbcSinkOptions.DATA_SAVE_MODE, JdbcSinkOptions.WRITE_MODE,
-                JdbcSinkOptions.CUSTOM_SQL, JdbcSinkOptions.PRIMARY_KEYS,
-                JdbcSinkOptions.BATCH_SIZE, JdbcSinkOptions.PREPARED_STATEMENT_CACHE_SIZE,
-                JdbcSinkOptions.QUERY_TIMEOUT_SEC, JdbcSinkOptions.MAX_RETRIES,
-                JdbcSinkOptions.DIRTY_DATA_POLICY,
-                JdbcSinkOptions.CREATE_PRIMARY_KEY).build();
+        return JdbcCommonOptions.baseConnectionRule()
+                .optional(
+                        JdbcSinkOptions.TABLE_PATH,
+                        JdbcSinkOptions.SCHEMA_SAVE_MODE,
+                        JdbcSinkOptions.DATA_SAVE_MODE,
+                        JdbcSinkOptions.WRITE_MODE,
+                        JdbcSinkOptions.CUSTOM_SQL,
+                        JdbcSinkOptions.PRIMARY_KEYS,
+                        JdbcSinkOptions.BATCH_SIZE,
+                        JdbcSinkOptions.PREPARED_STATEMENT_CACHE_SIZE,
+                        JdbcSinkOptions.QUERY_TIMEOUT_SEC,
+                        JdbcSinkOptions.MAX_RETRIES,
+                        JdbcSinkOptions.DIRTY_DATA_POLICY,
+                        JdbcSinkOptions.CREATE_PRIMARY_KEY)
+                .build();
     }
 
     @Override
-    public SinkPreparer createPreparer(ReadonlyConfig config) {
-        return new JdbcSinkPreparer(JdbcSinkConfig.of(config));
+    public SinkPreparer createPreparer(
+            ReadonlyConfig config) {
+
+        return new JdbcSinkPreparer(
+                JdbcSinkConfig.of(
+                        config));
     }
 
     @Override
-    public SinkWriter<FluxRow> createSink(ReadonlyConfig config, PreparedSinkMetadata metadata) {
-        return new JdbcSinkWriter(JdbcSinkConfig.of(config), metadata);
+    public SinkWriter<FluxRow> createSink(
+            ReadonlyConfig config,
+            PreparedSinkMetadata metadata) {
+
+        return new JdbcSinkWriter(
+                JdbcSinkConfig.of(
+                        config),
+                metadata);
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceFactory.java
@@ -1,7 +1,9 @@
 package com.link.up.connector.jdbc.source;
 
+import com.google.auto.service.AutoService;
 import com.link.up.api.configuration.ReadonlyConfig;
 import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
 import com.link.up.api.source.SourceFactoryContext;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.factory.TableSourceFactory;
@@ -12,21 +14,28 @@ import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
 import com.link.up.connector.jdbc.options.MultiTableCommonOptions;
 import com.link.up.connector.jdbc.utils.JdbcCatalogUtils;
-import com.google.auto.service.AutoService;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * JDBC Source 工厂。
- * <p>
- * 主要负责：
- * <p>
- * 1. 解析并校验 Source 配置；
- * 2. 校验数据库方言是否可用；
- * 3. 创建 JDBC Source；
- * 4. 发现源表结构。
- * <p>
- * 表读取、分片生成和连接管理不在 Factory 中处理。
+ *
+ * <p>主要负责：
+ *
+ * <ol>
+ *   <li>解析并校验 Source 配置；</li>
+ *   <li>校验数据库方言是否可用；</li>
+ *   <li>创建 JDBC Source；</li>
+ *   <li>发现源表结构。</li>
+ * </ol>
+ *
+ * <p>表读取、分片生成和连接管理不在 Factory 中处理。
  */
 @AutoService(TableSourceFactory.class)
 public final class JdbcSourceFactory
@@ -37,6 +46,16 @@ public final class JdbcSourceFactory
     @Override
     public String factoryIdentifier() {
         return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY,
+                        ConnectorCapability.MULTI_TABLE,
+                        ConnectorCapability.CUSTOM_SQL,
+                        ConnectorCapability.PARTITION_SPLIT));
     }
 
     @Override
@@ -68,16 +87,22 @@ public final class JdbcSourceFactory
                 loadDialect(config);
 
         Map<?, JdbcSourceTable> tables =
-                JdbcCatalogUtils.getTables(config, dialect);
+                JdbcCatalogUtils.getTables(
+                        config,
+                        dialect);
 
         List<CatalogTable> result =
-                new ArrayList<>(tables.size());
+                new ArrayList<CatalogTable>(
+                        tables.size());
 
-        for (JdbcSourceTable table : tables.values()) {
-            result.add(table.getCatalogTable());
+        for (JdbcSourceTable table :
+                tables.values()) {
+            result.add(
+                    table.getCatalogTable());
         }
 
-        return Collections.unmodifiableList(result);
+        return Collections.unmodifiableList(
+                result);
     }
 
     @Override
@@ -126,13 +151,14 @@ public final class JdbcSourceFactory
                         context.getOptions(),
                         "source options must not be null");
 
-        return JdbcSourceConfig.of(options);
+        return JdbcSourceConfig.of(
+                options);
     }
 
     /**
      * 加载当前数据库方言。
-     * <p>
-     * 这里只完成方言识别，不修改配置，也不建立数据库连接。
+     *
+     * <p>这里只完成方言识别，不修改配置，也不建立数据库连接。
      */
     private JdbcDialect loadDialect(
             JdbcSourceConfig config) {

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/JdbcConnectorSchemaTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/JdbcConnectorSchemaTest.java
@@ -1,0 +1,110 @@
+package com.link.up.connector.jdbc;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.connector.schema.ConnectorOptionSchema;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.connector.schema.ConnectorSchema;
+import com.link.up.api.connector.schema.ConnectorSchemaExporter;
+import com.link.up.connector.jdbc.sink.JdbcSinkFactory;
+import com.link.up.connector.jdbc.source.JdbcSourceFactory;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcConnectorSchemaTest {
+
+    @Test
+    public void shouldExportJdbcSourceMetadata() {
+        JdbcSourceFactory factory =
+                new JdbcSourceFactory();
+
+        ConnectorSchema schema =
+                new ConnectorSchemaExporter()
+                        .export(
+                                factory,
+                                ConnectorRole.SOURCE,
+                                factory.optionRule());
+
+        assertEquals(
+                "jdbc",
+                schema.getConnectorId());
+
+        ConnectorOptionSchema url =
+                option(schema, "url");
+
+        assertTrue(url.isRequired());
+        assertEquals(
+                "JDBC_URL",
+                url.getSemanticType());
+        assertEquals(
+                ConnectorOptionScope.DATASOURCE,
+                url.getScope());
+
+        ConnectorOptionSchema password =
+                option(schema, "password");
+
+        assertTrue(
+                password.isSensitive());
+
+        assertTrue(
+                schema.getCapabilities()
+                        .contains(
+                                ConnectorCapability
+                                        .TABLE_SCHEMA_DISCOVERY));
+        assertTrue(
+                schema.getCapabilities()
+                        .contains(
+                                ConnectorCapability
+                                        .PARTITION_SPLIT));
+    }
+
+    @Test
+    public void shouldExportJdbcSinkMetadata() {
+        JdbcSinkFactory factory =
+                new JdbcSinkFactory();
+
+        ConnectorSchema schema =
+                new ConnectorSchemaExporter()
+                        .export(
+                                factory,
+                                ConnectorRole.SINK,
+                                factory.optionRule());
+
+        assertEquals(
+                "TABLE_PATH",
+                option(
+                        schema,
+                        "table_path")
+                        .getSemanticType());
+
+        assertTrue(
+                schema.getCapabilities()
+                        .contains(
+                                ConnectorCapability.UPSERT));
+        assertTrue(
+                schema.getCapabilities()
+                        .contains(
+                                ConnectorCapability
+                                        .DIRTY_DATA_HANDLING));
+    }
+
+    private ConnectorOptionSchema option(
+            ConnectorSchema schema,
+            String key) {
+
+        for (ConnectorOptionSchema option :
+                schema.getOptions()) {
+
+            if (key.equals(
+                    option.getKey())) {
+                return option;
+            }
+        }
+
+        throw new AssertionError(
+                "Option not found: "
+                        + key);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/JdbcConnectorSchemaTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/JdbcConnectorSchemaTest.java
@@ -79,6 +79,20 @@ public class JdbcConnectorSchemaTest {
                         "table_path")
                         .getSemanticType());
 
+        assertEquals(
+                "DIRTY_DATA_OUTPUT",
+                option(
+                        schema,
+                        "dirty_data_output_type")
+                        .getSemanticType());
+
+        assertEquals(
+                "FILE_PATH",
+                option(
+                        schema,
+                        "dirty_data_output_path")
+                        .getSemanticType());
+
         assertTrue(
                 schema.getCapabilities()
                         .contains(

--- a/link-up-framework/src/main/java/com/link/up/framework/connector/FactoryRegistry.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/connector/FactoryRegistry.java
@@ -9,163 +9,450 @@ import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
 
 /**
  * Discovers application and isolated connector factories.
  */
-public final class FactoryRegistry implements AutoCloseable {
-    private final Map<String, TableSourceFactory<?>> sourceFactories = new LinkedHashMap<String, TableSourceFactory<?>>();
-    private final Map<String, SinkFactory> sinkFactories = new LinkedHashMap<String, SinkFactory>();
-    private final Map<Factory, FactoryOrigin> origins = new IdentityHashMap<Factory, FactoryOrigin>();
-    private final List<ConnectorClassLoader> pluginLoaders = new ArrayList<ConnectorClassLoader>();
+public final class FactoryRegistry
+        implements AutoCloseable {
 
-    public FactoryRegistry(ClassLoader classLoader) {
-        this(classLoader, Collections.<Path>emptyList());
+    private final Map<String, TableSourceFactory<?>>
+            sourceFactories =
+            new LinkedHashMap<String, TableSourceFactory<?>>();
+
+    private final Map<String, SinkFactory>
+            sinkFactories =
+            new LinkedHashMap<String, SinkFactory>();
+
+    private final Map<Factory, FactoryOrigin>
+            origins =
+            new IdentityHashMap<Factory, FactoryOrigin>();
+
+    private final List<ConnectorClassLoader>
+            pluginLoaders =
+            new ArrayList<ConnectorClassLoader>();
+
+    public FactoryRegistry(
+            ClassLoader classLoader) {
+
+        this(
+                classLoader,
+                Collections.<Path>emptyList());
     }
 
-    public FactoryRegistry(ClassLoader classLoader, Iterable<Path> pluginDirectories) {
-        ClassLoader parent = Objects.requireNonNull(classLoader, "classLoader must not be null");
-        discoverFrom(parent, "application classpath");
-        for (Path directory : pluginDirectories)
-            discoverPlugin(parent, Objects.requireNonNull(directory, "plugin directory must not be null"));
+    public FactoryRegistry(
+            ClassLoader classLoader,
+            Iterable<Path> pluginDirectories) {
+
+        ClassLoader parent =
+                Objects.requireNonNull(
+                        classLoader,
+                        "classLoader must not be null");
+
+        discoverFrom(
+                parent,
+                "application classpath");
+
+        for (Path directory :
+                pluginDirectories) {
+
+            discoverPlugin(
+                    parent,
+                    Objects.requireNonNull(
+                            directory,
+                            "plugin directory must not be null"));
+        }
     }
 
-    public static FactoryRegistry discover(ClassLoader classLoader) {
-        return new FactoryRegistry(effective(classLoader));
+    public static FactoryRegistry discover(
+            ClassLoader classLoader) {
+
+        return new FactoryRegistry(
+                effective(classLoader));
     }
 
-    public static FactoryRegistry discover(ClassLoader classLoader, Path... pluginDirectories) {
-        List<Path> paths = new ArrayList<Path>();
-        if (pluginDirectories != null) Collections.addAll(paths, pluginDirectories);
-        return new FactoryRegistry(effective(classLoader), paths);
+    public static FactoryRegistry discover(
+            ClassLoader classLoader,
+            Path... pluginDirectories) {
+
+        List<Path> paths =
+                new ArrayList<Path>();
+
+        if (pluginDirectories != null) {
+            Collections.addAll(
+                    paths,
+                    pluginDirectories);
+        }
+
+        return new FactoryRegistry(
+                effective(classLoader),
+                paths);
     }
 
-    public static FactoryRegistry discover(ClassLoader classLoader, Iterable<Path> pluginDirectories) {
-        return new FactoryRegistry(effective(classLoader), pluginDirectories);
+    public static FactoryRegistry discover(
+            ClassLoader classLoader,
+            Iterable<Path> pluginDirectories) {
+
+        return new FactoryRegistry(
+                effective(classLoader),
+                pluginDirectories);
     }
 
-    private static String describe(Factory factory, FactoryOrigin origin) {
-        Package p = factory.getClass().getPackage();
-        String version = p == null ? null : p.getImplementationVersion();
-        return factory.getClass().getName() + " (version=" + (version == null ? "unknown" : version) + ", pluginPath=" + origin.path + ")";
+    private static String describe(
+            Factory factory,
+            FactoryOrigin origin) {
+
+        Package implementationPackage =
+                factory.getClass()
+                        .getPackage();
+
+        String version =
+                implementationPackage == null
+                        ? null
+                        : implementationPackage
+                        .getImplementationVersion();
+
+        return factory.getClass().getName()
+                + " (version="
+                + (version == null
+                ? "unknown"
+                : version)
+                + ", pluginPath="
+                + origin.path
+                + ")";
     }
 
-    private static <T> T required(Map<String, T> map, String id, String kind) {
-        T factory = map.get(normalize(id));
-        if (factory == null)
-            throw new ConnectorException("Could not find " + kind + " factory for identifier '" + id + "'. Available identifiers: " + map.keySet());
+    private static <T> T required(
+            Map<String, T> map,
+            String id,
+            String kind) {
+
+        T factory =
+                map.get(normalize(id));
+
+        if (factory == null) {
+            throw new ConnectorException(
+                    "Could not find "
+                            + kind
+                            + " factory for identifier '"
+                            + id
+                            + "'. Available identifiers: "
+                            + map.keySet());
+        }
+
         return factory;
     }
 
-    private static ClassLoader effective(ClassLoader loader) {
-        return loader == null ? Thread.currentThread().getContextClassLoader() : loader;
+    private static ClassLoader effective(
+            ClassLoader loader) {
+
+        return loader == null
+                ? Thread.currentThread()
+                .getContextClassLoader()
+                : loader;
     }
 
-    private static String normalize(String id) {
-        Objects.requireNonNull(id, "factory identifier must not be null");
-        String value = id.trim().toLowerCase(Locale.ROOT);
-        if (value.isEmpty()) throw new IllegalArgumentException("factory identifier must not be blank");
+    private static String normalize(
+            String id) {
+
+        Objects.requireNonNull(
+                id,
+                "factory identifier must not be null");
+
+        String value =
+                id.trim()
+                        .toLowerCase(
+                                Locale.ROOT);
+
+        if (value.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "factory identifier must not be blank");
+        }
+
         return value;
     }
 
-    public TableSourceFactory<?> getSourceFactory(String identifier) {
-        return required(sourceFactories, identifier, "source");
+    public TableSourceFactory<?> getSourceFactory(
+            String identifier) {
+
+        return required(
+                sourceFactories,
+                identifier,
+                "source");
     }
 
-    public SinkFactory getSinkFactory(String identifier) {
-        return required(sinkFactories, identifier, "sink");
+    public SinkFactory getSinkFactory(
+            String identifier) {
+
+        return required(
+                sinkFactories,
+                identifier,
+                "sink");
     }
 
-    public ClassLoader getClassLoader(Factory factory) {
-        FactoryOrigin origin = origins.get(factory);
-        return origin == null ? factory.getClass().getClassLoader() : origin.loader;
+    /**
+     * 返回当前注册的 Source 工厂快照。
+     */
+    public Map<String, TableSourceFactory<?>>
+    getSourceFactories() {
+
+        return Collections.unmodifiableMap(
+                new LinkedHashMap<String, TableSourceFactory<?>>(
+                        sourceFactories));
     }
 
-    private void discoverPlugin(ClassLoader parent, Path directory) {
+    /**
+     * 返回当前注册的 Sink 工厂快照。
+     */
+    public Map<String, SinkFactory>
+    getSinkFactories() {
+
+        return Collections.unmodifiableMap(
+                new LinkedHashMap<String, SinkFactory>(
+                        sinkFactories));
+    }
+
+    public ClassLoader getClassLoader(
+            Factory factory) {
+
+        FactoryOrigin origin =
+                origins.get(factory);
+
+        return origin == null
+                ? factory.getClass()
+                .getClassLoader()
+                : origin.loader;
+    }
+
+    private void discoverPlugin(
+            ClassLoader parent,
+            Path directory) {
+
         final URL[] urls;
+
         try {
-            if (!Files.isDirectory(directory))
-                throw new ConnectorException("Plugin path is not a directory: " + directory);
-            List<URL> result = new ArrayList<URL>();
-            java.nio.file.DirectoryStream<Path> jars = Files.newDirectoryStream(directory, "*.jar");
+            if (!Files.isDirectory(
+                    directory)) {
+                throw new ConnectorException(
+                        "Plugin path is not a directory: "
+                                + directory);
+            }
+
+            List<URL> result =
+                    new ArrayList<URL>();
+
+            java.nio.file.DirectoryStream<Path>
+                    jars =
+                    Files.newDirectoryStream(
+                            directory,
+                            "*.jar");
+
             try {
-                for (Path jar : jars) result.add(jar.toUri().toURL());
+                for (Path jar : jars) {
+                    result.add(
+                            jar.toUri()
+                                    .toURL());
+                }
             } finally {
                 jars.close();
             }
-            urls = result.toArray(new URL[result.size()]);
-        } catch (IOException e) {
-            throw new ConnectorException("Could not read plugin path '" + directory + "'", e);
+
+            urls =
+                    result.toArray(
+                            new URL[result.size()]);
+
+        } catch (IOException exception) {
+            throw new ConnectorException(
+                    "Could not read plugin path '"
+                            + directory
+                            + "'",
+                    exception);
         }
-        ConnectorClassLoader loader = new ConnectorClassLoader(urls, parent);
+
+        ConnectorClassLoader loader =
+                new ConnectorClassLoader(
+                        urls,
+                        parent);
+
         try {
-            discoverFrom(loader, directory.toAbsolutePath().toString());
+            discoverFrom(
+                    loader,
+                    directory
+                            .toAbsolutePath()
+                            .toString());
+
             pluginLoaders.add(loader);
-        } catch (RuntimeException e) {
+
+        } catch (RuntimeException exception) {
             try {
                 loader.close();
-            } catch (IOException close) {
-                e.addSuppressed(close);
+            } catch (IOException closeFailure) {
+                exception.addSuppressed(
+                        closeFailure);
             }
-            throw e;
+
+            throw exception;
         }
     }
 
-    private void discoverFrom(ClassLoader loader, String path) {
-        discoverSources(loader, path);
-        discoverSinks(loader, path);
+    private void discoverFrom(
+            ClassLoader loader,
+            String path) {
+
+        discoverSources(
+                loader,
+                path);
+
+        discoverSinks(
+                loader,
+                path);
     }
 
-    private void discoverSources(ClassLoader loader, String path) {
+    private void discoverSources(
+            ClassLoader loader,
+            String path) {
+
         try {
-            for (TableSourceFactory<?> factory : ServiceLoader.load(TableSourceFactory.class, loader))
-                put(sourceFactories, factory, "source", loader, path);
-        } catch (ServiceConfigurationError e) {
-            throw new ConnectorException("Could not load source factories from plugin path '" + path + "'", e);
+            for (TableSourceFactory<?> factory :
+                    ServiceLoader.load(
+                            TableSourceFactory.class,
+                            loader)) {
+
+                put(
+                        sourceFactories,
+                        factory,
+                        "source",
+                        loader,
+                        path);
+            }
+        } catch (ServiceConfigurationError error) {
+            throw new ConnectorException(
+                    "Could not load source factories from plugin path '"
+                            + path
+                            + "'",
+                    error);
         }
     }
 
-    private void discoverSinks(ClassLoader loader, String path) {
+    private void discoverSinks(
+            ClassLoader loader,
+            String path) {
+
         try {
-            for (SinkFactory factory : ServiceLoader.load(SinkFactory.class, loader))
-                put(sinkFactories, factory, "sink", loader, path);
-        } catch (ServiceConfigurationError e) {
-            throw new ConnectorException("Could not load sink factories from plugin path '" + path + "'", e);
+            for (SinkFactory factory :
+                    ServiceLoader.load(
+                            SinkFactory.class,
+                            loader)) {
+
+                put(
+                        sinkFactories,
+                        factory,
+                        "sink",
+                        loader,
+                        path);
+            }
+        } catch (ServiceConfigurationError error) {
+            throw new ConnectorException(
+                    "Could not load sink factories from plugin path '"
+                            + path
+                            + "'",
+                    error);
         }
     }
 
-    private <T extends Factory> void put(Map<String, T> factories, T factory, String kind, ClassLoader loader, String path) {
-        String id = normalize(factory.factoryIdentifier());
-        T prior = factories.get(id);
+    private <T extends Factory> void put(
+            Map<String, T> factories,
+            T factory,
+            String kind,
+            ClassLoader loader,
+            String path) {
+
+        String id =
+                normalize(
+                        factory.factoryIdentifier());
+
+        T prior =
+                factories.get(id);
+
         if (prior != null) {
-            FactoryOrigin previous = origins.get(prior);
-            throw new ConnectorException("Duplicated " + kind + " factory identifier '" + id + "': "
-                    + describe(prior, previous) + " conflicts with " + describe(factory, new FactoryOrigin(loader, path)));
+            FactoryOrigin previous =
+                    origins.get(prior);
+
+            throw new ConnectorException(
+                    "Duplicated "
+                            + kind
+                            + " factory identifier '"
+                            + id
+                            + "': "
+                            + describe(
+                            prior,
+                            previous)
+                            + " conflicts with "
+                            + describe(
+                            factory,
+                            new FactoryOrigin(
+                                    loader,
+                                    path)));
         }
-        factories.put(id, factory);
-        origins.put(factory, new FactoryOrigin(loader, path));
+
+        factories.put(
+                id,
+                factory);
+
+        origins.put(
+                factory,
+                new FactoryOrigin(
+                        loader,
+                        path));
     }
 
     @Override
     public void close() {
         IOException failure = null;
-        for (ConnectorClassLoader loader : pluginLoaders)
+
+        for (ConnectorClassLoader loader :
+                pluginLoaders) {
+
             try {
                 loader.close();
-            } catch (IOException e) {
-                if (failure == null) failure = e;
-                else failure.addSuppressed(e);
+            } catch (IOException exception) {
+                if (failure == null) {
+                    failure = exception;
+                } else {
+                    failure.addSuppressed(
+                            exception);
+                }
             }
+        }
+
         pluginLoaders.clear();
-        if (failure != null) throw new ConnectorException("Could not close connector class loaders", failure);
+
+        if (failure != null) {
+            throw new ConnectorException(
+                    "Could not close connector class loaders",
+                    failure);
+        }
     }
 
     private static final class FactoryOrigin {
+
         private final ClassLoader loader;
         private final String path;
 
-        private FactoryOrigin(ClassLoader loader, String path) {
+        private FactoryOrigin(
+                ClassLoader loader,
+                String path) {
+
             this.loader = loader;
             this.path = path;
         }

--- a/link-up-framework/src/main/java/com/link/up/framework/connector/schema/ConnectorSchemaCatalog.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/connector/schema/ConnectorSchemaCatalog.java
@@ -1,0 +1,225 @@
+package com.link.up.framework.connector.schema;
+
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.connector.schema.ConnectorSchema;
+import com.link.up.api.connector.schema.ConnectorSchemaExporter;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.framework.connector.FactoryRegistry;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Worker 启动时生成的 Connector Schema 只读目录。
+ *
+ * <p>目录只保留不可变协议对象，不持有 Connector ClassLoader。
+ */
+public final class ConnectorSchemaCatalog {
+
+    private final Map<ConnectorRole, Map<String, ConnectorSchema>>
+            schemas;
+
+    public ConnectorSchemaCatalog(
+            List<ConnectorSchema> schemas) {
+
+        Map<ConnectorRole, Map<String, ConnectorSchema>>
+                index =
+                new EnumMap<ConnectorRole, Map<String, ConnectorSchema>>(
+                        ConnectorRole.class);
+
+        for (ConnectorRole role :
+                ConnectorRole.values()) {
+            index.put(
+                    role,
+                    new LinkedHashMap<String, ConnectorSchema>());
+        }
+
+        for (ConnectorSchema schema :
+                schemas) {
+
+            String id =
+                    normalize(
+                            schema.getConnectorId());
+
+            ConnectorSchema previous =
+                    index.get(schema.getRole())
+                            .put(
+                                    id,
+                                    schema);
+
+            if (previous != null) {
+                throw new IllegalArgumentException(
+                        "Duplicated Connector Schema: "
+                                + schema.getRole()
+                                + "/"
+                                + id);
+            }
+        }
+
+        Map<ConnectorRole, Map<String, ConnectorSchema>>
+                immutable =
+                new EnumMap<ConnectorRole, Map<String, ConnectorSchema>>(
+                        ConnectorRole.class);
+
+        for (Map.Entry<ConnectorRole, Map<String, ConnectorSchema>>
+                entry :
+                index.entrySet()) {
+
+            immutable.put(
+                    entry.getKey(),
+                    Collections.unmodifiableMap(
+                            new LinkedHashMap<String, ConnectorSchema>(
+                                    entry.getValue())));
+        }
+
+        this.schemas =
+                Collections.unmodifiableMap(
+                        immutable);
+    }
+
+    public static ConnectorSchemaCatalog discover(
+            ClassLoader classLoader,
+            Path... pluginDirectories) {
+
+        FactoryRegistry registry =
+                FactoryRegistry.discover(
+                        classLoader,
+                        pluginDirectories);
+
+        try {
+            ConnectorSchemaExporter exporter =
+                    new ConnectorSchemaExporter();
+
+            List<ConnectorSchema> schemas =
+                    new ArrayList<ConnectorSchema>();
+
+            for (TableSourceFactory<?> factory :
+                    registry.getSourceFactories()
+                            .values()) {
+
+                schemas.add(
+                        exporter.export(
+                                factory,
+                                ConnectorRole.SOURCE,
+                                factory.optionRule()));
+            }
+
+            for (SinkFactory factory :
+                    registry.getSinkFactories()
+                            .values()) {
+
+                schemas.add(
+                        exporter.export(
+                                factory,
+                                ConnectorRole.SINK,
+                                factory.optionRule()));
+            }
+
+            return new ConnectorSchemaCatalog(
+                    schemas);
+        } finally {
+            registry.close();
+        }
+    }
+
+    public List<ConnectorSchema> list() {
+        List<ConnectorSchema> result =
+                new ArrayList<ConnectorSchema>();
+
+        for (Map<String, ConnectorSchema> byId :
+                schemas.values()) {
+            result.addAll(
+                    byId.values());
+        }
+
+        sort(result);
+
+        return Collections.unmodifiableList(
+                result);
+    }
+
+    public List<ConnectorSchema> list(
+            ConnectorRole role) {
+
+        List<ConnectorSchema> result =
+                new ArrayList<ConnectorSchema>(
+                        schemas.get(role)
+                                .values());
+
+        sort(result);
+
+        return Collections.unmodifiableList(
+                result);
+    }
+
+    public ConnectorSchema get(
+            String connectorId,
+            ConnectorRole role) {
+
+        ConnectorSchema schema =
+                schemas.get(role)
+                        .get(
+                                normalize(
+                                        connectorId));
+
+        if (schema == null) {
+            throw new IllegalArgumentException(
+                    "Connector Schema not found: "
+                            + role
+                            + "/"
+                            + connectorId);
+        }
+
+        return schema;
+    }
+
+    private static void sort(
+            List<ConnectorSchema> schemas) {
+
+        Collections.sort(
+                schemas,
+                new Comparator<ConnectorSchema>() {
+                    public int compare(
+                            ConnectorSchema first,
+                            ConnectorSchema second) {
+
+                        int id =
+                                first.getConnectorId()
+                                        .compareTo(
+                                                second.getConnectorId());
+
+                        return id != 0
+                                ? id
+                                : first.getRole()
+                                .compareTo(
+                                        second.getRole());
+                    }
+                });
+    }
+
+    private static String normalize(
+            String connectorId) {
+
+        if (connectorId == null
+                || connectorId
+                .trim()
+                .isEmpty()) {
+
+            throw new IllegalArgumentException(
+                    "connectorId must not be blank");
+        }
+
+        return connectorId
+                .trim()
+                .toLowerCase(
+                        Locale.ROOT);
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/connector/schema/ConnectorSchemaCatalogTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/connector/schema/ConnectorSchemaCatalogTest.java
@@ -1,0 +1,88 @@
+package com.link.up.framework.connector.schema;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.connector.schema.ConnectorSchema;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ConnectorSchemaCatalogTest {
+
+    @Test
+    public void shouldIndexSchemasByRoleAndIdentifier() {
+        ConnectorSchema source =
+                schema(
+                        "jdbc",
+                        ConnectorRole.SOURCE);
+
+        ConnectorSchema sink =
+                schema(
+                        "jdbc",
+                        ConnectorRole.SINK);
+
+        ConnectorSchemaCatalog catalog =
+                new ConnectorSchemaCatalog(
+                        Arrays.asList(
+                                sink,
+                                source));
+
+        assertEquals(
+                2,
+                catalog.list().size());
+
+        assertEquals(
+                source,
+                catalog.get(
+                        "JDBC",
+                        ConnectorRole.SOURCE));
+
+        assertEquals(
+                1,
+                catalog.list(
+                                ConnectorRole.SINK)
+                        .size());
+    }
+
+    @Test
+    public void shouldRejectMissingSchema() {
+        ConnectorSchemaCatalog catalog =
+                new ConnectorSchemaCatalog(
+                        Collections.singletonList(
+                                schema(
+                                        "jdbc",
+                                        ConnectorRole.SOURCE)));
+
+        try {
+            catalog.get(
+                    "doris",
+                    ConnectorRole.SOURCE);
+            fail("Expected missing schema failure");
+        } catch (IllegalArgumentException expected) {
+            assertEquals(
+                    "Connector Schema not found: SOURCE/doris",
+                    expected.getMessage());
+        }
+    }
+
+    private ConnectorSchema schema(
+            String connectorId,
+            ConnectorRole role) {
+
+        return new ConnectorSchema(
+                connectorId,
+                role,
+                "1",
+                "sha256:test",
+                "example.Factory",
+                "1.0.0",
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.singletonList(
+                        ConnectorCapability.MULTI_TABLE));
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/FluxServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/FluxServer.java
@@ -1,5 +1,6 @@
 package com.link.up.server;
 
+import com.link.up.framework.connector.schema.ConnectorSchemaCatalog;
 import com.link.up.server.config.FluxServerConfig;
 import com.link.up.server.http.JettyServer;
 import com.link.up.server.runtime.InMemoryJobRepository;
@@ -10,6 +11,7 @@ import com.link.up.server.runtime.LocalJobExecutor;
 import com.link.up.server.runtime.LocalJobIdGenerator;
 import com.link.up.server.runtime.LocalJobManager;
 import com.link.up.server.runtime.WorkerIdentity;
+import com.link.up.server.service.ConnectorRestService;
 import com.link.up.server.service.JobRestService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,7 +34,8 @@ public final class FluxServer {
     }
 
     private static final Logger LOG =
-            LogManager.getLogger(FluxServer.class);
+            LogManager.getLogger(
+                    FluxServer.class);
 
     private FluxServer() {
     }
@@ -41,21 +44,29 @@ public final class FluxServer {
             throws Exception {
 
         final FluxServerConfig config =
-                FluxServerConfig.fromArgs(args);
+                FluxServerConfig.fromArgs(
+                        args);
 
         List<Path> pluginDirectories =
                 config.getPluginDirectories();
 
+        ClassLoader classLoader =
+                Thread.currentThread()
+                        .getContextClassLoader();
+
+        Path[] pluginPaths =
+                pluginDirectories.toArray(
+                        new Path[pluginDirectories.size()]);
+
         JobExecutor jobExecutor =
                 new LocalJobExecutor(
-                        Thread.currentThread()
-                                .getContextClassLoader(),
-                        pluginDirectories.toArray(
-                                new Path[pluginDirectories.size()]));
+                        classLoader,
+                        pluginPaths);
 
         JobRepository repository =
                 new InMemoryJobRepository(
                         config.getHistoryLimit());
+
         JobIdGenerator jobIdGenerator =
                 new LocalJobIdGenerator();
 
@@ -72,24 +83,40 @@ public final class FluxServer {
                 new WorkerIdentity(
                         config.getNodeId(),
                         config.getNodeName(),
-                        WorkerIdentity.implementationVersion());
+                        WorkerIdentity
+                                .implementationVersion());
 
-        JobRestService service =
+        JobRestService jobService =
                 new JobRestService(
                         manager,
                         workerIdentity,
                         config.getJobThreads(),
                         config.getMaxQueuedJobs());
 
+        ConnectorSchemaCatalog connectorCatalog =
+                ConnectorSchemaCatalog.discover(
+                        classLoader,
+                        pluginPaths);
+
+        ConnectorRestService connectorService =
+                new ConnectorRestService(
+                        connectorCatalog);
+
         final JettyServer server =
-                new JettyServer(config, service);
+                new JettyServer(
+                        config,
+                        jobService,
+                        connectorService);
+
         final AtomicBoolean shutdown =
                 new AtomicBoolean(false);
 
         final Runnable shutdownAction =
                 new Runnable() {
                     public void run() {
-                        if (!shutdown.compareAndSet(false, true)) {
+                        if (!shutdown.compareAndSet(
+                                false,
+                                true)) {
                             return;
                         }
 
@@ -110,27 +137,32 @@ public final class FluxServer {
                         shutdownAction,
                         "link-up-shutdown");
 
-        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        Runtime.getRuntime()
+                .addShutdownHook(
+                        shutdownHook);
 
         try {
             server.start();
 
             LOG.info(
-                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, host={}, port={}, jobThreads={}, pluginDirectories={}",
+                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, host={}, port={}, jobThreads={}, connectorSchemas={}, pluginDirectories={}",
                     workerIdentity.getNodeId(),
                     workerIdentity.getInstanceId(),
                     config.getHost(),
                     server.getLocalPort(),
                     config.getJobThreads(),
+                    connectorCatalog.list().size(),
                     config.getPluginDirectories());
 
             server.join();
+
         } finally {
             shutdownAction.run();
 
             try {
                 Runtime.getRuntime()
-                        .removeShutdownHook(shutdownHook);
+                        .removeShutdownHook(
+                                shutdownHook);
             } catch (IllegalStateException ignored) {
                 // JVM 已经进入关闭流程。
             }
@@ -138,16 +170,23 @@ public final class FluxServer {
     }
 
     private static void configureDefaultLogFile() {
-        if (hasText(System.getProperty(LOG_FILE_PROPERTY))
-                || hasText(System.getenv("LOGFILE"))) {
+        if (hasText(
+                System.getProperty(
+                        LOG_FILE_PROPERTY))
+                || hasText(
+                System.getenv(
+                        "LOGFILE"))) {
             return;
         }
 
         String logDirectory =
-                System.getProperty("link.up.log.dir");
+                System.getProperty(
+                        "link.up.log.dir");
 
         if (!hasText(logDirectory)) {
-            logDirectory = System.getenv("LINK_UP_LOG_DIR");
+            logDirectory =
+                    System.getenv(
+                            "LINK_UP_LOG_DIR");
         }
 
         if (!hasText(logDirectory)) {
@@ -162,7 +201,11 @@ public final class FluxServer {
                         .toString());
     }
 
-    private static boolean hasText(String value) {
-        return value != null && !value.trim().isEmpty();
+    private static boolean hasText(
+            String value) {
+
+        return value != null
+                && !value.trim()
+                .isEmpty();
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/http/JettyServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/JettyServer.java
@@ -1,11 +1,14 @@
 package com.link.up.server.http;
 
+import com.link.up.framework.connector.schema.ConnectorSchemaCatalog;
 import com.link.up.server.config.FluxServerConfig;
+import com.link.up.server.http.servlet.ConnectorsServlet;
 import com.link.up.server.http.servlet.HealthServlet;
 import com.link.up.server.http.servlet.JobResourceServlet;
 import com.link.up.server.http.servlet.JobsServlet;
 import com.link.up.server.http.servlet.NodeServlet;
 import com.link.up.server.http.servlet.NotFoundServlet;
+import com.link.up.server.service.ConnectorRestService;
 import com.link.up.server.service.JobRestService;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
@@ -15,6 +18,7 @@ import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 import javax.servlet.DispatcherType;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -31,10 +35,25 @@ public final class JettyServer
 
     public JettyServer(
             FluxServerConfig config,
-            JobRestService service) {
+            JobRestService jobService) {
+
+        this(
+                config,
+                jobService,
+                new ConnectorRestService(
+                        new ConnectorSchemaCatalog(
+                                Collections.emptyList())));
+    }
+
+    public JettyServer(
+            FluxServerConfig config,
+            JobRestService jobService,
+            ConnectorRestService connectorService) {
 
         int minimumThreads =
-                Math.min(4, config.getHttpThreads());
+                Math.min(
+                        4,
+                        config.getHttpThreads());
 
         QueuedThreadPool threadPool =
                 new QueuedThreadPool(
@@ -42,18 +61,29 @@ public final class JettyServer
                         minimumThreads,
                         60_000);
 
-        threadPool.setName("link-up-http");
+        threadPool.setName(
+                "link-up-http");
 
-        this.server = new Server(threadPool);
+        this.server =
+                new Server(threadPool);
+
         this.server.setStopTimeout(
                 config.getShutdownTimeoutMillis());
 
-        this.connector = new ServerConnector(server);
-        connector.setHost(config.getHost());
-        connector.setPort(config.getPort());
-        connector.setIdleTimeout(30_000L);
-        connector.setAcceptQueueSize(128);
-        server.addConnector(connector);
+        this.connector =
+                new ServerConnector(server);
+
+        connector.setHost(
+                config.getHost());
+        connector.setPort(
+                config.getPort());
+        connector.setIdleTimeout(
+                30_000L);
+        connector.setAcceptQueueSize(
+                128);
+
+        server.addConnector(
+                connector);
 
         ServletContextHandler context =
                 new ServletContextHandler(
@@ -65,38 +95,68 @@ public final class JettyServer
                 new FilterHolder(
                         new ExceptionHandlingFilter()),
                 "/*",
-                EnumSet.of(DispatcherType.REQUEST));
+                EnumSet.of(
+                        DispatcherType.REQUEST));
 
         context.addServlet(
-                new ServletHolder(new HealthServlet()),
+                new ServletHolder(
+                        new HealthServlet()),
                 RestConstants.HEALTH);
+
         context.addServlet(
-                new ServletHolder(new NodeServlet(service)),
+                new ServletHolder(
+                        new NodeServlet(
+                                jobService)),
                 RestConstants.NODE);
+
+        context.addServlet(
+                new ServletHolder(
+                        new ConnectorsServlet(
+                                connectorService)),
+                RestConstants.CONNECTORS + "/*");
+
         context.addServlet(
                 new ServletHolder(
                         new JobsServlet(
-                                service,
+                                jobService,
                                 config.getMaxRequestBytes())),
                 RestConstants.JOBS);
+
         context.addServlet(
                 new ServletHolder(
-                        new JobResourceServlet(service)),
+                        new JobResourceServlet(
+                                jobService)),
                 RestConstants.JOBS + "/*");
+
         context.addServlet(
-                new ServletHolder(new NotFoundServlet()),
+                new ServletHolder(
+                        new NotFoundServlet()),
                 "/");
 
         server.setHandler(context);
     }
 
-    public void start() throws Exception { server.start(); }
-    public void join() throws InterruptedException { server.join(); }
-    public int getLocalPort() { return connector.getLocalPort(); }
-    public boolean isStarted() { return server.isStarted(); }
+    public void start() throws Exception {
+        server.start();
+    }
+
+    public void join()
+            throws InterruptedException {
+        server.join();
+    }
+
+    public int getLocalPort() {
+        return connector.getLocalPort();
+    }
+
+    public boolean isStarted() {
+        return server.isStarted();
+    }
 
     public void stop() throws Exception {
-        if (closed.compareAndSet(false, true)) {
+        if (closed.compareAndSet(
+                false,
+                true)) {
             server.stop();
         }
     }

--- a/link-up-server/src/main/java/com/link/up/server/http/RestConstants.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/RestConstants.java
@@ -14,6 +14,9 @@ public final class RestConstants {
     public static final String JOBS =
             API_PREFIX + "/jobs";
 
+    public static final String CONNECTORS =
+            API_PREFIX + "/connectors";
+
     private RestConstants() {
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/ConnectorsServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/ConnectorsServlet.java
@@ -1,0 +1,64 @@
+package com.link.up.server.http.servlet;
+
+import com.link.up.server.http.FluxServlet;
+import com.link.up.server.http.RestException;
+import com.link.up.server.service.ConnectorRestService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Connector Schema 只读接口。
+ */
+public final class ConnectorsServlet
+        extends FluxServlet {
+
+    private final ConnectorRestService service;
+
+    public ConnectorsServlet(
+            ConnectorRestService service) {
+
+        this.service = service;
+    }
+
+    @Override
+    protected void doGet(
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws IOException {
+
+        List<String> segments =
+                pathSegments(request);
+
+        if (segments.isEmpty()) {
+            write(
+                    response,
+                    200,
+                    service.list(
+                            request.getParameter(
+                                    "role")));
+            return;
+        }
+
+        if (segments.size() == 2
+                && "schema".equalsIgnoreCase(
+                segments.get(1))) {
+
+            write(
+                    response,
+                    200,
+                    service.schema(
+                            segments.get(0),
+                            request.getParameter(
+                                    "role")));
+            return;
+        }
+
+        throw new RestException(
+                404,
+                "FLUX-REST-404",
+                "Connector resource not found");
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/service/ConnectorRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/ConnectorRestService.java
@@ -1,0 +1,87 @@
+package com.link.up.server.service;
+
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.connector.schema.ConnectorSchema;
+import com.link.up.framework.connector.schema.ConnectorSchemaCatalog;
+import com.link.up.server.http.RestException;
+
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Connector Schema REST 查询服务。
+ */
+public final class ConnectorRestService {
+
+    private final ConnectorSchemaCatalog catalog;
+
+    public ConnectorRestService(
+            ConnectorSchemaCatalog catalog) {
+
+        if (catalog == null) {
+            throw new IllegalArgumentException(
+                    "catalog must not be null");
+        }
+
+        this.catalog = catalog;
+    }
+
+    public List<ConnectorSchema> list(
+            String roleValue) {
+
+        if (roleValue == null
+                || roleValue.trim().isEmpty()) {
+            return catalog.list();
+        }
+
+        return catalog.list(
+                role(roleValue));
+    }
+
+    public ConnectorSchema schema(
+            String connectorId,
+            String roleValue) {
+
+        if (roleValue == null
+                || roleValue.trim().isEmpty()) {
+
+            throw new RestException(
+                    400,
+                    "FLUX-CONNECTOR-ROLE-REQUIRED",
+                    "Query parameter 'role' is required");
+        }
+
+        ConnectorRole role =
+                role(roleValue);
+
+        try {
+            return catalog.get(
+                    connectorId,
+                    role);
+        } catch (IllegalArgumentException exception) {
+            throw new RestException(
+                    404,
+                    "FLUX-CONNECTOR-SCHEMA-NOT-FOUND",
+                    "Connector Schema not found: "
+                            + role
+                            + "/"
+                            + connectorId);
+        }
+    }
+
+    private ConnectorRole role(
+            String value) {
+
+        try {
+            return ConnectorRole.valueOf(
+                    value.trim()
+                            .toUpperCase(
+                                    Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new RestException(
+                    400,
+                    "FLUX-CONNECTOR-ROLE-INVALID",
+                    "role must be SOURCE or SINK");
+        }
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/service/ConnectorRestServiceTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/service/ConnectorRestServiceTest.java
@@ -1,0 +1,81 @@
+package com.link.up.server.service;
+
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.connector.schema.ConnectorSchema;
+import com.link.up.framework.connector.schema.ConnectorSchemaCatalog;
+import com.link.up.server.http.RestException;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class ConnectorRestServiceTest {
+
+    @Test
+    public void shouldFilterAndReadSchema() {
+        ConnectorSchema source =
+                schema(
+                        "jdbc",
+                        ConnectorRole.SOURCE);
+
+        ConnectorRestService service =
+                new ConnectorRestService(
+                        new ConnectorSchemaCatalog(
+                                Collections.singletonList(
+                                        source)));
+
+        assertEquals(
+                1,
+                service.list("source")
+                        .size());
+
+        assertEquals(
+                source,
+                service.schema(
+                        "jdbc",
+                        "SOURCE"));
+    }
+
+    @Test
+    public void shouldRequireRoleForSingleSchema() {
+        ConnectorRestService service =
+                new ConnectorRestService(
+                        new ConnectorSchemaCatalog(
+                                Collections.singletonList(
+                                        schema(
+                                                "jdbc",
+                                                ConnectorRole.SOURCE))));
+
+        try {
+            service.schema(
+                    "jdbc",
+                    null);
+            fail("Expected role validation");
+        } catch (RestException expected) {
+            assertEquals(
+                    400,
+                    expected.getHttpStatus());
+            assertEquals(
+                    "FLUX-CONNECTOR-ROLE-REQUIRED",
+                    expected.getCode());
+        }
+    }
+
+    private ConnectorSchema schema(
+            String connectorId,
+            ConnectorRole role) {
+
+        return new ConnectorSchema(
+                connectorId,
+                role,
+                "1",
+                "sha256:test",
+                "example.Factory",
+                "1.0.0",
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList());
+    }
+}


### PR DESCRIPTION
## Summary

This introduces the first phase of the Link-Up **Connector Schema foundation** so control planes such as Yak Ops can build dynamic forms without duplicating Connector validation rules.

- add a frontend-framework-neutral Connector Schema protocol
- export existing `OptionRule` definitions into stable option, rule and condition DTOs
- describe value types, defaults, enum choices, aliases, required fields and nested conditional rules
- add explicit option metadata for sensitive values, semantic type and configuration scope
- add Connector roles, capability declarations, manual schema versions and deterministic SHA-256 fingerprints
- discover Source and Sink schemas from the application classpath and configured plugin directories
- expose read-only Connector Schema REST endpoints
- annotate the current JDBC Source and Sink options with real semantic and scope metadata
- declare current JDBC execution capabilities
- document the protocol boundaries and add API, registry, REST and JDBC coverage

## API

```http
GET /api/v1/connectors
GET /api/v1/connectors?role=SOURCE
GET /api/v1/connectors?role=SINK
GET /api/v1/connectors/{connectorId}/schema?role=SOURCE
GET /api/v1/connectors/{connectorId}/schema?role=SINK
```

The single-schema endpoint requires an explicit role because one identifier can provide both roles, as JDBC currently does.

## Schema model

Each schema includes:

- `connectorId` and `role`
- manually maintained `schemaVersion`
- deterministic `schemaFingerprint`
- implementation class and package version for diagnostics
- option key, cross-language value type and Java diagnostic type
- collection element type where available
- default value and allowed values
- description and fallback keys
- absolute required state
- `sensitive`, `semanticType` and `scope`
- structural rules for required, exclusive, bundled, conditional and constrained options
- AND/OR condition chains without relying on Java `toString()` output
- Connector capabilities such as table discovery, multi-table, custom SQL, partition splitting, upsert and dirty-data handling

## JDBC metadata

The current JDBC Connector now marks connection options as `DATASOURCE`, task options as `TASK`, and execution tuning as `RUNTIME`. Password and free-form connection properties are marked sensitive.

The final review also reconciled `JdbcSinkFactory.optionRule()` with the options actually read by `JdbcSinkConfig`, adding the previously omitted dirty-data output and threshold options so the exported Schema matches runtime behavior.

## Compatibility

- `Factory.schemaVersion()` and `Factory.capabilities()` are default methods, so existing Connector implementations remain source and binary compatible.
- the existing `Option` constructor is unchanged
- HOCON parsing and job submission behavior are unchanged
- schema export converts custom defaults to JSON-safe protocol values and does not retain plugin objects or Connector ClassLoaders
- the existing two-argument `JettyServer` constructor remains available for compatibility and tests

## Validation

- added JUnit coverage for schema export, conditional rules, enum choices, sensitive metadata and stable fingerprints
- added registry and REST service coverage
- added JDBC Source/Sink schema coverage, including dirty-data configuration
- performed Java 8-compatible static compilation of the API schema/exporter, framework catalog and server REST components with local stubs
- performed structural source checks for package consistency, duplicate public classes and balanced source blocks
- verified the branch contains only Connector Schema-related changes

Full Maven reactor execution was not available because Maven is not installed in the execution environment. Repository CI should run the complete compile and test suite for this draft.

## Phase-one non-goals

This PR intentionally does not introduce:

- Yak Ops Presentation Profiles, grouping, ordering or widgets
- database/table/field discovery Action APIs
- online Connector validation or job planning APIs
- JSON JobSpec submission
- replacement of HOCON
- any CDC or realtime synchronization capability
