### PR TITLE
feat(protocol): accept structured JobSpec submissions

### DIFF
--- a/docs/job-spec.md
+++ b/docs/job-spec.md
@@ -1,0 +1,45 @@
+# Link-Up Structured JobSpec
+
+`JobSpec` is the control-plane protocol for submitting one offline batch synchronization job. It is independent of HOCON and independent of any frontend framework.
+
+```json
+{
+  "apiVersion": "link-up/v1",
+  "kind": "BatchSyncJob",
+  "name": "orders-to-warehouse",
+  "source": {
+    "connectorId": "jdbc",
+    "options": {
+      "url": "jdbc:mysql://db:3306/source",
+      "driver": "com.mysql.cj.jdbc.Driver",
+      "table_path": "sales.orders",
+      "fetch_size": 1000
+    }
+  },
+  "sink": {
+    "connectorId": "doris",
+    "options": {
+      "fenodes": "doris-fe:8030",
+      "table": "warehouse.orders"
+    }
+  },
+  "runtime": {
+    "batchSize": 1000,
+    "sourceParallelism": 2,
+    "sinkParallelism": 2,
+    "pipelineParallelism": 2,
+    "maxBufferedBatches": 64
+  }
+}
+```
+
+## Ownership
+
+- Connector option names and validation rules come from each Connector Schema.
+- The control plane resolves data-source references and secrets before submission.
+- Link-Up compiles `JobSpec` into its internal `JobDefinition` and owns final runtime validation.
+- `connectorId` is opaque to the protocol. Adding Doris, HTTP or file connectors does not require a new control-plane serialization format.
+
+## Compatibility
+
+`application/hocon` and JSON requests containing `hocon` remain available for CLI and migration use. A JSON submission must contain exactly one of `jobSpec` or `hocon`. Control planes should use `jobSpec`.

--- a/docs/worker-protocol.md
+++ b/docs/worker-protocol.md
@@ -28,7 +28,7 @@ RUNNING
 
 终态不可再次转换。每次状态转换都会增加 `stateVersion`，并记录在 `transitions` 中。取消请求不会引入额外的 `CANCELLING` 业务状态；`cancellationRequested=true` 表示取消意图已被接收，实际状态仍保持 `QUEUED` 或 `RUNNING`，直到进入终态。
 
-## JSON 提交协议
+## 结构化 JSON 提交协议
 
 ```http
 POST /api/v1/jobs
@@ -40,13 +40,38 @@ Content-Type: application/json
   "externalExecutionId": "yak-execution-10086",
   "idempotencyKey": "60af452d-813c-4e51-87d9-4b00b5e2b53f",
   "definitionVersion": 3,
-  "hocon": "job { ... }"
+  "jobSpec": {
+    "apiVersion": "link-up/v1",
+    "kind": "BatchSyncJob",
+    "name": "orders-sync",
+    "source": {
+      "connectorId": "jdbc",
+      "options": {
+        "url": "jdbc:mysql://source:3306/demo",
+        "table_path": "orders"
+      }
+    },
+    "sink": {
+      "connectorId": "jdbc",
+      "options": {
+        "url": "jdbc:mysql://sink:3306/demo",
+        "table_path": "orders_copy"
+      }
+    },
+    "runtime": {
+      "batchSize": 1000,
+      "sourceParallelism": 1,
+      "sinkParallelism": 1,
+      "pipelineParallelism": 1,
+      "maxBufferedBatches": 64
+    }
+  }
 }
 ```
 
-Worker 会计算配置摘要。相同 `externalExecutionId`、`idempotencyKey`、`definitionVersion` 和配置摘要的重复请求返回同一个 `jobId`；复用相同标识但提交不同内容时返回 HTTP `409` 和错误码 `FLUX-JOB-IDEMPOTENCY-CONFLICT`。
+Worker 会对规范化后的 `jobSpec` 计算配置摘要。相同 `externalExecutionId`、`idempotencyKey`、`definitionVersion` 和配置摘要的重复请求返回同一个 `jobId`；复用相同标识但提交不同内容时返回 HTTP `409` 和错误码 `FLUX-JOB-IDEMPOTENCY-CONFLICT`。
 
-旧版 `application/hocon` 和 `text/plain` 提交仍然保留，但只用于 CLI 或过渡期调用，不适合控制面可靠重试。
+JSON 请求必须且只能包含 `jobSpec` 或 `hocon` 其中一个。`hocon`、`application/hocon` 和 `text/plain` 仍保留给 CLI 与迁移场景，控制面必须使用结构化 `jobSpec`。完整字段说明见 `docs/job-spec.md`。
 
 ## 查询与取消
 

