### PR TITLE
fix(jdbc): correct MySQL DDL mapper selection

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
@@ -5,8 +5,8 @@ import com.link.up.api.table.catalog.TablePath;
 import com.link.up.connector.jdbc.catalog.mysql.MySqlCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.catalog.mysql.MySqlTypeMapper;
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
-import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
 
 /** Generates the CREATE TABLE statement used for offline sink preparation. */
 final class JdbcCreateTableSqlResolver {
@@ -25,10 +25,19 @@ final class JdbcCreateTableSqlResolver {
             return null;
         }
 
-        JdbcTypeMapper typeMapper =
-                dialect.typeMapper();
+        /*
+         * MySqlDialect#typeMapper() returns the runtime mapper from
+         * core.dialect.mysql, while MySqlCreateTableSqlBuilder intentionally
+         * uses the catalog mapper from catalog.mysql. They are different
+         * classes with the same simple name and cannot be cast to each other.
+         *
+         * Use the dialect identifier to select the matching catalog DDL
+         * builder, and construct the same mapper configuration used by
+         * MySqlDialect#createCatalog().
+         */
+        if (DatabaseIdentifier.MYSQL.equalsIgnoreCase(
+                dialect.name())) {
 
-        if (typeMapper instanceof MySqlTypeMapper) {
             TablePath targetPath =
                     resolveTargetPath(
                             connectionConfig,
@@ -46,7 +55,7 @@ final class JdbcCreateTableSqlResolver {
             return new MySqlCreateTableSqlBuilder(
                     targetPath,
                     ddlTable,
-                    (MySqlTypeMapper) typeMapper)
+                    new MySqlTypeMapper(false))
                     .build();
         }
 


### PR DESCRIPTION
## 问题

合并 PR #58 后，`JdbcCreateTableSqlResolver` 无法编译：

```text
JdbcTypeMapper 无法转换为 catalog.mysql.MySqlTypeMapper
```

## 根因

项目中存在两个同名但无继承关系的类型：

- `com.link.up.connector.jdbc.core.dialect.mysql.MySqlTypeMapper`
  - 实现 `JdbcTypeMapper`
  - 由 `MySqlDialect#typeMapper()` 返回
- `com.link.up.connector.jdbc.catalog.mysql.MySqlTypeMapper`
  - 供 `MySqlCreateTableSqlBuilder` 和 `MySqlCatalog` 使用
  - 未实现 `JdbcTypeMapper`

原实现导入了 Catalog Mapper，却对 `dialect.typeMapper()` 的返回值执行 `instanceof` 和强制转换。由于 Catalog Mapper 是 `final` 且不实现 `JdbcTypeMapper`，Java 编译器可以直接判定该转换永远不成立。

## 修复

- 不再对两个同名 Mapper 做类型转换；
- 使用 `DatabaseIdentifier.MYSQL` 判断方言；
- 构造与 `MySqlDialect#createCatalog()` 一致的 Catalog Mapper：`new MySqlTypeMapper(false)`；
- 保持现有目标 database 归一化和建表 SQL 生成逻辑不变。

## 影响

只修复 MySQL DDL 返回链路的编译错误，不修改离线任务协议、执行状态机、指标或数据库结构。

## 验证

这是一个编译期类型错误修复。建议合并前执行：

```bash
mvn -pl link-up-connectors/link-up-connector-jdbc -am clean test
```
