### PR TITLE
feat(connector): add safe worker-side preflight

### DIFF
--- a/docs/connector-preflight.md
+++ b/docs/connector-preflight.md
@@ -1,0 +1,100 @@
+# Connector 安全预检协议
+
+## 目标
+
+Yak Ops 进行多 Worker 调度时，需要确认数据源和目标端从实际 Link-Up Worker 所在网络可达。
+
+预检必须满足：
+
+- 不创建任务实例
+- 不进入 Worker 任务队列
+- 不读取业务表数据
+- 不执行建表、更新或写入
+- 请求和错误日志不得泄露密码
+
+## REST API
+
+```http
+POST /api/v1/connectors/{connectorId}/preflight?role=SOURCE|SINK
+Content-Type: application/json
+```
+
+请求：
+
+```json
+{
+  "options": {
+    "url": "jdbc:mysql://db.example:3306/app",
+    "driver": "com.mysql.cj.jdbc.Driver",
+    "user": "app_user",
+    "password": "******"
+  }
+}
+```
+
+成功响应：
+
+```json
+{
+  "connectorId": "jdbc",
+  "role": "SOURCE",
+  "status": "REACHABLE",
+  "durationMillis": 35,
+  "checkedAtMillis": 1785672000000
+}
+```
+
+常见错误：
+
+| HTTP | code | 含义 |
+|---|---|---|
+| 400 | `FLUX-CONNECTOR-PREFLIGHT-CONFIG-INVALID` | Connector 配置不合法 |
+| 404 | `FLUX-CONNECTOR-NOT-FOUND` | Worker 未安装该 Connector |
+| 422 | `FLUX-CONNECTOR-PREFLIGHT-UNSUPPORTED` | Connector 尚未实现安全预检 |
+| 501 | `FLUX-CONNECTOR-PREFLIGHT-DISABLED` | 当前服务未启用预检执行器 |
+| 503 | `FLUX-CONNECTOR-PREFLIGHT-FAILED` | 外部系统不可达或连接验证失败 |
+
+## Connector SPI
+
+Connector 可以选择实现：
+
+```java
+public interface ConnectorPreflightSupport {
+
+    void preflight(
+            ReadonlyConfig options,
+            ClassLoader classLoader)
+            throws Exception;
+}
+```
+
+实现约束：
+
+1. 只验证配置和外部系统连接。
+2. 不得创建业务对象、表、Topic 或索引。
+3. 不得写入业务数据。
+4. 必须及时关闭连接、流和其他外部资源。
+5. 抛出的错误不得主动包含密码、Token 或完整凭据。
+6. 未实现该接口的 Connector 会明确返回 `UNSUPPORTED`，不会假装预检成功。
+
+## JDBC 实现
+
+JDBC Source 和 Sink 均实现安全预检：
+
+1. 使用原 Connector 配置规则解析参数。
+2. 通过 Connector 所属 ClassLoader 加载 JDBC Driver。
+3. 建立一次 JDBC Connection。
+4. 调用 `Connection.isValid(timeoutSeconds)`。
+5. 立即关闭 Connection。
+
+预检不会执行 SQL，也不会触发表结构发现、自动建表或 Sink Preparer。
+
+## 生命周期
+
+Link-Up Server 使用同一个 `FactoryRegistry`：
+
+- 生成 Connector Schema
+- 执行 Connector preflight
+- 在 Worker 关闭时统一释放 Connector ClassLoader
+
+因此不会为了每次预检重新发现插件或重复创建插件类加载器。

