### PR TITLE
fix(server): recover control-plane registration after restart

### DIFF
--- a/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationAgent.java
+++ b/link-up-server/src/main/java/com/link/up/server/registration/ControlPlaneRegistrationAgent.java
@@ -34,6 +34,9 @@ public final class ControlPlaneRegistrationAgent
             LogManager.getLogger(ControlPlaneRegistrationAgent.class);
     private static final String PROTOCOL_VERSION =
             "link-up-registration/v1";
+    private static final long INITIAL_FAILURE_DELAY_MILLIS = 1_000L;
+    private static final long RESTART_CONFLICT_RETRY_MILLIS = 5_000L;
+    private static final long MAX_FAILURE_DELAY_MILLIS = 60_000L;
 
     private final ControlPlaneRegistrationConfig config;
     private final JobRestService jobService;
@@ -47,7 +50,7 @@ public final class ControlPlaneRegistrationAgent
     private volatile String registeredInstanceId;
     private volatile long sequence;
     private volatile long heartbeatMillis;
-    private volatile long failureDelayMillis = 1_000L;
+    private volatile long failureDelayMillis = INITIAL_FAILURE_DELAY_MILLIS;
 
     public ControlPlaneRegistrationAgent(
             ControlPlaneRegistrationConfig config,
@@ -91,7 +94,7 @@ public final class ControlPlaneRegistrationAgent
             } else {
                 heartbeat();
             }
-            failureDelayMillis = 1_000L;
+            failureDelayMillis = INITIAL_FAILURE_DELAY_MILLIS;
             nextDelay = heartbeatMillis;
         } catch (ControlPlaneException exception) {
             if (exception.requiresRegistration()) {
@@ -99,8 +102,17 @@ public final class ControlPlaneRegistrationAgent
                 registeredInstanceId = null;
                 // 保留已知序列；控制面复用旧租约时可以继续递增，创建新租约时高序列也合法。
             }
-            nextDelay = failureDelayMillis;
-            failureDelayMillis = Math.min(60_000L, failureDelayMillis * 2L);
+            nextDelay = retryDelayForStatus(
+                    exception.getStatusCode(),
+                    failureDelayMillis);
+            if (exception.isRegistrationConflict()) {
+                // 重启时旧租约可能尚未过期。固定短周期重试，避免指数退避把恢复再拖延一分钟。
+                failureDelayMillis = INITIAL_FAILURE_DELAY_MILLIS;
+            } else {
+                failureDelayMillis = Math.min(
+                        MAX_FAILURE_DELAY_MILLIS,
+                        failureDelayMillis * 2L);
+            }
             LOG.warn(
                     "Link-Up dynamic registration failed, status={}, retryInMs={}, message={}",
                     exception.getStatusCode(),
@@ -108,13 +120,22 @@ public final class ControlPlaneRegistrationAgent
                     exception.getMessage());
         } catch (RuntimeException exception) {
             nextDelay = failureDelayMillis;
-            failureDelayMillis = Math.min(60_000L, failureDelayMillis * 2L);
+            failureDelayMillis = Math.min(
+                    MAX_FAILURE_DELAY_MILLIS,
+                    failureDelayMillis * 2L);
             LOG.warn(
                     "Link-Up dynamic registration failed, retryInMs={}",
                     nextDelay,
                     exception);
         }
         schedule(nextDelay);
+    }
+
+    static long retryDelayForStatus(int statusCode, long currentFailureDelayMillis) {
+        if (statusCode == 409) {
+            return RESTART_CONFLICT_RETRY_MILLIS;
+        }
+        return Math.max(INITIAL_FAILURE_DELAY_MILLIS, currentFailureDelayMillis);
     }
 
     private void register() {
@@ -346,6 +367,10 @@ public final class ControlPlaneRegistrationAgent
 
         boolean requiresRegistration() {
             return statusCode == 401 || statusCode == 404 || statusCode == 409;
+        }
+
+        boolean isRegistrationConflict() {
+            return statusCode == 409;
         }
     }
 }

--- a/link-up-server/src/test/java/com/link/up/server/registration/ControlPlaneRegistrationAgentRetryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/registration/ControlPlaneRegistrationAgentRetryTest.java
@@ -1,0 +1,37 @@
+package com.link.up.server.registration;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ControlPlaneRegistrationAgentRetryTest {
+
+    @Test
+    public void shouldRetryRegistrationConflictsWithoutExponentialBackoff() {
+        assertEquals(
+                5_000L,
+                ControlPlaneRegistrationAgent.retryDelayForStatus(409, 32_000L));
+        assertEquals(
+                32_000L,
+                ControlPlaneRegistrationAgent.retryDelayForStatus(500, 32_000L));
+    }
+
+    @Test
+    public void shouldClassifyRestartConflictAsRegistrationRequired() {
+        ControlPlaneRegistrationAgent.ControlPlaneException conflict =
+                new ControlPlaneRegistrationAgent.ControlPlaneException(
+                        409,
+                        "old lease is still active");
+        ControlPlaneRegistrationAgent.ControlPlaneException serverError =
+                new ControlPlaneRegistrationAgent.ControlPlaneException(
+                        500,
+                        "server error");
+
+        assertTrue(conflict.requiresRegistration());
+        assertTrue(conflict.isRegistrationConflict());
+        assertFalse(serverError.requiresRegistration());
+        assertFalse(serverError.isRegistrationConflict());
+    }
+}


### PR DESCRIPTION
## 背景

Link-Up Worker 重启后会保留稳定 `nodeId`，但生成新的 `instanceId`。在旧 Yak Ops 租约尚未过期或控制面尚未完成实例接管时，注册接口可能短暂返回 `409 Conflict`。

原实现对 409 也采用指数退避，重试间隔可能增长到 60 秒，导致租约已经可接管后仍需继续等待。

## 修改内容

- 将注册冲突单独识别为重启接管等待状态。
- `409 Conflict` 使用固定 5 秒重试，不再进入指数退避。
- 401、404、409 仍会清空本地租约并重新走注册流程。
- 其他网络和服务端错误继续使用原有指数退避。
- 新增重试策略和错误分类单元测试。

## 用户影响

配合 Yak Ops PR #177，同节点重启通常会在首次注册时直接完成接管；即使连接的是尚未升级的 Yak Ops，也会以稳定短周期重试，在旧租约过期后尽快恢复注册和任务调度。

## 验证

- 新增 `ControlPlaneRegistrationAgentRetryTest`。
- PR CI 将继续验证 `link-up-server` 编译和测试。

## 关联 PR

- weifuwan/yak-ops#177