### PR TITLE
fix: resolve MySQL sink database and routed job logs

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/mysql/MySqlDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/mysql/MySqlDialect.java
@@ -115,8 +115,13 @@ public final class MySqlDialect
         }
 
         if (!JdbcDialect.hasText(database)) {
+            database = databaseFromUrl(
+                    connectionConfig.getUrl());
+        }
+
+        if (!JdbcDialect.hasText(database)) {
             throw new IllegalArgumentException(
-                    "MySQL 表路径缺少 database："
+                    "MySQL 表路径缺少 database，且 JDBC URL 未指定默认数据库："
                             + tablePath);
         }
 
@@ -124,6 +129,65 @@ public final class MySqlDialect
                 + "."
                 + quoteIdentifier(
                 tablePath.getTableName());
+    }
+
+    private static String databaseFromUrl(
+            String url) {
+
+        if (!JdbcDialect.hasText(url)) {
+            return null;
+        }
+
+        String normalized = url.trim();
+        int protocolSeparator =
+                normalized.indexOf("://");
+
+        if (protocolSeparator < 0) {
+            return null;
+        }
+
+        int databaseStart =
+                normalized.indexOf(
+                        '/',
+                        protocolSeparator + 3);
+
+        if (databaseStart < 0
+                || databaseStart
+                == normalized.length() - 1) {
+            return null;
+        }
+
+        int databaseEnd =
+                normalized.length();
+
+        int queryStart =
+                normalized.indexOf(
+                        '?',
+                        databaseStart + 1);
+
+        if (queryStart >= 0) {
+            databaseEnd = queryStart;
+        }
+
+        int fragmentStart =
+                normalized.indexOf(
+                        '#',
+                        databaseStart + 1);
+
+        if (fragmentStart >= 0
+                && fragmentStart < databaseEnd) {
+            databaseEnd = fragmentStart;
+        }
+
+        String database =
+                normalized.substring(
+                        databaseStart + 1,
+                        databaseEnd)
+                        .trim();
+
+        return JdbcDialect.hasText(database)
+                ? database
+                : null;
     }
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/mysql/MySqlDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/mysql/MySqlDialectTest.java
@@ -1,0 +1,89 @@
+package com.link.up.connector.jdbc.core.dialect.mysql;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class MySqlDialectTest {
+
+    @Test
+    public void usesDatabaseFromJdbcUrlForUnqualifiedTable() {
+        MySqlDialect dialect =
+                dialect(
+                        "jdbc:mysql://127.0.0.1:3306/test1?useSSL=false",
+                        null);
+
+        assertEquals(
+                "`test1`.`test1234`",
+                dialect.tableIdentifier(
+                        TablePath.of("test1234")));
+    }
+
+    @Test
+    public void explicitTableDatabaseTakesPrecedence() {
+        MySqlDialect dialect =
+                dialect(
+                        "jdbc:mysql://127.0.0.1:3306/test1",
+                        null);
+
+        assertEquals(
+                "`archive`.`test1234`",
+                dialect.tableIdentifier(
+                        TablePath.of(
+                                "archive",
+                                "test1234")));
+    }
+
+    @Test
+    public void configuredSchemaTakesPrecedenceOverJdbcUrl() {
+        MySqlDialect dialect =
+                dialect(
+                        "jdbc:mysql://127.0.0.1:3306/test1",
+                        "configured_db");
+
+        assertEquals(
+                "`configured_db`.`test1234`",
+                dialect.tableIdentifier(
+                        TablePath.of("test1234")));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsUnqualifiedTableWithoutDefaultDatabase() {
+        MySqlDialect dialect =
+                dialect(
+                        "jdbc:mysql://127.0.0.1:3306",
+                        null);
+
+        dialect.tableIdentifier(
+                TablePath.of("test1234"));
+    }
+
+    private static MySqlDialect dialect(
+            String url,
+            String schema) {
+
+        Map<String, Object> values =
+                new LinkedHashMap<String, Object>();
+
+        values.put("url", url);
+        values.put(
+                "driver",
+                "com.mysql.cj.jdbc.Driver");
+
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+
+        JdbcConnectionConfig config =
+                JdbcConnectionConfig.of(
+                        ReadonlyConfig.fromMap(values));
+
+        return new MySqlDialect(config);
+    }
+}

--- a/link-up-dist/src/main/dist/config/log4j2.xml
+++ b/link-up-dist/src/main/dist/config/log4j2.xml
@@ -29,9 +29,9 @@
             <Routes pattern="$${ctx:jobLogFile:-__NO_JOB__}">
                 <Route key="__NO_JOB__" ref="NoJobFile"/>
                 <Route>
-                    <RollingFile name="JobFile-$${ctx:jobLogFile}"
-                                 fileName="${JOB_LOG_DIR}/$${ctx:jobLogFile}"
-                                 filePattern="${JOB_LOG_DIR}/archive/$${ctx:jobLogFile}.%d{yyyy-MM-dd}-%i.gz">
+                    <RollingFile name="JobFile-${ctx:jobLogFile}"
+                                 fileName="${JOB_LOG_DIR}/${ctx:jobLogFile}"
+                                 filePattern="${JOB_LOG_DIR}/archive/${ctx:jobLogFile}.%d{yyyy-MM-dd}-%i.gz">
                         <PatternLayout pattern="${PATTERN}"/>
                         <Policies>
                             <TimeBasedTriggeringPolicy/>

--- a/link-up-framework/src/main/resources/log4j2.xml
+++ b/link-up-framework/src/main/resources/log4j2.xml
@@ -29,9 +29,9 @@
             <Routes pattern="$${ctx:jobLogFile:-__NO_JOB__}">
                 <Route key="__NO_JOB__" ref="NoJobFile"/>
                 <Route>
-                    <RollingFile name="JobFile-$${ctx:jobLogFile}"
-                                 fileName="${JOB_LOG_DIR}/$${ctx:jobLogFile}"
-                                 filePattern="${JOB_LOG_DIR}/archive/$${ctx:jobLogFile}.%d{yyyy-MM-dd}-%i.gz">
+                    <RollingFile name="JobFile-${ctx:jobLogFile}"
+                                 fileName="${JOB_LOG_DIR}/${ctx:jobLogFile}"
+                                 filePattern="${JOB_LOG_DIR}/archive/${ctx:jobLogFile}.%d{yyyy-MM-dd}-%i.gz">
                         <PatternLayout pattern="${PATTERN}"/>
                         <Policies>
                             <TimeBasedTriggeringPolicy/>


### PR DESCRIPTION
## What changed

- Resolve an unqualified MySQL Sink table against the database declared in the JDBC URL when no explicit database or `schema` is configured.
- Preserve the existing precedence: `database.table` > configured `schema` > JDBC URL database.
- Add unit coverage for URL fallback, explicit database precedence, configured schema precedence, and missing-default failure.
- Fix both runtime and distribution Log4j2 `RoutingAppender` configurations so `jobLogFile` is evaluated when the dynamic route is created.

## Root cause

The submitted Sink used `table_path=test1234` with `jdbc:mysql://127.0.0.1:3306/test1`. `MySqlDialect.tableIdentifier` only checked the table path and configured `schema`, so SQL generation failed with `MySQL 表路径缺少 database：test1234` even though the JDBC URL already selected `test1`.

The routed Log4j2 appender also used `$${ctx:jobLogFile}` inside the dynamic `<Route>`. That extra escaping left the literal `${ctx:jobLogFile}` in the Windows file path, where the colon caused `InvalidPathException`.

## Impact

Yak Ops can continue submitting a single MySQL target table name when the JDBC URL contains the database, and per-job log files are created with their actual generated names on Windows and Linux.

## Validation

- Added `MySqlDialectTest` covering the database-resolution precedence and failure case.
- Reviewed the branch diff to confirm only the MySQL dialect, its test, and the two mirrored Log4j2 configurations changed.
- GitHub Actions is expected to run the repository Maven verification on this draft PR.