### PR TITLE
feat(server): add dynamic control-plane registration

### DIFF
--- a/docs/dynamic-registration.md
+++ b/docs/dynamic-registration.md
@@ -1,0 +1,121 @@
+# Link-Up Worker 动态注册
+
+## 概述
+
+Link-Up Worker 可以在 HTTP 服务启动后主动注册到 Yak Ops，并持续发送签名心跳。动态注册默认关闭，不影响现有独立运行方式。
+
+注册心跳会报告：
+
+- nodeId、nodeName、instanceId
+- 对外可访问的 Worker Base URL
+- 引擎版本和启动时间
+- 运行并发、等待队列和当前负载
+- Connector、角色、Schema 指纹和能力集合
+
+Yak Ops 返回 leaseId 和建议心跳间隔。Worker 在优雅关闭时会主动注销租约。
+
+## 配置
+
+环境变量：
+
+```bash
+export LINK_UP_REGISTRATION_ENABLED=true
+export LINK_UP_CONTROL_PLANE_URL='https://yak-ops.example.com'
+export LINK_UP_REGISTRATION_SECRET='replace-with-at-least-16-random-characters'
+export LINK_UP_ADVERTISED_BASE_URL='http://link-up-worker-01:18080'
+export LINK_UP_REGISTRATION_HEARTBEAT_MILLIS=20000
+export LINK_UP_REGISTRATION_LABELS='region=south,zone=az-1'
+```
+
+等价 JVM 参数：
+
+```text
+-Dlink.up.registration.enabled=true
+-Dlink.up.registration.control-plane-url=https://yak-ops.example.com
+-Dlink.up.registration.secret=...
+-Dlink.up.registration.advertised-base-url=http://link-up-worker-01:18080
+-Dlink.up.registration.heartbeat-millis=20000
+-Dlink.up.registration.labels=region=south,zone=az-1
+```
+
+可选超时：
+
+```text
+LINK_UP_REGISTRATION_CONNECT_TIMEOUT_MILLIS=5000
+LINK_UP_REGISTRATION_REQUEST_TIMEOUT_MILLIS=10000
+```
+
+`LINK_UP_ADVERTISED_BASE_URL` 必须是 Yak Ops 和其他控制面实例真正能够访问的地址，不应使用容器内部不可达的 `127.0.0.1`。
+
+## 签名
+
+所有注册请求都使用 HMAC-SHA256：
+
+```text
+POST\n
+/api/v1/offline/worker-registration/register\n
+<timestampMillis>\n
+<nonce>\n
+<sha256(rawBody)>
+```
+
+请求头：
+
+```text
+X-Yak-Registration-Timestamp
+X-Yak-Registration-Nonce
+X-Yak-Registration-Signature
+```
+
+共享密钥必须与 Yak Ops 的 `YAK_OFFLINE_REGISTRATION_SECRET` 完全一致。密钥尾部字符会原样参与签名，不会被当成 URL 处理。
+
+## 生命周期
+
+启动：
+
+1. Worker HTTP 服务完成监听。
+2. 注册代理向 Yak Ops 发送注册请求。
+3. Yak Ops 返回 leaseId。
+4. 代理按照控制面建议间隔发送心跳。
+
+网络异常：
+
+- 使用 1 秒起步、最大 60 秒的指数退避。
+- `401 / 404 / 409` 会触发重新注册。
+- 已知心跳序列不会因不确定网络重试回退。
+- 相同进程实例重试注册时，Yak Ops 可以复用原租约。
+
+关闭：
+
+1. 先向 Yak Ops 发送 deregister。
+2. 再停止 Worker HTTP 服务。
+3. 再关闭任务运行时和 Connector ClassLoader。
+
+无法完成优雅注销时，Yak Ops 会在租约到期后自动将节点标记为 DOWN。
+
+## 管理边界
+
+Worker 拥有：
+
+- advertised base URL
+- instanceId 和引擎版本
+- 容量与负载
+- Connector 能力
+- 租约续期
+
+Yak Ops 拥有：
+
+- 显示名称
+- 标签的后续管理值
+- 调度权重
+- 启用、排空和禁用状态
+
+首次动态注册会提交初始标签；后续心跳不会覆盖管理员在 Yak Ops 中调整后的标签。
+
+## 安全建议
+
+- 生产环境使用 HTTPS。
+- 使用至少 32 字节随机共享密钥。
+- 通过 Kubernetes Secret、Vault 或等价方案注入密钥。
+- 不要把密钥写入镜像、启动日志或仓库。
+- advertised URL 应限制在可信网络内，避免将 Worker 管理接口直接暴露到公网。

--- a/link-up-server/src/main/java/com/link/up/server/FluxServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/FluxServer.java
@@ -4,6 +4,8 @@ import com.link.up.framework.connector.FactoryRegistry;
 import com.link.up.framework.connector.schema.ConnectorSchemaCatalog;
 import com.link.up.server.config.FluxServerConfig;
 import com.link.up.server.http.JettyServer;