--- a/link-up-api/src/main/java/com/link/up/api/job/JobSpec.java
+++ b/link-up-api/src/main/java/com/link/up/api/job/JobSpec.java
@@ -1,0 +1,86 @@
+package com.link.up.api.job;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Framework-neutral structured offline batch job protocol. */
+public final class JobSpec implements Serializable {
+    public static final String CURRENT_API_VERSION = "link-up/v1";
+    public static final String BATCH_SYNC_KIND = "BatchSyncJob";
+
+    private String apiVersion = CURRENT_API_VERSION;
+    private String kind = BATCH_SYNC_KIND;
+    private String name;
+    private Connector source;
+    private Connector sink;
+    private Runtime runtime = new Runtime();
+
+    public JobSpec() {}
+
+    public String getApiVersion() { return apiVersion; }
+    public void setApiVersion(String apiVersion) { this.apiVersion = apiVersion; }
+    public String getKind() { return kind; }
+    public void setKind(String kind) { this.kind = kind; }
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public Connector getSource() { return source; }
+    public void setSource(Connector source) { this.source = source; }
+    public Connector getSink() { return sink; }
+    public void setSink(Connector sink) { this.sink = sink; }
+    public Runtime getRuntime() { return runtime; }
+    public void setRuntime(Runtime runtime) { this.runtime = runtime; }
+
+    public static final class Connector implements Serializable {
+        private String connectorId;
+        private Map<String, Object> options = new LinkedHashMap<String, Object>();
+
+        public Connector() {}
+        public String getConnectorId() { return connectorId; }
+        public void setConnectorId(String connectorId) { this.connectorId = connectorId; }
+        public Map<String, Object> getOptions() { return options; }
+        public void setOptions(Map<String, Object> options) {
+            this.options = options == null
+                    ? new LinkedHashMap<String, Object>()
+                    : new LinkedHashMap<String, Object>(options);
+        }
+    }
+
+    public static final class Runtime implements Serializable {
+        private Integer batchSize;
+        private Integer sourceParallelism;
+        private Integer sinkParallelism;
+        private Integer pipelineParallelism;
+        private Integer maxBufferedBatches;
+        private Long maxBufferedRecords;
+        private Long maxBufferedBytes;
+        private Long maxRecordsPerSecond;
+        private Long maxBytesPerSecond;
+        private String sinkPartitionStrategy;
+        private String splitAssignmentMode;
+
+        public Runtime() {}
+        public Integer getBatchSize() { return batchSize; }
+        public void setBatchSize(Integer batchSize) { this.batchSize = batchSize; }
+        public Integer getSourceParallelism() { return sourceParallelism; }
+        public void setSourceParallelism(Integer sourceParallelism) { this.sourceParallelism = sourceParallelism; }
+        public Integer getSinkParallelism() { return sinkParallelism; }
+        public void setSinkParallelism(Integer sinkParallelism) { this.sinkParallelism = sinkParallelism; }
+        public Integer getPipelineParallelism() { return pipelineParallelism; }
+        public void setPipelineParallelism(Integer pipelineParallelism) { this.pipelineParallelism = pipelineParallelism; }
+        public Integer getMaxBufferedBatches() { return maxBufferedBatches; }
+        public void setMaxBufferedBatches(Integer maxBufferedBatches) { this.maxBufferedBatches = maxBufferedBatches; }
+        public Long getMaxBufferedRecords() { return maxBufferedRecords; }
+        public void setMaxBufferedRecords(Long maxBufferedRecords) { this.maxBufferedRecords = maxBufferedRecords; }
+        public Long getMaxBufferedBytes() { return maxBufferedBytes; }
+        public void setMaxBufferedBytes(Long maxBufferedBytes) { this.maxBufferedBytes = maxBufferedBytes; }
+        public Long getMaxRecordsPerSecond() { return maxRecordsPerSecond; }
+        public void setMaxRecordsPerSecond(Long maxRecordsPerSecond) { this.maxRecordsPerSecond = maxRecordsPerSecond; }
+        public Long getMaxBytesPerSecond() { return maxBytesPerSecond; }
+        public void setMaxBytesPerSecond(Long maxBytesPerSecond) { this.maxBytesPerSecond = maxBytesPerSecond; }
+        public String getSinkPartitionStrategy() { return sinkPartitionStrategy; }
+        public void setSinkPartitionStrategy(String sinkPartitionStrategy) { this.sinkPartitionStrategy = sinkPartitionStrategy; }
+        public String getSplitAssignmentMode() { return splitAssignmentMode; }
+        public void setSplitAssignmentMode(String splitAssignmentMode) { this.splitAssignmentMode = splitAssignmentMode; }
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/job/JobSpecCompiler.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/JobSpecCompiler.java
@@ -1,0 +1,104 @@
+package com.link.up.framework.job;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.job.JobSpec;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+
+/** Compiles the public structured JobSpec protocol into Link-Up runtime definitions. */
+public final class JobSpecCompiler {
+
+    public JobDefinition compile(JobSpec spec) {
+        if (spec == null) {
+            throw new IllegalArgumentException("jobSpec must not be null");
+        }
+        requireProtocol(spec.getApiVersion(), spec.getKind());
+        JobSpec.Connector sourceSpec = requireConnector(spec.getSource(), "source");
+        JobSpec.Connector sinkSpec = requireConnector(spec.getSink(), "sink");
+        JobSpec.Runtime runtime = spec.getRuntime() == null ? new JobSpec.Runtime() : spec.getRuntime();
+
+        SourceDefinition source = new SourceDefinition(
+                requireText(sourceSpec.getConnectorId(), "source.connectorId"),
+                ReadonlyConfig.fromMap(copy(sourceSpec.getOptions())));
+        SinkDefinition sink = new SinkDefinition(
+                requireText(sinkSpec.getConnectorId(), "sink.connectorId"),
+                ReadonlyConfig.fromMap(copy(sinkSpec.getOptions())));
+
+        ExecutionConfig execution = new ExecutionConfig(
+                positive(runtime.getBatchSize(), ExecutionConfig.DEFAULT_BATCH_SIZE, "runtime.batchSize"),
+                positive(runtime.getSourceParallelism(), ExecutionConfig.DEFAULT_SOURCE_PARALLELISM,
+                        "runtime.sourceParallelism"),
+                positive(runtime.getSinkParallelism(), ExecutionConfig.DEFAULT_SINK_PARALLELISM,
+                        "runtime.sinkParallelism"),
+                positive(runtime.getPipelineParallelism(), ExecutionConfig.DEFAULT_PIPELINE_PARALLELISM,
+                        "runtime.pipelineParallelism"),
+                positive(runtime.getMaxBufferedBatches(), ExecutionConfig.DEFAULT_CHANNEL_CAPACITY,
+                        "runtime.maxBufferedBatches"),
+                optional(runtime.getMaxBufferedRecords()),
+                optional(runtime.getMaxBufferedBytes()),
+                optional(runtime.getMaxRecordsPerSecond()),
+                optional(runtime.getMaxBytesPerSecond()),
+                enumValue(runtime.getSinkPartitionStrategy(), SinkPartitionStrategy.TABLE_AFFINITY,
+                        SinkPartitionStrategy.class, "runtime.sinkPartitionStrategy"),
+                enumValue(runtime.getSplitAssignmentMode(), SplitAssignmentMode.STATIC_ROUND_ROBIN,
+                        SplitAssignmentMode.class, "runtime.splitAssignmentMode"));
+
+        return new JobDefinition(requireText(spec.getName(), "name"), source, sink, execution);
+    }
+
+    private void requireProtocol(String apiVersion, String kind) {
+        String normalizedVersion = requireText(apiVersion, "apiVersion");
+        String normalizedKind = requireText(kind, "kind");
+        if (!JobSpec.CURRENT_API_VERSION.equals(normalizedVersion)) {
+            throw new IllegalArgumentException("Unsupported jobSpec apiVersion: " + normalizedVersion);
+        }
+        if (!JobSpec.BATCH_SYNC_KIND.equals(normalizedKind)) {
+            throw new IllegalArgumentException("Unsupported jobSpec kind: " + normalizedKind);
+        }
+    }
+
+    private JobSpec.Connector requireConnector(JobSpec.Connector connector, String name) {
+        if (connector == null) {
+            throw new IllegalArgumentException(name + " must not be null");
+        }
+        return connector;
+    }
+
+    private Map<String, Object> copy(Map<String, Object> options) {
+        return options == null
+                ? new LinkedHashMap<String, Object>()
+                : new LinkedHashMap<String, Object>(options);
+    }
+
+    private int positive(Integer value, int fallback, String name) {
+        int resolved = value == null ? fallback : value.intValue();
+        if (resolved <= 0) {
+            throw new IllegalArgumentException(name + " must be greater than 0");
+        }
+        return resolved;
+    }
+
+    private long optional(Long value) {
+        return value == null ? -1L : value.longValue();
+    }
+
+    private <E extends Enum<E>> E enumValue(
+            String value, E fallback, Class<E> type, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            return fallback;
+        }
+        try {
+            return Enum.valueOf(type, value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalArgumentException("Unknown " + name + ": " + value, exception);
+        }
+    }
+
+    private String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/job/JobSpecCompilerTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/job/JobSpecCompilerTest.java
@@ -1,0 +1,89 @@
+package com.link.up.framework.job;
+
+import com.link.up.api.job.JobSpec;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobSpecCompilerTest {
+
+    @Test
+    public void shouldCompileStructuredConnectorOptions() {
+        JobSpec spec = new JobSpec();
+        spec.setName("structured-sync");
+        spec.setSource(connector("jdbc", sourceOptions()));
+        spec.setSink(connector("doris", sinkOptions()));
+
+        JobSpec.Runtime runtime = new JobSpec.Runtime();
+        runtime.setBatchSize(512);
+        runtime.setSourceParallelism(2);
+        runtime.setSinkParallelism(3);
+        runtime.setPipelineParallelism(4);
+        runtime.setMaxBufferedBatches(16);
+        runtime.setMaxRecordsPerSecond(1000L);
+        spec.setRuntime(runtime);
+
+        JobDefinition definition = new JobSpecCompiler().compile(spec);
+
+        assertEquals("structured-sync", definition.getName());
+        assertEquals("jdbc", definition.getSource().getType());
+        assertEquals("doris", definition.getSink().getType());
+        assertEquals("orders", definition.getSource().getOptions().getSourceMap().get("table_path"));
+        assertEquals(Arrays.asList("id", "tenant_id"),
+                definition.getSink().getOptions().getSourceMap().get("primary_keys"));
+        assertEquals(512, definition.getExecutionConfig().getBatchSize());
+        assertEquals(2, definition.getExecutionConfig().getSourceParallelism());
+        assertEquals(3, definition.getExecutionConfig().getSinkParallelism());
+        assertEquals(4, definition.getExecutionConfig().getPipelineParallelism());
+        assertEquals(1000L, definition.getExecutionConfig().getMaxRecordsPerSecond());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectUnsupportedProtocolVersion() {
+        JobSpec spec = new JobSpec();
+        spec.setApiVersion("link-up/v99");
+        spec.setName("invalid");
+        spec.setSource(connector("jdbc", sourceOptions()));
+        spec.setSink(connector("jdbc", sinkOptions()));
+        new JobSpecCompiler().compile(spec);
+    }
+
+    @Test
+    public void shouldCopyOptionMaps() {
+        Map<String, Object> options = sourceOptions();
+        JobSpec spec = new JobSpec();
+        spec.setName("copy-check");
+        spec.setSource(connector("jdbc", options));
+        spec.setSink(connector("jdbc", sinkOptions()));
+
+        JobDefinition definition = new JobSpecCompiler().compile(spec);
+        options.put("late_mutation", true);
+
+        assertTrue(!definition.getSource().getOptions().getSourceMap().containsKey("late_mutation"));
+    }
+
+    private static JobSpec.Connector connector(String id, Map<String, Object> options) {
+        JobSpec.Connector connector = new JobSpec.Connector();
+        connector.setConnectorId(id);
+        connector.setOptions(options);
+        return connector;
+    }
+
+    private static Map<String, Object> sourceOptions() {
+        Map<String, Object> options = new LinkedHashMap<String, Object>();
+        options.put("url", "jdbc:mysql://127.0.0.1:3306/demo");
+        options.put("table_path", "orders");
+        return options;
+    }
+
+    private static Map<String, Object> sinkOptions() {
+        Map<String, Object> options = new LinkedHashMap<String, Object>();
+        options.put("table_path", "orders_archive");
+        options.put("primary_keys", Arrays.asList("id", "tenant_id"));
+        return options;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobSubmitRequest.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobSubmitRequest.java
@@ -1,50 +1,24 @@
 package com.link.up.server.dto;
 
-/**
- * Link-Up Worker JSON 提交协议。
- */
-public final class JobSubmitRequest {
+import com.link.up.api.job.JobSpec;
 
+/** Link-Up Worker idempotent JSON submission protocol. */
+public final class JobSubmitRequest {
     private String externalExecutionId;
     private String idempotencyKey;
     private Integer definitionVersion;
+    private JobSpec jobSpec;
     private String hocon;
 
-    public JobSubmitRequest() {
-    }
-
-    public String getExternalExecutionId() {
-        return externalExecutionId;
-    }
-
-    public void setExternalExecutionId(
-            String externalExecutionId) {
-        this.externalExecutionId = externalExecutionId;
-    }
-
-    public String getIdempotencyKey() {
-        return idempotencyKey;
-    }
-
-    public void setIdempotencyKey(
-            String idempotencyKey) {
-        this.idempotencyKey = idempotencyKey;
-    }
-
-    public Integer getDefinitionVersion() {
-        return definitionVersion;
-    }
-
-    public void setDefinitionVersion(
-            Integer definitionVersion) {
-        this.definitionVersion = definitionVersion;
-    }
-
-    public String getHocon() {
-        return hocon;
-    }
-
-    public void setHocon(String hocon) {
-        this.hocon = hocon;
-    }
+    public JobSubmitRequest() {}
+    public String getExternalExecutionId() { return externalExecutionId; }
+    public void setExternalExecutionId(String value) { this.externalExecutionId = value; }
+    public String getIdempotencyKey() { return idempotencyKey; }
+    public void setIdempotencyKey(String value) { this.idempotencyKey = value; }
+    public Integer getDefinitionVersion() { return definitionVersion; }
+    public void setDefinitionVersion(Integer value) { this.definitionVersion = value; }
+    public JobSpec getJobSpec() { return jobSpec; }
+    public void setJobSpec(JobSpec jobSpec) { this.jobSpec = jobSpec; }
+    public String getHocon() { return hocon; }
+    public void setHocon(String hocon) { this.hocon = hocon; }
 }

--- a/link-up-server/src/main/java/com/link/up/server/service/JobRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobRestService.java
@@ -1,7 +1,13 @@
 package com.link.up.server.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.link.up.api.job.JobSpec;
 import com.link.up.framework.job.JobConfigParser;
 import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.JobSpecCompiler;
 import com.link.up.server.dto.JobResponse;
 import com.link.up.server.dto.JobSubmitRequest;
 import com.link.up.server.dto.PageResponse;
@@ -13,7 +19,6 @@ import com.link.up.server.runtime.JobSubmission;
 import com.link.up.server.runtime.ServerJobStatus;
 import com.link.up.server.runtime.WorkerIdentity;
 import com.typesafe.config.ConfigException;
-
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -23,291 +28,201 @@ import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
-/**
- * REST 输入与单节点离线 Worker 运行时之间的适配层。
- */
+/** REST inputs to single-node offline Worker runtime adapter. */
 public final class JobRestService {
-
     private static final int MAX_PAGE_SIZE = 200;
 
     private final JobManager manager;
-    private final JobConfigParser parser;
+    private final JobConfigParser hoconParser;
+    private final JobSpecCompiler jobSpecCompiler;
+    private final ObjectMapper protocolMapper;
     private final WorkerIdentity workerIdentity;
     private final int maxConcurrentJobs;
     private final int maxQueuedJobs;
 
     public JobRestService(JobManager manager) {
-        this(
-                manager,
-                new WorkerIdentity(
-                        "embedded-link-up-node",
-                        "Embedded Link-Up Offline Worker",
+        this(manager,
+                new WorkerIdentity("embedded-link-up-node", "Embedded Link-Up Offline Worker",
                         WorkerIdentity.implementationVersion()),
-                1,
-                1);
+                1, 1);
     }
 
-    public JobRestService(
-            JobManager manager,
-            WorkerIdentity workerIdentity,
-            int maxConcurrentJobs,
-            int maxQueuedJobs) {
-
+    public JobRestService(JobManager manager, WorkerIdentity workerIdentity,
+                          int maxConcurrentJobs, int maxQueuedJobs) {
         this.manager = manager;
-        this.parser = new JobConfigParser();
+        this.hoconParser = new JobConfigParser();
+        this.jobSpecCompiler = new JobSpecCompiler();
+        this.protocolMapper = new ObjectMapper()
+                .configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true)
+                .configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
         this.workerIdentity = workerIdentity;
         this.maxConcurrentJobs = maxConcurrentJobs;
         this.maxQueuedJobs = maxQueuedJobs;
     }
 
     public JobSnapshot.Summary submit(String hocon) {
-        return submitLegacyResponse(hocon)
-                .toSummary();
+        return submitLegacyResponse(hocon).toSummary();
     }
 
     public JobResponse submitLegacyResponse(String hocon) {
         String token = UUID.randomUUID().toString();
-
         JobSubmitRequest request = new JobSubmitRequest();
         request.setExternalExecutionId("legacy-" + token);
         request.setIdempotencyKey(token);
         request.setDefinitionVersion(1);
         request.setHocon(hocon);
-
         return submit(request);
     }
 
     public JobResponse submit(JobSubmitRequest request) {
         if (request == null) {
-            throw new IllegalArgumentException(
-                    "Submit request must not be null");
+            throw new IllegalArgumentException("Submit request must not be null");
+        }
+        String externalExecutionId = requireText(request.getExternalExecutionId(), "externalExecutionId");
+        String idempotencyKey = requireText(request.getIdempotencyKey(), "idempotencyKey");
+        Integer definitionVersion = request.getDefinitionVersion();
+        if (definitionVersion == null || definitionVersion.intValue() <= 0) {
+            throw new IllegalArgumentException("definitionVersion must be greater than 0");
         }
 
-        String externalExecutionId =
-                requireText(
-                        request.getExternalExecutionId(),
-                        "externalExecutionId");
-        String idempotencyKey =
-                requireText(
-                        request.getIdempotencyKey(),
-                        "idempotencyKey");
-        Integer definitionVersion =
-                request.getDefinitionVersion();
-
-        if (definitionVersion == null || definitionVersion <= 0) {
-            throw new IllegalArgumentException(
-                    "definitionVersion must be greater than 0");
+        boolean hasJobSpec = request.getJobSpec() != null;
+        boolean hasHocon = hasText(request.getHocon());
+        if (hasJobSpec == hasHocon) {
+            throw new IllegalArgumentException("Exactly one of jobSpec or hocon must be provided");
         }
 
-        String hocon = requireText(request.getHocon(), "hocon");
-        JobDefinition definition = parse(hocon);
+        JobDefinition definition;
+        String configDigest;
+        if (hasJobSpec) {
+            definition = jobSpecCompiler.compile(request.getJobSpec());
+            configDigest = sha256("job-spec\n" + canonical(request.getJobSpec()));
+        } else {
+            String hocon = requireText(request.getHocon(), "hocon");
+            definition = parseHocon(hocon);
+            configDigest = sha256("hocon\n" + hocon);
+        }
 
-        JobSubmission submission =
-                new JobSubmission(
-                        externalExecutionId,
-                        idempotencyKey,
-                        definitionVersion,
-                        sha256(hocon),
-                        definition);
-
+        JobSubmission submission = new JobSubmission(
+                externalExecutionId, idempotencyKey, definitionVersion.intValue(),
+                configDigest, definition);
         return response(manager.submit(submission));
     }
 
-    public JobSnapshot job(String jobId) {
-        return manager.getJob(jobId);
+    public JobSnapshot job(String jobId) { return manager.getJob(jobId); }
+    public JobResponse jobResponse(String jobId) { return response(manager.getJob(jobId)); }
+    public JobResponse jobByExternalExecutionId(String externalExecutionId) {
+        return response(manager.getJobByExternalExecutionId(externalExecutionId));
     }
-
-    public JobResponse jobResponse(String jobId) {
-        return response(manager.getJob(jobId));
-    }
-
-    public JobResponse jobByExternalExecutionId(
-            String externalExecutionId) {
-
-        return response(
-                manager.getJobByExternalExecutionId(
-                        externalExecutionId));
-    }
-
     public List<JobSnapshot.Pipeline> pipelines(String jobId) {
         return manager.getJob(jobId).getPipelines();
     }
-
     public List<JobSnapshot.Task> tasks(String jobId) {
-        List<JobSnapshot.Task> tasks =
-                new ArrayList<JobSnapshot.Task>();
-
+        List<JobSnapshot.Task> tasks = new ArrayList<JobSnapshot.Task>();
         for (JobSnapshot.Pipeline pipeline : pipelines(jobId)) {
             tasks.addAll(pipeline.getTasks());
         }
-
         return Collections.unmodifiableList(tasks);
     }
+    public JobSnapshot.Metrics metrics(String jobId) { return manager.getJob(jobId).getMetrics(); }
 
-    public JobSnapshot.Metrics metrics(String jobId) {
-        return manager.getJob(jobId).getMetrics();
-    }
-
-    public PageResponse<JobSnapshot.Summary> jobs(
-            String statusValue,
-            int page,
-            int pageSize) {
-
-        List<JobSnapshot.Summary> summaries =
-                new ArrayList<JobSnapshot.Summary>();
-
+    public PageResponse<JobSnapshot.Summary> jobs(String statusValue, int page, int pageSize) {
+        List<JobSnapshot.Summary> summaries = new ArrayList<JobSnapshot.Summary>();
         for (JobSnapshot snapshot : filtered(statusValue)) {
             summaries.add(snapshot.toSummary());
         }
-
         return page(summaries, page, pageSize);
     }
 
-    public PageResponse<JobResponse> executionPage(
-            String statusValue,
-            int page,
-            int pageSize) {
-
-        List<JobResponse> responses =
-                new ArrayList<JobResponse>();
-
+    public PageResponse<JobResponse> executionPage(String statusValue, int page, int pageSize) {
+        List<JobResponse> responses = new ArrayList<JobResponse>();
         for (JobSnapshot snapshot : filtered(statusValue)) {
             responses.add(response(snapshot));
         }
-
         return page(responses, page, pageSize);
     }
 
-    public JobSnapshot.Summary cancel(String jobId) {
-        return manager.cancel(jobId).toSummary();
-    }
-
-    public JobResponse cancelResponse(String jobId) {
-        return response(manager.cancel(jobId));
-    }
-
+    public JobSnapshot.Summary cancel(String jobId) { return manager.cancel(jobId).toSummary(); }
+    public JobResponse cancelResponse(String jobId) { return response(manager.cancel(jobId)); }
     public WorkerNodeResponse node() {
-        return new WorkerNodeResponse(
-                workerIdentity,
-                manager,
-                maxConcurrentJobs,
-                maxQueuedJobs);
+        return new WorkerNodeResponse(workerIdentity, manager, maxConcurrentJobs, maxQueuedJobs);
     }
 
-    private JobDefinition parse(String hocon) {
+    private JobDefinition parseHocon(String hocon) {
         try {
-            return parser.parse(hocon);
+            return hoconParser.parse(hocon);
         } catch (ConfigException exception) {
-            throw new IllegalArgumentException(
-                    "Invalid HOCON job configuration");
+            throw new IllegalArgumentException("Invalid HOCON job configuration", exception);
+        }
+    }
+
+    private String canonical(JobSpec spec) {
+        try {
+            return protocolMapper.writeValueAsString(spec);
+        } catch (JsonProcessingException exception) {
+            throw new IllegalArgumentException("Invalid structured jobSpec", exception);
         }
     }
 
     private List<JobSnapshot> filtered(String statusValue) {
         ServerJobStatus status = parseStatus(statusValue);
-        List<JobSnapshot> result =
-                new ArrayList<JobSnapshot>();
-
+        List<JobSnapshot> result = new ArrayList<JobSnapshot>();
         for (JobSnapshot snapshot : manager.listJobs()) {
             if (status == null || snapshot.getStatus() == status) {
                 result.add(snapshot);
             }
         }
-
         return result;
     }
 
-    private <T> PageResponse<T> page(
-            List<T> values,
-            int page,
-            int pageSize) {
-
+    private <T> PageResponse<T> page(List<T> values, int page, int pageSize) {
         validatePage(page, pageSize);
-
         long startLong = (long) (page - 1) * pageSize;
-        int from =
-                startLong >= values.size()
-                        ? values.size()
-                        : (int) startLong;
+        int from = startLong >= values.size() ? values.size() : (int) startLong;
         int to = Math.min(values.size(), from + pageSize);
-
-        return new PageResponse<T>(
-                values.subList(from, to),
-                page,
-                pageSize,
-                values.size());
+        return new PageResponse<T>(values.subList(from, to), page, pageSize, values.size());
     }
 
     private void validatePage(int page, int pageSize) {
-        if (page < 1) {
-            throw new IllegalArgumentException(
-                    "page must be greater than 0");
-        }
-
+        if (page < 1) throw new IllegalArgumentException("page must be greater than 0");
         if (pageSize < 1 || pageSize > MAX_PAGE_SIZE) {
-            throw new IllegalArgumentException(
-                    "pageSize must be between 1 and "
-                            + MAX_PAGE_SIZE);
+            throw new IllegalArgumentException("pageSize must be between 1 and " + MAX_PAGE_SIZE);
         }
     }
 
     private JobResponse response(JobSnapshot snapshot) {
-        JobExecutionMetadata metadata =
-                manager.getMetadata(snapshot.getJobId());
-
-        return new JobResponse(
-                snapshot,
-                metadata,
-                workerIdentity);
+        JobExecutionMetadata metadata = manager.getMetadata(snapshot.getJobId());
+        return new JobResponse(snapshot, metadata, workerIdentity);
     }
 
     private ServerJobStatus parseStatus(String statusValue) {
-        if (statusValue == null || statusValue.trim().isEmpty()) {
-            return null;
-        }
-
+        if (!hasText(statusValue)) return null;
         try {
-            return ServerJobStatus.valueOf(
-                    statusValue.trim()
-                            .toUpperCase(Locale.ROOT));
+            return ServerJobStatus.valueOf(statusValue.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException exception) {
-            throw new IllegalArgumentException(
-                    "Unknown job status: " + statusValue);
+            throw new IllegalArgumentException("Unknown job status: " + statusValue, exception);
         }
     }
 
-    private static String requireText(String value, String name) {
-        if (value == null || value.trim().isEmpty()) {
-            throw new IllegalArgumentException(
-                    name + " must not be blank");
-        }
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
 
+    private static String requireText(String value, String name) {
+        if (!hasText(value)) throw new IllegalArgumentException(name + " must not be blank");
         return value.trim();
     }
 
     private static String sha256(String value) {
         try {
-            MessageDigest digest =
-                    MessageDigest.getInstance("SHA-256");
-            byte[] bytes =
-                    digest.digest(
-                            value.getBytes(StandardCharsets.UTF_8));
-            StringBuilder result =
-                    new StringBuilder(bytes.length * 2);
-
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] bytes = digest.digest(value.getBytes(StandardCharsets.UTF_8));
+            StringBuilder result = new StringBuilder(bytes.length * 2);
             for (byte current : bytes) {
-                result.append(
-                        String.format(
-                                Locale.ROOT,
-                                "%02x",
-                                current & 0xff));
+                result.append(String.format(Locale.ROOT, "%02x", current & 0xff));
             }
-
             return result.toString();
         } catch (NoSuchAlgorithmException exception) {
-            throw new IllegalStateException(
-                    "SHA-256 is not available",
-                    exception);
+            throw new IllegalStateException("SHA-256 is not available", exception);
         }
     }
 }


### PR DESCRIPTION
## Summary

This completes phase four of the Connector configuration architecture on the Link-Up side: the Worker now accepts a framework-neutral structured `JobSpec` and compiles it directly into the existing runtime `JobDefinition`.

- add public `JobSpec` protocol DTO in `link-up-api`
- add `JobSpecCompiler` in `link-up-framework`
- accept `jobSpec` in the idempotent JSON submission protocol
- require exactly one of `jobSpec` or legacy `hocon`
- calculate deterministic structured payload digests for idempotency
- keep `application/hocon`, `text/plain`, and JSON `hocon` for CLI/migration compatibility
- preserve the existing queue, lifecycle, retry-safe lookup, cancellation, metrics, and state machine
- document the protocol and add compiler tests

## Structured protocol

```json
{
  "externalExecutionId": "yak-execution-10086",
  "idempotencyKey": "60af452d-813c-4e51-87d9-4b00b5e2b53f",
  "definitionVersion": 3,
  "jobSpec": {
    "apiVersion": "link-up/v1",
    "kind": "BatchSyncJob",
    "name": "orders-sync",
    "source": {
      "connectorId": "jdbc",
      "options": {"table_path": "sales.orders"}
    },
    "sink": {
      "connectorId": "doris",
      "options": {"table": "warehouse.orders"}
    },
    "runtime": {
      "batchSize": 1000,
      "sourceParallelism": 2,
      "sinkParallelism": 2,
      "pipelineParallelism": 2,
      "maxBufferedBatches": 64
    }
  }
}
```

`connectorId` and `options` are intentionally opaque to the protocol. Doris, HTTP, file, or future Connectors do not require a new REST payload format.

## Compiler boundary

```text
JobSpec
  ↓
JobSpecCompiler
  ↓
JobDefinition
  ↓
existing Link-Up runtime
```

The compiler validates the protocol version, job kind, connector IDs, positive runtime settings, and enum values. Connector factories remain responsible for final option validation.

## Compatibility

The legacy HOCON parser is retained only at the Worker boundary. Structured and HOCON payload digests use different prefixes so they cannot accidentally collide in the idempotency registry.

## Validation

- Java 8 static compilation completed for `JobSpec`, `JobSpecCompiler`, `JobSubmitRequest`, and the updated REST service using dependency stubs
- added compiler tests for mixed connector IDs, runtime mapping, protocol rejection, option copying, and list-valued options
- branch is based on latest `main` commit `333cca44d1b0b901894fd4a0374df1d59cc7c49a`

The execution environment does not include Maven, so the complete reactor and repository test suite still need to run in CI or a local checkout.

## Follow-up dependency

The companion Yak Ops PR switches the control plane from generated HOCON to this structured `jobSpec` request. Merge/deploy this Worker protocol change before enabling that control-plane submission path.