### PR TITLE
feat: support fixed column mapping runtime

### DIFF
--- a/docs/job-spec.md
+++ b/docs/job-spec.md
@@ -23,6 +23,12 @@
       "table": "warehouse.orders"
     }
   },
+  "mapping": {
+    "columns": [
+      {"source": "order_id", "target": "id"},
+      {"source": "created_at", "target": "create_time"}
+    ]
+  },
   "runtime": {
     "batchSize": 1000,
     "sourceParallelism": 2,
@@ -33,12 +39,26 @@
 }
 ```
 
+## Column mapping
+
+`mapping.columns` is an optional fixed column contract. It is not a general transform or expression language.
+
+- Each item copies one source column into one target column.
+- Array order defines the output row and target write order.
+- Unmapped source columns are not emitted to the sink.
+- Source and target names must be unique inside one mapping.
+- Link-Up validates source fields after metadata discovery, projects each `FluxRow` by precomputed indexes, and supplies the renamed output schema to sink preparation.
+- When all source primary-key columns are retained, their names are rewritten to the corresponding target names.
+- Explicit mapping currently requires exactly one source table.
+- An absent mapping preserves the original schema and row order and is omitted from canonical protocol JSON for retry compatibility.
+
 ## Ownership
 
 - Connector option names and validation rules come from each Connector Schema.
 - The control plane resolves data-source references and secrets before submission.
 - Link-Up compiles `JobSpec` into its internal `JobDefinition` and owns final runtime validation.
 - `connectorId` is opaque to the protocol. Adding Doris, HTTP or file connectors does not require a new control-plane serialization format.
+- Column mapping belongs to the Link-Up framework and is not duplicated inside individual connectors.
 
 ## Compatibility
 

--- a/link-up-api/src/main/java/com/link/up/api/job/JobSpec.java
+++ b/link-up-api/src/main/java/com/link/up/api/job/JobSpec.java
@@ -1,7 +1,9 @@
 package com.link.up.api.job;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /** Framework-neutral structured offline batch job protocol. */
@@ -15,6 +17,7 @@ public final class JobSpec implements Serializable {
     private Connector source;
     private Connector sink;
     private Runtime runtime = new Runtime();
+    private Mapping mapping = new Mapping();
 
     public JobSpec() {}
 
@@ -30,6 +33,10 @@ public final class JobSpec implements Serializable {
     public void setSink(Connector sink) { this.sink = sink; }
     public Runtime getRuntime() { return runtime; }
     public void setRuntime(Runtime runtime) { this.runtime = runtime; }
+    public Mapping getMapping() { return mapping; }
+    public void setMapping(Mapping mapping) {
+        this.mapping = mapping == null ? new Mapping() : mapping;
+    }
 
     public static final class Connector implements Serializable {
         private String connectorId;
@@ -44,6 +51,33 @@ public final class JobSpec implements Serializable {
                     ? new LinkedHashMap<String, Object>()
                     : new LinkedHashMap<String, Object>(options);
         }
+    }
+
+    /** Fixed column selection, ordering and rename contract. */
+    public static final class Mapping implements Serializable {
+        private List<Column> columns = new ArrayList<Column>();
+
+        public Mapping() {}
+
+        public List<Column> getColumns() { return columns; }
+
+        public void setColumns(List<Column> columns) {
+            this.columns = columns == null
+                    ? new ArrayList<Column>()
+                    : new ArrayList<Column>(columns);
+        }
+    }
+
+    public static final class Column implements Serializable {
+        private String source;
+        private String target;
+
+        public Column() {}
+
+        public String getSource() { return source; }
+        public void setSource(String source) { this.source = source; }
+        public String getTarget() { return target; }
+        public void setTarget(String target) { this.target = target; }
     }
 
     public static final class Runtime implements Serializable {

--- a/link-up-api/src/main/java/com/link/up/api/job/JobSpec.java
+++ b/link-up-api/src/main/java/com/link/up/api/job/JobSpec.java
@@ -1,5 +1,6 @@
 package com.link.up.api.job;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -17,7 +18,7 @@ public final class JobSpec implements Serializable {
     private Connector source;
     private Connector sink;
     private Runtime runtime = new Runtime();
-    private Mapping mapping = new Mapping();
+    private Mapping mapping;
 
     public JobSpec() {}
 
@@ -33,10 +34,10 @@ public final class JobSpec implements Serializable {
     public void setSink(Connector sink) { this.sink = sink; }
     public Runtime getRuntime() { return runtime; }
     public void setRuntime(Runtime runtime) { this.runtime = runtime; }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     public Mapping getMapping() { return mapping; }
-    public void setMapping(Mapping mapping) {
-        this.mapping = mapping == null ? new Mapping() : mapping;
-    }
+    public void setMapping(Mapping mapping) { this.mapping = mapping; }
 
     public static final class Connector implements Serializable {
         private String connectorId;

--- a/link-up-api/src/main/java/com/link/up/api/source/RecordBatch.java
+++ b/link-up-api/src/main/java/com/link/up/api/source/RecordBatch.java
@@ -64,16 +64,33 @@ public final class RecordBatch<T> implements Serializable {
             List<T> records) {
 
         Objects.requireNonNull(split, "split must not be null");
+        return of(split.dataSetId(), split.splitId(), records);
+    }
+
+    /**
+     * Rebuilds a batch while preserving its dataset and split identity.
+     */
+    public static <T> RecordBatch<T> of(
+            String dataSetId,
+            String splitId,
+            List<T> records) {
+
         Objects.requireNonNull(records, "records must not be null");
 
+        if (dataSetId == null || dataSetId.trim().isEmpty()) {
+            throw new IllegalArgumentException("dataSetId must not be blank");
+        }
+        if (splitId == null || splitId.trim().isEmpty()) {
+            throw new IllegalArgumentException("splitId must not be blank");
+        }
         if (records.isEmpty()) {
             throw new IllegalArgumentException(
                     "records must not be empty");
         }
 
         return new RecordBatch<>(
-                split.dataSetId(),
-                split.splitId(),
+                dataSetId.trim(),
+                splitId.trim(),
                 Collections.unmodifiableList(
                         new ArrayList<>(records)),
                 false);

--- a/link-up-framework/src/main/java/com/link/up/framework/connector/ConnectorPreparer.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/connector/ConnectorPreparer.java
@@ -11,9 +11,11 @@ import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.factory.TableSourceFactory;
 import com.link.up.framework.classloading.ClassLoaderScope;
+import com.link.up.framework.job.ColumnMapping;
 import com.link.up.framework.job.JobDefinition;
 import com.link.up.framework.job.SinkDefinition;
 import com.link.up.framework.job.SourceDefinition;
+import com.link.up.framework.mapping.ColumnMappingPlanner;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -67,14 +69,34 @@ public final class ConnectorPreparer {
                         definition.getExecutionConfig()
                                 .getSourceParallelism());
 
+        source = applyColumnMapping(source, definition.getColumnMapping());
+
         Map<String, List<PreparedSink>> sinks =
-                prepareSinks(definition.getSink(), definition.getExecutionConfig().getSinkParallelism(), source.getTables());
+                prepareSinks(
+                        definition.getSink(),
+                        definition.getExecutionConfig().getSinkParallelism(),
+                        source.getOutputTables());
 
         return new PreparedJob(
                 definition.getName(),
                 source,
                 sinks,
                 definition.getExecutionConfig());
+    }
+
+    private <SplitT extends SourceSplit> PreparedSource<SplitT> applyColumnMapping(
+            PreparedSource<SplitT> source,
+            ColumnMapping mapping) {
+        ColumnMappingPlanner.Result result =
+                new ColumnMappingPlanner().plan(source.getTables(), mapping);
+
+        return new PreparedSource<SplitT>(
+                source.getFactoryIdentifier(),
+                source.getSource(),
+                source.getTables(),
+                result.getOutputTables(),
+                result.getPlans(),
+                source.getClassLoader());
     }
 
     private PreparedSource<?> prepareSource(

--- a/link-up-framework/src/main/java/com/link/up/framework/connector/PreparedSource.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/connector/PreparedSource.java
@@ -4,6 +4,7 @@ import com.link.up.api.source.Source;
 import com.link.up.api.source.SourceSplit;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
+import com.link.up.framework.mapping.ColumnMappingPlan;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -20,7 +21,13 @@ public final class PreparedSource<
 
     private final Source<SplitT> source;
 
+    /** Physical source schemas used by readers and split planning. */
     private final Map<TablePath, CatalogTable> tables;
+
+    /** Schemas emitted to channels and supplied to sink preparation. */
+    private final Map<TablePath, CatalogTable> outputTables;
+
+    private final Map<TablePath, ColumnMappingPlan> columnMappingPlans;
 
     private final ClassLoader classLoader;
 
@@ -36,6 +43,22 @@ public final class PreparedSource<
             Source<SplitT> source,
             Map<TablePath, CatalogTable> tables,
             ClassLoader classLoader) {
+        this(
+                factoryIdentifier,
+                source,
+                tables,
+                tables,
+                Collections.<TablePath, ColumnMappingPlan>emptyMap(),
+                classLoader);
+    }
+
+    public PreparedSource(
+            String factoryIdentifier,
+            Source<SplitT> source,
+            Map<TablePath, CatalogTable> tables,
+            Map<TablePath, CatalogTable> outputTables,
+            Map<TablePath, ColumnMappingPlan> columnMappingPlans,
+            ClassLoader classLoader) {
 
         this.factoryIdentifier =
                 Objects.requireNonNull(
@@ -47,16 +70,24 @@ public final class PreparedSource<
                         source,
                         "source must not be null");
 
-        this.tables =
-                Collections.unmodifiableMap(
-                        new LinkedHashMap<
-                                TablePath,
-                                CatalogTable>(
-                                Objects.requireNonNull(
-                                        tables,
-                                        "tables must not be null")));
+        this.tables = immutable(tables, "tables");
+        this.outputTables = immutable(outputTables, "outputTables");
+        this.columnMappingPlans = immutable(columnMappingPlans, "columnMappingPlans");
+
+        if (!this.tables.keySet().equals(this.outputTables.keySet())) {
+            throw new IllegalArgumentException(
+                    "source and output table paths must match");
+        }
 
         this.classLoader = Objects.requireNonNull(classLoader, "classLoader must not be null");
+    }
+
+    private static <T> Map<TablePath, T> immutable(
+            Map<TablePath, T> values,
+            String name) {
+        return Collections.unmodifiableMap(
+                new LinkedHashMap<TablePath, T>(
+                        Objects.requireNonNull(values, name + " must not be null")));
     }
 
     public String getFactoryIdentifier() {
@@ -73,5 +104,13 @@ public final class PreparedSource<
 
     public Map<TablePath, CatalogTable> getTables() {
         return tables;
+    }
+
+    public Map<TablePath, CatalogTable> getOutputTables() {
+        return outputTables;
+    }
+
+    public ColumnMappingPlan getColumnMappingPlan(TablePath tablePath) {
+        return columnMappingPlans.get(tablePath);
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/task/SourceTask.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/task/SourceTask.java
@@ -12,9 +12,9 @@ import com.link.up.framework.connector.PreparedSource;
 import com.link.up.framework.execution.TaskContext;
 import com.link.up.framework.execution.TaskId;
 import com.link.up.framework.execution.split.SplitProvider;
+import com.link.up.framework.mapping.ColumnMappingPlan;
 import com.link.up.framework.planner.SourceTaskPlan;
 
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -126,7 +126,7 @@ public final class SourceTask<
                     RecordEnvelope<FluxRow> envelope =
                             createEnvelope(
                                     batch,
-                                    preparedSource.getTables());
+                                    preparedSource);
 
                     context.getMetrics()
                             .incrementBatchCount();
@@ -203,7 +203,7 @@ public final class SourceTask<
                     context.getMetrics().setCurrentPosition(batch.getDataSetId(), batch.getSplitId());
                     context.getMetrics().incrementBatchCount();
                     context.getMetrics().addSourceReadRecords(batch.getRecords().size());
-                    outputGate.write(createEnvelope(batch, preparedSource.getTables()));
+                    outputGate.write(createEnvelope(batch, preparedSource));
                 }
             } catch (Throwable failure) {
                 provider.fail(split, failure);
@@ -231,7 +231,7 @@ public final class SourceTask<
 
     private RecordEnvelope<FluxRow> createEnvelope(
             RecordBatch<FluxRow> batch,
-            Map<TablePath, CatalogTable> tables) {
+            PreparedSource<SplitT> preparedSource) {
 
         String dataSetId =
                 batch.getDataSetId();
@@ -247,17 +247,29 @@ public final class SourceTask<
                 TablePath.parse(dataSetId);
 
         CatalogTable catalogTable =
-                tables.get(tablePath);
+                preparedSource.getOutputTables().get(tablePath);
 
         if (catalogTable == null) {
             throw new IllegalStateException(
-                    "No discovered source table for batch: "
+                    "No output source table for batch: "
                             + dataSetId);
+        }
+
+        RecordBatch<FluxRow> outputBatch = batch;
+        ColumnMappingPlan mappingPlan =
+                preparedSource.getColumnMappingPlan(tablePath);
+
+        if (mappingPlan != null) {
+            outputBatch = RecordBatch.of(
+                    batch.getDataSetId(),
+                    batch.getSplitId(),
+                    mappingPlan.project(batch.getRecords()));
+            catalogTable = mappingPlan.getOutputTable();
         }
 
         return new RecordEnvelope<FluxRow>(
                 tablePath,
                 catalogTable,
-                batch);
+                outputBatch);
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/job/ColumnMapping.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/ColumnMapping.java
@@ -1,0 +1,68 @@
+package com.link.up.framework.job;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Fixed column selection, ordering and rename contract.
+ *
+ * <p>This is deliberately not a general transform model. Each item copies one
+ * source column into one target column, and item order defines the output row
+ * order.</p>
+ */
+public final class ColumnMapping {
+
+    private static final ColumnMapping EMPTY =
+            new ColumnMapping(Collections.<Item>emptyList());
+
+    private final List<Item> columns;
+
+    public ColumnMapping(List<Item> columns) {
+        List<Item> safe = new ArrayList<Item>();
+        if (columns != null) {
+            for (Item item : columns) {
+                safe.add(Objects.requireNonNull(item, "mapping item must not be null"));
+            }
+        }
+        this.columns = Collections.unmodifiableList(safe);
+    }
+
+    public static ColumnMapping empty() {
+        return EMPTY;
+    }
+
+    public boolean isEmpty() {
+        return columns.isEmpty();
+    }
+
+    public List<Item> getColumns() {
+        return columns;
+    }
+
+    public static final class Item {
+        private final String source;
+        private final String target;
+
+        public Item(String source, String target) {
+            this.source = requireText(source, "source");
+            this.target = requireText(target, "target");
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+
+        private static String requireText(String value, String name) {
+            if (value == null || value.trim().isEmpty()) {
+                throw new IllegalArgumentException("mapping." + name + " must not be blank");
+            }
+            return value.trim();
+        }
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/job/JobDefinition.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/JobDefinition.java
@@ -15,11 +15,22 @@ public final class JobDefinition {
 
     private final ExecutionConfig executionConfig;
 
+    private final ColumnMapping columnMapping;
+
     public JobDefinition(
             String name,
             SourceDefinition source,
             SinkDefinition sink,
             ExecutionConfig executionConfig) {
+        this(name, source, sink, executionConfig, ColumnMapping.empty());
+    }
+
+    public JobDefinition(
+            String name,
+            SourceDefinition source,
+            SinkDefinition sink,
+            ExecutionConfig executionConfig,
+            ColumnMapping columnMapping) {
 
         this.name = requireName(name);
 
@@ -37,6 +48,11 @@ public final class JobDefinition {
                 Objects.requireNonNull(
                         executionConfig,
                         "executionConfig must not be null");
+
+        this.columnMapping =
+                columnMapping == null
+                        ? ColumnMapping.empty()
+                        : columnMapping;
     }
 
     private static String requireName(String name) {
@@ -68,5 +84,9 @@ public final class JobDefinition {
 
     public ExecutionConfig getExecutionConfig() {
         return executionConfig;
+    }
+
+    public ColumnMapping getColumnMapping() {
+        return columnMapping;
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/job/JobSpecCompiler.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/JobSpecCompiler.java
@@ -2,9 +2,13 @@ package com.link.up.framework.job;
 
 import com.link.up.api.configuration.ReadonlyConfig;
 import com.link.up.api.job.JobSpec;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /** Compiles the public structured JobSpec protocol into Link-Up runtime definitions. */
 public final class JobSpecCompiler {
@@ -44,7 +48,40 @@ public final class JobSpecCompiler {
                 enumValue(runtime.getSplitAssignmentMode(), SplitAssignmentMode.STATIC_ROUND_ROBIN,
                         SplitAssignmentMode.class, "runtime.splitAssignmentMode"));
 
-        return new JobDefinition(requireText(spec.getName(), "name"), source, sink, execution);
+        return new JobDefinition(
+                requireText(spec.getName(), "name"),
+                source,
+                sink,
+                execution,
+                compileMapping(spec.getMapping()));
+    }
+
+    private ColumnMapping compileMapping(JobSpec.Mapping mapping) {
+        if (mapping == null || mapping.getColumns() == null || mapping.getColumns().isEmpty()) {
+            return ColumnMapping.empty();
+        }
+
+        List<ColumnMapping.Item> items = new ArrayList<ColumnMapping.Item>();
+        Set<String> sources = new HashSet<String>();
+        Set<String> targets = new HashSet<String>();
+
+        for (JobSpec.Column column : mapping.getColumns()) {
+            if (column == null) {
+                throw new IllegalArgumentException("mapping.columns must not contain null items");
+            }
+            ColumnMapping.Item item = new ColumnMapping.Item(column.getSource(), column.getTarget());
+            if (!sources.add(item.getSource())) {
+                throw new IllegalArgumentException(
+                        "Duplicate source column in mapping: " + item.getSource());
+            }
+            if (!targets.add(item.getTarget())) {
+                throw new IllegalArgumentException(
+                        "Duplicate target column in mapping: " + item.getTarget());
+            }
+            items.add(item);
+        }
+
+        return new ColumnMapping(items);
     }
 
     private void requireProtocol(String apiVersion, String kind) {

--- a/link-up-framework/src/main/java/com/link/up/framework/mapping/ColumnMappingPlan.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/mapping/ColumnMappingPlan.java
@@ -1,0 +1,41 @@
+package com.link.up.framework.mapping;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.type.FluxRow;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable runtime plan for projecting and reordering one dataset. */
+public final class ColumnMappingPlan {
+
+    private final int[] sourceIndexes;
+    private final CatalogTable outputTable;
+
+    ColumnMappingPlan(int[] sourceIndexes, CatalogTable outputTable) {
+        this.sourceIndexes = sourceIndexes.clone();
+        this.outputTable = Objects.requireNonNull(outputTable, "outputTable must not be null");
+    }
+
+    public CatalogTable getOutputTable() {
+        return outputTable;
+    }
+
+    public List<FluxRow> project(List<FluxRow> rows) {
+        Objects.requireNonNull(rows, "rows must not be null");
+        if (rows.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<FluxRow> result = new ArrayList<FluxRow>(rows.size());
+        for (FluxRow row : rows) {
+            if (row == null) {
+                throw new IllegalArgumentException("source rows must not contain null values");
+            }
+            result.add(row.project(sourceIndexes));
+        }
+        return result;
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/mapping/ColumnMappingPlanner.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/mapping/ColumnMappingPlanner.java
@@ -1,0 +1,111 @@
+package com.link.up.framework.mapping;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.framework.job.ColumnMapping;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Builds fixed column projection plans after source schema discovery. */
+public final class ColumnMappingPlanner {
+
+    public Result plan(
+            Map<TablePath, CatalogTable> sourceTables,
+            ColumnMapping mapping) {
+
+        Objects.requireNonNull(sourceTables, "sourceTables must not be null");
+        ColumnMapping safeMapping = mapping == null ? ColumnMapping.empty() : mapping;
+
+        if (safeMapping.isEmpty()) {
+            return new Result(sourceTables, Collections.<TablePath, ColumnMappingPlan>emptyMap());
+        }
+
+        if (sourceTables.size() != 1) {
+            throw new IllegalArgumentException(
+                    "Explicit column mapping currently requires exactly one source table");
+        }
+
+        Map.Entry<TablePath, CatalogTable> entry = sourceTables.entrySet().iterator().next();
+        TablePath tablePath = entry.getKey();
+        CatalogTable sourceTable = entry.getValue();
+        TableSchema sourceSchema = sourceTable.getTableSchema();
+        TableSchema.Builder outputSchema = TableSchema.builder();
+        int[] sourceIndexes = new int[safeMapping.getColumns().size()];
+        Map<String, String> targetBySource = new LinkedHashMap<String, String>();
+
+        for (int i = 0; i < safeMapping.getColumns().size(); i++) {
+            ColumnMapping.Item item = safeMapping.getColumns().get(i);
+            int sourceIndex = sourceSchema.indexOf(item.getSource());
+            if (sourceIndex < 0) {
+                throw new IllegalArgumentException(
+                        "Mapped source column does not exist: " + item.getSource());
+            }
+
+            Column sourceColumn = sourceSchema.getColumn(sourceIndex);
+            sourceIndexes[i] = sourceIndex;
+            outputSchema.column(sourceColumn.rename(item.getTarget()));
+            targetBySource.put(item.getSource(), item.getTarget());
+        }
+
+        PrimaryKey primaryKey = sourceSchema.getPrimaryKey();
+        if (primaryKey != null) {
+            List<String> mappedPrimaryKeys = new ArrayList<String>();
+            boolean complete = true;
+            for (String sourcePrimaryKey : primaryKey.getColumnNames()) {
+                String targetPrimaryKey = targetBySource.get(sourcePrimaryKey);
+                if (targetPrimaryKey == null) {
+                    complete = false;
+                    break;
+                }
+                mappedPrimaryKeys.add(targetPrimaryKey);
+            }
+            if (complete) {
+                outputSchema.primaryKey(
+                        PrimaryKey.of(primaryKey.getName(), mappedPrimaryKeys));
+            }
+        }
+
+        CatalogTable outputTable = sourceTable.withSchema(outputSchema.build());
+        ColumnMappingPlan mappingPlan = new ColumnMappingPlan(sourceIndexes, outputTable);
+
+        Map<TablePath, CatalogTable> outputTables =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        outputTables.put(tablePath, outputTable);
+
+        Map<TablePath, ColumnMappingPlan> plans =
+                new LinkedHashMap<TablePath, ColumnMappingPlan>();
+        plans.put(tablePath, mappingPlan);
+
+        return new Result(outputTables, plans);
+    }
+
+    public static final class Result {
+        private final Map<TablePath, CatalogTable> outputTables;
+        private final Map<TablePath, ColumnMappingPlan> plans;
+
+        Result(
+                Map<TablePath, CatalogTable> outputTables,
+                Map<TablePath, ColumnMappingPlan> plans) {
+            this.outputTables = Collections.unmodifiableMap(
+                    new LinkedHashMap<TablePath, CatalogTable>(outputTables));
+            this.plans = Collections.unmodifiableMap(
+                    new LinkedHashMap<TablePath, ColumnMappingPlan>(plans));
+        }
+
+        public Map<TablePath, CatalogTable> getOutputTables() {
+            return outputTables;
+        }
+
+        public Map<TablePath, ColumnMappingPlan> getPlans() {
+            return plans;
+        }
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/planner/JobPlanner.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planner/JobPlanner.java
@@ -52,8 +52,8 @@ public final class JobPlanner {
         for (Map.Entry<String, List<SplitT>> entry : byDataSet.entrySet()) {
             String dataSetId = entry.getKey();
             TablePath path = TablePath.parse(dataSetId);
-            CatalogTable table = preparedSource.getTables().get(path);
-            if (table == null) throw new IllegalStateException("No catalog table for data set: " + dataSetId);
+            CatalogTable table = preparedSource.getOutputTables().get(path);
+            if (table == null) throw new IllegalStateException("No output catalog table for data set: " + dataSetId);
             List<List<SplitT>> assignments = splitAssigner.assign(entry.getValue(), config.getSourceParallelism());
             SplitProvider<SplitT> provider = config.getSplitAssignmentMode() == SplitAssignmentMode.DYNAMIC ? new LocalSplitQueue<SplitT>(entry.getValue()) : null;
             String pipelineId = "pipeline-" + dataSetId;

--- a/link-up-framework/src/test/java/com/link/up/framework/mapping/ColumnMappingPlannerTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/mapping/ColumnMappingPlannerTest.java
@@ -1,5 +1,6 @@
 package com.link.up.framework.mapping;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.link.up.api.job.JobSpec;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.Column;
@@ -8,7 +9,6 @@ import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.type.BasicType;
 import com.link.up.api.table.type.FluxRow;
-import com.link.up.framework.job.ColumnMapping;
 import com.link.up.framework.job.JobDefinition;
 import com.link.up.framework.job.JobSpecCompiler;
 import org.junit.Test;
@@ -18,6 +18,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class ColumnMappingPlannerTest {
 
@@ -56,6 +57,13 @@ public class ColumnMappingPlannerTest {
                 .get(0);
         assertEquals("Alice", projected.getField(0));
         assertEquals(7L, projected.getField(1));
+    }
+
+    @Test
+    public void omitsAbsentMappingFromProtocolJson() throws Exception {
+        String json = new ObjectMapper().writeValueAsString(baseSpec());
+
+        assertFalse(json.contains("\"mapping\""));
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/link-up-framework/src/test/java/com/link/up/framework/mapping/ColumnMappingPlannerTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/mapping/ColumnMappingPlannerTest.java
@@ -1,0 +1,93 @@
+package com.link.up.framework.mapping;
+
+import com.link.up.api.job.JobSpec;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.framework.job.ColumnMapping;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.JobSpecCompiler;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ColumnMappingPlannerTest {
+
+    @Test
+    public void compilesMappedSchemaAndProjectsRowsInTargetOrder() {
+        JobSpec spec = baseSpec();
+        JobSpec.Mapping mapping = new JobSpec.Mapping();
+        mapping.setColumns(Arrays.asList(
+                column("name", "user_name"),
+                column("id", "user_id")));
+        spec.setMapping(mapping);
+
+        JobDefinition definition = new JobSpecCompiler().compile(spec);
+        TablePath path = TablePath.of("demo", "users");
+        TableSchema sourceSchema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).nullable(false).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .column(Column.builder("age", BasicType.INT_TYPE).build())
+                .primaryKey(PrimaryKey.of("pk_users", Arrays.asList("id")))
+                .build();
+        Map<TablePath, CatalogTable> sourceTables =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        sourceTables.put(path, CatalogTable.builder(path, sourceSchema).build());
+
+        ColumnMappingPlanner.Result result =
+                new ColumnMappingPlanner().plan(sourceTables, definition.getColumnMapping());
+        CatalogTable output = result.getOutputTables().get(path);
+
+        assertEquals("user_name", output.getTableSchema().getColumn(0).getName());
+        assertEquals("user_id", output.getTableSchema().getColumn(1).getName());
+        assertEquals(Arrays.asList("user_id"),
+                output.getTableSchema().getPrimaryKey().getColumnNames());
+
+        FluxRow projected = result.getPlans().get(path)
+                .project(Arrays.asList(FluxRow.of(7L, "Alice", 30)))
+                .get(0);
+        assertEquals("Alice", projected.getField(0));
+        assertEquals(7L, projected.getField(1));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsDuplicateTargetColumns() {
+        JobSpec spec = baseSpec();
+        JobSpec.Mapping mapping = new JobSpec.Mapping();
+        mapping.setColumns(Arrays.asList(
+                column("id", "target_id"),
+                column("name", "target_id")));
+        spec.setMapping(mapping);
+
+        new JobSpecCompiler().compile(spec);
+    }
+
+    private JobSpec baseSpec() {
+        JobSpec spec = new JobSpec();
+        spec.setName("mapped-users");
+        spec.setSource(connector("jdbc"));
+        spec.setSink(connector("jdbc"));
+        return spec;
+    }
+
+    private JobSpec.Connector connector(String connectorId) {
+        JobSpec.Connector connector = new JobSpec.Connector();
+        connector.setConnectorId(connectorId);
+        return connector;
+    }
+
+    private JobSpec.Column column(String source, String target) {
+        JobSpec.Column column = new JobSpec.Column();
+        column.setSource(source);
+        column.setTarget(target);
+        return column;
+    }
+}


### PR DESCRIPTION
## 变更说明

- 在结构化 `JobSpec` 中新增顶层 `mapping.columns` 协议，字段顺序即目标写入顺序。
- 增加固定 `ColumnMapping`、规划器和运行时计划，仅支持字段选择、重排和重命名，不引入通用 Transform/FieldMapper。
- 保留 Source 原始 Schema 用于分片和读取，同时生成映射后的输出 Schema 供 Sink 预处理、自动建表和目标字段校验使用。
- SourceTask 写入 Channel 前通过预计算字段下标投影 `FluxRow`，保证 Sink SQL 字段顺序与参数顺序一致。
- 完整保留来源主键时，将主键字段同步重命名到目标 Schema。
- 显式映射暂时限制为单来源表，并校验空字段、重复来源字段、重复目标字段和不存在的来源字段。
- 补充 `docs/job-spec.md`，明确固定映射的协议边界与执行语义。

## 兼容性

- 未配置 `mapping` 时沿用原始 Schema 与行数据，旧 JobSpec、HOCON 解析和现有四参数 `JobDefinition` 构造方式保持兼容。
- 未配置映射时，`mapping` 不会进入规范化 JSON，避免 Worker 升级后改变旧任务的幂等摘要。
- 映射能力位于 framework 层，不进入 JDBC/Doris 等 Connector 的配置协议。

## 验证

- 新增 `ColumnMappingPlannerTest`，覆盖协议编译、Schema 重排改名、主键重命名、行数据投影、重复目标字段校验及空映射序列化兼容性。
- 当前仓库未为最新提交返回 Actions/Check 运行记录，因此 PR 保持 Draft，等待可用构建环境执行全仓编译与测试。

## 配套 PR

Yak Ops 控制面：weifuwan/yak-ops#182。建议先合入并发布本 PR，再合入控制面 PR。