### PR TITLE
fix(jdbc): reconcile normalized prepared table metadata

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceSplitGenerator.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceSplitGenerator.java
@@ -41,15 +41,9 @@ final class JdbcSourceSplitGenerator {
 
         JdbcDialect dialect = JdbcDialectLoader.load(config.getConnectionConfig());
         Map<TablePath, JdbcSourceTable> sourceTables =
-                JdbcCatalogUtils.getTables(config, dialect);
-
-        for (JdbcSourceTable sourceTable : sourceTables.values()) {
-            if (!tables.containsKey(sourceTable.getTablePath())) {
-                throw new IllegalArgumentException(
-                        "No prepared table metadata for "
-                                + sourceTable.getTablePath());
-            }
-        }
+                reconcilePreparedTables(
+                        JdbcCatalogUtils.getTables(config, dialect),
+                        tables);
 
         Map<TablePath, JdbcSourceTable> plannedTables = new LinkedHashMap<TablePath, JdbcSourceTable>();
         JdbcSplitStatisticsProvider statisticsProvider = new JdbcSplitStatisticsProvider(config.getConnectionConfig(), dialect);
@@ -89,5 +83,79 @@ final class JdbcSourceSplitGenerator {
         }
         plannedTables.values().removeIf(java.util.Objects::isNull);
         return new JdbcSourceSplitEnumerator(config, plannedTables, parallelism).enumerateSplits();
+    }
+
+    /**
+     * Reconciles the connector's second metadata discovery with the metadata
+     * already prepared by the framework.
+     *
+     * <p>A JDBC catalog may normalize an unqualified configured path such as
+     * {@code sink_user_info} to {@code test1.sink_user_info}. The discovered
+     * {@link JdbcSourceTable} historically retained the unqualified path while
+     * its {@link CatalogTable} contained the normalized path. Using the former
+     * as the data-set identity made split planning fail with
+     * {@code No prepared table metadata} even though preparation and sink DDL
+     * had succeeded.</p>
+     */
+    static Map<TablePath, JdbcSourceTable> reconcilePreparedTables(
+            Map<TablePath, JdbcSourceTable> discoveredTables,
+            Map<TablePath, CatalogTable> preparedTables) {
+
+        Objects.requireNonNull(discoveredTables, "discoveredTables must not be null");
+        Objects.requireNonNull(preparedTables, "preparedTables must not be null");
+
+        Map<TablePath, JdbcSourceTable> result =
+                new LinkedHashMap<TablePath, JdbcSourceTable>();
+
+        for (JdbcSourceTable discoveredTable : discoveredTables.values()) {
+            if (discoveredTable == null) {
+                throw new IllegalArgumentException("discoveredTables must not contain null values");
+            }
+
+            CatalogTable discoveredCatalogTable =
+                    Objects.requireNonNull(
+                            discoveredTable.getCatalogTable(),
+                            "discovered CatalogTable must not be null");
+
+            TablePath normalizedPath =
+                    Objects.requireNonNull(
+                            discoveredCatalogTable.getTablePath(),
+                            "discovered CatalogTable path must not be null");
+
+            CatalogTable preparedCatalogTable =
+                    preparedTables.get(normalizedPath);
+
+            if (preparedCatalogTable == null) {
+                throw new IllegalArgumentException(
+                        "No prepared table metadata for "
+                                + normalizedPath
+                                + ", preparedTables="
+                                + preparedTables.keySet());
+            }
+
+            JdbcSourceTable normalizedTable =
+                    JdbcSourceTable.builder()
+                            .tablePath(normalizedPath)
+                            .query(discoveredTable.getQuery())
+                            .partitionColumn(discoveredTable.getPartitionColumn())
+                            .partitionNumber(discoveredTable.getPartitionNumber())
+                            .partitionStart(discoveredTable.getPartitionStart())
+                            .partitionEnd(discoveredTable.getPartitionEnd())
+                            .useSelectCount(discoveredTable.getUseSelectCount())
+                            .skipAnalyze(discoveredTable.getSkipAnalyze())
+                            .catalogTable(preparedCatalogTable)
+                            .build();
+
+            JdbcSourceTable previous =
+                    result.put(normalizedPath, normalizedTable);
+
+            if (previous != null) {
+                throw new IllegalArgumentException(
+                        "Duplicated normalized source table path: "
+                                + normalizedPath);
+            }
+        }
+
+        return result;
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/source/JdbcSourceSplitGeneratorTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/source/JdbcSourceSplitGeneratorTest.java
@@ -1,0 +1,83 @@
+package com.link.up.connector.jdbc.source;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcSourceSplitGeneratorTest {
+
+    @Test
+    public void reconcilesUnqualifiedPathWithPreparedCatalogMetadata() {
+        TablePath configuredPath =
+                TablePath.of("sink_user_info");
+        TablePath normalizedPath =
+                TablePath.of("test1", "sink_user_info");
+
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(
+                                Column.builder(
+                                                "id",
+                                                BasicType.LONG_TYPE)
+                                        .nullable(false)
+                                        .build())
+                        .build();
+
+        CatalogTable discoveredCatalogTable =
+                CatalogTable.builder(
+                                normalizedPath,
+                                schema)
+                        .comment("second discovery")
+                        .build();
+
+        CatalogTable preparedCatalogTable =
+                CatalogTable.builder(
+                                normalizedPath,
+                                schema)
+                        .comment("prepared metadata")
+                        .build();
+
+        JdbcSourceTable discoveredTable =
+                JdbcSourceTable.builder()
+                        .tablePath(configuredPath)
+                        .catalogTable(discoveredCatalogTable)
+                        .build();
+
+        Map<TablePath, JdbcSourceTable> discoveredTables =
+                new LinkedHashMap<TablePath, JdbcSourceTable>();
+        discoveredTables.put(
+                configuredPath,
+                discoveredTable);
+
+        Map<TablePath, CatalogTable> preparedTables =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        preparedTables.put(
+                normalizedPath,
+                preparedCatalogTable);
+
+        Map<TablePath, JdbcSourceTable> result =
+                JdbcSourceSplitGenerator.reconcilePreparedTables(
+                        discoveredTables,
+                        preparedTables);
+
+        assertFalse(result.containsKey(configuredPath));
+        assertTrue(result.containsKey(normalizedPath));
+        assertEquals(
+                normalizedPath,
+                result.get(normalizedPath).getTablePath());
+        assertSame(
+                preparedCatalogTable,
+                result.get(normalizedPath).getCatalogTable());
+    }
+}


### PR DESCRIPTION
## 背景

Yak Ops 提交 MySQL 单表同步任务时，可以只配置未限定表名，例如：

```text
source.table_path = sink_user_info
source.url = jdbc:mysql://127.0.0.1:3306/test1
```

JDBC Catalog 会把该表规范化为 `test1.sink_user_info`。准备阶段保存的 `CatalogTable` 因此使用完整路径，但 Split 生成阶段第二次发现得到的 `JdbcSourceTable` 仍保留原始的 `sink_user_info`。

这会导致任务在目标表已经创建后、真正读取和写入前失败：

```text
No prepared table metadata for sink_user_info
```

## 根因

Split 生成阶段使用第二次发现结果中的未限定 `JdbcSourceTable.tablePath` 去查询准备阶段以完整 `CatalogTable.tablePath` 为键的元数据 Map。

同一张表出现了两种数据集标识：

```text
sink_user_info

test1.sink_user_info
```

因此 `Map.containsKey` 校验失败，Reader 和 Sink Writer 都不会启动。

## 修改

- 在生成 JDBC Split 前，将第二次发现的表与准备阶段元数据进行对齐；
- 使用 `CatalogTable.tablePath` 作为规范化后的数据集标识；
- 复用准备阶段的 `CatalogTable`，避免 Split、Pipeline 和 Sink 路由使用不同元数据对象；
- 保留 query、分片边界及其他表级配置；
- 在无法找到准备元数据时输出已准备表集合，改善诊断信息；
- 增加回归测试，覆盖 `sink_user_info` 被 Catalog 规范化为 `test1.sink_user_info` 的场景。

## 影响

修复后，以下流程可以继续进入 Source Reader 和 JDBC Sink Writer：

```text
加载来源元数据
  -> 自动创建目标表
  -> 生成 Source Split
  -> 读取来源数据
  -> 写入目标表
```

显式配置完整表路径的任务行为不变，多表任务也继续按规范化后的表路径建立独立 Pipeline。

## 验证

- 增加 `JdbcSourceSplitGeneratorTest#reconcilesUnqualifiedPathWithPreparedCatalogMetadata`；
- 分支基于当前 `main`，仅修改 JDBC Source Split 生成器并增加对应测试；
- 当前仓库没有与该提交关联的 GitHub Actions workflow，完整 Maven 测试仍需在本地或后续 CI 环境执行。
