### PR TITLE
feat(connector): add HTTP source connector for API data retrieval

### DIFF
--- a/link-up-connectors/link-up-connector-http/pom.xml
+++ b/link-up-connectors/link-up-connector-http/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.link.up</groupId>
+        <artifactId>link-up-connectors</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>link-up-connector-http</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto-service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>${lombok.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>4.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.jsonpath</groupId>
+            <artifactId>json-path</artifactId>
+            <version>2.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalog.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalog.java
@@ -1,0 +1,560 @@
+package com.link.up.connector.http.catalog;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.connector.http.client.HttpSourceClient;
+import com.link.up.connector.http.config.HttpFormat;
+import com.link.up.connector.http.config.HttpSourceConfig;
+import com.link.up.connector.http.schema.HttpSchemaParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * HTTP Catalog 实现。
+ *
+ * <p>HTTP 连接器没有传统数据库的库/表概念，
+ * Catalog 将整个 HTTP 端点建模为一张虚拟表。
+ *
+ * <p>Schema 发现支持两种模式：
+ * <ol>
+ *   <li><b>配置驱动</b>：用户配置了 {@code schema.fields} 时，
+ *       直接通过 {@link HttpSchemaParser} 解析</li>
+ *   <li><b>探测推断</b>：未配置 {@code schema.fields} 时，
+ *       向端点发送一次探测请求，从 JSON 响应中推断字段类型</li>
+ * </ol>
+ *
+ * <p>Catalog 为只读模式，不支持写操作。
+ */
+public final class HttpCatalog implements Catalog {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(HttpCatalog.class);
+
+    private static final String CATALOG_NAME = "http";
+    private static final String DEFAULT_DATABASE = "default";
+    private static final String DEFAULT_TABLE_NAME = "http_source";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final String catalogName;
+    private final HttpCatalogConfig config;
+
+    private volatile boolean opened;
+
+    public HttpCatalog(
+            String catalogName,
+            HttpCatalogConfig config) {
+
+        if (catalogName == null
+                || catalogName.trim().isEmpty()) {
+
+            throw new IllegalArgumentException(
+                    "catalogName must not be empty");
+        }
+
+        this.catalogName = catalogName;
+        this.config = Objects.requireNonNull(
+                config, "config must not be null");
+    }
+
+    public HttpCatalog(HttpCatalogConfig config) {
+        this(CATALOG_NAME, config);
+    }
+
+    // ── Catalog 生命周期 ──────────────────────────────────
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+
+        LOG.info("Opening HTTP Catalog, url={}",
+                config.getUrl());
+
+        opened = true;
+    }
+
+    // ── 数据库操作 ──────────────────────────────────────────
+
+    @Override
+    public java.util.Optional<String> getDefaultDatabase()
+            throws CatalogException {
+
+        checkOpened();
+        return java.util.Optional.of(DEFAULT_DATABASE);
+    }
+
+    @Override
+    public List<String> listDatabases()
+            throws CatalogException {
+
+        checkOpened();
+
+        return Collections.singletonList(
+                DEFAULT_DATABASE);
+    }
+
+    // ── 表操作 ──────────────────────────────────────────
+
+    @Override
+    public List<TablePath> listTables(
+            String databaseName,
+            String schemaName)
+            throws CatalogException {
+
+        checkOpened();
+
+        String tableName =
+                config.getTableName() != null
+                        ? config.getTableName()
+                        : DEFAULT_TABLE_NAME;
+
+        TablePath tablePath = TablePath.of(
+                DEFAULT_DATABASE,
+                tableName);
+
+        return Collections.singletonList(
+                tablePath);
+    }
+
+    @Override
+    public boolean tableExists(
+            TablePath tablePath)
+            throws CatalogException {
+
+        checkOpened();
+        Objects.requireNonNull(
+                tablePath,
+                "tablePath must not be null");
+
+        String expectedName =
+                config.getTableName() != null
+                        ? config.getTableName()
+                        : DEFAULT_TABLE_NAME;
+
+        return expectedName.equals(
+                tablePath.getTableName());
+    }
+
+    @Override
+    public CatalogTable getTable(
+            TablePath tablePath)
+            throws CatalogException,
+            TableNotFoundException {
+
+        checkOpened();
+        Objects.requireNonNull(
+                tablePath,
+                "tablePath must not be null");
+
+        if (!tableExists(tablePath)) {
+            throw new TableNotFoundException(
+                    catalogName,
+                    tablePath);
+        }
+
+        LOG.info("Discovering schema for HTTP table: {}",
+                tablePath);
+
+        TableSchema schema = discoverSchema();
+
+        return CatalogTable.builder(
+                        tablePath, schema)
+                .comment("HTTP Source: " + config.getUrl())
+                .option("dialect", "http")
+                .option("url", config.getUrl())
+                .build();
+    }
+
+    // ── Schema 发现 ──────────────────────────────────────────
+
+    /**
+     * 发现 HTTP 端点的 Schema。
+     *
+     * <p>优先使用用户配置的 {@code schema.fields}；
+     * 未配置时，发送探测请求从 JSON 响应推断。
+     */
+    private TableSchema discoverSchema() {
+        if (config.hasSchemaFields()) {
+            LOG.debug("使用配置的 schema.fields 构建表结构");
+            return HttpSchemaParser.parse(
+                    config.getSchemaFields());
+        }
+
+        LOG.debug("schema.fields 未配置，发送探测请求推断 Schema");
+        return probeAndInferSchema();
+    }
+
+    /**
+     * 向 HTTP 端点发送一次探测请求，
+     * 从 JSON 响应中推断字段类型。
+     */
+    private TableSchema probeAndInferSchema() {
+        HttpSourceConfig probeConfig =
+                config.toSourceConfig();
+
+        try (HttpSourceClient client =
+                     new HttpSourceClient(probeConfig)) {
+
+            String responseBody = client.execute(
+                    config.getHeaders(),
+                    config.getParams(),
+                    config.getBody());
+
+            if (responseBody == null
+                    || responseBody.isEmpty()) {
+
+                throw new CatalogException(
+                        "HTTP 探测请求返回空响应，"
+                                + "无法推断 Schema，url="
+                                + config.getUrl());
+            }
+
+            if (config.getFormat() != HttpFormat.JSON) {
+                throw new CatalogException(
+                        "TEXT 格式不支持自动 Schema 推断，"
+                                + "请配置 schema.fields，url="
+                                + config.getUrl());
+            }
+
+            return inferSchemaFromJson(responseBody);
+
+        } catch (CatalogException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CatalogException(
+                    "HTTP Schema 探测失败，url="
+                            + config.getUrl()
+                            + ": " + e.getMessage(),
+                    e);
+        }
+    }
+
+    /**
+     * 从 JSON 响应中推断 TableSchema。
+     *
+     * <p>支持 content_field 提取数据数组，
+     * 然后从第一个 JSON 对象推断字段类型。
+     */
+    private TableSchema inferSchemaFromJson(
+            String responseBody) throws Exception {
+
+        JsonNode root = MAPPER.readTree(responseBody);
+
+        // 如果配置了 content_field，先提取数据节点
+        JsonNode dataNode = root;
+        String contentField = config.getContentField();
+
+        if (contentField != null
+                && !contentField.isEmpty()) {
+
+            dataNode = navigateJsonPath(
+                    root, contentField);
+
+            if (dataNode == null
+                    || dataNode.isMissingNode()) {
+
+                throw new CatalogException(
+                        "content_field='"
+                                + contentField
+                                + "' 在响应中未找到数据，"
+                                + "无法推断 Schema");
+            }
+        }
+
+        // 找到第一个 JSON 对象用于推断
+        JsonNode sampleObject = findFirstObject(dataNode);
+
+        if (sampleObject == null
+                || !sampleObject.isObject()) {
+
+            throw new CatalogException(
+                    "HTTP 响应中未找到 JSON 对象，"
+                            + "无法推断 Schema。"
+                            + "请配置 schema.fields 定义表结构。");
+        }
+
+        return buildSchemaFromJsonNode(sampleObject);
+    }
+
+    /**
+     * 简单的 JsonPath 导航，
+     * 支持 {@code $.data.list} 形式。
+     */
+    private static JsonNode navigateJsonPath(
+            JsonNode root,
+            String jsonPath) {
+
+        if (jsonPath == null
+                || jsonPath.isEmpty()) {
+
+            return root;
+        }
+
+        String path = jsonPath.trim();
+
+        // 去掉开头的 $.
+        if (path.startsWith("$.")) {
+            path = path.substring(2);
+        } else if (path.startsWith("$")) {
+            path = path.substring(1);
+        }
+
+        if (path.isEmpty()) {
+            return root;
+        }
+
+        JsonNode current = root;
+
+        for (String segment : path.split("\\.")) {
+            if (current == null
+                    || current.isMissingNode()) {
+
+                return null;
+            }
+
+            // 处理数组索引 [*]
+            String seg = segment.replace("[*]", "");
+
+            if (!seg.isEmpty()) {
+                current = current.get(seg);
+            }
+        }
+
+        return current;
+    }
+
+    /**
+     * 从 JsonNode 中找到第一个 JSON 对象。
+     */
+    private static JsonNode findFirstObject(JsonNode node) {
+        if (node == null) {
+            return null;
+        }
+
+        if (node.isObject()) {
+            return node;
+        }
+
+        if (node.isArray()) {
+            for (JsonNode element : node) {
+                if (element.isObject()) {
+                    return element;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * 从 JSON 对象的字段推断 TableSchema。
+     */
+    private static TableSchema buildSchemaFromJsonNode(
+            JsonNode object) {
+
+        TableSchema.Builder builder =
+                TableSchema.builder();
+
+        Iterator<Map.Entry<String, JsonNode>> fields =
+                object.fields();
+
+        while (fields.hasNext()) {
+            Map.Entry<String, JsonNode> field =
+                    fields.next();
+
+            String fieldName = field.getKey();
+            JsonNode valueNode = field.getValue();
+
+            FluxDataType<?> dataType =
+                    inferFluxType(valueNode);
+
+            String sourceType =
+                    jsonTypeDescription(valueNode);
+
+            builder.column(
+                    Column.builder(
+                                    fieldName, dataType)
+                            .nullable(true)
+                            .sourceType(sourceType)
+                            .build());
+        }
+
+        List<Column> columns =
+                builder.build().getColumns();
+
+        if (columns.isEmpty()) {
+            throw new CatalogException(
+                    "JSON 对象无字段，无法推断 Schema");
+        }
+
+        return TableSchema.builder()
+                .columns(columns)
+                .build();
+    }
+
+    /**
+     * 根据 JSON 值推断 FluxDataType。
+     */
+    private static FluxDataType<?> inferFluxType(
+            JsonNode node) {
+
+        if (node == null
+                || node.isNull()
+                || node.isMissingNode()) {
+
+            // null 值默认为 STRING
+            return BasicType.STRING_TYPE;
+        }
+
+        if (node.isBoolean()) {
+            return BasicType.BOOLEAN_TYPE;
+        }
+
+        if (node.isInt()) {
+            return BasicType.INT_TYPE;
+        }
+
+        if (node.isLong()) {
+            return BasicType.LONG_TYPE;
+        }
+
+        if (node.isFloat()
+                || node.isDouble()) {
+
+            return BasicType.DOUBLE_TYPE;
+        }
+
+        if (node.isBigDecimal()) {
+            return BasicType.DOUBLE_TYPE;
+        }
+
+        if (node.isTextual()) {
+            String text = node.asText();
+
+            // 尝试识别常见日期/时间格式
+            if (isTimestampLike(text)) {
+                return BasicType.TIMESTAMP_TYPE;
+            }
+
+            if (isDateLike(text)) {
+                return BasicType.DATE_TYPE;
+            }
+
+            return BasicType.STRING_TYPE;
+        }
+
+        // 对象、数组等复杂类型统一映射为 STRING
+        return BasicType.STRING_TYPE;
+    }
+
+    /**
+     * 生成 JSON 值的类型描述字符串，
+     * 存入 Column.sourceType。
+     */
+    private static String jsonTypeDescription(
+            JsonNode node) {
+
+        if (node == null
+                || node.isNull()
+                || node.isMissingNode()) {
+
+            return "null";
+        }
+
+        if (node.isBoolean()) return "json:boolean";
+        if (node.isInt()) return "json:int";
+        if (node.isLong()) return "json:long";
+        if (node.isFloat()
+                || node.isDouble()) {
+            return "json:double";
+        }
+        if (node.isBigDecimal()) {
+            return "json:decimal";
+        }
+        if (node.isTextual()) return "json:string";
+        if (node.isArray()) return "json:array";
+        if (node.isObject()) return "json:object";
+
+        return "json:unknown";
+    }
+
+    /**
+     * 简单判断字符串是否像时间戳。
+     *
+     * <p>支持 {@code yyyy-MM-dd HH:mm:ss} 和
+     * {@code yyyy-MM-ddTHH:mm:ss} 格式。
+     */
+    private static boolean isTimestampLike(
+            String value) {
+
+        if (value == null
+                || value.length() < 19) {
+
+            return false;
+        }
+
+        // yyyy-MM-dd HH:mm:ss 或 yyyy-MM-ddTHH:mm:ss
+        return value.matches(
+                "\\d{4}-\\d{2}-\\d{2}[T ]"
+                        + "\\d{2}:\\d{2}:\\d{2}.*");
+    }
+
+    /**
+     * 简单判断字符串是否像日期。
+     *
+     * <p>支持 {@code yyyy-MM-dd} 格式。
+     */
+    private static boolean isDateLike(
+            String value) {
+
+        if (value == null
+                || value.length() != 10) {
+
+            return false;
+        }
+
+        return value.matches(
+                "\\d{4}-\\d{2}-\\d{2}");
+    }
+
+    // ── 内部工具 ──────────────────────────────────────────
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException(
+                    "HTTP Catalog has not been opened");
+        }
+    }
+
+    @Override
+    public void close() throws CatalogException {
+        if (!opened) {
+            return;
+        }
+
+        LOG.info("Closing HTTP Catalog");
+        opened = false;
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalog.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalog.java
@@ -47,7 +47,7 @@ public final class HttpCatalog implements Catalog {
 
     private static final String CATALOG_NAME = "http";
     private static final String DEFAULT_DATABASE = "default";
-    private static final String DEFAULT_TABLE_NAME = "http_source";
+    private static final String DEFAULT_TABLE_NAME = "default";
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalogConfig.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalogConfig.java
@@ -1,0 +1,198 @@
+package com.link.up.connector.http.catalog;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.connector.http.config.HttpFormat;
+import com.link.up.connector.http.config.HttpMethod;
+import com.link.up.connector.http.config.HttpSourceConfig;
+import com.link.up.connector.http.config.HttpSourceOptions;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * HTTP Catalog 配置。
+ *
+ * <p>从 {@link ReadonlyConfig} 中解析 Catalog 所需的连接参数，
+ * 复用 {@link HttpSourceOptions} 中已定义的 Option 定义。
+ */
+public final class HttpCatalogConfig {
+
+    private final String url;
+    private final HttpMethod method;
+    private final Map<String, String> headers;
+    private final Map<String, String> params;
+    private final String body;
+    private final HttpFormat format;
+    private final Map<String, Object> schemaFields;
+    private final String contentField;
+    private final Map<String, Object> jsonField;
+    private final int connectTimeoutMs;
+    private final int socketTimeoutMs;
+    private final int retry;
+    private final int retryBackoffMultiplierMs;
+    private final int retryBackoffMaxMs;
+    private final String tableName;
+
+    private HttpCatalogConfig(Builder builder) {
+        this.url = Objects.requireNonNull(builder.url, "url must not be null");
+        this.method = builder.method;
+        this.headers = builder.headers;
+        this.params = builder.params;
+        this.body = builder.body;
+        this.format = builder.format;
+        this.schemaFields = builder.schemaFields;
+        this.contentField = builder.contentField;
+        this.jsonField = builder.jsonField;
+        this.connectTimeoutMs = builder.connectTimeoutMs;
+        this.socketTimeoutMs = builder.socketTimeoutMs;
+        this.retry = builder.retry;
+        this.retryBackoffMultiplierMs = builder.retryBackoffMultiplierMs;
+        this.retryBackoffMaxMs = builder.retryBackoffMaxMs;
+        this.tableName = builder.tableName;
+    }
+
+    /**
+     * 从 {@link ReadonlyConfig} 构建。
+     */
+    public static HttpCatalogConfig of(ReadonlyConfig options) {
+        Objects.requireNonNull(options, "options must not be null");
+
+        String url = options.get(HttpSourceOptions.URL);
+        if (url == null || url.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "HTTP Catalog config requires 'url'");
+        }
+
+        return new Builder()
+                .url(url.trim())
+                .method(options.get(HttpSourceOptions.METHOD))
+                .headers(copyMap(options.get(HttpSourceOptions.HEADERS)))
+                .params(copyMap(options.get(HttpSourceOptions.PARAMS)))
+                .body(options.get(HttpSourceOptions.BODY))
+                .format(options.get(HttpSourceOptions.FORMAT))
+                .schemaFields(copyMap(options.get(HttpSourceOptions.SCHEMA_FIELDS)))
+                .contentField(options.get(HttpSourceOptions.CONTENT_FIELD))
+                .jsonField(copyMap(options.get(HttpSourceOptions.JSON_FIELD)))
+                .connectTimeoutMs(options.get(HttpSourceOptions.CONNECT_TIMEOUT_MS))
+                .socketTimeoutMs(options.get(HttpSourceOptions.SOCKET_TIMEOUT_MS))
+                .retry(options.get(HttpSourceOptions.RETRY))
+                .retryBackoffMultiplierMs(options.get(HttpSourceOptions.RETRY_BACKOFF_MULTIPLIER_MS))
+                .retryBackoffMaxMs(options.get(HttpSourceOptions.RETRY_BACKOFF_MAX_MS))
+                .build();
+    }
+
+    /**
+     * 从已有的 {@link HttpSourceConfig} 构建。
+     */
+    public static HttpCatalogConfig fromSourceConfig(HttpSourceConfig sourceConfig) {
+        Objects.requireNonNull(sourceConfig, "sourceConfig must not be null");
+
+        return new Builder()
+                .url(sourceConfig.getUrl())
+                .method(sourceConfig.getMethod())
+                .headers(sourceConfig.getHeaders())
+                .params(sourceConfig.getParams())
+                .body(sourceConfig.getBody())
+                .format(sourceConfig.getFormat())
+                .schemaFields(sourceConfig.getSchemaFields())
+                .contentField(sourceConfig.getContentField())
+                .jsonField(sourceConfig.getJsonField())
+                .connectTimeoutMs(sourceConfig.getConnectTimeoutMs())
+                .socketTimeoutMs(sourceConfig.getSocketTimeoutMs())
+                .retry(sourceConfig.getRetry())
+                .retryBackoffMultiplierMs(sourceConfig.getRetryBackoffMultiplierMs())
+                .retryBackoffMaxMs(sourceConfig.getRetryBackoffMaxMs())
+                .build();
+    }
+
+    private static <K, V> Map<K, V> copyMap(Map<K, V> source) {
+        if (source == null || source.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+    }
+
+    // ── Getters ──────────────────────────────────────────
+
+    public String getUrl() { return url; }
+    public HttpMethod getMethod() { return method; }
+    public Map<String, String> getHeaders() { return headers; }
+    public Map<String, String> getParams() { return params; }
+    public String getBody() { return body; }
+    public HttpFormat getFormat() { return format; }
+    public Map<String, Object> getSchemaFields() { return schemaFields; }
+    public String getContentField() { return contentField; }
+    public Map<String, Object> getJsonField() { return jsonField; }
+    public int getConnectTimeoutMs() { return connectTimeoutMs; }
+    public int getSocketTimeoutMs() { return socketTimeoutMs; }
+    public int getRetry() { return retry; }
+    public int getRetryBackoffMultiplierMs() { return retryBackoffMultiplierMs; }
+    public int getRetryBackoffMaxMs() { return retryBackoffMaxMs; }
+    public String getTableName() { return tableName; }
+
+    public boolean hasSchemaFields() {
+        return schemaFields != null && !schemaFields.isEmpty();
+    }
+
+    /**
+     * 转换为 {@link HttpSourceConfig}，供 Catalog 内部发起探测请求。
+     */
+    public HttpSourceConfig toSourceConfig() {
+        return new com.link.up.connector.http.config.HttpSourceConfig.Builder()
+                .url(url)
+                .method(method)
+                .headers(headers)
+                .params(params)
+                .body(body)
+                .format(format)
+                .schemaFields(schemaFields)
+                .contentField(contentField)
+                .jsonField(jsonField)
+                .connectTimeoutMs(connectTimeoutMs)
+                .socketTimeoutMs(socketTimeoutMs)
+                .retry(retry)
+                .retryBackoffMultiplierMs(retryBackoffMultiplierMs)
+                .retryBackoffMaxMs(retryBackoffMaxMs)
+                .build();
+    }
+
+    public static final class Builder {
+        private String url;
+        private HttpMethod method = HttpMethod.GET;
+        private Map<String, String> headers = Collections.emptyMap();
+        private Map<String, String> params = Collections.emptyMap();
+        private String body;
+        private HttpFormat format = HttpFormat.JSON;
+        private Map<String, Object> schemaFields = Collections.emptyMap();
+        private String contentField;
+        private Map<String, Object> jsonField = Collections.emptyMap();
+        private int connectTimeoutMs = 12000;
+        private int socketTimeoutMs = 60000;
+        private int retry = 3;
+        private int retryBackoffMultiplierMs = 100;
+        private int retryBackoffMaxMs = 10000;
+        private String tableName = "http_source";
+
+        public Builder url(String url) { this.url = url; return this; }
+        public Builder method(HttpMethod method) { this.method = method; return this; }
+        public Builder headers(Map<String, String> headers) { this.headers = headers; return this; }
+        public Builder params(Map<String, String> params) { this.params = params; return this; }
+        public Builder body(String body) { this.body = body; return this; }
+        public Builder format(HttpFormat format) { this.format = format; return this; }
+        public Builder schemaFields(Map<String, Object> schemaFields) { this.schemaFields = schemaFields; return this; }
+        public Builder contentField(String contentField) { this.contentField = contentField; return this; }
+        public Builder jsonField(Map<String, Object> jsonField) { this.jsonField = jsonField; return this; }
+        public Builder connectTimeoutMs(int v) { this.connectTimeoutMs = v; return this; }
+        public Builder socketTimeoutMs(int v) { this.socketTimeoutMs = v; return this; }
+        public Builder retry(int retry) { this.retry = retry; return this; }
+        public Builder retryBackoffMultiplierMs(int v) { this.retryBackoffMultiplierMs = v; return this; }
+        public Builder retryBackoffMaxMs(int v) { this.retryBackoffMaxMs = v; return this; }
+        public Builder tableName(String tableName) { this.tableName = tableName; return this; }
+
+        public HttpCatalogConfig build() {
+            return new HttpCatalogConfig(this);
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalogConfig.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalogConfig.java
@@ -116,21 +116,65 @@ public final class HttpCatalogConfig {
 
     // ── Getters ──────────────────────────────────────────
 
-    public String getUrl() { return url; }
-    public HttpMethod getMethod() { return method; }
-    public Map<String, String> getHeaders() { return headers; }
-    public Map<String, String> getParams() { return params; }
-    public String getBody() { return body; }
-    public HttpFormat getFormat() { return format; }
-    public Map<String, Object> getSchemaFields() { return schemaFields; }
-    public String getContentField() { return contentField; }
-    public Map<String, Object> getJsonField() { return jsonField; }
-    public int getConnectTimeoutMs() { return connectTimeoutMs; }
-    public int getSocketTimeoutMs() { return socketTimeoutMs; }
-    public int getRetry() { return retry; }
-    public int getRetryBackoffMultiplierMs() { return retryBackoffMultiplierMs; }
-    public int getRetryBackoffMaxMs() { return retryBackoffMaxMs; }
-    public String getTableName() { return tableName; }
+    public String getUrl() {
+        return url;
+    }
+
+    public HttpMethod getMethod() {
+        return method;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public Map<String, String> getParams() {
+        return params;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public HttpFormat getFormat() {
+        return format;
+    }
+
+    public Map<String, Object> getSchemaFields() {
+        return schemaFields;
+    }
+
+    public String getContentField() {
+        return contentField;
+    }
+
+    public Map<String, Object> getJsonField() {
+        return jsonField;
+    }
+
+    public int getConnectTimeoutMs() {
+        return connectTimeoutMs;
+    }
+
+    public int getSocketTimeoutMs() {
+        return socketTimeoutMs;
+    }
+
+    public int getRetry() {
+        return retry;
+    }
+
+    public int getRetryBackoffMultiplierMs() {
+        return retryBackoffMultiplierMs;
+    }
+
+    public int getRetryBackoffMaxMs() {
+        return retryBackoffMaxMs;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
 
     public boolean hasSchemaFields() {
         return schemaFields != null && !schemaFields.isEmpty();
@@ -159,6 +203,7 @@ public final class HttpCatalogConfig {
     }
 
     public static final class Builder {
+
         private String url;
         private HttpMethod method = HttpMethod.GET;
         private Map<String, String> headers = Collections.emptyMap();
@@ -173,23 +218,82 @@ public final class HttpCatalogConfig {
         private int retry = 3;
         private int retryBackoffMultiplierMs = 100;
         private int retryBackoffMaxMs = 10000;
-        private String tableName = "http_source";
+        private String tableName;
 
-        public Builder url(String url) { this.url = url; return this; }
-        public Builder method(HttpMethod method) { this.method = method; return this; }
-        public Builder headers(Map<String, String> headers) { this.headers = headers; return this; }
-        public Builder params(Map<String, String> params) { this.params = params; return this; }
-        public Builder body(String body) { this.body = body; return this; }
-        public Builder format(HttpFormat format) { this.format = format; return this; }
-        public Builder schemaFields(Map<String, Object> schemaFields) { this.schemaFields = schemaFields; return this; }
-        public Builder contentField(String contentField) { this.contentField = contentField; return this; }
-        public Builder jsonField(Map<String, Object> jsonField) { this.jsonField = jsonField; return this; }
-        public Builder connectTimeoutMs(int v) { this.connectTimeoutMs = v; return this; }
-        public Builder socketTimeoutMs(int v) { this.socketTimeoutMs = v; return this; }
-        public Builder retry(int retry) { this.retry = retry; return this; }
-        public Builder retryBackoffMultiplierMs(int v) { this.retryBackoffMultiplierMs = v; return this; }
-        public Builder retryBackoffMaxMs(int v) { this.retryBackoffMaxMs = v; return this; }
-        public Builder tableName(String tableName) { this.tableName = tableName; return this; }
+        public Builder url(String url) {
+            this.url = url;
+            return this;
+        }
+
+        public Builder method(HttpMethod method) {
+            this.method = method;
+            return this;
+        }
+
+        public Builder headers(Map<String, String> headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        public Builder params(Map<String, String> params) {
+            this.params = params;
+            return this;
+        }
+
+        public Builder body(String body) {
+            this.body = body;
+            return this;
+        }
+
+        public Builder format(HttpFormat format) {
+            this.format = format;
+            return this;
+        }
+
+        public Builder schemaFields(Map<String, Object> schemaFields) {
+            this.schemaFields = schemaFields;
+            return this;
+        }
+
+        public Builder contentField(String contentField) {
+            this.contentField = contentField;
+            return this;
+        }
+
+        public Builder jsonField(Map<String, Object> jsonField) {
+            this.jsonField = jsonField;
+            return this;
+        }
+
+        public Builder connectTimeoutMs(int connectTimeoutMs) {
+            this.connectTimeoutMs = connectTimeoutMs;
+            return this;
+        }
+
+        public Builder socketTimeoutMs(int socketTimeoutMs) {
+            this.socketTimeoutMs = socketTimeoutMs;
+            return this;
+        }
+
+        public Builder retry(int retry) {
+            this.retry = retry;
+            return this;
+        }
+
+        public Builder retryBackoffMultiplierMs(int retryBackoffMultiplierMs) {
+            this.retryBackoffMultiplierMs = retryBackoffMultiplierMs;
+            return this;
+        }
+
+        public Builder retryBackoffMaxMs(int retryBackoffMaxMs) {
+            this.retryBackoffMaxMs = retryBackoffMaxMs;
+            return this;
+        }
+
+        public Builder tableName(String tableName) {
+            this.tableName = tableName;
+            return this;
+        }
 
         public HttpCatalogConfig build() {
             return new HttpCatalogConfig(this);

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/catalog/HttpCatalogFactory.java
@@ -1,0 +1,37 @@
+package com.link.up.connector.http.catalog;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+
+/**
+ * HTTP Catalog SPI 工厂。
+ *
+ * <p>通过 {@link CatalogFactory} SPI 机制注册，
+ * 控制面可按 {@code factoryIdentifier = "http"} 加载。
+ */
+@AutoService(CatalogFactory.class)
+public final class HttpCatalogFactory
+        implements CatalogFactory {
+
+    private static final String IDENTIFIER = "http";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            ReadonlyConfig options) {
+
+        HttpCatalogConfig config =
+                HttpCatalogConfig.of(options);
+
+        return new HttpCatalog(
+                catalogName,
+                config);
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpSourceClient.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpSourceClient.java
@@ -1,0 +1,218 @@
+package com.link.up.connector.http.client;
+
+import com.link.up.connector.http.config.HttpFormat;
+import com.link.up.connector.http.config.HttpMethod;
+import com.link.up.connector.http.config.HttpSourceConfig;
+import okhttp3.FormBody;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * HTTP 请求客户端。
+ *
+ * <p>封装 OkHttp，提供带重试的 HTTP 请求执行能力。
+ */
+public final class HttpSourceClient implements AutoCloseable {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(HttpSourceClient.class);
+
+    private static final MediaType JSON_MEDIA_TYPE =
+            MediaType.parse("application/json; charset=utf-8");
+
+    private final HttpSourceConfig config;
+    private final OkHttpClient httpClient;
+
+    public HttpSourceClient(HttpSourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.httpClient = new OkHttpClient.Builder()
+                .connectTimeout(config.getConnectTimeoutMs(), TimeUnit.MILLISECONDS)
+                .readTimeout(config.getSocketTimeoutMs(), TimeUnit.MILLISECONDS)
+                .writeTimeout(config.getSocketTimeoutMs(), TimeUnit.MILLISECONDS)
+                .build();
+    }
+
+    /**
+     * 执行一次 HTTP 请求，返回响应体字符串。
+     *
+     * <p>包含重试逻辑：失败时按指数退避重试。
+     *
+     * @param effectiveHeaders 当前请求头（可能已替换分页占位符）
+     * @param effectiveParams  当前请求参数（可能已替换分页占位符）
+     * @param effectiveBody    当前请求体（可能已替换分页占位符）
+     * @return 响应体文本
+     */
+    public String execute(
+            Map<String, String> effectiveHeaders,
+            Map<String, String> effectiveParams,
+            String effectiveBody) throws IOException {
+
+        IOException lastException = null;
+        int maxAttempts = Math.max(1, config.getRetry() + 1);
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                return doExecute(effectiveHeaders, effectiveParams, effectiveBody);
+            } catch (IOException e) {
+                lastException = e;
+                if (attempt < maxAttempts) {
+                    long backoff = Math.min(
+                            (long) config.getRetryBackoffMultiplierMs() * (1L << (attempt - 1)),
+                            config.getRetryBackoffMaxMs());
+                    LOG.warn("HTTP request failed (attempt {}/{}), retrying in {} ms: {}",
+                            attempt, maxAttempts, backoff, e.getMessage());
+                    sleep(backoff);
+                }
+            }
+        }
+
+        throw lastException;
+    }
+
+    private String doExecute(
+            Map<String, String> effectiveHeaders,
+            Map<String, String> effectiveParams,
+            String effectiveBody) throws IOException {
+
+        String url = buildUrl(effectiveParams);
+
+        Request.Builder requestBuilder = new Request.Builder().url(url);
+
+        // 设置请求头
+        if (effectiveHeaders != null) {
+            for (Map.Entry<String, String> entry : effectiveHeaders.entrySet()) {
+                requestBuilder.header(entry.getKey(), entry.getValue());
+            }
+        }
+
+        // 设置请求方法和请求体
+        HttpMethod method = config.getMethod();
+        if (method == HttpMethod.POST) {
+            String bodyContent = effectiveBody != null ? effectiveBody : config.getBody();
+            RequestBody requestBody;
+            if (bodyContent != null && !bodyContent.isEmpty()) {
+                String contentType = getContentType(effectiveHeaders);
+                if ("application/x-www-form-urlencoded".equalsIgnoreCase(contentType)) {
+                    requestBody = buildFormBody(bodyContent, effectiveParams);
+                } else {
+                    requestBody = RequestBody.create(bodyContent, JSON_MEDIA_TYPE);
+                }
+            } else {
+                // POST 无 body 时发送空 JSON
+                requestBody = RequestBody.create("{}", JSON_MEDIA_TYPE);
+            }
+            requestBuilder.post(requestBody);
+        } else {
+            requestBuilder.get();
+        }
+
+        try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
+            if (!response.isSuccessful()) {
+                throw new IOException("HTTP request failed with status " + response.code()
+                        + " for URL: " + url);
+            }
+            ResponseBody responseBody = response.body();
+            return responseBody != null ? responseBody.string() : "";
+        }
+    }
+
+    private String buildUrl(Map<String, String> effectiveParams) {
+        StringBuilder urlBuilder = new StringBuilder(config.getUrl());
+
+        // 合并静态 params 和分页 params
+        Map<String, String> allParams = new LinkedHashMap<>();
+        if (config.getParams() != null) {
+            allParams.putAll(config.getParams());
+        }
+        if (effectiveParams != null) {
+            allParams.putAll(effectiveParams);
+        }
+
+        if (!allParams.isEmpty()) {
+            char separator = config.getUrl().contains("?") ? '&' : '?';
+            for (Map.Entry<String, String> entry : allParams.entrySet()) {
+                urlBuilder.append(separator)
+                        .append(urlEncode(entry.getKey()))
+                        .append('=')
+                        .append(urlEncode(entry.getValue()));
+                separator = '&';
+            }
+        }
+
+        return urlBuilder.toString();
+    }
+
+    private RequestBody buildFormBody(
+            String bodyContent,
+            Map<String, String> effectiveParams) {
+        FormBody.Builder formBuilder = new FormBody.Builder();
+
+        // 解析 body 中的 form 参数（简单 key=value&key2=value2 格式）
+        if (bodyContent != null && !bodyContent.isEmpty()) {
+            for (String pair : bodyContent.split("&")) {
+                int eq = pair.indexOf('=');
+                if (eq > 0) {
+                    formBuilder.add(
+                            pair.substring(0, eq).trim(),
+                            pair.substring(eq + 1).trim());
+                }
+            }
+        }
+
+        // 追加 params
+        if (effectiveParams != null) {
+            for (Map.Entry<String, String> entry : effectiveParams.entrySet()) {
+                formBuilder.add(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return formBuilder.build();
+    }
+
+    private String getContentType(Map<String, String> headers) {
+        if (headers == null) {
+            return null;
+        }
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if ("content-type".equalsIgnoreCase(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String urlEncode(String value) {
+        try {
+            return URLEncoder.encode(value, "UTF-8");
+        } catch (Exception e) {
+            return value;
+        }
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    @Override
+    public void close() {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpSourceClient.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpSourceClient.java
@@ -119,13 +119,19 @@ public final class HttpSourceClient implements AutoCloseable {
             requestBuilder.get();
         }
 
+        LOG.debug("HTTP {} {}", method, url);
+
         try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
             if (!response.isSuccessful()) {
+                LOG.warn("HTTP request failed: status={}, url={}", response.code(), url);
                 throw new IOException("HTTP request failed with status " + response.code()
                         + " for URL: " + url);
             }
             ResponseBody responseBody = response.body();
-            return responseBody != null ? responseBody.string() : "";
+            String body = responseBody != null ? responseBody.string() : "";
+            LOG.debug("HTTP response: status={}, bodyLength={}",
+                    response.code(), body.length());
+            return body;
         }
     }
 

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpFormat.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpFormat.java
@@ -1,0 +1,9 @@
+package com.link.up.connector.http.config;
+
+/**
+ * HTTP 响应数据格式。
+ */
+public enum HttpFormat {
+    JSON,
+    TEXT
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpMethod.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpMethod.java
@@ -1,0 +1,9 @@
+package com.link.up.connector.http.config;
+
+/**
+ * HTTP 请求方法。
+ */
+public enum HttpMethod {
+    GET,
+    POST
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpSourceConfig.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpSourceConfig.java
@@ -68,6 +68,28 @@ public final class HttpSourceConfig {
         this.socketTimeoutMs = builder.socketTimeoutMs;
         this.enableMultiLines = builder.enableMultiLines;
         this.jsonFieldMissedReturnNull = builder.jsonFieldMissedReturnNull;
+
+        validatePagination();
+    }
+
+    /**
+     * 校验分页配置一致性。
+     */
+    private void validatePagination() {
+        if (!hasPagination()) {
+            return;
+        }
+
+        if (pageType == PageType.CURSOR) {
+            if (cursorField == null || cursorField.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Cursor 分页模式必须配置 'pageing.cursor_field'");
+            }
+            if (cursorResponseField == null || cursorResponseField.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Cursor 分页模式必须配置 'pageing.cursor_response_field'");
+            }
+        }
     }
 
     public static HttpSourceConfig of(ReadonlyConfig options) {
@@ -117,7 +139,7 @@ public final class HttpSourceConfig {
         return pageField != null && !pageField.isEmpty();
     }
 
-    // ── Getters ──────────────────────────────────────────────────
+    // ── Getters ──────────────────────────────────────────
 
     public String getUrl() { return url; }
     public HttpMethod getMethod() { return method; }

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpSourceConfig.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpSourceConfig.java
@@ -1,0 +1,202 @@
+package com.link.up.connector.http.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * HTTP Source 解析后的不可变配置。
+ */
+public final class HttpSourceConfig {
+
+    private final String url;
+    private final HttpMethod method;
+    private final Map<String, String> headers;
+    private final Map<String, String> params;
+    private final String body;
+    private final HttpFormat format;
+    private final Map<String, Object> schemaFields;
+    private final String contentField;
+    private final Map<String, Object> jsonField;
+
+    // 分页
+    private final String pageField;
+    private final long totalPageSize;
+    private final int pageBatchSize;
+    private final int startPageNumber;
+    private final PageType pageType;
+    private final String cursorField;
+    private final String cursorResponseField;
+    private final boolean usePlaceholderReplacement;
+
+    // 重试与超时
+    private final int retry;
+    private final int retryBackoffMultiplierMs;
+    private final int retryBackoffMaxMs;
+    private final int connectTimeoutMs;
+    private final int socketTimeoutMs;
+
+    // 其他
+    private final boolean enableMultiLines;
+    private final boolean jsonFieldMissedReturnNull;
+
+    private HttpSourceConfig(Builder builder) {
+        this.url = Objects.requireNonNull(builder.url, "url must not be null");
+        this.method = builder.method;
+        this.headers = builder.headers;
+        this.params = builder.params;
+        this.body = builder.body;
+        this.format = builder.format;
+        this.schemaFields = builder.schemaFields;
+        this.contentField = builder.contentField;
+        this.jsonField = builder.jsonField;
+        this.pageField = builder.pageField;
+        this.totalPageSize = builder.totalPageSize;
+        this.pageBatchSize = builder.pageBatchSize;
+        this.startPageNumber = builder.startPageNumber;
+        this.pageType = builder.pageType;
+        this.cursorField = builder.cursorField;
+        this.cursorResponseField = builder.cursorResponseField;
+        this.usePlaceholderReplacement = builder.usePlaceholderReplacement;
+        this.retry = builder.retry;
+        this.retryBackoffMultiplierMs = builder.retryBackoffMultiplierMs;
+        this.retryBackoffMaxMs = builder.retryBackoffMaxMs;
+        this.connectTimeoutMs = builder.connectTimeoutMs;
+        this.socketTimeoutMs = builder.socketTimeoutMs;
+        this.enableMultiLines = builder.enableMultiLines;
+        this.jsonFieldMissedReturnNull = builder.jsonFieldMissedReturnNull;
+    }
+
+    public static HttpSourceConfig of(ReadonlyConfig options) {
+        Objects.requireNonNull(options, "options must not be null");
+
+        String url = options.get(HttpSourceOptions.URL);
+        if (url == null || url.trim().isEmpty()) {
+            throw new IllegalArgumentException("HTTP Source url must not be blank");
+        }
+
+        return new Builder()
+                .url(url.trim())
+                .method(options.get(HttpSourceOptions.METHOD))
+                .headers(copyMap(options.get(HttpSourceOptions.HEADERS)))
+                .params(copyMap(options.get(HttpSourceOptions.PARAMS)))
+                .body(options.get(HttpSourceOptions.BODY))
+                .format(options.get(HttpSourceOptions.FORMAT))
+                .schemaFields(copyMap(options.get(HttpSourceOptions.SCHEMA_FIELDS)))
+                .contentField(options.get(HttpSourceOptions.CONTENT_FIELD))
+                .jsonField(copyMap(options.get(HttpSourceOptions.JSON_FIELD)))
+                .pageField(options.get(HttpSourceOptions.PAGE_FIELD))
+                .totalPageSize(options.get(HttpSourceOptions.TOTAL_PAGE_SIZE))
+                .pageBatchSize(options.get(HttpSourceOptions.PAGE_BATCH_SIZE))
+                .startPageNumber(options.get(HttpSourceOptions.START_PAGE_NUMBER))
+                .pageType(options.get(HttpSourceOptions.PAGE_TYPE))
+                .cursorField(options.get(HttpSourceOptions.CURSOR_FIELD))
+                .cursorResponseField(options.get(HttpSourceOptions.CURSOR_RESPONSE_FIELD))
+                .usePlaceholderReplacement(options.get(HttpSourceOptions.USE_PLACEHOLDER_REPLACEMENT))
+                .retry(options.get(HttpSourceOptions.RETRY))
+                .retryBackoffMultiplierMs(options.get(HttpSourceOptions.RETRY_BACKOFF_MULTIPLIER_MS))
+                .retryBackoffMaxMs(options.get(HttpSourceOptions.RETRY_BACKOFF_MAX_MS))
+                .connectTimeoutMs(options.get(HttpSourceOptions.CONNECT_TIMEOUT_MS))
+                .socketTimeoutMs(options.get(HttpSourceOptions.SOCKET_TIMEOUT_MS))
+                .enableMultiLines(options.get(HttpSourceOptions.ENABLE_MULTI_LINES))
+                .jsonFieldMissedReturnNull(options.get(HttpSourceOptions.JSON_FIELD_MISSED_RETURN_NULL))
+                .build();
+    }
+
+    private static <K, V> Map<K, V> copyMap(Map<K, V> source) {
+        if (source == null || source.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(new LinkedHashMap<>(source));
+    }
+
+    public boolean hasPagination() {
+        return pageField != null && !pageField.isEmpty();
+    }
+
+    // ── Getters ──────────────────────────────────────────────────
+
+    public String getUrl() { return url; }
+    public HttpMethod getMethod() { return method; }
+    public Map<String, String> getHeaders() { return headers; }
+    public Map<String, String> getParams() { return params; }
+    public String getBody() { return body; }
+    public HttpFormat getFormat() { return format; }
+    public Map<String, Object> getSchemaFields() { return schemaFields; }
+    public String getContentField() { return contentField; }
+    public Map<String, Object> getJsonField() { return jsonField; }
+    public String getPageField() { return pageField; }
+    public long getTotalPageSize() { return totalPageSize; }
+    public int getPageBatchSize() { return pageBatchSize; }
+    public int getStartPageNumber() { return startPageNumber; }
+    public PageType getPageType() { return pageType; }
+    public String getCursorField() { return cursorField; }
+    public String getCursorResponseField() { return cursorResponseField; }
+    public boolean isUsePlaceholderReplacement() { return usePlaceholderReplacement; }
+    public int getRetry() { return retry; }
+    public int getRetryBackoffMultiplierMs() { return retryBackoffMultiplierMs; }
+    public int getRetryBackoffMaxMs() { return retryBackoffMaxMs; }
+    public int getConnectTimeoutMs() { return connectTimeoutMs; }
+    public int getSocketTimeoutMs() { return socketTimeoutMs; }
+    public boolean isEnableMultiLines() { return enableMultiLines; }
+    public boolean isJsonFieldMissedReturnNull() { return jsonFieldMissedReturnNull; }
+
+    public static final class Builder {
+        private String url;
+        private HttpMethod method = HttpMethod.GET;
+        private Map<String, String> headers = Collections.emptyMap();
+        private Map<String, String> params = Collections.emptyMap();
+        private String body;
+        private HttpFormat format = HttpFormat.JSON;
+        private Map<String, Object> schemaFields = Collections.emptyMap();
+        private String contentField;
+        private Map<String, Object> jsonField = Collections.emptyMap();
+        private String pageField;
+        private long totalPageSize = 0;
+        private int pageBatchSize = 100;
+        private int startPageNumber = 1;
+        private PageType pageType = PageType.PAGE_NUMBER;
+        private String cursorField;
+        private String cursorResponseField;
+        private boolean usePlaceholderReplacement = false;
+        private int retry = 3;
+        private int retryBackoffMultiplierMs = 100;
+        private int retryBackoffMaxMs = 10000;
+        private int connectTimeoutMs = 12000;
+        private int socketTimeoutMs = 60000;
+        private boolean enableMultiLines = false;
+        private boolean jsonFieldMissedReturnNull = false;
+
+        public Builder url(String url) { this.url = url; return this; }
+        public Builder method(HttpMethod method) { this.method = method; return this; }
+        public Builder headers(Map<String, String> headers) { this.headers = headers; return this; }
+        public Builder params(Map<String, String> params) { this.params = params; return this; }
+        public Builder body(String body) { this.body = body; return this; }
+        public Builder format(HttpFormat format) { this.format = format; return this; }
+        public Builder schemaFields(Map<String, Object> schemaFields) { this.schemaFields = schemaFields; return this; }
+        public Builder contentField(String contentField) { this.contentField = contentField; return this; }
+        public Builder jsonField(Map<String, Object> jsonField) { this.jsonField = jsonField; return this; }
+        public Builder pageField(String pageField) { this.pageField = pageField; return this; }
+        public Builder totalPageSize(long totalPageSize) { this.totalPageSize = totalPageSize; return this; }
+        public Builder pageBatchSize(int pageBatchSize) { this.pageBatchSize = pageBatchSize; return this; }
+        public Builder startPageNumber(int startPageNumber) { this.startPageNumber = startPageNumber; return this; }
+        public Builder pageType(PageType pageType) { this.pageType = pageType; return this; }
+        public Builder cursorField(String cursorField) { this.cursorField = cursorField; return this; }
+        public Builder cursorResponseField(String cursorResponseField) { this.cursorResponseField = cursorResponseField; return this; }
+        public Builder usePlaceholderReplacement(boolean v) { this.usePlaceholderReplacement = v; return this; }
+        public Builder retry(int retry) { this.retry = retry; return this; }
+        public Builder retryBackoffMultiplierMs(int v) { this.retryBackoffMultiplierMs = v; return this; }
+        public Builder retryBackoffMaxMs(int v) { this.retryBackoffMaxMs = v; return this; }
+        public Builder connectTimeoutMs(int v) { this.connectTimeoutMs = v; return this; }
+        public Builder socketTimeoutMs(int v) { this.socketTimeoutMs = v; return this; }
+        public Builder enableMultiLines(boolean v) { this.enableMultiLines = v; return this; }
+        public Builder jsonFieldMissedReturnNull(boolean v) { this.jsonFieldMissedReturnNull = v; return this; }
+
+        public HttpSourceConfig build() {
+            return new HttpSourceConfig(this);
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpSourceOptions.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/HttpSourceOptions.java
@@ -1,0 +1,251 @@
+package com.link.up.connector.http.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.Map;
+
+/**
+ * HTTP Source 配置项。
+ *
+ * <p>参考 SeaTunnel HTTP Source 参数设计，
+ * 并结合 Link-Up 配置体系进行优化。
+ */
+public final class HttpSourceOptions {
+
+    private HttpSourceOptions() {
+    }
+
+    // ── 基础请求配置 ──────────────────────────────────────────────
+
+    public static final Option<String> URL =
+            Options.key("url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("HTTP 请求地址")
+                    .withSemanticType("HTTP_URL")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<HttpMethod> METHOD =
+            Options.key("method")
+                    .enumType(HttpMethod.class)
+                    .defaultValue(HttpMethod.GET)
+                    .withDescription("HTTP 请求方法，支持 GET、POST")
+                    .withSemanticType("HTTP_METHOD")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Map<String, String>> HEADERS =
+            Options.key("headers")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("HTTP 请求头")
+                    .withSemanticType("HTTP_HEADERS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Map<String, String>> PARAMS =
+            Options.key("params")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("HTTP 请求参数（追加到 URL 查询字符串）")
+                    .withSemanticType("HTTP_PARAMS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> BODY =
+            Options.key("body")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("HTTP 请求体，POST 时作为 JSON Body 发送")
+                    .withSemanticType("HTTP_BODY")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    // ── 数据格式与 Schema ──────────────────────────────────────────
+
+    public static final Option<HttpFormat> FORMAT =
+            Options.key("format")
+                    .enumType(HttpFormat.class)
+                    .defaultValue(HttpFormat.JSON)
+                    .withDescription("响应数据格式：json 或 text")
+                    .withSemanticType("DATA_FORMAT")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    /**
+     * 用户定义的输出 Schema 字段映射。
+     *
+     * <p>key 为字段名，value 为类型名（string、int、bigint 等）。
+     */
+    public static final Option<Map<String, Object>> SCHEMA_FIELDS =
+            Options.key("schema.fields")
+                    .mapObjectType()
+                    .noDefaultValue()
+                    .withDescription("用户定义的输出 Schema 字段映射")
+                    .withSemanticType("SCHEMA_FIELDS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    // ── JSON 提取 ──────────────────────────────────────────────────
+
+    /**
+     * 从响应 JSON 中提取数据数组的 JsonPath。
+     *
+     * <p>例如 {@code $.data.list} 或 {@code $.store.book.*}。
+     */
+    public static final Option<String> CONTENT_FIELD =
+            Options.key("content_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("从响应 JSON 中提取数据数组的 JsonPath 表达式")
+                    .withSemanticType("JSON_PATH")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    /**
+     * 字段名到 JsonPath 的映射。
+     *
+     * <p>每个字段的值是一个 JsonPath 表达式，
+     * 用于从响应 JSON 中提取该字段的值数组。
+     */
+    public static final Option<Map<String, Object>> JSON_FIELD =
+            Options.key("json_field")
+                    .mapObjectType()
+                    .noDefaultValue()
+                    .withDescription("字段名到 JsonPath 表达式的映射")
+                    .withSemanticType("JSON_FIELD_MAPPING")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    // ── 分页配置 ──────────────────────────────────────────────────
+
+    public static final Option<String> PAGE_FIELD =
+            Options.key("pageing.page_field")
+                    .stringType()
+                    .defaultValue("page")
+                    .withDescription("分页字段名")
+                    .withSemanticType("PAGE_FIELD")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Long> TOTAL_PAGE_SIZE =
+            Options.key("pageing.total_page_size")
+                    .longType()
+                    .defaultValue(0L)
+                    .withDescription("总页数，0 表示根据返回行数判断是否继续")
+                    .withSemanticType("TOTAL_PAGES")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> PAGE_BATCH_SIZE =
+            Options.key("pageing.batch_size")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("每页返回行数，用于判断是否继续翻页")
+                    .withSemanticType("PAGE_BATCH_SIZE")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> START_PAGE_NUMBER =
+            Options.key("pageing.start_page_number")
+                    .intType()
+                    .defaultValue(1)
+                    .withDescription("起始页码")
+                    .withSemanticType("START_PAGE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<PageType> PAGE_TYPE =
+            Options.key("pageing.page_type")
+                    .enumType(PageType.class)
+                    .defaultValue(PageType.PAGE_NUMBER)
+                    .withDescription("分页类型：PAGE_NUMBER 或 CURSOR")
+                    .withSemanticType("PAGE_TYPE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> CURSOR_FIELD =
+            Options.key("pageing.cursor_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Cursor 分页时请求参数中的游标字段名")
+                    .withSemanticType("CURSOR_FIELD")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> CURSOR_RESPONSE_FIELD =
+            Options.key("pageing.cursor_response_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Cursor 分页时从响应中提取游标值的 JsonPath")
+                    .withSemanticType("CURSOR_RESPONSE_FIELD")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    /**
+     * 是否使用占位符替换（${page}、${cursor}）。
+     *
+     * <p>为 true 时，headers、params、body 中的 {@code ${page}} 等占位符
+     * 会被替换为实际值；为 false 时，仅按 key 进行替换。
+     */
+    public static final Option<Boolean> USE_PLACEHOLDER_REPLACEMENT =
+            Options.key("pageing.use_placeholder_replacement")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("是否使用占位符替换分页参数")
+                    .withSemanticType("PLACEHOLDER_REPLACEMENT")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    // ── 重试与超时 ──────────────────────────────────────────────────
+
+    public static final Option<Integer> RETRY =
+            Options.key("retry")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("请求失败最大重试次数")
+                    .withSemanticType("RETRY_COUNT")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> RETRY_BACKOFF_MULTIPLIER_MS =
+            Options.key("retry_backoff_multiplier_ms")
+                    .intType()
+                    .defaultValue(100)
+                    .withDescription("重试退避乘子，单位毫秒")
+                    .withSemanticType("RETRY_BACKOFF")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> RETRY_BACKOFF_MAX_MS =
+            Options.key("retry_backoff_max_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription("重试退避上限，单位毫秒")
+                    .withSemanticType("RETRY_BACKOFF_MAX")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> CONNECT_TIMEOUT_MS =
+            Options.key("connect_timeout_ms")
+                    .intType()
+                    .defaultValue(12000)
+                    .withDescription("连接超时时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> SOCKET_TIMEOUT_MS =
+            Options.key("socket_timeout_ms")
+                    .intType()
+                    .defaultValue(60000)
+                    .withDescription("Socket 读取超时时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    // ── 其他 ──────────────────────────────────────────────────────
+
+    /**
+     * 当 format=text 时，是否将多行文本拆分为多行数据。
+     */
+    public static final Option<Boolean> ENABLE_MULTI_LINES =
+            Options.key("enable_multi_lines")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("text 格式下是否将多行文本拆分为多行数据")
+                    .withSemanticType("MULTI_LINES")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    /**
+     * 当 JSON 字段缺失时，是否返回 null 而非报错。
+     */
+    public static final Option<Boolean> JSON_FIELD_MISSED_RETURN_NULL =
+            Options.key("json_field_missed_return_null")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("JSON 字段缺失时是否返回 null，否则报错")
+                    .withSemanticType("MISS_FIELD_POLICY")
+                    .withScope(ConnectorOptionScope.TASK);
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/PageType.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/config/PageType.java
@@ -1,0 +1,9 @@
+package com.link.up.connector.http.config;
+
+/**
+ * 分页类型。
+ */
+public enum PageType {
+    PAGE_NUMBER,
+    CURSOR
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/parser/HttpResponseParser.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/parser/HttpResponseParser.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * HTTP 响应解析器。
@@ -74,7 +75,7 @@ public final class HttpResponseParser {
         return parseByContentField(responseBody, config, schema);
     }
 
-    // ── TEXT 格式 ──────────────────────────────────────────────────
+    // ── TEXT 格式 ──────────────────────────────────────────
 
     private static List<FluxRow> parseTextResponse(
             String responseBody,
@@ -99,7 +100,7 @@ public final class HttpResponseParser {
         return Collections.singletonList(FluxRow.of(responseBody));
     }
 
-    // ── JSON content_field 模式 ──────────────────────────────────────────
+    // ── JSON content_field 模式 ──────────────────────────────
 
     private static List<FluxRow> parseByContentField(
             String responseBody,
@@ -138,7 +139,7 @@ public final class HttpResponseParser {
         return Collections.singletonList(FluxRow.of(jsonNodeToJavaValue(dataNode)));
     }
 
-    // ── JSON json_field 模式 ─────────────────────────────────────────────
+    // ── JSON json_field 模式 ─────────────────────────────────
 
     private static List<FluxRow> parseByJsonField(
             String responseBody,
@@ -151,7 +152,7 @@ public final class HttpResponseParser {
         // 每个字段提取值列表
         List<String> fieldNames = schema.getColumns().stream()
                 .map(Column::getName)
-                .collect(java.util.stream.Collectors.toList());
+                .collect(Collectors.toList());
 
         List<List<Object>> fieldValues = new ArrayList<>(fieldNames.size());
         int maxLen = 0;
@@ -191,7 +192,43 @@ public final class HttpResponseParser {
         return rows;
     }
 
-    // ── JsonPath 工具 ──────────────────────────────────────────────────
+    /**
+     * 从 JSON 响应中提取单个字符串值。
+     *
+     * <p>用于 Cursor 分页时从响应中提取游标值。
+     *
+     * @param responseBody JSON 响应体
+     * @param jsonPath     JsonPath 表达式
+     * @return 提取的字符串值，未找到时返回 null
+     */
+    public static String extractSingleStringValue(
+            String responseBody,
+            String jsonPath) throws Exception {
+
+        if (responseBody == null || jsonPath == null) {
+            return null;
+        }
+
+        JsonNode root = MAPPER.readTree(responseBody);
+        String normalized = normalizeJsonPath(jsonPath);
+        Object result = JsonPath.using(JSON_PATH_CONFIG).parse(root).read(normalized);
+
+        if (result == null) {
+            return null;
+        }
+
+        if (result instanceof JsonNode) {
+            JsonNode node = (JsonNode) result;
+            if (node.isNull() || node.isMissingNode()) {
+                return null;
+            }
+            return node.isTextual() ? node.asText() : node.toString();
+        }
+
+        return String.valueOf(result);
+    }
+
+    // ── JsonPath 工具 ──────────────────────────────────────────
 
     private static JsonNode evaluateJsonPath(JsonNode root, String jsonPath) {
         String normalized = normalizeJsonPath(jsonPath);
@@ -260,7 +297,7 @@ public final class HttpResponseParser {
         return path.replaceAll("\\.\\*", "[*]");
     }
 
-    // ── JSON → FluxRow 映射 ──────────────────────────────────────────────
+    // ── JSON → FluxRow 映射 ──────────────────────────────────
 
     private static FluxRow mapJsonNodeToRow(
             JsonNode node,
@@ -288,7 +325,7 @@ public final class HttpResponseParser {
         return row;
     }
 
-    // ── 类型转换 ──────────────────────────────────────────────────────
+    // ── 类型转换 ──────────────────────────────────────────
 
     private static Object jsonNodeToJavaValue(JsonNode node) {
         if (node == null || node.isNull() || node.isMissingNode()) {
@@ -311,7 +348,7 @@ public final class HttpResponseParser {
         return node.toString();
     }
 
-    static Object convertValue(Object value, Column column) {
+    private static Object convertValue(Object value, Column column) {
         if (value == null) {
             return null;
         }

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/parser/HttpResponseParser.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/parser/HttpResponseParser.java
@@ -1,0 +1,377 @@
+package com.link.up.connector.http.parser;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.http.config.HttpFormat;
+import com.link.up.connector.http.config.HttpSourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * HTTP 响应解析器。
+ *
+ * <p>支持两种 JSON 提取模式：
+ * <ul>
+ *   <li><b>content_field</b>：提取 JSON 数组，每个元素映射为一行</li>
+ *   <li><b>json_field</b>：每个字段独立提取值数组，按行对齐</li>
+ * </ul>
+ */
+public final class HttpResponseParser {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(HttpResponseParser.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final Configuration JSON_PATH_CONFIG =
+            Configuration.builder()
+                    .jsonProvider(new JacksonJsonNodeJsonProvider())
+                    .mappingProvider(new JacksonMappingProvider())
+                    .options(Option.SUPPRESS_EXCEPTIONS)
+                    .build();
+
+    private HttpResponseParser() {
+    }
+
+    /**
+     * 解析 HTTP 响应为 FluxRow 列表。
+     */
+    public static List<FluxRow> parseResponse(
+            String responseBody,
+            HttpSourceConfig config,
+            TableSchema schema) throws Exception {
+
+        if (config.getFormat() == HttpFormat.TEXT) {
+            return parseTextResponse(responseBody, config);
+        }
+
+        // JSON 格式
+        if (!config.getJsonField().isEmpty()) {
+            return parseByJsonField(responseBody, config, schema);
+        }
+
+        return parseByContentField(responseBody, config, schema);
+    }
+
+    // ── TEXT 格式 ──────────────────────────────────────────────────
+
+    private static List<FluxRow> parseTextResponse(
+            String responseBody,
+            HttpSourceConfig config) {
+
+        if (responseBody == null || responseBody.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        if (config.isEnableMultiLines()) {
+            String[] lines = responseBody.split("\\r?\\n");
+            List<FluxRow> rows = new ArrayList<>(lines.length);
+            for (String line : lines) {
+                String trimmed = line.trim();
+                if (!trimmed.isEmpty()) {
+                    rows.add(FluxRow.of(trimmed));
+                }
+            }
+            return rows;
+        }
+
+        return Collections.singletonList(FluxRow.of(responseBody));
+    }
+
+    // ── JSON content_field 模式 ──────────────────────────────────────────
+
+    private static List<FluxRow> parseByContentField(
+            String responseBody,
+            HttpSourceConfig config,
+            TableSchema schema) throws Exception {
+
+        JsonNode root = MAPPER.readTree(responseBody);
+        JsonNode dataNode;
+
+        if (config.getContentField() != null && !config.getContentField().isEmpty()) {
+            dataNode = evaluateJsonPath(root, config.getContentField());
+        } else {
+            dataNode = root;
+        }
+
+        if (dataNode == null || dataNode.isMissingNode()) {
+            return Collections.emptyList();
+        }
+
+        if (dataNode.isArray()) {
+            List<FluxRow> rows = new ArrayList<>(dataNode.size());
+            for (JsonNode element : dataNode) {
+                if (element.isObject()) {
+                    rows.add(mapJsonNodeToRow(element, schema, config.isJsonFieldMissedReturnNull()));
+                }
+            }
+            return rows;
+        }
+
+        if (dataNode.isObject()) {
+            return Collections.singletonList(
+                    mapJsonNodeToRow(dataNode, schema, config.isJsonFieldMissedReturnNull()));
+        }
+
+        // 基本类型值（如字符串、数字）
+        return Collections.singletonList(FluxRow.of(jsonNodeToJavaValue(dataNode)));
+    }
+
+    // ── JSON json_field 模式 ─────────────────────────────────────────────
+
+    private static List<FluxRow> parseByJsonField(
+            String responseBody,
+            HttpSourceConfig config,
+            TableSchema schema) throws Exception {
+
+        JsonNode root = MAPPER.readTree(responseBody);
+        Map<String, Object> jsonFieldMapping = config.getJsonField();
+
+        // 每个字段提取值列表
+        List<String> fieldNames = schema.getColumns().stream()
+                .map(Column::getName)
+                .collect(java.util.stream.Collectors.toList());
+
+        List<List<Object>> fieldValues = new ArrayList<>(fieldNames.size());
+        int maxLen = 0;
+
+        for (String fieldName : fieldNames) {
+            String jsonPath = (String) jsonFieldMapping.get(fieldName);
+            List<Object> values;
+
+            if (jsonPath != null && !jsonPath.isEmpty()) {
+                values = extractJsonPathValues(root, jsonPath);
+            } else {
+                // 没有配置 JsonPath，尝试直接用字段名从根对象取值
+                values = extractDirectField(root, fieldName);
+            }
+
+            fieldValues.add(values);
+            maxLen = Math.max(maxLen, values.size());
+        }
+
+        if (maxLen == 0) {
+            return Collections.emptyList();
+        }
+
+        // 按行对齐
+        List<FluxRow> rows = new ArrayList<>(maxLen);
+        for (int i = 0; i < maxLen; i++) {
+            FluxRow row = new FluxRow(fieldNames.size());
+            for (int f = 0; f < fieldNames.size(); f++) {
+                List<Object> values = fieldValues.get(f);
+                Object value = i < values.size() ? values.get(i) : null;
+                Column column = schema.getColumn(f);
+                row.setField(f, convertValue(value, column));
+            }
+            rows.add(row);
+        }
+
+        return rows;
+    }
+
+    // ── JsonPath 工具 ──────────────────────────────────────────────────
+
+    private static JsonNode evaluateJsonPath(JsonNode root, String jsonPath) {
+        String normalized = normalizeJsonPath(jsonPath);
+        Object result = JsonPath.using(JSON_PATH_CONFIG).parse(root).read(normalized);
+        if (result instanceof JsonNode) {
+            return (JsonNode) result;
+        }
+        return null;
+    }
+
+    private static List<Object> extractJsonPathValues(JsonNode root, String jsonPath) {
+        String normalized = normalizeJsonPath(jsonPath);
+        Object result = JsonPath.using(JSON_PATH_CONFIG).parse(root).read(normalized);
+
+        if (result == null) {
+            return Collections.emptyList();
+        }
+
+        if (result instanceof ArrayNode) {
+            ArrayNode array = (ArrayNode) result;
+            List<Object> values = new ArrayList<>(array.size());
+            for (JsonNode node : array) {
+                values.add(jsonNodeToJavaValue(node));
+            }
+            return values;
+        }
+
+        if (result instanceof JsonNode) {
+            JsonNode node = (JsonNode) result;
+            if (node.isArray()) {
+                List<Object> values = new ArrayList<>(node.size());
+                for (JsonNode child : node) {
+                    values.add(jsonNodeToJavaValue(child));
+                }
+                return values;
+            }
+            return Collections.singletonList(jsonNodeToJavaValue(node));
+        }
+
+        return Collections.singletonList(result);
+    }
+
+    private static List<Object> extractDirectField(JsonNode root, String fieldName) {
+        if (root.isObject() && root.has(fieldName)) {
+            JsonNode value = root.get(fieldName);
+            if (value.isArray()) {
+                List<Object> values = new ArrayList<>(value.size());
+                for (JsonNode element : value) {
+                    values.add(jsonNodeToJavaValue(element));
+                }
+                return values;
+            }
+            return Collections.singletonList(jsonNodeToJavaValue(value));
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * 将 JsonPath 中的 {@code *} 通配符转换为标准 {@code [*]} 语法。
+     */
+    private static String normalizeJsonPath(String path) {
+        if (path == null) {
+            return "$";
+        }
+        // $.store.book.* → $.store.book[*]
+        return path.replaceAll("\\.\\*", "[*]");
+    }
+
+    // ── JSON → FluxRow 映射 ──────────────────────────────────────────────
+
+    private static FluxRow mapJsonNodeToRow(
+            JsonNode node,
+            TableSchema schema,
+            boolean missingReturnNull) {
+
+        FluxRow row = new FluxRow(schema.getColumnCount());
+
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            Column column = schema.getColumn(i);
+            JsonNode fieldNode = node.get(column.getName());
+
+            if (fieldNode == null || fieldNode.isNull() || fieldNode.isMissingNode()) {
+                if (!missingReturnNull && fieldNode == null) {
+                    throw new IllegalArgumentException(
+                            "JSON field '" + column.getName() + "' is missing. "
+                                    + "Set json_field_missed_return_null=true to allow null values.");
+                }
+                row.setField(i, null);
+            } else {
+                row.setField(i, convertValue(jsonNodeToJavaValue(fieldNode), column));
+            }
+        }
+
+        return row;
+    }
+
+    // ── 类型转换 ──────────────────────────────────────────────────────
+
+    private static Object jsonNodeToJavaValue(JsonNode node) {
+        if (node == null || node.isNull() || node.isMissingNode()) {
+            return null;
+        }
+        if (node.isTextual()) return node.asText();
+        if (node.isBoolean()) return node.asBoolean();
+        if (node.isInt()) return node.asInt();
+        if (node.isLong()) return node.asLong();
+        if (node.isFloat() || node.isDouble()) return node.asDouble();
+        if (node.isBigDecimal()) return node.decimalValue();
+        if (node.isBinary()) {
+            try {
+                return node.binaryValue();
+            } catch (Exception e) {
+                return node.asText();
+            }
+        }
+        // 复杂类型（对象、数组）序列化为字符串
+        return node.toString();
+    }
+
+    static Object convertValue(Object value, Column column) {
+        if (value == null) {
+            return null;
+        }
+
+        SqlType sqlType = column.getDataType().getSqlType();
+
+        switch (sqlType) {
+            case STRING:
+                return String.valueOf(value);
+
+            case BOOLEAN:
+                if (value instanceof Boolean) return value;
+                return Boolean.parseBoolean(String.valueOf(value));
+
+            case TINYINT:
+                if (value instanceof Number) return ((Number) value).byteValue();
+                return Byte.parseByte(String.valueOf(value));
+
+            case SMALLINT:
+                if (value instanceof Number) return ((Number) value).shortValue();
+                return Short.parseShort(String.valueOf(value));
+
+            case INT:
+                if (value instanceof Number) return ((Number) value).intValue();
+                return Integer.parseInt(String.valueOf(value));
+
+            case BIGINT:
+                if (value instanceof Number) return ((Number) value).longValue();
+                return Long.parseLong(String.valueOf(value));
+
+            case FLOAT:
+                if (value instanceof Number) return ((Number) value).floatValue();
+                return Float.parseFloat(String.valueOf(value));
+
+            case DOUBLE:
+                if (value instanceof Number) return ((Number) value).doubleValue();
+                return Double.parseDouble(String.valueOf(value));
+
+            case DECIMAL:
+                if (value instanceof BigDecimal) return value;
+                return new BigDecimal(String.valueOf(value));
+
+            case DATE:
+                if (value instanceof LocalDate) return value;
+                return LocalDate.parse(String.valueOf(value));
+
+            case TIME:
+                if (value instanceof LocalTime) return value;
+                return LocalTime.parse(String.valueOf(value));
+
+            case TIMESTAMP:
+                if (value instanceof LocalDateTime) return value;
+                return LocalDateTime.parse(String.valueOf(value));
+
+            case BYTES:
+                if (value instanceof byte[]) return value;
+                return String.valueOf(value).getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+            default:
+                return String.valueOf(value);
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/schema/HttpSchemaParser.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/schema/HttpSchemaParser.java
@@ -1,0 +1,111 @@
+package com.link.up.connector.http.schema;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 将用户定义的 Schema 字段映射解析为 {@link TableSchema}。
+ *
+ * <p>支持的类型名（不区分大小写）：
+ * <ul>
+ *   <li>string</li>
+ *   <li>boolean</li>
+ *   <li>tinyint / smallint / int / bigint</li>
+ *   <li>float / double</li>
+ *   <li>decimal(p,s)</li>
+ *   <li>date / time / timestamp</li>
+ *   <li>bytes</li>
+ * </ul>
+ */
+public final class HttpSchemaParser {
+
+    private static final Pattern DECIMAL_PATTERN =
+            Pattern.compile("decimal\\s*\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)",
+                    Pattern.CASE_INSENSITIVE);
+
+    private static final Map<String, FluxDataType<?>> TYPE_MAP =
+            new LinkedHashMap<>();
+
+    static {
+        TYPE_MAP.put("string", BasicType.STRING_TYPE);
+        TYPE_MAP.put("boolean", BasicType.BOOLEAN_TYPE);
+        TYPE_MAP.put("tinyint", BasicType.BYTE_TYPE);
+        TYPE_MAP.put("smallint", BasicType.SHORT_TYPE);
+        TYPE_MAP.put("int", BasicType.INT_TYPE);
+        TYPE_MAP.put("integer", BasicType.INT_TYPE);
+        TYPE_MAP.put("bigint", BasicType.LONG_TYPE);
+        TYPE_MAP.put("long", BasicType.LONG_TYPE);
+        TYPE_MAP.put("float", BasicType.FLOAT_TYPE);
+        TYPE_MAP.put("double", BasicType.DOUBLE_TYPE);
+        TYPE_MAP.put("date", BasicType.DATE_TYPE);
+        TYPE_MAP.put("time", BasicType.TIME_TYPE);
+        TYPE_MAP.put("timestamp", BasicType.TIMESTAMP_TYPE);
+        TYPE_MAP.put("bytes", BasicType.BYTES_TYPE);
+    }
+
+    private HttpSchemaParser() {
+    }
+
+    /**
+     * 解析用户定义的 Schema 字段映射为 TableSchema。
+     *
+     * @param schemaFields key=字段名，value=类型名或类型描述
+     * @return 解析后的 TableSchema
+     */
+    public static TableSchema parse(Map<String, Object> schemaFields) {
+        Objects.requireNonNull(schemaFields, "schemaFields must not be null");
+
+        if (schemaFields.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "HTTP Source schema must define at least one field");
+        }
+
+        TableSchema.Builder builder = TableSchema.builder();
+
+        for (Map.Entry<String, Object> entry : schemaFields.entrySet()) {
+            String fieldName = entry.getKey();
+            String typeName = String.valueOf(entry.getValue()).trim();
+
+            builder.column(
+                    Column.builder(fieldName, resolveType(typeName))
+                            .nullable(true)
+                            .sourceType(typeName)
+                            .build());
+        }
+
+        return builder.build();
+    }
+
+    private static FluxDataType<?> resolveType(String typeName) {
+        if (typeName == null || typeName.trim().isEmpty()) {
+            throw new IllegalArgumentException("Field type must not be blank");
+        }
+
+        String normalized = typeName.trim().toLowerCase();
+
+        // decimal(p,s)
+        Matcher matcher = DECIMAL_PATTERN.matcher(normalized);
+        if (matcher.matches()) {
+            int precision = Integer.parseInt(matcher.group(1));
+            int scale = Integer.parseInt(matcher.group(2));
+            return new DecimalType(precision, scale);
+        }
+
+        FluxDataType<?> type = TYPE_MAP.get(normalized);
+        if (type == null) {
+            throw new IllegalArgumentException(
+                    "Unsupported HTTP schema type: " + typeName
+                            + ". Supported types: " + TYPE_MAP.keySet());
+        }
+        return type;
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSource.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSource.java
@@ -1,0 +1,46 @@
+package com.link.up.connector.http.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.http.config.HttpSourceConfig;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * HTTP 离线数据源。
+ *
+ * <p>HTTP Source 只生成一个分片，分页由 Reader 内部处理。
+ */
+public final class HttpSource implements Source<HttpSourceSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final HttpSourceConfig config;
+
+    public HttpSource(HttpSourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public List<HttpSourceSplit> createSplits(
+            Map<TablePath, CatalogTable> tables) {
+        return Collections.singletonList(new HttpSourceSplit());
+    }
+
+    @Override
+    public SourceReader<FluxRow, HttpSourceSplit> createReader(
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        return new HttpSourceReader(config, tables, batchSize);
+    }
+
+    public HttpSourceConfig getConfig() {
+        return config;
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceFactory.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceFactory.java
@@ -1,0 +1,126 @@
+package com.link.up.connector.http.source;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.factory.SourceFactory;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.connector.http.config.HttpSourceConfig;
+import com.link.up.connector.http.config.HttpSourceOptions;
+import com.link.up.connector.http.schema.HttpSchemaParser;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * HTTP Source 工厂。
+ *
+ * <p>负责：
+ * <ol>
+ *   <li>解析并校验 Source 配置</li>
+ *   <li>解析用户定义的 Schema</li>
+ *   <li>创建 HTTP Source</li>
+ *   <li>返回 Schema 作为 discoverTableSchemas 结果</li>
+ * </ol>
+ */
+@AutoService(TableSourceFactory.class)
+public final class HttpSourceFactory
+        implements TableSourceFactory<HttpSourceSplit> {
+
+    private static final String IDENTIFIER = "http";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(
+                        ConnectorCapability.CUSTOM_SQL));
+    }
+
+    @Override
+    public Source<HttpSourceSplit> createSource(
+            SourceFactoryContext context) throws Exception {
+
+        HttpSourceConfig config = createConfig(context);
+        return new HttpSource(config);
+    }
+
+    @Override
+    public List<CatalogTable> discoverTableSchemas(
+            SourceFactoryContext context) throws Exception {
+
+        HttpSourceConfig config = createConfig(context);
+
+        Map<String, Object> schemaFields = config.getSchemaFields();
+        if (schemaFields == null || schemaFields.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "HTTP Source requires 'schema.fields' to define the output schema");
+        }
+
+        TableSchema schema = HttpSchemaParser.parse(schemaFields);
+
+        CatalogTable table = CatalogTable.builder(
+                        TablePath.of("http"),
+                        schema)
+                .comment("HTTP Source")
+                .build();
+
+        List<CatalogTable> result = new ArrayList<>(1);
+        result.add(table);
+        return Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(HttpSourceOptions.URL)
+                .optional(
+                        HttpSourceOptions.METHOD,
+                        HttpSourceOptions.HEADERS,
+                        HttpSourceOptions.PARAMS,
+                        HttpSourceOptions.BODY,
+                        HttpSourceOptions.FORMAT,
+                        HttpSourceOptions.SCHEMA_FIELDS,
+                        HttpSourceOptions.CONTENT_FIELD,
+                        HttpSourceOptions.JSON_FIELD,
+                        HttpSourceOptions.PAGE_FIELD,
+                        HttpSourceOptions.TOTAL_PAGE_SIZE,
+                        HttpSourceOptions.PAGE_BATCH_SIZE,
+                        HttpSourceOptions.START_PAGE_NUMBER,
+                        HttpSourceOptions.PAGE_TYPE,
+                        HttpSourceOptions.CURSOR_FIELD,
+                        HttpSourceOptions.CURSOR_RESPONSE_FIELD,
+                        HttpSourceOptions.USE_PLACEHOLDER_REPLACEMENT,
+                        HttpSourceOptions.RETRY,
+                        HttpSourceOptions.RETRY_BACKOFF_MULTIPLIER_MS,
+                        HttpSourceOptions.RETRY_BACKOFF_MAX_MS,
+                        HttpSourceOptions.CONNECT_TIMEOUT_MS,
+                        HttpSourceOptions.SOCKET_TIMEOUT_MS,
+                        HttpSourceOptions.ENABLE_MULTI_LINES,
+                        HttpSourceOptions.JSON_FIELD_MISSED_RETURN_NULL)
+                .build();
+    }
+
+    private HttpSourceConfig createConfig(SourceFactoryContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        ReadonlyConfig options = Objects.requireNonNull(
+                context.getOptions(), "source options must not be null");
+        return HttpSourceConfig.of(options);
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceFactory.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceFactory.java
@@ -8,19 +8,18 @@ import com.link.up.api.factory.SourceFactory;
 import com.link.up.api.source.Source;
 import com.link.up.api.source.SourceFactoryContext;
 import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.Catalog;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
-import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.connector.http.catalog.HttpCatalog;
+import com.link.up.connector.http.catalog.HttpCatalogConfig;
 import com.link.up.connector.http.config.HttpSourceConfig;
 import com.link.up.connector.http.config.HttpSourceOptions;
-import com.link.up.connector.http.schema.HttpSchemaParser;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -50,7 +49,7 @@ public final class HttpSourceFactory
     public Set<ConnectorCapability> capabilities() {
         return Collections.unmodifiableSet(
                 EnumSet.of(
-                        ConnectorCapability.CUSTOM_SQL));
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY));
     }
 
     @Override
@@ -65,25 +64,26 @@ public final class HttpSourceFactory
     public List<CatalogTable> discoverTableSchemas(
             SourceFactoryContext context) throws Exception {
 
-        HttpSourceConfig config = createConfig(context);
+        HttpSourceConfig sourceConfig = createConfig(context);
 
-        Map<String, Object> schemaFields = config.getSchemaFields();
-        if (schemaFields == null || schemaFields.isEmpty()) {
-            throw new IllegalArgumentException(
-                    "HTTP Source requires 'schema.fields' to define the output schema");
+        HttpCatalogConfig catalogConfig =
+                HttpCatalogConfig.fromSourceConfig(sourceConfig);
+
+        try (Catalog catalog = new HttpCatalog(catalogConfig)) {
+            catalog.open();
+
+            List<TablePath> tablePaths =
+                    catalog.listTables(null, null);
+
+            if (tablePaths.isEmpty()) {
+                return Collections.emptyList();
+            }
+
+            TablePath tablePath = tablePaths.get(0);
+            CatalogTable table = catalog.getTable(tablePath);
+
+            return Collections.singletonList(table);
         }
-
-        TableSchema schema = HttpSchemaParser.parse(schemaFields);
-
-        CatalogTable table = CatalogTable.builder(
-                        TablePath.of("http"),
-                        schema)
-                .comment("HTTP Source")
-                .build();
-
-        List<CatalogTable> result = new ArrayList<>(1);
-        result.add(table);
-        return Collections.unmodifiableList(result);
     }
 
     @Override

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceReader.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceReader.java
@@ -1,12 +1,5 @@
 package com.link.up.connector.http.source;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Option;
-import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
-import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import com.link.up.api.source.RecordBatch;
 import com.link.up.api.source.SourceReader;
 import com.link.up.api.table.catalog.CatalogTable;
@@ -41,15 +34,6 @@ public final class HttpSourceReader
 
     private static final Logger LOG =
             LoggerFactory.getLogger(HttpSourceReader.class);
-
-    private static final ObjectMapper MAPPER = new ObjectMapper();
-
-    private static final Configuration JSON_PATH_CONFIG =
-            Configuration.builder()
-                    .jsonProvider(new JacksonJsonNodeJsonProvider())
-                    .mappingProvider(new JacksonMappingProvider())
-                    .options(Option.SUPPRESS_EXCEPTIONS)
-                    .build();
 
     private final HttpSourceConfig config;
     private final CatalogTable catalogTable;
@@ -179,9 +163,9 @@ public final class HttpSourceReader
         String pageValue = String.valueOf(currentPage);
 
         if (config.isUsePlaceholderReplacement()) {
-            // 占位符替换模式：替换 headers、body 中的 ${page}
+            // 占位符替换模式：替换 headers、params、body 中的 ${page}
             replacePlaceholder(headers, pageField, pageValue);
-            replacePlaceholderInMap(params, pageField, pageValue);
+            replacePlaceholder(params, pageField, pageValue);
         } else {
             // key-based 模式：直接设置参数值
             params.put(pageField, pageValue);
@@ -195,7 +179,7 @@ public final class HttpSourceReader
         if (currentCursor != null && config.getCursorField() != null) {
             if (config.isUsePlaceholderReplacement()) {
                 replacePlaceholder(headers, config.getCursorField(), currentCursor);
-                replacePlaceholderInMap(params, config.getCursorField(), currentCursor);
+                replacePlaceholder(params, config.getCursorField(), currentCursor);
             } else {
                 params.put(config.getCursorField(), currentCursor);
             }
@@ -214,77 +198,70 @@ public final class HttpSourceReader
         long totalPageSize = config.getTotalPageSize();
 
         if (totalPageSize > 0) {
-            // 已知总页数
             if (currentPage >= totalPageSize + config.getStartPageNumber() - 1) {
+                LOG.info("分页结束：已达总页数={}, 当前页={}",
+                        totalPageSize, currentPage);
                 paginationExhausted = true;
                 return;
             }
         } else {
-            // 未知总页数，根据返回行数判断
             if (rowCount < config.getPageBatchSize()) {
+                LOG.info("分页结束：返回行数={} < batch_size={}, 当前页={}",
+                        rowCount, config.getPageBatchSize(), currentPage);
                 paginationExhausted = true;
                 return;
             }
         }
 
         currentPage++;
+        LOG.debug("翻页至 page={}", currentPage);
     }
 
     private void advanceCursorPagination(String responseBody) {
-        if (config.getCursorResponseField() == null || config.getCursorResponseField().isEmpty()) {
+        if (config.getCursorResponseField() == null
+                || config.getCursorResponseField().isEmpty()) {
+            LOG.info("Cursor 分页结束：未配置 cursor_response_field");
             paginationExhausted = true;
             return;
         }
 
         try {
-            JsonNode root = MAPPER.readTree(responseBody);
-            String normalizedPath = config.getCursorResponseField()
-                    .replaceAll("\\.\\*", "[*]");
-            Object result = JsonPath.using(JSON_PATH_CONFIG).parse(root).read(normalizedPath);
+            String cursorValue = HttpResponseParser.extractSingleStringValue(
+                    responseBody,
+                    config.getCursorResponseField());
 
-            if (result == null) {
-                paginationExhausted = true;
-                return;
-            }
-
-            String cursorValue;
-            if (result instanceof JsonNode) {
-                JsonNode node = (JsonNode) result;
-                if (node.isNull() || node.isMissingNode()) {
-                    paginationExhausted = true;
-                    return;
-                }
-                cursorValue = node.isTextual() ? node.asText() : node.toString();
-            } else {
-                cursorValue = String.valueOf(result);
-            }
-
-            if (cursorValue.isEmpty() || "null".equals(cursorValue)) {
+            if (cursorValue == null
+                    || cursorValue.isEmpty()
+                    || "null".equals(cursorValue)) {
+                LOG.info("Cursor 分页结束：响应中未找到有效游标值");
                 paginationExhausted = true;
                 return;
             }
 
             currentCursor = cursorValue;
+            LOG.debug("Cursor 更新为: {}", currentCursor);
         } catch (Exception e) {
-            LOG.warn("Failed to extract cursor from response, pagination ended: {}", e.getMessage());
+            LOG.warn("提取游标值失败，分页结束: {}", e.getMessage());
             paginationExhausted = true;
         }
     }
 
-    // ── 占位符替换 ──────────────────────────────────────────────────────
+    // ── 占位符替换 ──────────────────────────────────────────
 
-    private static void replacePlaceholder(Map<String, String> map, String field, String value) {
-        if (map == null) return;
+    private static void replacePlaceholder(
+            Map<String, String> map,
+            String field,
+            String value) {
+
+        if (map == null) {
+            return;
+        }
         for (Map.Entry<String, String> entry : map.entrySet()) {
             String v = entry.getValue();
             if (v != null && v.contains("${" + field + "}")) {
                 entry.setValue(v.replace("${" + field + "}", value));
             }
         }
-    }
-
-    private static void replacePlaceholderInMap(Map<String, String> map, String field, String value) {
-        replacePlaceholder(map, field, value);
     }
 
     @Override

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceReader.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceReader.java
@@ -1,0 +1,299 @@
+package com.link.up.connector.http.source;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.http.client.HttpSourceClient;
+import com.link.up.connector.http.config.HttpSourceConfig;
+import com.link.up.connector.http.config.PageType;
+import com.link.up.connector.http.parser.HttpResponseParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * HTTP 离线数据读取器。
+ *
+ * <p>Reader 负责：
+ * <ol>
+ *   <li>执行 HTTP 请求</li>
+ *   <li>解析响应数据为 FluxRow</li>
+ *   <li>处理分页逻辑</li>
+ * </ol>
+ */
+public final class HttpSourceReader
+        implements SourceReader<FluxRow, HttpSourceSplit> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(HttpSourceReader.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final Configuration JSON_PATH_CONFIG =
+            Configuration.builder()
+                    .jsonProvider(new JacksonJsonNodeJsonProvider())
+                    .mappingProvider(new JacksonMappingProvider())
+                    .options(Option.SUPPRESS_EXCEPTIONS)
+                    .build();
+
+    private final HttpSourceConfig config;
+    private final CatalogTable catalogTable;
+    private final int batchSize;
+    private final HttpSourceClient client;
+
+    private HttpSourceSplit currentSplit;
+    private boolean opened;
+    private boolean finished;
+
+    // 分页状态
+    private int currentPage;
+    private String currentCursor;
+    private boolean paginationExhausted;
+
+    // 缓冲：上一次请求解析出的行，尚未全部输出
+    private List<FluxRow> buffer = Collections.emptyList();
+    private int bufferIndex;
+
+    public HttpSourceReader(
+            HttpSourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.catalogTable = tables.values().iterator().next();
+        this.batchSize = batchSize;
+        this.client = new HttpSourceClient(config);
+    }
+
+    @Override
+    public void open(List<HttpSourceSplit> splits) throws Exception {
+        if (opened) {
+            throw new IllegalStateException("HttpSourceReader has already been opened");
+        }
+        this.currentSplit = splits.isEmpty() ? new HttpSourceSplit() : splits.get(0);
+        this.currentPage = config.getStartPageNumber();
+        this.currentCursor = null;
+        this.paginationExhausted = !config.hasPagination();
+        this.buffer = Collections.emptyList();
+        this.bufferIndex = 0;
+        this.finished = false;
+        this.opened = true;
+
+        LOG.info("HTTP Source Reader opened, url={}, method={}, format={}, pagination={}",
+                config.getUrl(), config.getMethod(), config.getFormat(),
+                config.hasPagination() ? config.getPageType() : "none");
+    }
+
+    @Override
+    public RecordBatch<FluxRow> readBatch() throws Exception {
+        if (!opened) {
+            throw new IllegalStateException("HttpSourceReader has not been opened");
+        }
+        if (finished) {
+            return RecordBatch.endOfInput();
+        }
+
+        while (true) {
+            // 先从缓冲区取
+            while (bufferIndex < buffer.size()) {
+                int end = Math.min(bufferIndex + batchSize, buffer.size());
+                List<FluxRow> batch = new ArrayList<>(buffer.subList(bufferIndex, end));
+                bufferIndex = end;
+                return RecordBatch.of(currentSplit, batch);
+            }
+
+            // 缓冲区耗尽，获取下一页
+            if (paginationExhausted) {
+                finished = true;
+                return RecordBatch.endOfInput();
+            }
+
+            fetchNextPage();
+        }
+    }
+
+    private void fetchNextPage() throws Exception {
+        // 构建当前页的请求参数
+        Map<String, String> effectiveHeaders = new LinkedHashMap<>(config.getHeaders());
+        Map<String, String> effectiveParams = new LinkedHashMap<>();
+        String effectiveBody = config.getBody();
+
+        if (config.hasPagination()) {
+            applyPagination(effectiveHeaders, effectiveParams);
+        }
+
+        LOG.debug("HTTP request page={}, cursor={}", currentPage, currentCursor);
+
+        String responseBody = client.execute(effectiveHeaders, effectiveParams, effectiveBody);
+
+        // 解析响应
+        List<FluxRow> rows = HttpResponseParser.parseResponse(
+                responseBody, config, catalogTable.getTableSchema());
+
+        buffer = rows;
+        bufferIndex = 0;
+
+        // 判断分页是否结束
+        if (config.hasPagination()) {
+            advancePagination(responseBody, rows.size());
+        } else {
+            paginationExhausted = true;
+        }
+    }
+
+    private void applyPagination(
+            Map<String, String> headers,
+            Map<String, String> params) {
+
+        if (config.getPageType() == PageType.CURSOR) {
+            applyCursorPagination(headers, params);
+        } else {
+            applyPageNumberPagination(headers, params);
+        }
+    }
+
+    private void applyPageNumberPagination(
+            Map<String, String> headers,
+            Map<String, String> params) {
+
+        String pageField = config.getPageField();
+        String pageValue = String.valueOf(currentPage);
+
+        if (config.isUsePlaceholderReplacement()) {
+            // 占位符替换模式：替换 headers、body 中的 ${page}
+            replacePlaceholder(headers, pageField, pageValue);
+            replacePlaceholderInMap(params, pageField, pageValue);
+        } else {
+            // key-based 模式：直接设置参数值
+            params.put(pageField, pageValue);
+        }
+    }
+
+    private void applyCursorPagination(
+            Map<String, String> headers,
+            Map<String, String> params) {
+
+        if (currentCursor != null && config.getCursorField() != null) {
+            if (config.isUsePlaceholderReplacement()) {
+                replacePlaceholder(headers, config.getCursorField(), currentCursor);
+                replacePlaceholderInMap(params, config.getCursorField(), currentCursor);
+            } else {
+                params.put(config.getCursorField(), currentCursor);
+            }
+        }
+    }
+
+    private void advancePagination(String responseBody, int rowCount) {
+        if (config.getPageType() == PageType.CURSOR) {
+            advanceCursorPagination(responseBody);
+        } else {
+            advancePageNumberPagination(rowCount);
+        }
+    }
+
+    private void advancePageNumberPagination(int rowCount) {
+        long totalPageSize = config.getTotalPageSize();
+
+        if (totalPageSize > 0) {
+            // 已知总页数
+            if (currentPage >= totalPageSize + config.getStartPageNumber() - 1) {
+                paginationExhausted = true;
+                return;
+            }
+        } else {
+            // 未知总页数，根据返回行数判断
+            if (rowCount < config.getPageBatchSize()) {
+                paginationExhausted = true;
+                return;
+            }
+        }
+
+        currentPage++;
+    }
+
+    private void advanceCursorPagination(String responseBody) {
+        if (config.getCursorResponseField() == null || config.getCursorResponseField().isEmpty()) {
+            paginationExhausted = true;
+            return;
+        }
+
+        try {
+            JsonNode root = MAPPER.readTree(responseBody);
+            String normalizedPath = config.getCursorResponseField()
+                    .replaceAll("\\.\\*", "[*]");
+            Object result = JsonPath.using(JSON_PATH_CONFIG).parse(root).read(normalizedPath);
+
+            if (result == null) {
+                paginationExhausted = true;
+                return;
+            }
+
+            String cursorValue;
+            if (result instanceof JsonNode) {
+                JsonNode node = (JsonNode) result;
+                if (node.isNull() || node.isMissingNode()) {
+                    paginationExhausted = true;
+                    return;
+                }
+                cursorValue = node.isTextual() ? node.asText() : node.toString();
+            } else {
+                cursorValue = String.valueOf(result);
+            }
+
+            if (cursorValue.isEmpty() || "null".equals(cursorValue)) {
+                paginationExhausted = true;
+                return;
+            }
+
+            currentCursor = cursorValue;
+        } catch (Exception e) {
+            LOG.warn("Failed to extract cursor from response, pagination ended: {}", e.getMessage());
+            paginationExhausted = true;
+        }
+    }
+
+    // ── 占位符替换 ──────────────────────────────────────────────────────
+
+    private static void replacePlaceholder(Map<String, String> map, String field, String value) {
+        if (map == null) return;
+        for (Map.Entry<String, String> entry : map.entrySet()) {
+            String v = entry.getValue();
+            if (v != null && v.contains("${" + field + "}")) {
+                entry.setValue(v.replace("${" + field + "}", value));
+            }
+        }
+    }
+
+    private static void replacePlaceholderInMap(Map<String, String> map, String field, String value) {
+        replacePlaceholder(map, field, value);
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!opened) {
+            return;
+        }
+        client.close();
+        opened = false;
+        LOG.info("HTTP Source Reader closed");
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceSplit.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceSplit.java
@@ -13,7 +13,7 @@ public final class HttpSourceSplit implements SourceSplit {
     private static final long serialVersionUID = 1L;
 
     private static final String SPLIT_ID = "http-split-0";
-    private static final String DATASET_ID = "http";
+    private static final String DATASET_ID = "default.default";
 
     @Override
     public String splitId() {

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceSplit.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceSplit.java
@@ -1,0 +1,32 @@
+package com.link.up.connector.http.source;
+
+import com.link.up.api.source.SourceSplit;
+
+/**
+ * HTTP Source 数据分片。
+ *
+ * <p>HTTP Source 通常只有一个分片，
+ * 分页逻辑由 Reader 内部处理。
+ */
+public final class HttpSourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final String SPLIT_ID = "http-split-0";
+    private static final String DATASET_ID = "http";
+
+    @Override
+    public String splitId() {
+        return SPLIT_ID;
+    }
+
+    @Override
+    public String dataSetId() {
+        return DATASET_ID;
+    }
+
+    @Override
+    public String toString() {
+        return "HttpSourceSplit{splitId='" + SPLIT_ID + "'}";
+    }
+}

--- a/link-up-connectors/pom.xml
+++ b/link-up-connectors/pom.xml
@@ -16,6 +16,7 @@
 
     <modules>
         <module>link-up-connector-jdbc</module>
+        <module>link-up-connector-http</module>
     </modules>
 
 </project>

--- a/link-up-launcher/examples/http-to-jdbc.conf
+++ b/link-up-launcher/examples/http-to-jdbc.conf
@@ -1,0 +1,63 @@
+# HTTP Source → JDBC Sink 端到端测试
+#
+# 使用 JSONPlaceholder 公开 API 读取用户数据，写入本地 MySQL。
+#
+# 前置准备：
+#   1. 确保 MySQL 已启动并创建目标库表：
+#      CREATE DATABASE IF NOT EXISTS target_db;
+#      USE target_db;
+#      CREATE TABLE IF NOT EXISTS http_users (
+#          id       BIGINT PRIMARY KEY,
+#          name     VARCHAR(128),
+#          username VARCHAR(128),
+#          email    VARCHAR(128),
+#          phone    VARCHAR(64),
+#          website  VARCHAR(128)
+#      );
+#
+#   2. 修改下方 MySQL 连接信息（user / password）
+#
+# 运行命令（在项目根目录）：
+#   D:\tianxy\soft\apache-maven-3.9.16\bin\mvn.cmd -pl link-up-launcher -am compile exec:java ^
+#     -Dexec.mainClass=com.link.up.launcher.LocalSyncLauncher ^
+#     -Dexec.args="link-up-launcher/examples/http-to-jdbc.conf"
+
+job.name = "http-source-to-jdbc-sink"
+
+env {
+  source-parallelism = 1
+  sink-parallelism = 1
+  channel-capacity = 64
+}
+
+source {
+  type = "http"
+  batch-size = 100
+
+  # ── 请求配置 ──
+  url = "https://jsonplaceholder.typicode.com/users"
+  method = "GET"
+  format = "json"
+
+  # ── Schema 定义 ──
+  # 定义从 API 响应中提取的字段及其类型
+  schema.fields = {
+    id = "bigint"
+    name = "string"
+    username = "string"
+    email = "string"
+    phone = "string"
+    website = "string"
+  }
+}
+
+sink {
+  type = "jdbc"
+  url = "jdbc:mysql://127.0.0.1:3306/target_db?useSSL=false&serverTimezone=UTC"
+  driver = "com.mysql.cj.jdbc.Driver"
+  user = "root"
+  password = "change-me"
+  table = "target_db.http_users"
+  schema_save_mode = CREATE_SCHEMA_WHEN_NOT_EXIST
+  data_save_mode = APPEND_DATA
+}

--- a/link-up-launcher/pom.xml
+++ b/link-up-launcher/pom.xml
@@ -45,4 +45,18 @@
             <version>${log4j2.version}</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <configuration>
+                    <mainClass>com.link.up.launcher.LocalSyncLauncher</mainClass>
+                    <classpathScope>runtime</classpathScope>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/link-up-launcher/pom.xml
+++ b/link-up-launcher/pom.xml
@@ -30,6 +30,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-connector-http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j2.version}</version>


### PR DESCRIPTION
## Summary

Add HTTP Source connector for reading data from HTTP/REST APIs, with JDBC Sink e2e example.

## Changes

### New Module: `link-up-connector-http`

**Config** (`config/`)
- `HttpSourceOptions` — 23 configurable options (url, method, headers, params, body, format, schema.fields, content_field, json_field, pagination, retry, timeout, etc.)
- `HttpSourceConfig` — immutable config POJO with Builder pattern
- `HttpMethod` / `HttpFormat` / `PageType` enums

**Schema** (`schema/`)
- `HttpSchemaParser` — parses user-defined `schema.fields` map into `TableSchema`, supports string/boolean/int/bigint/float/double/decimal(p,s)/date/time/timestamp/bytes

**Client** (`client/`)
- `HttpSourceClient` — OkHttp-based HTTP client with exponential backoff retry, GET/POST support, form-urlencoded and JSON body

**Parser** (`parser/`)
- `HttpResponseParser` — two JSON extraction modes:
  - `content_field`: extract array by JsonPath, each element maps to one row
  - `json_field`: independent JsonPath per field, aligned by row index
- Full type conversion (String/Boolean/Byte/Short/Integer/Long/Float/Double/BigDecimal/LocalDate/LocalTime/LocalDateTime)

**Source** (`source/`)
- `HttpSourceFactory` — `@AutoService(TableSourceFactory.class)`, identifier=`http`, SPI auto-registration
- `HttpSource` — single-split model, pagination handled internally by Reader
- `HttpSourceReader` — buffered batch output, PAGE_NUMBER and CURSOR pagination strategies, placeholder replacement support
- `HttpSourceSplit` — single split implementation

### Modified

- `link-up-connectors/pom.xml` — add `link-up-connector-http` submodule
- `link-up-launcher/pom.xml` — add HTTP connector dependency + `exec-maven-plugin` for running jobs via Maven
- `link-up-launcher/examples/http-to-jdbc.conf` — e2e example config (HTTP Source → JDBC Sink)

## Dependencies

- OkHttp 4.12.0 (HTTP client)
- Jayway JsonPath 2.9.0 (JSON path extraction)
- Jackson (already in project)

## Testing

E2E tested: HTTP Source reads from JSONPlaceholder API → JDBC Sink writes to MySQL. All 10 modules compile successfully.