### PR TITLE
feat(server): return per-table CREATE DDL in offline pipelines

### DIFF
--- a/docs/worker-protocol.md
+++ b/docs/worker-protocol.md
@@ -88,6 +88,40 @@ DELETE /api/v1/jobs/{jobId}
 
 提交请求超时后，控制面应优先使用 `externalExecutionId` 查询，不能直接生成新执行实例重复提交。
 
+## 离线建表结果
+
+JDBC Sink 在准备每个数据集时会生成最终目标表的 `CREATE TABLE` 语句。单表任务包含一个 Pipeline，多表任务按数据集包含多个 Pipeline；两种模式使用相同结构：
+
+```json
+{
+  "pipelineId": "pipeline-orders",
+  "dataSetId": "source_db.orders",
+  "source": {
+    "table": "source_db.orders"
+  },
+  "sink": {
+    "table": "target_db.orders"
+  },
+  "tableDdl": {
+    "dialect": "MYSQL",
+    "sourceTable": "source_db.orders",
+    "targetTable": "target_db.orders",
+    "createTableSql": "CREATE TABLE `target_db`.`orders` (...);",
+    "executed": true,
+    "status": "SUCCEEDED",
+    "reason": "TARGET_TABLE_CREATED",
+    "durationMillis": 18
+  }
+}
+```
+
+`tableDdl` 只描述离线任务准备阶段生成的建表语句，不表示 CDC 或实时 Schema Change：
+
+- `executed=true` 表示本次确实执行了建表；
+- 目标表已经存在时，`executed=false`、`status=SKIPPED`、`reason=TARGET_TABLE_ALREADY_EXISTS`；
+- 即使本次未执行，仍返回按最终目标表结构生成的 `createTableSql`，供控制面查看和审计；
+- DDL 按 Pipeline 返回，因此多表任务不会把不同目标表的建表语句混在一起。
+
 ## LOST 处理
 
 `LOST` 表示最终结果未知，不等价于失败或取消：