+import com.link.up.server.registration.ControlPlaneRegistrationAgent;
+import com.link.up.server.registration.ControlPlaneRegistrationConfig;
 import com.link.up.server.runtime.InMemoryJobRepository;
 import com.link.up.server.runtime.JobExecutor;
 import com.link.up.server.runtime.JobIdGenerator;
@@ -114,6 +116,15 @@ public final class FluxServer {
                         jobService,
                         connectorService);
 
+        final ControlPlaneRegistrationConfig registrationConfig =
+                ControlPlaneRegistrationConfig.load();
+
+        final ControlPlaneRegistrationAgent registrationAgent =
+                new ControlPlaneRegistrationAgent(
+                        registrationConfig,
+                        jobService,
+                        connectorCatalog);
+
         final AtomicBoolean shutdown =
                 new AtomicBoolean(false);
 
@@ -124,6 +135,15 @@ public final class FluxServer {
                                 false,
                                 true)) {
                             return;
+                        }
+
+                        // 先注销控制面租约，再停止 HTTP 服务和任务运行时。
+                        try {
+                            registrationAgent.close();
+                        } catch (RuntimeException exception) {
+                            LOG.warn(
+                                    "Failed to close control-plane registration agent",
+                                    exception);
                         }
 
                         try {
@@ -157,16 +177,18 @@ public final class FluxServer {
 
         try {
             server.start();
+            registrationAgent.start();
 
             LOG.info(
-                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, host={}, port={}, jobThreads={}, connectorSchemas={}, pluginDirectories={}",
+                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, host={}, port={}, jobThreads={}, connectorSchemas={}, pluginDirectories={}, dynamicRegistration={}",
                     workerIdentity.getNodeId(),
                     workerIdentity.getInstanceId(),
                     config.getHost(),
                     server.getLocalPort(),
                     config.getJobThreads(),
                     connectorCatalog.list().size(),
-                    config.getPluginDirectories());
+                    config.getPluginDirectories(),
+                    registrationConfig.isEnabled());
 
             server.join();
 

--- a/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationAgent.java
+++ b/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationAgent.java
@@ -1,0 +1,362 @@
+package com.link.up.server.registration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.connector.schema.ConnectorSchema;
+import com.link.up.framework.connector.schema.ConnectorSchemaCatalog;
+import com.link.up.server.dto.WorkerNodeResponse;
+import com.link.up.server.service.JobRestService;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Link-Up Worker 主动注册 Yak Ops、续租并在优雅关闭时注销。
+ */
+public final class ControlPlaneRegistrationAgent
+        implements AutoCloseable {
+
+    private static final Logger LOG =
+            LogManager.getLogger(ControlPlaneRegistrationAgent.class);
+
+    private static final String PROTOCOL_VERSION =
+            "link-up-registration/v1";
+
+    private final ControlPlaneRegistrationConfig config;
+    private final JobRestService jobService;
+    private final ConnectorSchemaCatalog connectorCatalog;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ScheduledExecutorService scheduler;
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    private volatile String leaseId;
+    private volatile String registeredInstanceId;
+    private volatile long sequence;
+    private volatile long heartbeatMillis;
+    private volatile long failureDelayMillis = 1_000L;
+
+    public ControlPlaneRegistrationAgent(
+            ControlPlaneRegistrationConfig config,
+            JobRestService jobService,
+            ConnectorSchemaCatalog connectorCatalog) {
+
+        this.config = config;
+        this.jobService = jobService;
+        this.connectorCatalog = connectorCatalog;
+        this.heartbeatMillis = config.getHeartbeatMillis();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactory() {
+                    public Thread newThread(Runnable runnable) {
+                        Thread thread = new Thread(
+                                runnable,
+                                "link-up-control-plane-registration");
+                        thread.setDaemon(true);
+                        return thread;
+                    }
+                });
+    }
+
+    public void start() {
+        if (!config.isEnabled()) {
+            LOG.info("Link-Up dynamic control-plane registration is disabled");
+            return;
+        }
+        if (started.compareAndSet(false, true)) {
+            schedule(0L);
+        }
+    }
+
+    private void cycle() {
+        if (closed.get()) {
+            return;
+        }
+        long nextDelay;
+        try {
+            if (leaseId == null) {
+                register();
+            } else {
+                heartbeat();
+            }
+            failureDelayMillis = 1_000L;
+            nextDelay = heartbeatMillis;
+        } catch (ControlPlaneException exception) {
+            if (exception.requiresRegistration()) {
+                leaseId = null;
+                registeredInstanceId = null;
+                sequence = 0L;
+            }
+            nextDelay = failureDelayMillis;
+            failureDelayMillis = Math.min(60_000L, failureDelayMillis * 2L);
+            LOG.warn(
+                    "Link-Up dynamic registration failed, status={}, retryInMs={}, message={}",
+                    exception.getStatusCode(),
+                    nextDelay,
+                    exception.getMessage());
+        } catch (RuntimeException exception) {
+            nextDelay = failureDelayMillis;
+            failureDelayMillis = Math.min(60_000L, failureDelayMillis * 2L);
+            LOG.warn(
+                    "Link-Up dynamic registration failed, retryInMs={}",
+                    nextDelay,
+                    exception);
+        }
+        schedule(nextDelay);
+    }
+
+    private void register() {
+        ObjectNode payload = runtimePayload();
+        payload.put("protocolVersion", PROTOCOL_VERSION);
+        ObjectNode labels = payload.putObject("labels");
+        for (Map.Entry<String, String> entry : config.getLabels().entrySet()) {
+            labels.put(entry.getKey(), entry.getValue());
+        }
+        JsonNode data = post(
+                "/api/v1/offline/worker-registration/register",
+                write(payload));
+        acceptLease(data);
+        LOG.info(
+                "Link-Up Worker dynamically registered, nodeId={}, instanceId={}, heartbeatMs={}",
+                payload.path("nodeId").asText(),
+                registeredInstanceId,
+                heartbeatMillis);
+    }
+
+    private void heartbeat() {
+        WorkerNodeResponse node = jobService.node();
+        if (!node.getInstanceId().equals(registeredInstanceId)) {
+            leaseId = null;
+            registeredInstanceId = null;
+            sequence = 0L;
+            register();
+            return;
+        }
+        ObjectNode payload = runtimePayload();
+        payload.put("protocolVersion", PROTOCOL_VERSION);
+        payload.put("leaseId", leaseId);
+        payload.put("sequence", ++sequence);
+        JsonNode data = post(
+                "/api/v1/offline/worker-registration/heartbeat",
+                write(payload));
+        acceptLease(data);
+    }
+
+    private ObjectNode runtimePayload() {
+        WorkerNodeResponse node = jobService.node();
+        ObjectNode payload = mapper.createObjectNode();
+        payload.put("nodeId", node.getNodeId());
+        payload.put("nodeName", node.getNodeName());
+        payload.put("instanceId", node.getInstanceId());
+        payload.put("baseUrl", config.getAdvertisedBaseUrl());
+        payload.put("engineVersion", node.getVersion());
+        payload.put("startedAtMillis", node.getStartedAtMillis());
+        payload.put("offlineOnly", node.isOfflineOnly());
+        payload.put("maxConcurrentJobs", node.getMaxConcurrentJobs());
+        payload.put("maxQueuedJobs", node.getMaxQueuedJobs());
+        payload.put("runningJobs", node.getRunningJobs());
+        payload.put("queuedJobs", node.getQueuedJobs());
+        ArrayNode connectors = payload.putArray("connectors");
+        for (ConnectorSchema schema : connectorCatalog.list()) {
+            ObjectNode connector = mapper.createObjectNode();
+            connector.put("connectorId", schema.getConnectorId());
+            connector.put("role", schema.getRole().name());
+            connector.put("schemaVersion", schema.getSchemaVersion());
+            connector.put("schemaFingerprint", schema.getSchemaFingerprint());
+            connector.put("implementationVersion", schema.getImplementationVersion());
+            ArrayNode capabilities = connector.putArray("capabilities");
+            for (ConnectorCapability capability : schema.getCapabilities()) {
+                capabilities.add(capability.name());
+            }
+            connectors.add(connector);
+        }
+        return payload;
+    }
+
+    private void acceptLease(JsonNode response) {
+        JsonNode data = response.has("data") ? response.path("data") : response;
+        String receivedLease = data.path("leaseId").asText(null);
+        String instanceId = data.path("instanceId").asText(null);
+        if (receivedLease == null || receivedLease.trim().isEmpty()) {
+            throw new ControlPlaneException(502, "Control plane response did not contain leaseId");
+        }
+        if (instanceId == null || instanceId.trim().isEmpty()) {
+            throw new ControlPlaneException(502, "Control plane response did not contain instanceId");
+        }
+        leaseId = receivedLease;
+        registeredInstanceId = instanceId;
+        long suggested = data.path("heartbeatIntervalMillis")
+                .asLong(config.getHeartbeatMillis());
+        heartbeatMillis = Math.max(5_000L, Math.min(60_000L, suggested));
+    }
+
+    private JsonNode post(String endpointPath, String body) {
+        HttpURLConnection connection = null;
+        try {
+            URL url = new URL(config.getControlPlaneUrl() + endpointPath);
+            connection = (HttpURLConnection) url.openConnection();
+            connection.setRequestMethod("POST");
+            connection.setConnectTimeout(config.getConnectTimeoutMillis());
+            connection.setReadTimeout(config.getRequestTimeoutMillis());
+            connection.setDoOutput(true);
+            connection.setRequestProperty("Content-Type", "application/json;charset=UTF-8");
+            connection.setRequestProperty("Accept", "application/json");
+
+            long timestamp = System.currentTimeMillis();
+            String nonce = UUID.randomUUID().toString().replace("-", "");
+            String signature = RegistrationRequestSigner.sign(
+                    "POST",
+                    url.getPath(),
+                    timestamp,
+                    nonce,
+                    body,
+                    config.getSecret());
+            connection.setRequestProperty(
+                    "X-Yak-Registration-Timestamp",
+                    String.valueOf(timestamp));
+            connection.setRequestProperty("X-Yak-Registration-Nonce", nonce);
+            connection.setRequestProperty("X-Yak-Registration-Signature", signature);
+
+            byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+            connection.setFixedLengthStreamingMode(bytes.length);
+            OutputStream output = connection.getOutputStream();
+            try {
+                output.write(bytes);
+            } finally {
+                output.close();
+            }
+
+            int status = connection.getResponseCode();
+            InputStream input = status >= 200 && status < 300
+                    ? connection.getInputStream()
+                    : connection.getErrorStream();
+            String response = input == null ? "" : read(input);
+            if (status < 200 || status >= 300) {
+                throw new ControlPlaneException(status, concise(response));
+            }
+            return response.isEmpty()
+                    ? mapper.createObjectNode()
+                    : mapper.readTree(response);
+        } catch (ControlPlaneException exception) {
+            throw exception;
+        } catch (Exception exception) {
+            throw new ControlPlaneException(0, exception.getMessage(), exception);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+    private String write(JsonNode payload) {
+        try {
+            return mapper.writeValueAsString(payload);
+        } catch (Exception exception) {
+            throw new IllegalStateException(
+                    "Could not serialize dynamic registration payload",
+                    exception);
+        }
+    }
+
+    private String read(InputStream input) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try {
+            byte[] buffer = new byte[4096];
+            int read;
+            while ((read = input.read(buffer)) >= 0) {
+                output.write(buffer, 0, read);
+            }
+            return new String(output.toByteArray(), StandardCharsets.UTF_8);
+        } finally {
+            input.close();
+        }
+    }
+
+    private String concise(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return "Control plane returned an empty error response";
+        }
+        String normalized = value.replaceAll(
+                "(?i)(password|passwd|pwd|secret)\\s*[=:]\\s*[^,;\\s\"}]+",
+                "$1=***");
+        return normalized.length() <= 1000
+                ? normalized
+                : normalized.substring(0, 1000);
+    }
+
+    private void schedule(long delayMillis) {
+        if (!closed.get()) {
+            scheduler.schedule(
+                    new Runnable() {
+                        public void run() {
+                            cycle();
+                        }
+                    },
+                    Math.max(0L, delayMillis),
+                    TimeUnit.MILLISECONDS);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (!started.get() || closed.get()) {
+            return;
+        }
+        try {
+            if (leaseId != null && registeredInstanceId != null) {
+                ObjectNode payload = mapper.createObjectNode();
+                WorkerNodeResponse node = jobService.node();
+                payload.put("protocolVersion", PROTOCOL_VERSION);
+                payload.put("leaseId", leaseId);
+                payload.put("nodeId", node.getNodeId());
+                payload.put("instanceId", registeredInstanceId);
+                payload.put("sequence", ++sequence);
+                post(
+                        "/api/v1/offline/worker-registration/deregister",
+                        write(payload));
+            }
+        } catch (RuntimeException exception) {
+            LOG.warn("Could not deregister Link-Up Worker during shutdown", exception);
+        } finally {
+            closed.set(true);
+            scheduler.shutdownNow();
+        }
+    }
+
+    static final class ControlPlaneException extends RuntimeException {
+        private final int statusCode;
+
+        ControlPlaneException(int statusCode, String message) {
+            super(message == null ? "Control plane request failed" : message);
+            this.statusCode = statusCode;
+        }
+
+        ControlPlaneException(int statusCode, String message, Throwable cause) {
+            super(message == null ? "Control plane request failed" : message, cause);
+            this.statusCode = statusCode;
+        }
+
+        int getStatusCode() {
+            return statusCode;
+        }
+
+        boolean requiresRegistration() {
+            return statusCode == 401 || statusCode == 404 || statusCode == 409;
+        }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationAgent.java
+++ b/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationAgent.java
@@ -26,15 +26,12 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * Link-Up Worker 主动注册 Yak Ops、续租并在优雅关闭时注销。
- */
+/** Link-Up Worker 主动注册 Yak Ops、续租并在优雅关闭时注销。 */
 public final class ControlPlaneRegistrationAgent
         implements AutoCloseable {
 
     private static final Logger LOG =
             LogManager.getLogger(ControlPlaneRegistrationAgent.class);
-
     private static final String PROTOCOL_VERSION =
             "link-up-registration/v1";
 
@@ -100,7 +97,7 @@ public final class ControlPlaneRegistrationAgent
             if (exception.requiresRegistration()) {
                 leaseId = null;
                 registeredInstanceId = null;
-                sequence = 0L;
+                // 保留已知序列；控制面复用旧租约时可以继续递增，创建新租约时高序列也合法。
             }
             nextDelay = failureDelayMillis;
             failureDelayMillis = Math.min(60_000L, failureDelayMillis * 2L);
@@ -143,7 +140,6 @@ public final class ControlPlaneRegistrationAgent
         if (!node.getInstanceId().equals(registeredInstanceId)) {
             leaseId = null;
             registeredInstanceId = null;
-            sequence = 0L;
             register();
             return;
         }
@@ -200,6 +196,7 @@ public final class ControlPlaneRegistrationAgent
         }
         leaseId = receivedLease;
         registeredInstanceId = instanceId;
+        sequence = Math.max(sequence, data.path("heartbeatSequence").asLong(0L));
         long suggested = data.path("heartbeatIntervalMillis")
                 .asLong(config.getHeartbeatMillis());
         heartbeatMillis = Math.max(5_000L, Math.min(60_000L, suggested));
@@ -220,12 +217,7 @@ public final class ControlPlaneRegistrationAgent
             long timestamp = System.currentTimeMillis();
             String nonce = UUID.randomUUID().toString().replace("-", "");
             String signature = RegistrationRequestSigner.sign(
-                    "POST",
-                    url.getPath(),
-                    timestamp,
-                    nonce,
-                    body,
-                    config.getSecret());
+                    "POST", url.getPath(), timestamp, nonce, body, config.getSecret());
             connection.setRequestProperty(
                     "X-Yak-Registration-Timestamp",
                     String.valueOf(timestamp));
@@ -314,11 +306,11 @@ public final class ControlPlaneRegistrationAgent
 
     @Override
     public void close() {
-        if (!started.get() || closed.get()) {
+        if (closed.getAndSet(true)) {
             return;
         }
         try {
-            if (leaseId != null && registeredInstanceId != null) {
+            if (started.get() && leaseId != null && registeredInstanceId != null) {
                 ObjectNode payload = mapper.createObjectNode();
                 WorkerNodeResponse node = jobService.node();
                 payload.put("protocolVersion", PROTOCOL_VERSION);
@@ -333,7 +325,6 @@ public final class ControlPlaneRegistrationAgent
         } catch (RuntimeException exception) {
             LOG.warn("Could not deregister Link-Up Worker during shutdown", exception);
         } finally {
-            closed.set(true);
             scheduler.shutdownNow();
         }
     }
@@ -351,9 +342,7 @@ public final class ControlPlaneRegistrationAgent
             this.statusCode = statusCode;
         }
 
-        int getStatusCode() {
-            return statusCode;
-        }
+        int getStatusCode() { return statusCode; }
 
         boolean requiresRegistration() {
             return statusCode == 401 || statusCode == 404 || statusCode == 409;

--- a/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationConfig.java
+++ b/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationConfig.java
@@ -31,9 +31,9 @@ public final class ControlPlaneRegistrationConfig {
             Map<String, String> labels) {
 
         this.enabled = enabled;
-        this.controlPlaneUrl = normalize(controlPlaneUrl);
-        this.secret = normalize(secret);
-        this.advertisedBaseUrl = normalize(advertisedBaseUrl);
+        this.controlPlaneUrl = normalizeUrl(controlPlaneUrl);
+        this.secret = normalizeText(secret);
+        this.advertisedBaseUrl = normalizeUrl(advertisedBaseUrl);
         this.heartbeatMillis = Math.max(5_000L, heartbeatMillis);
         this.connectTimeoutMillis = Math.max(1_000, connectTimeoutMillis);
         this.requestTimeoutMillis = Math.max(1_000, requestTimeoutMillis);
@@ -153,15 +153,20 @@ public final class ControlPlaneRegistrationConfig {
         }
     }
 
-    private static String normalize(String value) {
+    private static String normalizeText(String value) {
         if (value == null) {
             return null;
         }
         String normalized = value.trim();
-        if (normalized.endsWith("/")) {
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static String normalizeUrl(String value) {
+        String normalized = normalizeText(value);
+        while (normalized != null && normalized.endsWith("/")) {
             normalized = normalized.substring(0, normalized.length() - 1);
         }
-        return normalized.isEmpty() ? null : normalized;
+        return normalized;
     }
 
     public boolean isEnabled() { return enabled; }

--- a/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationConfig.java
+++ b/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationConfig.java
@@ -1,0 +1,175 @@
+package com.link.up.server.registration;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Worker 主动注册控制面配置。
+ *
+ * <p>优先读取 JVM 参数，其次读取环境变量。默认关闭，避免未配置密钥时暴露注册行为。
+ */
+public final class ControlPlaneRegistrationConfig {
+
+    private final boolean enabled;
+    private final String controlPlaneUrl;
+    private final String secret;
+    private final String advertisedBaseUrl;
+    private final long heartbeatMillis;
+    private final int connectTimeoutMillis;
+    private final int requestTimeoutMillis;
+    private final Map<String, String> labels;
+
+    private ControlPlaneRegistrationConfig(
+            boolean enabled,
+            String controlPlaneUrl,
+            String secret,
+            String advertisedBaseUrl,
+            long heartbeatMillis,
+            int connectTimeoutMillis,
+            int requestTimeoutMillis,
+            Map<String, String> labels) {
+
+        this.enabled = enabled;
+        this.controlPlaneUrl = normalize(controlPlaneUrl);
+        this.secret = normalize(secret);
+        this.advertisedBaseUrl = normalize(advertisedBaseUrl);
+        this.heartbeatMillis = Math.max(5_000L, heartbeatMillis);
+        this.connectTimeoutMillis = Math.max(1_000, connectTimeoutMillis);
+        this.requestTimeoutMillis = Math.max(1_000, requestTimeoutMillis);
+        this.labels = Collections.unmodifiableMap(
+                new LinkedHashMap<String, String>(labels));
+
+        if (enabled) {
+            requireUrl(this.controlPlaneUrl, "controlPlaneUrl");
+            requireUrl(this.advertisedBaseUrl, "advertisedBaseUrl");
+            if (this.secret == null || this.secret.length() < 16) {
+                throw new IllegalArgumentException(
+                        "registration secret must contain at least 16 characters");
+            }
+        }
+    }
+
+    public static ControlPlaneRegistrationConfig load() {
+        boolean enabled = booleanValue(
+                value("link.up.registration.enabled", "LINK_UP_REGISTRATION_ENABLED"),
+                false);
+        String controlPlaneUrl = value(
+                "link.up.registration.control-plane-url",
+                "LINK_UP_CONTROL_PLANE_URL");
+        String secret = value(
+                "link.up.registration.secret",
+                "LINK_UP_REGISTRATION_SECRET");
+        String advertisedBaseUrl = value(
+                "link.up.registration.advertised-base-url",
+                "LINK_UP_ADVERTISED_BASE_URL");
+        long heartbeatMillis = longValue(
+                value("link.up.registration.heartbeat-millis",
+                        "LINK_UP_REGISTRATION_HEARTBEAT_MILLIS"),
+                20_000L);
+        int connectTimeoutMillis = intValue(
+                value("link.up.registration.connect-timeout-millis",
+                        "LINK_UP_REGISTRATION_CONNECT_TIMEOUT_MILLIS"),
+                5_000);
+        int requestTimeoutMillis = intValue(
+                value("link.up.registration.request-timeout-millis",
+                        "LINK_UP_REGISTRATION_REQUEST_TIMEOUT_MILLIS"),
+                10_000);
+        Map<String, String> labels = labels(value(
+                "link.up.registration.labels",
+                "LINK_UP_REGISTRATION_LABELS"));
+        return new ControlPlaneRegistrationConfig(
+                enabled,
+                controlPlaneUrl,
+                secret,
+                advertisedBaseUrl,
+                heartbeatMillis,
+                connectTimeoutMillis,
+                requestTimeoutMillis,
+                labels);
+    }
+
+    private static String value(String property, String environment) {
+        String value = System.getProperty(property);
+        if (value == null || value.trim().isEmpty()) {
+            value = System.getenv(environment);
+        }
+        return value;
+    }
+
+    private static Map<String, String> labels(String value) {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        if (value == null || value.trim().isEmpty()) {
+            return result;
+        }
+        String[] entries = value.split(",");
+        for (String entry : entries) {
+            int separator = entry.indexOf('=');
+            if (separator <= 0) {
+                throw new IllegalArgumentException(
+                        "registration labels must use key=value syntax: " + entry);
+            }
+            String key = entry.substring(0, separator).trim();
+            String itemValue = entry.substring(separator + 1).trim();
+            if (key.isEmpty()) {
+                throw new IllegalArgumentException("registration label key must not be blank");
+            }
+            result.put(key, itemValue);
+        }
+        return result;
+    }
+
+    private static void requireUrl(String value, String name) {
+        if (value == null
+                || (!value.startsWith("http://") && !value.startsWith("https://"))) {
+            throw new IllegalArgumentException(
+                    name + " must start with http:// or https://");
+        }
+    }
+
+    private static boolean booleanValue(String value, boolean fallback) {
+        return value == null || value.trim().isEmpty()
+                ? fallback
+                : Boolean.parseBoolean(value.trim());
+    }
+
+    private static long longValue(String value, long fallback) {
+        try {
+            return value == null || value.trim().isEmpty()
+                    ? fallback
+                    : Long.parseLong(value.trim());
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException("registration long value is invalid: " + value);
+        }
+    }
+
+    private static int intValue(String value, int fallback) {
+        try {
+            return value == null || value.trim().isEmpty()
+                    ? fallback
+                    : Integer.parseInt(value.trim());
+        } catch (NumberFormatException exception) {
+            throw new IllegalArgumentException("registration integer value is invalid: " + value);
+        }
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        if (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    public boolean isEnabled() { return enabled; }
+    public String getControlPlaneUrl() { return controlPlaneUrl; }
+    public String getSecret() { return secret; }
+    public String getAdvertisedBaseUrl() { return advertisedBaseUrl; }
+    public long getHeartbeatMillis() { return heartbeatMillis; }
+    public int getConnectTimeoutMillis() { return connectTimeoutMillis; }
+    public int getRequestTimeoutMillis() { return requestTimeoutMillis; }
+    public Map<String, String> getLabels() { return labels; }
+}

--- a/link-up-server/src/main/java/com/link/up/server/registration/RegistrationRequestSigner.java
+++ b/link-up-server/src/main/java/com/link/up/server/registration/RegistrationRequestSigner.java
@@ -1,0 +1,52 @@
+package com.link.up.server.registration;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+/** HMAC-SHA256 registration request signer shared by register, heartbeat and deregister calls. */
+public final class RegistrationRequestSigner {
+
+    private RegistrationRequestSigner() {
+    }
+
+    public static String sign(
+            String method,
+            String path,
+            long timestamp,
+            String nonce,
+            String body,
+            String secret) {
+
+        String payload = body == null ? "" : body;
+        String canonical = method.toUpperCase()
+                + "\n" + path
+                + "\n" + timestamp
+                + "\n" + nonce
+                + "\n" + sha256(payload);
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(
+                    secret.getBytes(StandardCharsets.UTF_8),
+                    "HmacSHA256"));
+            return HexFormat.of().formatHex(
+                    mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception exception) {
+            throw new IllegalStateException(
+                    "Could not sign control-plane registration request",
+                    exception);
+        }
+    }
+
+    public static String sha256(String value) {
+        try {
+            return HexFormat.of().formatHex(
+                    MessageDigest.getInstance("SHA-256")
+                            .digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception exception) {
+            throw new IllegalStateException("Could not calculate SHA-256", exception);
+        }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/registration/RegistrationRequestSigner.java
+++ b/link-up-server/src/main/java/com/link/up/server/registration/RegistrationRequestSigner.java
@@ -2,12 +2,13 @@ package com.link.up.server.registration;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.util.HexFormat;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 /** HMAC-SHA256 registration request signer shared by register, heartbeat and deregister calls. */
 public final class RegistrationRequestSigner {
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
 
     private RegistrationRequestSigner() {
     }
@@ -31,8 +32,7 @@ public final class RegistrationRequestSigner {
             mac.init(new SecretKeySpec(
                     secret.getBytes(StandardCharsets.UTF_8),
                     "HmacSHA256"));
-            return HexFormat.of().formatHex(
-                    mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8)));
+            return hex(mac.doFinal(canonical.getBytes(StandardCharsets.UTF_8)));
         } catch (Exception exception) {
             throw new IllegalStateException(
                     "Could not sign control-plane registration request",
@@ -42,11 +42,20 @@ public final class RegistrationRequestSigner {
 
     public static String sha256(String value) {
         try {
-            return HexFormat.of().formatHex(
-                    MessageDigest.getInstance("SHA-256")
-                            .digest(value.getBytes(StandardCharsets.UTF_8)));
+            return hex(MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8)));
         } catch (Exception exception) {
             throw new IllegalStateException("Could not calculate SHA-256", exception);
         }
+    }
+
+    private static String hex(byte[] bytes) {
+        char[] result = new char[bytes.length * 2];
+        for (int index = 0; index < bytes.length; index++) {
+            int value = bytes[index] & 0xff;
+            result[index * 2] = HEX[value >>> 4];
+            result[index * 2 + 1] = HEX[value & 0x0f];
+        }
+        return new String(result);
     }
 }

--- a/link-up-server/src/test/java/com/link/up/server/registration/ControlPlaneRegistrationConfigTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/registration/ControlPlaneRegistrationConfigTest.java
@@ -1,0 +1,43 @@
+package com.link.up.server.registration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ControlPlaneRegistrationConfigTest {
+
+    @Test
+    public void shouldLoadPropertiesAndPreserveSecretSuffix() {
+        set("link.up.registration.enabled", "true");
+        set("link.up.registration.control-plane-url", "http://yak-ops:8080/");
+        set("link.up.registration.secret", "0123456789abcdef/");
+        set("link.up.registration.advertised-base-url", "http://worker-a:18080/");
+        set("link.up.registration.labels", "region=south,zone=az-1");
+        try {
+            ControlPlaneRegistrationConfig config =
+                    ControlPlaneRegistrationConfig.load();
+
+            assertTrue(config.isEnabled());
+            assertEquals("http://yak-ops:8080", config.getControlPlaneUrl());
+            assertEquals("http://worker-a:18080", config.getAdvertisedBaseUrl());
+            assertEquals("0123456789abcdef/", config.getSecret());
+            assertEquals("south", config.getLabels().get("region"));
+            assertEquals("az-1", config.getLabels().get("zone"));
+        } finally {
+            clear("link.up.registration.enabled");
+            clear("link.up.registration.control-plane-url");
+            clear("link.up.registration.secret");
+            clear("link.up.registration.advertised-base-url");
+            clear("link.up.registration.labels");
+        }
+    }
+
+    private void set(String name, String value) {
+        System.setProperty(name, value);
+    }
+
+    private void clear(String name) {
+        System.clearProperty(name);
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/registration/RegistrationRequestSignerTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/registration/RegistrationRequestSignerTest.java
@@ -1,0 +1,23 @@
+package com.link.up.server.registration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class RegistrationRequestSignerTest {
+
+    @Test
+    public void shouldProduceStableHmacSignature() {
+        String signature = RegistrationRequestSigner.sign(
+                "POST",
+                "/api/v1/offline/worker-registration/register",
+                1785700000123L,
+                "1234567890abcdef1234567890abcdef",
+                "{\"nodeId\":\"worker-a\"}",
+                "0123456789abcdef/");
+
+        assertEquals(
+                "3a82a2ca22da29a61be4df9184039be15e7b4ad10c43f50acc50d72bd79cbb23",
+                signature);
+    }
+}


### PR DESCRIPTION
## 背景

前三阶段已经完成 Worker 管理、多 Worker 调度、Connector 能力调度和 Worker 视角可达性预检。本 PR 完成第四阶段 Worker 侧 **动态注册代理**：Link-Up HTTP 服务启动后可以主动登记到 Yak Ops，持续续租，并在优雅关闭时注销。

## 注册协议

Worker 调用：

```http
POST /api/v1/offline/worker-registration/register
POST /api/v1/offline/worker-registration/heartbeat
POST /api/v1/offline/worker-registration/deregister
```

每个请求携带：

```text
X-Yak-Registration-Timestamp
X-Yak-Registration-Nonce
X-Yak-Registration-Signature
```

HMAC-SHA256 原文：

```text
HTTP_METHOD\nREQUEST_URI\nTIMESTAMP_MILLIS\nNONCE\nSHA256(RAW_JSON_BODY)
```

## Worker 上报内容

- nodeId、nodeName、instanceId
- advertised base URL
- 引擎版本和启动时间
- 最大并发、最大队列、运行数和排队数
- Connector、SOURCE/SINK 角色、Schema 版本/指纹、实现版本和能力集合
- 首次注册标签

## 生命周期

- HTTP 服务成功监听后启动注册代理
- 控制面返回 leaseId 和建议心跳间隔
- 代理按建议间隔续租
- 网络失败采用 1 秒起步、最大 60 秒的指数退避
- `401 / 404 / 409` 会清除旧 leaseId 并重新注册
- 心跳序列在不确定网络恢复时不会回退
- Worker 关闭时先注销租约，再停止 HTTP、任务运行时和 Connector ClassLoader
- 无法优雅注销时由 Yak Ops 租约超时兜底

## 配置

动态注册默认关闭：

```bash
export LINK_UP_REGISTRATION_ENABLED=true
export LINK_UP_CONTROL_PLANE_URL='https://yak-ops.example.com'
export LINK_UP_REGISTRATION_SECRET='replace-with-at-least-16-random-characters'
export LINK_UP_ADVERTISED_BASE_URL='http://link-up-worker-01:18080'
export LINK_UP_REGISTRATION_HEARTBEAT_MILLIS=20000
export LINK_UP_REGISTRATION_LABELS='region=south,zone=az-1'
```

也支持同名 `link.up.registration.*` JVM 参数。

## 安全

- 默认关闭，只有显式启用才发送注册请求
- 共享密钥至少 16 个字符，建议使用 32 字节以上随机值
- 密钥尾部字符原样参与签名，不会按 URL 规则裁剪
- 错误响应日志会脱敏 password、pwd 和 secret
- 推荐生产环境同时使用 HTTPS

## 测试

新增：

- 固定 HMAC 测试向量
- 环境/JVM 配置加载测试
- URL 尾部斜杠标准化
- 密钥尾部斜杠保留测试

## 依赖

需要配套 Yak Ops 动态注册控制面 PR。部署顺序应先升级 Yak Ops，再滚动升级 Link-Up Worker。

## 当前验证边界

当前执行环境无法解析 `github.com`，因此未能克隆仓库执行完整 Maven Reactor。已完成 Java 8 API、启动/关闭顺序、签名原文、配置映射和协议字段的源码级审查；PR 保持 Draft，待 CI 和真实控制面联调通过后转 Ready。