--- a/link-up-api/src/main/java/com/link/up/api/connector/preflight/ConnectorPreflightSupport.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/preflight/ConnectorPreflightSupport.java
@@ -1,0 +1,22 @@
+package com.link.up.api.connector.preflight;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+
+/**
+ * Connector 可选的只读连通性预检能力。
+ *
+ * <p>实现必须只验证配置和外部系统连接，不得创建任务、写入业务数据或修改外部结构。
+ */
+public interface ConnectorPreflightSupport {
+
+    /**
+     * 从当前 Worker 进程视角验证 Connector 配置和外部系统可达性。
+     *
+     * @param options Connector 运行配置
+     * @param classLoader Connector 所属类加载器
+     */
+    void preflight(
+            ReadonlyConfig options,
+            ClassLoader classLoader)
+            throws Exception;
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkFactory.java
@@ -3,6 +3,7 @@ package com.link.up.connector.jdbc.sink;
 import com.google.auto.service.AutoService;
 import com.link.up.api.configuration.ReadonlyConfig;
 import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.preflight.ConnectorPreflightSupport;
 import com.link.up.api.connector.schema.ConnectorCapability;
 import com.link.up.api.factory.SinkFactory;
 import com.link.up.api.sink.PreparedSinkMetadata;
@@ -12,6 +13,7 @@ import com.link.up.api.table.type.FluxRow;
 import com.link.up.connector.jdbc.config.JdbcCommonOptions;
 import com.link.up.connector.jdbc.config.JdbcSinkConfig;
 import com.link.up.connector.jdbc.config.JdbcSinkOptions;
+import com.link.up.connector.jdbc.utils.JdbcConnectionPreflight;
 
 import java.util.Collections;
 import java.util.EnumSet;
@@ -22,7 +24,8 @@ import java.util.Set;
  */
 @AutoService(SinkFactory.class)
 public final class JdbcSinkFactory
-        implements SinkFactory {
+        implements SinkFactory,
+        ConnectorPreflightSupport {
 
     @Override
     public String factoryIdentifier() {
@@ -38,6 +41,21 @@ public final class JdbcSinkFactory
                         ConnectorCapability.UPSERT,
                         ConnectorCapability.AUTO_CREATE_TABLE,
                         ConnectorCapability.DIRTY_DATA_HANDLING));
+    }
+
+    @Override
+    public void preflight(
+            ReadonlyConfig options,
+            ClassLoader classLoader)
+            throws Exception {
+
+        // 解析 Sink 规则，但不创建 Preparer/Writer，也不执行建表或写入。
+        JdbcSinkConfig.of(
+                options);
+
+        JdbcConnectionPreflight.validate(
+                options,
+                classLoader);
     }
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceFactory.java
@@ -3,6 +3,7 @@ package com.link.up.connector.jdbc.source;
 import com.google.auto.service.AutoService;
 import com.link.up.api.configuration.ReadonlyConfig;
 import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.preflight.ConnectorPreflightSupport;
 import com.link.up.api.connector.schema.ConnectorCapability;
 import com.link.up.api.source.SourceFactoryContext;
 import com.link.up.api.table.catalog.CatalogTable;
@@ -14,6 +15,7 @@ import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
 import com.link.up.connector.jdbc.options.MultiTableCommonOptions;
 import com.link.up.connector.jdbc.utils.JdbcCatalogUtils;
+import com.link.up.connector.jdbc.utils.JdbcConnectionPreflight;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,7 +41,8 @@ import java.util.Set;
  */
 @AutoService(TableSourceFactory.class)
 public final class JdbcSourceFactory
-        implements TableSourceFactory<JdbcSourceSplit> {
+        implements TableSourceFactory<JdbcSourceSplit>,
+        ConnectorPreflightSupport {
 
     private static final String IDENTIFIER = "jdbc";
 
@@ -56,6 +59,23 @@ public final class JdbcSourceFactory
                         ConnectorCapability.MULTI_TABLE,
                         ConnectorCapability.CUSTOM_SQL,
                         ConnectorCapability.PARTITION_SPLIT));
+    }
+
+    @Override
+    public void preflight(
+            ReadonlyConfig options,
+            ClassLoader classLoader)
+            throws Exception {
+
+        // 先解析 Source 规则，再执行不读表、不执行 SQL 的 JDBC 连接验证。
+        JdbcSourceConfig.of(
+                Objects.requireNonNull(
+                        options,
+                        "source options must not be null"));
+
+        JdbcConnectionPreflight.validate(
+                options,
+                classLoader);
     }
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/utils/JdbcConnectionPreflight.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/utils/JdbcConnectionPreflight.java
@@ -1,0 +1,88 @@
+package com.link.up.connector.jdbc.utils;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Properties;
+
+/**
+ * JDBC 只读连接预检。
+ *
+ * <p>仅加载驱动、建立连接并调用 {@link Connection#isValid(int)}，不执行 SQL，
+ * 不开启事务，也不修改数据库对象。
+ */
+public final class JdbcConnectionPreflight {
+
+    private JdbcConnectionPreflight() {
+    }
+
+    public static void validate(
+            ReadonlyConfig options,
+            ClassLoader classLoader)
+            throws Exception {
+
+        Objects.requireNonNull(
+                options,
+                "options must not be null");
+
+        ClassLoader loader =
+                Objects.requireNonNull(
+                        classLoader,
+                        "classLoader must not be null");
+
+        JdbcConnectionConfig config =
+                JdbcConnectionConfig.of(
+                        options);
+
+        Class<?> driverType =
+                Class.forName(
+                        config.getDriverName(),
+                        true,
+                        loader);
+
+        if (!Driver.class.isAssignableFrom(
+                driverType)) {
+            throw new IllegalArgumentException(
+                    "Configured JDBC driver does not implement java.sql.Driver: "
+                            + config.getDriverName());
+        }
+
+        Driver driver =
+                (Driver) driverType
+                        .getDeclaredConstructor()
+                        .newInstance();
+
+        Properties properties =
+                config.toProperties();
+
+        Connection connection =
+                driver.connect(
+                        config.getUrl(),
+                        properties);
+
+        if (connection == null) {
+            throw new SQLException(
+                    "JDBC driver rejected URL: "
+                            + config.getUrl());
+        }
+
+        try {
+            int timeout =
+                    Math.max(
+                            1,
+                            config.getConnectionCheckTimeoutSeconds());
+
+            if (!connection.isValid(
+                    timeout)) {
+                throw new SQLException(
+                        "JDBC connection validation returned false");
+            }
+        } finally {
+            connection.close();
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/utils/JdbcConnectionPreflightTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/utils/JdbcConnectionPreflightTest.java
@@ -1,0 +1,83 @@
+package com.link.up.connector.jdbc.utils;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class JdbcConnectionPreflightTest {
+
+    @Test
+    public void shouldValidateReachableDatabaseWithoutWriting() throws Exception {
+        String url =
+                "jdbc:h2:mem:preflight_success;DB_CLOSE_DELAY=-1";
+
+        try (Connection connection =
+                     DriverManager.getConnection(url);
+             Statement statement =
+                     connection.createStatement()) {
+            statement.execute(
+                    "CREATE TABLE probe_guard(id INT PRIMARY KEY)");
+        }
+
+        JdbcConnectionPreflight.validate(
+                config(url),
+                Thread.currentThread()
+                        .getContextClassLoader());
+
+        try (Connection connection =
+                     DriverManager.getConnection(url);
+             Statement statement =
+                     connection.createStatement();
+             ResultSet resultSet =
+                     statement.executeQuery(
+                             "SELECT COUNT(*) FROM probe_guard")) {
+            resultSet.next();
+            assertEquals(
+                    0,
+                    resultSet.getInt(1));
+        }
+    }
+
+    @Test
+    public void shouldFailForUnreachableDatabase() throws Exception {
+        try {
+            JdbcConnectionPreflight.validate(
+                    config(
+                            "jdbc:h2:tcp://127.0.0.1:1/does-not-exist"),
+                    Thread.currentThread()
+                            .getContextClassLoader());
+            fail("Expected JDBC preflight failure");
+        } catch (Exception expected) {
+            // 连接拒绝或超时即证明失败路径被正确传播。
+        }
+    }
+
+    private ReadonlyConfig config(
+            String url) {
+
+        Map<String, Object> values =
+                new LinkedHashMap<String, Object>();
+
+        values.put(
+                "url",
+                url);
+        values.put(
+                "driver",
+                "org.h2.Driver");
+        values.put(
+                "connection_check_timeout_sec",
+                Integer.valueOf(2));
+
+        return ReadonlyConfig.fromMap(
+                values);
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/connector/schema/ConnectorSchemaCatalog.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/connector/schema/ConnectorSchemaCatalog.java
@@ -16,6 +16,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Worker 启动时生成的 Connector Schema 只读目录。
@@ -95,39 +96,51 @@ public final class ConnectorSchemaCatalog {
                         pluginDirectories);
 
         try {
-            ConnectorSchemaExporter exporter =
-                    new ConnectorSchemaExporter();
-
-            List<ConnectorSchema> schemas =
-                    new ArrayList<ConnectorSchema>();
-
-            for (TableSourceFactory<?> factory :
-                    registry.getSourceFactories()
-                            .values()) {
-
-                schemas.add(
-                        exporter.export(
-                                factory,
-                                ConnectorRole.SOURCE,
-                                factory.optionRule()));
-            }
-
-            for (SinkFactory factory :
-                    registry.getSinkFactories()
-                            .values()) {
-
-                schemas.add(
-                        exporter.export(
-                                factory,
-                                ConnectorRole.SINK,
-                                factory.optionRule()));
-            }
-
-            return new ConnectorSchemaCatalog(
-                    schemas);
+            return fromRegistry(
+                    registry);
         } finally {
             registry.close();
         }
+    }
+
+    /** 使用已经加载的 FactoryRegistry 构建 Schema 目录，不接管其生命周期。 */
+    public static ConnectorSchemaCatalog fromRegistry(
+            FactoryRegistry registry) {
+
+        Objects.requireNonNull(
+                registry,
+                "registry must not be null");
+
+        ConnectorSchemaExporter exporter =
+                new ConnectorSchemaExporter();
+
+        List<ConnectorSchema> schemas =
+                new ArrayList<ConnectorSchema>();
+
+        for (TableSourceFactory<?> factory :
+                registry.getSourceFactories()
+                        .values()) {
+
+            schemas.add(
+                    exporter.export(
+                            factory,
+                            ConnectorRole.SOURCE,
+                            factory.optionRule()));
+        }
+
+        for (SinkFactory factory :
+                registry.getSinkFactories()
+                        .values()) {
+
+            schemas.add(
+                    exporter.export(
+                            factory,
+                            ConnectorRole.SINK,
+                            factory.optionRule()));
+        }
+
+        return new ConnectorSchemaCatalog(
+                schemas);
     }
 
     public List<ConnectorSchema> list() {

--- a/link-up-server/src/main/java/com/link/up/server/FluxServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/FluxServer.java
@@ -1,5 +1,6 @@
 package com.link.up.server;
 
+import com.link.up.framework.connector.FactoryRegistry;
 import com.link.up.framework.connector.schema.ConnectorSchemaCatalog;
 import com.link.up.server.config.FluxServerConfig;
 import com.link.up.server.http.JettyServer;
@@ -93,14 +94,19 @@ public final class FluxServer {
                         config.getJobThreads(),
                         config.getMaxQueuedJobs());
 
-        ConnectorSchemaCatalog connectorCatalog =
-                ConnectorSchemaCatalog.discover(
+        final FactoryRegistry connectorRegistry =
+                FactoryRegistry.discover(
                         classLoader,
                         pluginPaths);
 
+        ConnectorSchemaCatalog connectorCatalog =
+                ConnectorSchemaCatalog.fromRegistry(
+                        connectorRegistry);
+
         ConnectorRestService connectorService =
                 new ConnectorRestService(
-                        connectorCatalog);
+                        connectorCatalog,
+                        connectorRegistry);
 
         final JettyServer server =
                 new JettyServer(
@@ -129,6 +135,14 @@ public final class FluxServer {
                         }
 
                         manager.close();
+
+                        try {
+                            connectorRegistry.close();
+                        } catch (RuntimeException exception) {
+                            LOG.warn(
+                                    "Failed to close connector registry",
+                                    exception);
+                        }
                     }
                 };
 

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/ConnectorsServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/ConnectorsServlet.java
@@ -1,7 +1,10 @@
 package com.link.up.server.http.servlet;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.link.up.server.http.FluxServlet;
+import com.link.up.server.http.JsonSupport;
 import com.link.up.server.http.RestException;
+import com.link.up.server.service.ConnectorPreflightRequest;
 import com.link.up.server.service.ConnectorRestService;
 
 import javax.servlet.http.HttpServletRequest;
@@ -10,10 +13,13 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * Connector Schema 只读接口。
+ * Connector Schema 查询与只读预检接口。
  */
 public final class ConnectorsServlet
         extends FluxServlet {
+
+    private static final int MAX_PREFLIGHT_REQUEST_BYTES =
+            1024 * 1024;
 
     private final ConnectorRestService service;
 
@@ -56,7 +62,64 @@ public final class ConnectorsServlet
             return;
         }
 
-        throw new RestException(
+        throw notFound();
+    }
+
+    @Override
+    protected void doPost(
+            HttpServletRequest request,
+            HttpServletResponse response)
+            throws IOException {
+
+        List<String> segments =
+                pathSegments(request);
+
+        if (segments.size() == 2
+                && "preflight".equalsIgnoreCase(
+                segments.get(1))) {
+
+            validateSubmitContentType(
+                    request);
+
+            ConnectorPreflightRequest body;
+
+            try {
+                String json =
+                        requestBody(
+                                request,
+                                MAX_PREFLIGHT_REQUEST_BYTES);
+
+                body =
+                        json == null
+                                || json.trim().isEmpty()
+                                ? new ConnectorPreflightRequest()
+                                : JsonSupport.mapper()
+                                .readValue(
+                                        json,
+                                        ConnectorPreflightRequest.class);
+            } catch (JsonProcessingException exception) {
+                throw new RestException(
+                        400,
+                        "FLUX-CONNECTOR-PREFLIGHT-JSON-INVALID",
+                        "Connector preflight request must be valid JSON");
+            }
+
+            write(
+                    response,
+                    200,
+                    service.preflight(
+                            segments.get(0),
+                            request.getParameter(
+                                    "role"),
+                            body.getOptions()));
+            return;
+        }
+
+        throw notFound();
+    }
+
+    private RestException notFound() {
+        return new RestException(
                 404,
                 "FLUX-REST-404",
                 "Connector resource not found");

--- a/link-up-server/src/main/java/com/link/up/server/service/ConnectorPreflightRequest.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/ConnectorPreflightRequest.java
@@ -1,0 +1,32 @@
+package com.link.up.server.service;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Connector 预检请求，只携带实际运行 options。 */
+public final class ConnectorPreflightRequest {
+
+    private Map<String, Object> options;
+
+    public ConnectorPreflightRequest() {
+    }
+
+    public Map<String, Object> getOptions() {
+        return options == null
+                ? Collections.<String, Object>emptyMap()
+                : Collections.unmodifiableMap(
+                        new LinkedHashMap<String, Object>(
+                                options));
+    }
+
+    public void setOptions(
+            Map<String, Object> options) {
+
+        this.options =
+                options == null
+                        ? Collections.<String, Object>emptyMap()
+                        : new LinkedHashMap<String, Object>(
+                                options);
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/service/ConnectorPreflightResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/ConnectorPreflightResponse.java
@@ -1,0 +1,45 @@
+package com.link.up.server.service;
+
+/** Connector 预检成功响应。失败通过统一 REST 错误协议返回。 */
+public final class ConnectorPreflightResponse {
+
+    private final String connectorId;
+    private final String role;
+    private final String status;
+    private final long durationMillis;
+    private final long checkedAtMillis;
+
+    public ConnectorPreflightResponse(
+            String connectorId,
+            String role,
+            String status,
+            long durationMillis,
+            long checkedAtMillis) {
+
+        this.connectorId = connectorId;
+        this.role = role;
+        this.status = status;
+        this.durationMillis = durationMillis;
+        this.checkedAtMillis = checkedAtMillis;
+    }
+
+    public String getConnectorId() {
+        return connectorId;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+
+    public long getCheckedAtMillis() {
+        return checkedAtMillis;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/service/ConnectorRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/ConnectorRestService.java
@@ -1,22 +1,39 @@
 package com.link.up.server.service;
 
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.connector.preflight.ConnectorPreflightSupport;
 import com.link.up.api.connector.schema.ConnectorRole;
 import com.link.up.api.connector.schema.ConnectorSchema;
+import com.link.up.api.factory.Factory;
+import com.link.up.framework.connector.FactoryRegistry;
 import com.link.up.framework.connector.schema.ConnectorSchemaCatalog;
 import com.link.up.server.http.RestException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
- * Connector Schema REST 查询服务。
+ * Connector Schema 查询与只读预检服务。
  */
 public final class ConnectorRestService {
 
     private final ConnectorSchemaCatalog catalog;
+    private final FactoryRegistry registry;
 
+    /** 保留只读 Schema 查询测试和旧调用兼容。 */
     public ConnectorRestService(
             ConnectorSchemaCatalog catalog) {
+
+        this(
+                catalog,
+                null);
+    }
+
+    public ConnectorRestService(
+            ConnectorSchemaCatalog catalog,
+            FactoryRegistry registry) {
 
         if (catalog == null) {
             throw new IllegalArgumentException(
@@ -24,6 +41,7 @@ public final class ConnectorRestService {
         }
 
         this.catalog = catalog;
+        this.registry = registry;
     }
 
     public List<ConnectorSchema> list(
@@ -69,6 +87,111 @@ public final class ConnectorRestService {
         }
     }
 
+    public ConnectorPreflightResponse preflight(
+            String connectorId,
+            String roleValue,
+            Map<String, Object> options) {
+
+        if (registry == null) {
+            throw new RestException(
+                    501,
+                    "FLUX-CONNECTOR-PREFLIGHT-DISABLED",
+                    "Connector preflight is not available in this server");
+        }
+
+        ConnectorRole role =
+                roleRequired(
+                        roleValue);
+
+        Factory factory;
+
+        try {
+            factory =
+                    role == ConnectorRole.SOURCE
+                            ? registry.getSourceFactory(
+                            connectorId)
+                            : registry.getSinkFactory(
+                            connectorId);
+        } catch (RuntimeException exception) {
+            throw new RestException(
+                    404,
+                    "FLUX-CONNECTOR-NOT-FOUND",
+                    "Connector factory not found: "
+                            + role
+                            + "/"
+                            + connectorId);
+        }
+
+        if (!(factory instanceof ConnectorPreflightSupport)) {
+            throw new RestException(
+                    422,
+                    "FLUX-CONNECTOR-PREFLIGHT-UNSUPPORTED",
+                    "Connector does not support safe preflight: "
+                            + role
+                            + "/"
+                            + connectorId);
+        }
+
+        Map<String, Object> safeOptions =
+                options == null
+                        ? Collections.<String, Object>emptyMap()
+                        : options;
+
+        long started =
+                System.nanoTime();
+
+        try {
+            ((ConnectorPreflightSupport) factory)
+                    .preflight(
+                            ReadonlyConfig.fromMap(
+                                    safeOptions),
+                            registry.getClassLoader(
+                                    factory));
+        } catch (IllegalArgumentException exception) {
+            throw new RestException(
+                    400,
+                    "FLUX-CONNECTOR-PREFLIGHT-CONFIG-INVALID",
+                    sanitize(
+                            exception.getMessage(),
+                            "Connector preflight configuration is invalid"));
+        } catch (Exception exception) {
+            throw new RestException(
+                    503,
+                    "FLUX-CONNECTOR-PREFLIGHT-FAILED",
+                    sanitize(
+                            exception.getMessage(),
+                            "Connector preflight failed"));
+        }
+
+        long durationMillis =
+                Math.max(
+                        0L,
+                        (System.nanoTime() - started)
+                                / 1_000_000L);
+
+        return new ConnectorPreflightResponse(
+                factory.factoryIdentifier(),
+                role.name(),
+                "REACHABLE",
+                durationMillis,
+                System.currentTimeMillis());
+    }
+
+    private ConnectorRole roleRequired(
+            String roleValue) {
+
+        if (roleValue == null
+                || roleValue.trim().isEmpty()) {
+            throw new RestException(
+                    400,
+                    "FLUX-CONNECTOR-ROLE-REQUIRED",
+                    "Query parameter 'role' is required");
+        }
+
+        return role(
+                roleValue);
+    }
+
     private ConnectorRole role(
             String value) {
 
@@ -83,5 +206,26 @@ public final class ConnectorRestService {
                     "FLUX-CONNECTOR-ROLE-INVALID",
                     "role must be SOURCE or SINK");
         }
+    }
+
+    private String sanitize(
+            String message,
+            String fallback) {
+
+        if (message == null
+                || message.trim().isEmpty()) {
+            return fallback;
+        }
+
+        String sanitized =
+                message.replaceAll(
+                        "(?i)(password|passwd|pwd)\\s*[=:]\\s*[^,;\\s]+",
+                        "$1=***");
+
+        return sanitized.length() <= 1000
+                ? sanitized
+                : sanitized.substring(
+                0,
+                1000);
     }
 }

--- a/link-up-server/src/test/java/com/link/up/server/service/ConnectorRestServiceTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/service/ConnectorRestServiceTest.java
@@ -63,6 +63,32 @@ public class ConnectorRestServiceTest {
         }
     }
 
+    @Test
+    public void shouldKeepLegacyConstructorButDisablePreflight() {
+        ConnectorRestService service =
+                new ConnectorRestService(
+                        new ConnectorSchemaCatalog(
+                                Collections.singletonList(
+                                        schema(
+                                                "jdbc",
+                                                ConnectorRole.SOURCE))));
+
+        try {
+            service.preflight(
+                    "jdbc",
+                    "SOURCE",
+                    Collections.<String, Object>emptyMap());
+            fail("Expected preflight disabled error");
+        } catch (RestException expected) {
+            assertEquals(
+                    501,
+                    expected.getHttpStatus());
+            assertEquals(
+                    "FLUX-CONNECTOR-PREFLIGHT-DISABLED",
+                    expected.getCode());
+        }
+    }
+
     private ConnectorSchema schema(
             String connectorId,
             ConnectorRole role) {


### PR DESCRIPTION
## 背景

Yak Ops 第三阶段能力调度不仅需要确认 Worker 安装了正确的 Connector，还需要确认 Source 和 Sink 从实际 Link-Up Worker 所在网络能够访问。

本 PR 为 Link-Up 增加 **Connector 安全预检协议**。预检不创建任务、不进入执行队列、不读取业务数据，也不执行建表或写入。

配套 Yak Ops Draft PR：#165

## REST API

```http
POST /api/v1/connectors/{connectorId}/preflight?role=SOURCE|SINK
Content-Type: application/json
```

请求：

```json
{
  "options": {
    "url": "jdbc:mysql://db.example:3306/app",
    "driver": "com.mysql.cj.jdbc.Driver",
    "user": "app_user",
    "password": "******"
  }
}
```

成功响应：

```json
{
  "connectorId": "jdbc",
  "role": "SOURCE",
  "status": "REACHABLE",
  "durationMillis": 35,
  "checkedAtMillis": 1785672000000
}
```

统一错误：

- `400 FLUX-CONNECTOR-PREFLIGHT-CONFIG-INVALID`
- `404 FLUX-CONNECTOR-NOT-FOUND`
- `422 FLUX-CONNECTOR-PREFLIGHT-UNSUPPORTED`
- `501 FLUX-CONNECTOR-PREFLIGHT-DISABLED`
- `503 FLUX-CONNECTOR-PREFLIGHT-FAILED`

## Connector SPI

新增可选接口：

```java
public interface ConnectorPreflightSupport {

    void preflight(
            ReadonlyConfig options,
            ClassLoader classLoader)
            throws Exception;
}
```

未实现该接口的 Connector 会明确返回 `UNSUPPORTED`，不会被误判为可达。

## JDBC 实现

JDBC Source 和 Sink 均实现安全预检：

1. 复用原 Connector 配置规则解析参数
2. 使用 Connector 所属 ClassLoader 加载 JDBC Driver
3. 建立一次 Connection
4. 调用 `Connection.isValid(timeoutSeconds)`
5. 立即关闭 Connection

不会执行 SQL，不会调用表发现，不会创建 Sink Preparer，也不会触发自动建表或业务写入。

## 插件生命周期

Link-Up Server 现在保留单一 `FactoryRegistry`：

- 生成 Connector Schema
- 执行 Connector preflight
- Worker 关闭时统一释放 Connector ClassLoader

避免每次预检重新发现插件或重复创建类加载器。

## 安全与兼容

- 请求大小限制为 1 MiB
- 继续使用 JSON Content-Type 校验
- 常见密码字段在错误信息中脱敏
- 旧 `ConnectorRestService(ConnectorSchemaCatalog)` 构造器继续可用
- 旧构造器下 preflight 明确返回 `501`，避免旧测试和嵌入式调用破坏
- Schema 查询 API 保持不变

## 测试

新增和更新测试覆盖：

- JDBC 可达连接预检成功
- 预检不会向现有表写入数据
- 无效地址预检失败
- Schema 查询原行为保持不变
- role 必填校验保持不变
- 旧服务构造器下 preflight 明确关闭

## 文档

新增 `docs/connector-preflight.md`，说明协议、SPI、安全边界和 JDBC 实现。

## 合并与发布顺序

建议先合并并发布本 PR，再启用 Yak Ops #165 的严格可达性模式。

升级窗口中 Yak Ops 可以临时配置：

```yaml
yak:
  sync:
    offline:
      capability:
        reachability-required: false
```

全部 Worker 升级完成后恢复 `true`。

当前 PR 保持 Draft，用于联动验证 Yak Ops 的多 Worker 可达性调度。