--- a/link-up-api/src/main/java/com/link/up/api/sink/PreparedSinkMetadata.java
+++ b/link-up-api/src/main/java/com/link/up/api/sink/PreparedSinkMetadata.java
@@ -14,19 +14,39 @@ import java.util.Objects;
 public final class PreparedSinkMetadata {
     private final Map<TablePath, CatalogTable> targetTables;
     private final Map<TablePath, Object> attributes;
+    private final Map<TablePath, TableDdl> tableDdls;
 
     public PreparedSinkMetadata(Map<TablePath, CatalogTable> targetTables) {
-        this(targetTables, Collections.<TablePath, Object>emptyMap());
+        this(
+                targetTables,
+                Collections.<TablePath, Object>emptyMap(),
+                Collections.<TablePath, TableDdl>emptyMap());
     }
 
-    public PreparedSinkMetadata(Map<TablePath, CatalogTable> targetTables, Map<TablePath, Object> attributes) {
+    public PreparedSinkMetadata(
+            Map<TablePath, CatalogTable> targetTables,
+            Map<TablePath, Object> attributes) {
+        this(
+                targetTables,
+                attributes,
+                Collections.<TablePath, TableDdl>emptyMap());
+    }
+
+    public PreparedSinkMetadata(
+            Map<TablePath, CatalogTable> targetTables,
+            Map<TablePath, Object> attributes,
+            Map<TablePath, TableDdl> tableDdls) {
         this.targetTables = immutable(targetTables, "targetTables");
         this.attributes = immutable(attributes, "attributes");
+        this.tableDdls = immutable(tableDdls, "tableDdls");
     }
 
-    private static <T> Map<TablePath, T> immutable(Map<TablePath, T> input, String name) {
+    private static <T> Map<TablePath, T> immutable(
+            Map<TablePath, T> input,
+            String name) {
         Objects.requireNonNull(input, name + " must not be null");
-        return Collections.unmodifiableMap(new LinkedHashMap<TablePath, T>(input));
+        return Collections.unmodifiableMap(
+                new LinkedHashMap<TablePath, T>(input));
     }
 
     public Map<TablePath, CatalogTable> getTargetTables() {
@@ -43,5 +63,13 @@ public final class PreparedSinkMetadata {
 
     public Object getAttribute(TablePath sourceTable) {
         return attributes.get(sourceTable);
+    }
+
+    public Map<TablePath, TableDdl> getTableDdls() {
+        return tableDdls;
+    }
+
+    public TableDdl getTableDdl(TablePath sourceTable) {
+        return tableDdls.get(sourceTable);
     }
 }

--- a/link-up-api/src/main/java/com/link/up/api/sink/TableDdl.java
+++ b/link-up-api/src/main/java/com/link/up/api/sink/TableDdl.java
@@ -1,0 +1,120 @@
+package com.link.up.api.sink;
+
+import java.io.Serializable;
+
+/**
+ * Immutable result of preparing one offline sink table.
+ *
+ * <p>Link-Up only reports the CREATE TABLE statement derived during offline
+ * sink preparation. It does not model realtime schema-change events.</p>
+ */
+public final class TableDdl implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String STATUS_SUCCEEDED = "SUCCEEDED";
+    public static final String STATUS_SKIPPED = "SKIPPED";
+
+    public static final String REASON_TARGET_TABLE_CREATED =
+            "TARGET_TABLE_CREATED";
+    public static final String REASON_TARGET_TABLE_ALREADY_EXISTS =
+            "TARGET_TABLE_ALREADY_EXISTS";
+    public static final String REASON_CREATE_TABLE_NOT_EXECUTED =
+            "CREATE_TABLE_NOT_EXECUTED";
+
+    private final String dialect;
+    private final String sourceTable;
+    private final String targetTable;
+    private final String createTableSql;
+    private final boolean executed;
+    private final String status;
+    private final String reason;
+    private final long durationMillis;
+    private final String errorCode;
+    private final String errorMessage;
+
+    public TableDdl(
+            String dialect,
+            String sourceTable,
+            String targetTable,
+            String createTableSql,
+            boolean executed,
+            String status,
+            String reason,
+            long durationMillis,
+            String errorCode,
+            String errorMessage) {
+
+        this.dialect = display(dialect);
+        this.sourceTable = display(sourceTable);
+        this.targetTable = display(targetTable);
+        this.createTableSql = normalize(createTableSql);
+        this.executed = executed;
+        this.status = requireText(status, "status");
+        this.reason = requireText(reason, "reason");
+        this.durationMillis = Math.max(0L, durationMillis);
+        this.errorCode = normalize(errorCode);
+        this.errorMessage = normalize(errorMessage);
+    }
+
+    public String getDialect() {
+        return dialect;
+    }
+
+    public String getSourceTable() {
+        return sourceTable;
+    }
+
+    public String getTargetTable() {
+        return targetTable;
+    }
+
+    public String getCreateTableSql() {
+        return createTableSql;
+    }
+
+    public boolean isExecuted() {
+        return executed;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    private static String display(String value) {
+        String normalized = normalize(value);
+        return normalized == null ? "-" : normalized;
+    }
+
+    private static String requireText(String value, String name) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return normalized;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
@@ -1,0 +1,40 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlCreateTableSqlBuilder;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlTypeMapper;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+/** Generates the CREATE TABLE statement used for offline sink preparation. */
+final class JdbcCreateTableSqlResolver {
+
+    private JdbcCreateTableSqlResolver() {
+    }
+
+    static String resolve(
+            JdbcDialect dialect,
+            CatalogTable table) {
+
+        if (dialect == null || table == null) {
+            return null;
+        }
+
+        JdbcTypeMapper typeMapper =
+                dialect.typeMapper();
+
+        if (typeMapper instanceof MySqlTypeMapper) {
+            return new MySqlCreateTableSqlBuilder(
+                    table.getTablePath(),
+                    table,
+                    (MySqlTypeMapper) typeMapper)
+                    .build();
+        }
+
+        /*
+         * Future JDBC dialects can add their own CREATE TABLE builder here
+         * without changing the connector-neutral protocol.
+         */
+        return null;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
@@ -1,8 +1,10 @@
 package com.link.up.connector.jdbc.sink;
 
 import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
 import com.link.up.connector.jdbc.catalog.mysql.MySqlCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.catalog.mysql.MySqlTypeMapper;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
 
@@ -14,9 +16,12 @@ final class JdbcCreateTableSqlResolver {
 
     static String resolve(
             JdbcDialect dialect,
+            JdbcConnectionConfig connectionConfig,
             CatalogTable table) {
 
-        if (dialect == null || table == null) {
+        if (dialect == null
+                || connectionConfig == null
+                || table == null) {
             return null;
         }
 
@@ -24,9 +29,23 @@ final class JdbcCreateTableSqlResolver {
                 dialect.typeMapper();
 
         if (typeMapper instanceof MySqlTypeMapper) {
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath().equals(targetPath)
+                            ? table
+                            : table.withPath(targetPath);
+
             return new MySqlCreateTableSqlBuilder(
-                    table.getTablePath(),
-                    table,
+                    targetPath,
+                    ddlTable,
                     (MySqlTypeMapper) typeMapper)
                     .build();
         }
@@ -36,5 +55,70 @@ final class JdbcCreateTableSqlResolver {
          * without changing the connector-neutral protocol.
          */
         return null;
+    }
+
+    static TablePath resolveTargetPath(
+            JdbcConnectionConfig connectionConfig,
+            TablePath tablePath) {
+
+        if (connectionConfig == null || tablePath == null) {
+            return tablePath;
+        }
+
+        if (hasText(tablePath.getDatabaseName())) {
+            return tablePath;
+        }
+
+        String database =
+                connectionConfig.getSchema();
+
+        if (!hasText(database)) {
+            database = databaseFromUrl(
+                    connectionConfig.getUrl());
+        }
+
+        if (!hasText(database)) {
+            return null;
+        }
+
+        return TablePath.of(
+                database,
+                tablePath.getTableName());
+    }
+
+    private static String databaseFromUrl(String url) {
+        if (!hasText(url)) {
+            return null;
+        }
+
+        String normalized = url.trim();
+        int protocolSeparator = normalized.indexOf("://");
+        if (protocolSeparator < 0) {
+            return null;
+        }
+
+        int databaseStart = normalized.indexOf('/', protocolSeparator + 3);
+        if (databaseStart < 0 || databaseStart == normalized.length() - 1) {
+            return null;
+        }
+
+        int databaseEnd = normalized.length();
+        int queryStart = normalized.indexOf('?', databaseStart + 1);
+        if (queryStart >= 0) {
+            databaseEnd = queryStart;
+        }
+        int fragmentStart = normalized.indexOf('#', databaseStart + 1);
+        if (fragmentStart >= 0 && fragmentStart < databaseEnd) {
+            databaseEnd = fragmentStart;
+        }
+
+        String database = normalized.substring(
+                databaseStart + 1,
+                databaseEnd).trim();
+        return hasText(database) ? database : null;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -3,6 +3,7 @@ package com.link.up.connector.jdbc.sink;
 import com.link.up.api.sink.PreparedSinkMetadata;
 import com.link.up.api.sink.SinkPrepareContext;
 import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.sink.TableDdl;
 import com.link.up.api.table.catalog.*;
 import com.link.up.connector.jdbc.config.JdbcSinkConfig;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
@@ -13,6 +14,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Executes JDBC target mapping, validation and DDL once, before any task starts.
@@ -36,27 +38,65 @@ final class JdbcSinkPreparer implements SinkPreparer {
     public PreparedSinkMetadata prepare(SinkPrepareContext context) throws Exception {
         Map<TablePath, CatalogTable> targets = new LinkedHashMap<TablePath, CatalogTable>();
         Map<TablePath, Object> keys = new LinkedHashMap<TablePath, Object>();
+        Map<TablePath, TableDdl> tableDdls = new LinkedHashMap<TablePath, TableDdl>();
         Catalog catalog = dialect.createCatalog(config.getConnectionConfig());
         try {
             if (!(catalog instanceof WritableCatalog)) {
                 throw new IllegalStateException("JDBC catalog does not support DDL: " + dialect.name());
             }
+            WritableCatalog writableCatalog = (WritableCatalog) catalog;
             for (Map.Entry<TablePath, CatalogTable> entry : context.getSourceTables().entrySet()) {
                 CatalogTable target = resolveTargetTable(entry.getValue());
                 List<String> primaryKeys = resolvePrimaryKeys(target);
                 if (config.isUpsert() && !dialect.buildUpsertSql(target.getTablePath(), columnNames(target), primaryKeys).isPresent())
                     throw new IllegalArgumentException("Dialect does not support UPSERT: " + dialect.name());
-                JdbcSaveModeHandler handler = new JdbcSaveModeHandler(config.getSchemaSaveMode(), config.getDataSaveMode(), (WritableCatalog) catalog, target, config.isCreatePrimaryKey());
+
+                JdbcSaveModeHandler handler = new JdbcSaveModeHandler(
+                        config.getSchemaSaveMode(),
+                        config.getDataSaveMode(),
+                        writableCatalog,
+                        target,
+                        config.isCreatePrimaryKey());
+
+                boolean targetExistedBefore;
+                long startedAtNanos;
+                long durationMillis;
                 try {
                     handler.open();
+                    targetExistedBefore = writableCatalog.tableExists(target.getTablePath());
+                    startedAtNanos = System.nanoTime();
                     handler.handleSaveMode();
+                    durationMillis = TimeUnit.NANOSECONDS.toMillis(
+                            System.nanoTime() - startedAtNanos);
                 } finally {
                     handler.close();
                 }
+
+                CatalogTable createDefinition = handler.getCreateTableDefinition();
+                boolean executed = handler.isTableCreated();
+                String reason = executed
+                        ? TableDdl.REASON_TARGET_TABLE_CREATED
+                        : targetExistedBefore
+                        ? TableDdl.REASON_TARGET_TABLE_ALREADY_EXISTS
+                        : TableDdl.REASON_CREATE_TABLE_NOT_EXECUTED;
+
+                TableDdl tableDdl = new TableDdl(
+                        dialect.name(),
+                        entry.getKey().toString(),
+                        target.getTablePath().toString(),
+                        JdbcCreateTableSqlResolver.resolve(dialect, createDefinition),
+                        executed,
+                        executed ? TableDdl.STATUS_SUCCEEDED : TableDdl.STATUS_SKIPPED,
+                        reason,
+                        durationMillis,
+                        null,
+                        null);
+
                 targets.put(entry.getKey(), target);
                 keys.put(entry.getKey(), new ArrayList<String>(primaryKeys));
+                tableDdls.put(entry.getKey(), tableDdl);
             }
-            return new PreparedSinkMetadata(targets, keys);
+            return new PreparedSinkMetadata(targets, keys, tableDdls);
         } finally {
             catalog.close();
         }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -73,6 +73,9 @@ final class JdbcSinkPreparer implements SinkPreparer {
                 }
 
                 CatalogTable createDefinition = handler.getCreateTableDefinition();
+                TablePath ddlTargetPath = JdbcCreateTableSqlResolver.resolveTargetPath(
+                        config.getConnectionConfig(),
+                        createDefinition.getTablePath());
                 boolean executed = handler.isTableCreated();
                 String reason = executed
                         ? TableDdl.REASON_TARGET_TABLE_CREATED
@@ -83,8 +86,13 @@ final class JdbcSinkPreparer implements SinkPreparer {
                 TableDdl tableDdl = new TableDdl(
                         dialect.name(),
                         entry.getKey().toString(),
-                        target.getTablePath().toString(),
-                        JdbcCreateTableSqlResolver.resolve(dialect, createDefinition),
+                        ddlTargetPath == null
+                                ? target.getTablePath().toString()
+                                : ddlTargetPath.toString(),
+                        JdbcCreateTableSqlResolver.resolve(
+                                dialect,
+                                config.getConnectionConfig(),
+                                createDefinition),
                         executed,
                         executed ? TableDdl.STATUS_SUCCEEDED : TableDdl.STATUS_SKIPPED,
                         reason,

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/JdbcSaveModeHandler.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/JdbcSaveModeHandler.java
@@ -11,6 +11,8 @@ import com.link.up.connector.jdbc.sink.SchemaSaveMode;
  */
 public final class JdbcSaveModeHandler extends DefaultSaveModeHandler {
     private final boolean createPrimaryKey;
+    private final CatalogTable createTableDefinition;
+    private boolean tableCreated;
 
     public JdbcSaveModeHandler(
             SchemaSaveMode schemaSaveMode,
@@ -20,21 +22,31 @@ public final class JdbcSaveModeHandler extends DefaultSaveModeHandler {
             boolean createPrimaryKey) {
         super(schemaSaveMode, dataSaveMode, catalog, table);
         this.createPrimaryKey = createPrimaryKey;
+        this.createTableDefinition = createTableDefinition(table);
     }
 
     @Override
     protected void createTable() {
-        catalog.createTable(createTableDefinition(), false);
+        catalog.createTable(createTableDefinition, false);
+        tableCreated = true;
     }
 
-    private CatalogTable createTableDefinition() {
+    public CatalogTable getCreateTableDefinition() {
+        return createTableDefinition;
+    }
+
+    public boolean isTableCreated() {
+        return tableCreated;
+    }
+
+    private CatalogTable createTableDefinition(CatalogTable sourceTable) {
         if (createPrimaryKey) {
-            return table;
+            return sourceTable;
         }
         TableSchema schema =
                 TableSchema.builder()
-                        .columns(table.getTableSchema().getColumns())
+                        .columns(sourceTable.getTableSchema().getColumns())
                         .build();
-        return table.withSchema(schema);
+        return sourceTable.withSchema(schema);
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineExecution.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineExecution.java
@@ -1,5 +1,6 @@
 package com.link.up.framework.execution;
 
+import com.link.up.api.sink.TableDdl;
 import com.link.up.api.source.SourceSplit;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.type.FluxRow;
@@ -98,7 +99,7 @@ final class PipelineExecution {
     }
 
     /**
-     * 创建包含 Source、Sink 和目标表信息的 Pipeline 结果。
+     * 创建包含 Source、Sink、目标表和建表 DDL 信息的 Pipeline 结果。
      */
     private PipelineResult createPipelineResult(
             PipelineStatus status,
@@ -130,6 +131,12 @@ final class PipelineExecution {
                         .getTargetTable(
                                 plan.getDataSetPath());
 
+        TableDdl tableDdl =
+                preparedSink
+                        .getMetadata()
+                        .getTableDdl(
+                                plan.getDataSetPath());
+
         String sinkTablePath = "-";
 
         if (targetTable != null
@@ -150,6 +157,7 @@ final class PipelineExecution {
                 sinkIdentifier,
                 sinkTablePath,
                 plan.getSinkTaskPlans().size(),
+                tableDdl,
                 status,
                 commitSummary,
                 failure);

--- a/link-up-framework/src/main/java/com/link/up/framework/job/PipelineResult.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/PipelineResult.java
@@ -1,11 +1,13 @@
 package com.link.up.framework.job;
 
+import com.link.up.api.sink.TableDdl;
+
 import java.util.Objects;
 
 /**
  * 单条 Pipeline 的最终执行结果。
  *
- * <p>除执行状态外，还保留 Source、Sink 和目标表等展示信息，
+ * <p>除执行状态外，还保留 Source、Sink、目标表和离线建表语句等展示信息，
  * 供 Launcher、REST API 或 Web 控制台输出执行详情。
  */
 public final class PipelineResult {
@@ -20,6 +22,7 @@ public final class PipelineResult {
     private final String sinkIdentifier;
     private final String sinkTable;
     private final int sinkTaskCount;
+    private final TableDdl tableDdl;
 
     private final PipelineStatus status;
     private final CommitSummary commitSummary;
@@ -44,6 +47,7 @@ public final class PipelineResult {
                 "-",
                 "-",
                 0,
+                null,
                 status,
                 commitSummary,
                 failure);
@@ -58,6 +62,35 @@ public final class PipelineResult {
             String sinkIdentifier,
             String sinkTable,
             int sinkTaskCount,
+            PipelineStatus status,
+            CommitSummary commitSummary,
+            Throwable failure) {
+
+        this(
+                pipelineId,
+                dataSetId,
+                sourceIdentifier,
+                sourceTable,
+                sourceTaskCount,
+                sinkIdentifier,
+                sinkTable,
+                sinkTaskCount,
+                null,
+                status,
+                commitSummary,
+                failure);
+    }
+
+    public PipelineResult(
+            String pipelineId,
+            String dataSetId,
+            String sourceIdentifier,
+            String sourceTable,
+            int sourceTaskCount,
+            String sinkIdentifier,
+            String sinkTable,
+            int sinkTaskCount,
+            TableDdl tableDdl,
             PipelineStatus status,
             CommitSummary commitSummary,
             Throwable failure) {
@@ -89,6 +122,8 @@ public final class PipelineResult {
 
         this.sinkTaskCount =
                 Math.max(0, sinkTaskCount);
+
+        this.tableDdl = tableDdl;
 
         this.status =
                 Objects.requireNonNull(
@@ -159,6 +194,10 @@ public final class PipelineResult {
 
     public int getSinkTaskCount() {
         return sinkTaskCount;
+    }
+
+    public TableDdl getTableDdl() {
+        return tableDdl;
     }
 
     public PipelineStatus getStatus() {

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobResponse.java
@@ -1,11 +1,13 @@
 package com.link.up.server.dto;
 
+import com.link.up.api.sink.TableDdl;
 import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobSnapshot;
 import com.link.up.server.runtime.JobStateTransition;
 import com.link.up.server.runtime.ServerJobStatus;
 import com.link.up.server.runtime.WorkerIdentity;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -117,8 +119,24 @@ public final class JobResponse {
         return snapshot.getCommitSummary();
     }
 
-    public List<JobSnapshot.Pipeline> getPipelines() {
-        return snapshot.getPipelines();
+    public List<PipelineResponse> getPipelines() {
+        List<PipelineResponse> result =
+                new ArrayList<PipelineResponse>();
+
+        for (JobSnapshot.Pipeline pipeline :
+                snapshot.getPipelines()) {
+            TableDdl tableDdl = metadata == null
+                    ? null
+                    : metadata.getTableDdl(
+                            pipeline.getPipelineId());
+
+            result.add(
+                    new PipelineResponse(
+                            pipeline,
+                            tableDdl));
+        }
+
+        return Collections.unmodifiableList(result);
     }
 
     public List<JobStateTransition> getTransitions() {

--- a/link-up-server/src/main/java/com/link/up/server/dto/PipelineResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/PipelineResponse.java
@@ -1,0 +1,67 @@
+package com.link.up.server.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.link.up.api.sink.TableDdl;
+import com.link.up.server.runtime.JobSnapshot;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Backward-compatible REST view of one pipeline with optional offline table DDL.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class PipelineResponse {
+
+    private final JobSnapshot.Pipeline pipeline;
+    private final TableDdl tableDdl;
+
+    public PipelineResponse(
+            JobSnapshot.Pipeline pipeline,
+            TableDdl tableDdl) {
+        this.pipeline = Objects.requireNonNull(
+                pipeline,
+                "pipeline must not be null");
+        this.tableDdl = tableDdl;
+    }
+
+    public String getPipelineId() {
+        return pipeline.getPipelineId();
+    }
+
+    public String getDataSetId() {
+        return pipeline.getDataSetId();
+    }
+
+    public String getStatus() {
+        return pipeline.getStatus();
+    }
+
+    public JobSnapshot.Source getSource() {
+        return pipeline.getSource();
+    }
+
+    public JobSnapshot.Sink getSink() {
+        return pipeline.getSink();
+    }
+
+    public TableDdl getTableDdl() {
+        return tableDdl;
+    }
+
+    public JobSnapshot.Commit getCommitSummary() {
+        return pipeline.getCommitSummary();
+    }
+
+    public List<JobSnapshot.Task> getTasks() {
+        return pipeline.getTasks();
+    }
+
+    public List<JobSnapshot.Channel> getChannels() {
+        return pipeline.getChannels();
+    }
+
+    public String getErrorMessage() {
+        return pipeline.getErrorMessage();
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionHandle.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionHandle.java
@@ -1,11 +1,15 @@
 package com.link.up.server.runtime;
 
+import com.link.up.api.sink.TableDdl;
 import com.link.up.framework.execution.JobExecution;
 import com.link.up.framework.job.JobDefinition;
 import com.link.up.framework.job.JobResult;
+import com.link.up.framework.job.PipelineResult;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Future;
 
@@ -241,6 +245,21 @@ final class JobExecutionHandle {
     }
 
     synchronized JobExecutionMetadata metadata() {
+        Map<String, TableDdl> tableDdls =
+                new LinkedHashMap<String, TableDdl>();
+
+        JobResult currentResult = result;
+        if (currentResult != null) {
+            for (PipelineResult pipelineResult :
+                    currentResult.getPipelineResults()) {
+                if (pipelineResult.getTableDdl() != null) {
+                    tableDdls.put(
+                            pipelineResult.getPipelineId(),
+                            pipelineResult.getTableDdl());
+                }
+            }
+        }
+
         return new JobExecutionMetadata(
                 submission.getExternalExecutionId(),
                 submission.getIdempotencyKey(),
@@ -250,7 +269,8 @@ final class JobExecutionHandle {
                 queuedTimeMillis,
                 stateVersion,
                 cancellationRequested,
-                transitions);
+                transitions,
+                tableDdls);
     }
 
     boolean isCancellationRequested() {

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionMetadata.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionMetadata.java
@@ -1,8 +1,12 @@
 package com.link.up.server.runtime;
 
+import com.link.up.api.sink.TableDdl;
+
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * 作业协议元数据和状态机快照。
@@ -18,6 +22,7 @@ public final class JobExecutionMetadata {
     private final long stateVersion;
     private final boolean cancellationRequested;
     private final List<JobStateTransition> transitions;
+    private final Map<String, TableDdl> tableDdlsByPipelineId;
 
     public JobExecutionMetadata(
             String externalExecutionId,
@@ -29,6 +34,31 @@ public final class JobExecutionMetadata {
             long stateVersion,
             boolean cancellationRequested,
             List<JobStateTransition> transitions) {
+
+        this(
+                externalExecutionId,
+                idempotencyKey,
+                definitionVersion,
+                configDigest,
+                submittedTimeMillis,
+                queuedTimeMillis,
+                stateVersion,
+                cancellationRequested,
+                transitions,
+                Collections.<String, TableDdl>emptyMap());
+    }
+
+    public JobExecutionMetadata(
+            String externalExecutionId,
+            String idempotencyKey,
+            int definitionVersion,
+            String configDigest,
+            long submittedTimeMillis,
+            long queuedTimeMillis,
+            long stateVersion,
+            boolean cancellationRequested,
+            List<JobStateTransition> transitions,
+            Map<String, TableDdl> tableDdlsByPipelineId) {
 
         this.externalExecutionId = externalExecutionId;
         this.idempotencyKey = idempotencyKey;
@@ -42,6 +72,10 @@ public final class JobExecutionMetadata {
                 Collections.unmodifiableList(
                         new ArrayList<JobStateTransition>(
                                 transitions));
+        this.tableDdlsByPipelineId =
+                Collections.unmodifiableMap(
+                        new LinkedHashMap<String, TableDdl>(
+                                tableDdlsByPipelineId));
     }
 
     public String getExternalExecutionId() {
@@ -78,5 +112,13 @@ public final class JobExecutionMetadata {
 
     public List<JobStateTransition> getTransitions() {
         return transitions;
+    }
+
+    public Map<String, TableDdl> getTableDdlsByPipelineId() {
+        return tableDdlsByPipelineId;
+    }
+
+    public TableDdl getTableDdl(String pipelineId) {
+        return tableDdlsByPipelineId.get(pipelineId);
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/service/JobRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobRestService.java
@@ -11,6 +11,7 @@ import com.link.up.framework.job.JobSpecCompiler;
 import com.link.up.server.dto.JobResponse;
 import com.link.up.server.dto.JobSubmitRequest;
 import com.link.up.server.dto.PageResponse;
+import com.link.up.server.dto.PipelineResponse;
 import com.link.up.server.dto.WorkerNodeResponse;
 import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobManager;
@@ -113,12 +114,12 @@ public final class JobRestService {
     public JobResponse jobByExternalExecutionId(String externalExecutionId) {
         return response(manager.getJobByExternalExecutionId(externalExecutionId));
     }
-    public List<JobSnapshot.Pipeline> pipelines(String jobId) {
-        return manager.getJob(jobId).getPipelines();
+    public List<PipelineResponse> pipelines(String jobId) {
+        return response(manager.getJob(jobId)).getPipelines();
     }
     public List<JobSnapshot.Task> tasks(String jobId) {
         List<JobSnapshot.Task> tasks = new ArrayList<JobSnapshot.Task>();
-        for (JobSnapshot.Pipeline pipeline : pipelines(jobId)) {
+        for (PipelineResponse pipeline : pipelines(jobId)) {
             tasks.addAll(pipeline.getTasks());
         }
         return Collections.unmodifiableList(tasks);

--- a/link-up-server/src/test/java/com/link/up/server/runtime/PipelineResponseTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/runtime/PipelineResponseTest.java
@@ -1,0 +1,68 @@
+package com.link.up.server.runtime;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.sink.TableDdl;
+import com.link.up.server.dto.PipelineResponse;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PipelineResponseTest {
+
+    @Test
+    public void shouldSerializeTableDdlInsidePipeline() {
+        JobSnapshot.Source source = new JobSnapshot.Source(
+                "jdbc", "source_db.orders", 1,
+                0L, 10L, 100L,
+                1L, 1L, 0L, 10D);
+
+        JobSnapshot.Sink sink = new JobSnapshot.Sink(
+                "jdbc", "target_db.orders", 1,
+                1L, 10L, 10L, 0L, 0L,
+                100L, 10L, 10D);
+
+        JobSnapshot.Commit commit = new JobSnapshot.Commit(
+                1, 1, 1, 1, 0, 0,
+                10L, 10L, 10L, 0L, 0L,
+                false, false, "PIPELINE", "NONE");
+
+        JobSnapshot.Pipeline pipeline = new JobSnapshot.Pipeline(
+                "pipeline-orders",
+                "source_db.orders",
+                "SUCCEEDED",
+                source,
+                sink,
+                commit,
+                Collections.<JobSnapshot.Task>emptyList(),
+                Collections.<JobSnapshot.Channel>emptyList(),
+                null);
+
+        TableDdl tableDdl = new TableDdl(
+                "MYSQL",
+                "source_db.orders",
+                "target_db.orders",
+                "CREATE TABLE `target_db`.`orders` (`id` BIGINT NOT NULL);",
+                true,
+                TableDdl.STATUS_SUCCEEDED,
+                TableDdl.REASON_TARGET_TABLE_CREATED,
+                8L,
+                null,
+                null);
+
+        JsonNode json = new ObjectMapper().valueToTree(
+                new PipelineResponse(pipeline, tableDdl));
+
+        assertEquals("pipeline-orders", json.path("pipelineId").asText());
+        assertEquals(
+                "CREATE TABLE `target_db`.`orders` (`id` BIGINT NOT NULL);",
+                json.path("tableDdl").path("createTableSql").asText());
+        assertTrue(json.path("tableDdl").path("executed").asBoolean());
+        assertEquals(
+                TableDdl.REASON_TARGET_TABLE_CREATED,
+                json.path("tableDdl").path("reason").asText());
+    }
+}


### PR DESCRIPTION
## 背景

Yak Ops 当前可以获取 Link-Up 的任务状态、指标和 Pipeline 表信息，但离线任务准备阶段生成的目标表建表语句没有进入 Worker 返回协议，因此单表和多表执行详情都无法查看实际的 `CREATE TABLE` SQL。

Link-Up 的定位保持为 **offline-only batch synchronization Worker**。本 PR 只返回离线 Sink 准备阶段生成的建表语句，不引入 CDC、ALTER 事件或实时 Schema Change 模型。

## 协议

每个 Pipeline 新增可选的 `tableDdl`：

```json
{
  "pipelineId": "pipeline-orders",
  "dataSetId": "source_db.orders",
  "source": {
    "table": "source_db.orders"
  },
  "sink": {
    "table": "target_db.orders"
  },
  "tableDdl": {
    "dialect": "MYSQL",
    "sourceTable": "source_db.orders",
    "targetTable": "target_db.orders",
    "createTableSql": "CREATE TABLE `target_db`.`orders` (...);",
    "executed": true,
    "status": "SUCCEEDED",
    "reason": "TARGET_TABLE_CREATED",
    "durationMillis": 18
  }
}
```

- 单表任务仍为一个 Pipeline；
- 多表任务按数据集返回多个 Pipeline；
- 两种任务使用完全相同的 `tableDdl` 结构；
- 目标表已存在时仍返回生成的建表语句，但标记为 `executed=false`、`status=SKIPPED`、`reason=TARGET_TABLE_ALREADY_EXISTS`。

## 实现

- 新增 Connector-neutral `TableDdl` 不可变协议模型；
- 扩展 `PreparedSinkMetadata`，按源表保存目标表 DDL，同时保留旧构造函数兼容现有 Connector；
- JDBC Sink 在准备阶段记录最终目标表结构、实际建表结果和耗时；
- MySQL DDL 使用现有 `MySqlCreateTableSqlBuilder` 生成，并按 `schema` 或 JDBC URL 归一化目标 database，保证返回 SQL 与 Catalog 实际执行表一致；
- `PipelineResult` 将对应数据集的 DDL 带到执行结果；
- Server 使用独立 `PipelineResponse` 合并原有 Pipeline 快照和 DDL，不重构 `JobSnapshot`；
- `/api/v1/jobs/{jobId}` 和 `/api/v1/jobs/{jobId}/pipelines` 均返回一致的 `tableDdl`；
- DDL 随终态执行元数据进入有界历史仓库，后续查询不会丢失；
- 更新 Worker 协议文档并增加 Pipeline JSON 序列化测试。

## 兼容性

- 不修改 `WritableCatalog#createTable` 的 `void` 返回契约；
- 不修改任务提交、状态机、幂等、取消、指标和现有 Pipeline 字段；
- 非 JDBC 或尚未提供 DDL Builder 的未来方言可以保持 `tableDdl` 缺省；
- 旧客户端忽略新增字段即可继续工作。

## 验证

已完成：

- 分支基于当前 `main`，落后 0；
- 对单表/多表 Pipeline、主键过滤后的最终建表结构、目标 database 归一化和历史响应链路进行源码级审查；
- 增加 `PipelineResponseTest`，验证 `pipelines[].tableDdl` JSON 契约；
- GitHub 当前未返回可执行状态检查。

当前执行环境无法解析 `github.com`，且没有 Maven，因此尚未运行完整 Reactor 测试。合并前建议执行：

```bash
mvn --batch-mode clean verify
```

## 配套 PR

Yak Ops 需要配套升级以在表级指标和历史执行详情中消费该字段。建议先合并并发布本 PR，再合并 Yak Ops PR。