### PR TITLE
refactor: separate coordinator, scheduler and executor roles (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,16 +25,30 @@ The rules are intentionally strict:
 - `link-up-launcher` and `link-up-server` are composition roots that assemble the framework with concrete connectors.
 
 The runtime architecture is Flink-inspired at the role level (`Source`, `SourceReader`, `SourceSplit`, planner, task runtime),
-without copying Flink's distributed complexity. The core lifecycle is now explicit:
+without copying Flink's distributed complexity. The model lifecycle is explicit:
 
 ```text
 JobSpec -> JobDefinition -> PreparedJob -> JobGraph -> ExecutionGraph -> JobResult
 ```
 
-`JobGraph` is the immutable physical plan; `ExecutionGraph` owns mutable state for one run, including cancellation,
-metrics, timestamps, status, and the terminal result. See [architecture](docs/architecture.md),
+Runtime responsibilities are also separated by role:
+
+```text
+JobExecution
+  -> JobCoordinator
+     -> PipelineScheduler
+        -> PipelineExecutor
+           -> PipelineExecution
+              -> ExecutionCoordinator
+                 -> TaskExecutor
+```
+
+`JobGraph` is the immutable physical plan; `ExecutionGraph` owns mutable state for one run. `JobCoordinator` owns the
+job lifecycle and result aggregation, while scheduler/executor roles own pipeline concurrency and execution separately.
+See [architecture](docs/architecture.md),
 [ADR-0001](docs/adr/0001-flink-inspired-runtime-roles.md),
-[ADR-0002](docs/adr/0002-jobgraph-executiongraph.md), and the
+[ADR-0002](docs/adr/0002-jobgraph-executiongraph.md),
+[ADR-0003](docs/adr/0003-runtime-role-separation.md), and the
 [connector development guide](docs/connector-development.md).
 
 ## Quick start

--- a/docs/adr/0003-runtime-role-separation.md
+++ b/docs/adr/0003-runtime-role-separation.md
@@ -1,0 +1,130 @@
+# ADR-0003: Separate runtime coordination, scheduling, and execution
+
+- Status: Accepted
+- Date: 2026-08-24
+
+## Context
+
+Phase 2 separated the immutable `JobGraph` from mutable `ExecutionGraph`, but `JobExecution` still owned several runtime
+roles at once. It transitioned job state, created the pipeline thread pool, submitted `PipelineGraph` work, collected
+completion-order results, propagated first failure cancellation, instantiated `PipelineExecution`, aggregated commit
+summaries, and exposed the public cancellation/metrics handle.
+
+That implementation worked for the local runtime, but the role boundary was still ambiguous. In particular, adding a
+future scheduling policy would require editing the same class that owns job lifecycle and public execution access.
+
+Phase 1 defined role names as contracts: a Coordinator coordinates lifecycle, a Scheduler decides when executable work
+runs, and an Executor executes already-planned work. Phase 3 applies that vocabulary to the active runtime.
+
+## Decision
+
+The local runtime is separated into the following chain:
+
+```text
+JobExecution                 public execution facade / handle
+    |
+    v
+JobCoordinator               job lifecycle + failure policy + result aggregation
+    |
+    +--> PipelineScheduler   pipeline concurrency + completion-order collection
+    |        |
+    |        v
+    |    PipelineExecutor    execute one PipelineGraph
+    |        |
+    |        v
+    |    PipelineExecution   materialize channels and runtime tasks
+    |        |
+    |        v
+    |    ExecutionCoordinator
+    |        |
+    |        v
+    |    TaskExecutor        execute concrete SourceTask / SinkTask
+    |
+    v
+ExecutionGraph               mutable state root for the run
+```
+
+### `JobExecution`
+
+`JobExecution` remains the public runtime handle used by the server. It owns the `ExecutionGraph` reference and delegates
+`execute()` to `JobCoordinator`. It exposes cancellation, metrics, run identity, and the execution graph without owning
+pipeline scheduling logic.
+
+It must not own an `ExecutorService`, `JobGraph`, `PipelineGraph`, or pipeline scheduling policy as mutable fields.
+
+### `JobCoordinator`
+
+`JobCoordinator` owns job-level lifecycle semantics:
+
+- transition the `ExecutionGraph` to running;
+- invoke the configured `PipelineScheduler`;
+- derive the final `JobStatus` from scheduling failure/cancellation;
+- aggregate `PipelineResult` commit summaries into `JobResult`;
+- complete or fail the `ExecutionGraph`;
+- own job-level log context and terminal logging.
+
+It does not create pipeline worker threads and does not instantiate `PipelineExecution` directly.
+
+### `PipelineScheduler`
+
+`PipelineScheduler` owns pipeline concurrency policy. The local implementation, `LocalPipelineScheduler`:
+
+- bounds concurrency using `runtime.pipelineParallelism`;
+- submits immutable `PipelineGraph` units;
+- collects results in completion order, preserving previous runtime behavior;
+- propagates the first pipeline failure into the shared `CancellationToken`;
+- interrupts submitted work if the scheduling thread itself is interrupted.
+
+The scheduler does not perform source/sink I/O and does not own `ExecutionGraph` state.
+
+### `PipelineExecutor`
+
+`PipelineExecutor` executes one already-selected `PipelineGraph`. `LocalPipelineExecutor` materializes the existing
+`PipelineExecution` using the current `ExecutionGraph` runtime resources and classloader.
+
+It does not decide concurrency or job-level failure policy.
+
+### Existing task-level roles
+
+`PipelineExecution`, `ExecutionCoordinator`, and `TaskExecutor` remain in place. They form a lower-level runtime boundary:
+
+- `PipelineExecution` materializes channels, dynamic split providers, and executable tasks for one pipeline;
+- `ExecutionCoordinator` coordinates source/sink task outcomes inside that pipeline;
+- `TaskExecutor` owns the task worker threads.
+
+Phase 3 therefore introduces hierarchy rather than replacing the proven task runtime.
+
+## Consequences
+
+Positive:
+
+- `JobExecution` becomes a thin public facade instead of a runtime god object;
+- pipeline scheduling can evolve independently from lifecycle/result aggregation;
+- local execution remains behind a narrow `PipelineExecutor` role;
+- tests can inject scheduler/executor doubles without opening connector resources;
+- scheduling concurrency and first-failure behavior now have focused unit tests;
+- future scheduling policies have an explicit extension seam without changing `JobGraph` or `ExecutionGraph`.
+
+Trade-offs:
+
+- the framework gains several small internal role classes;
+- `LocalPipelineScheduler` still uses an in-process fixed thread pool and is not a distributed scheduler;
+- job-level and task-level coordinators coexist intentionally at different hierarchy levels;
+- `PipelineExecution` is still a concrete local runtime class and may be refined in a later phase.
+
+## Compatibility
+
+This decision preserves:
+
+- public `JobExecution` constructors and cancellation/metrics accessors;
+- `JobSpec` and connector APIs;
+- pipeline parallelism semantics;
+- completion-order `PipelineResult` collection;
+- first-failure cancellation propagation;
+- static/dynamic split behavior;
+- sink commit/result aggregation semantics.
+
+## Non-goals
+
+Phase 3 does not introduce remote execution, resource placement, retries, checkpoints, HA, worker discovery, or
+`SourceSplitEnumerator` integration. Those require separate design decisions.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,9 +11,10 @@ The architecture is evolving incrementally instead of through a full rewrite:
 - one canonical implementation for each framework role;
 - explicit module and package dependency direction;
 - separate protocol, definition, physical-plan, runtime-state, and read-model lifecycles;
-- predictable naming for factories, planners, coordinators, executors, readers, writers, and repositories;
+- predictable naming for factories, planners, coordinators, schedulers, executors, readers, writers, and repositories;
 - a repeatable connector package template;
-- no mutable runtime ownership inside planner models.
+- no mutable runtime ownership inside planner models;
+- no single runtime class owning lifecycle, scheduling, and execution at the same time.
 
 Link-Up does not attempt to reproduce Flink's distributed scheduler, RPC stack, checkpoint subsystem, resource manager,
 or compatibility surface.
@@ -40,7 +41,7 @@ Forbidden dependencies: `link-up-framework`, `link-up-server`, `link-up-launcher
 ### `link-up-framework`
 
 Owns local engine internals: connector discovery/preparation, job compilation, physical planning, channels, routing,
-execution state, task execution, metrics, and connector classloader isolation.
+execution state, runtime coordination/scheduling, task execution, metrics, and connector classloader isolation.
 
 It may depend on `link-up-api`. It must not import concrete connector implementations.
 
@@ -78,10 +79,15 @@ PreparedJob                  resolved connector/schema resources
     v
 JobGraph                     immutable physical graph
     |
-    | JobExecution
+    | JobExecution facade
     v
 ExecutionGraph               mutable state for one run
     |
+    | JobCoordinator
+    v
+PipelineScheduler            pipeline concurrency
+    |
+    | PipelineExecutor
     v
 PipelineExecution
     |
@@ -95,12 +101,16 @@ JobResult                    terminal engine result
 JobSnapshot                  server-side read model
 ```
 
-The core distinction is:
+The core distinctions are:
 
 - `JobGraph` answers **what should be executed**;
-- `ExecutionGraph` answers **what is happening in this run**.
+- `ExecutionGraph` answers **what is happening in this run**;
+- `JobCoordinator` answers **how the run transitions and finishes**;
+- `PipelineScheduler` answers **when pipeline units are allowed to run**;
+- `PipelineExecutor` answers **how one selected pipeline is executed**.
 
-See [ADR-0002](adr/0002-jobgraph-executiongraph.md) for the decision and consequences.
+See [ADR-0002](adr/0002-jobgraph-executiongraph.md) and
+[ADR-0003](adr/0003-runtime-role-separation.md) for the decisions and consequences.
 
 ## Physical planning
 
@@ -117,10 +127,12 @@ A `PipelineGraph` is the physical execution boundary for one logical data set. I
 - the output catalog table;
 - source task plans;
 - sink task plans;
-- immutable source splits represented by the pipeline;
+- the original immutable source-split sequence represented by the pipeline;
 - the split-assignment mode.
 
-The graph records the selected policy but does not instantiate a mutable split queue.
+The graph records the selected policy but does not instantiate a mutable split queue. The original source enumeration
+order is stored independently from round-robin task assignments so dynamic execution does not accidentally reorder
+split acquisition.
 
 ### `SourceTaskPlan` / `SinkTaskPlan`
 
@@ -144,16 +156,69 @@ Every invocation of a `JobGraph` gets a distinct `ExecutionGraph`. It owns:
 The object is intentionally small. It is the state root that future scheduling, recovery, or read-only runtime snapshots
 should extend rather than adding more mutable state to `JobGraph` or `JobExecution`.
 
+## Runtime role hierarchy
+
+Phase 3 separates job coordination, pipeline scheduling, pipeline execution, and task execution:
+
+```text
+JobExecution                     facade / server-facing execution handle
+    |
+    v
+JobCoordinator                   job lifecycle + failure policy + result aggregation
+    |
+    +--> PipelineScheduler       bounded pipeline concurrency
+    |        |
+    |        v
+    |    PipelineExecutor        execute one PipelineGraph
+    |        |
+    |        v
+    |    PipelineExecution       materialize runtime-only pipeline resources
+    |        |
+    |        v
+    |    ExecutionCoordinator    coordinate SourceTask/SinkTask outcomes
+    |        |
+    |        v
+    |    TaskExecutor            task worker threads
+    |
+    v
+ExecutionGraph                   mutable state root
+```
+
 ### `JobExecution`
 
-`JobExecution` is the local coordinator for one `ExecutionGraph`. It:
+`JobExecution` is a public facade and cancellation/metrics handle. It creates the runtime role composition for a local
+run and delegates `execute()` to `JobCoordinator`.
 
-- marks the execution lifecycle;
-- starts pipeline executions with the configured pipeline parallelism;
-- propagates cancellation after the first failure;
-- aggregates pipeline outcomes into `JobResult`.
+`JobExecution` must not own pipeline thread pools, `JobGraph`/`PipelineGraph` scheduling logic, or result aggregation.
 
-It does not compile `JobSpec`, prepare connectors, or mutate the physical graph.
+### `JobCoordinator`
+
+`JobCoordinator` owns job-level lifecycle semantics:
+
+- mark the `ExecutionGraph` running;
+- invoke `PipelineScheduler`;
+- derive the final job status from first failure/cancellation;
+- aggregate `PipelineResult` commit summaries into `JobResult`;
+- complete/fail the `ExecutionGraph`;
+- own job-level log context and final status logging.
+
+It does not create an `ExecutorService` and does not instantiate `PipelineExecution` directly.
+
+### `PipelineScheduler`
+
+`PipelineScheduler` owns pipeline concurrency and completion-order collection. `LocalPipelineScheduler` uses
+`runtime.pipelineParallelism` to bound an in-process fixed thread pool. It delegates each selected `PipelineGraph` to a
+`PipelineExecutor` and propagates the first pipeline failure to the shared cancellation token.
+
+The scheduler must not own `ExecutionGraph`, connector resources, channels, or source/sink I/O.
+
+### `PipelineExecutor`
+
+`PipelineExecutor` executes one already-selected `PipelineGraph`. `LocalPipelineExecutor` supplies the current
+`ExecutionGraph` runtime resources and classloader to `PipelineExecution`.
+
+Because Log4j thread context is thread-local, `LocalPipelineExecutor` also restores `runId`, `jobId`, `jobName`, and
+`jobLogFile` on scheduler worker threads before entering pipeline execution.
 
 ### `PipelineExecution`
 
@@ -177,6 +242,12 @@ PipelineExecution
 ```
 
 For static assignment, each `SourceTask` consumes the immutable split list already present in its `SourceTaskPlan`.
+
+### `ExecutionCoordinator` and `TaskExecutor`
+
+These remain the lower-level task runtime. `ExecutionCoordinator` coordinates source/sink task outcomes within one
+pipeline; `TaskExecutor` owns the task worker threads. The existence of `JobCoordinator` does not duplicate this role:
+the two coordinators operate at different hierarchy levels.
 
 ## Framework package roles
 
@@ -209,18 +280,20 @@ Planner code must not:
 
 ### `framework.execution`
 
-Owns runtime lifecycle, `ExecutionGraph`, cancellation, coordination, runtime resource materialization, and task execution.
-Concrete executable tasks belong under `framework.execution.task`.
+Owns runtime lifecycle, `ExecutionGraph`, job coordination, pipeline scheduling/execution, cancellation, runtime resource
+materialization, and task execution. Concrete executable source/sink tasks belong under `framework.execution.task`.
 
 The active execution path is:
 
 ```text
 JobExecution
-  -> ExecutionGraph
-  -> PipelineExecution
-     -> ExecutionCoordinator
-        -> TaskExecutor
-           -> execution.task.SourceTask / execution.task.SinkTask
+  -> JobCoordinator
+     -> PipelineScheduler
+        -> PipelineExecutor
+           -> PipelineExecution
+              -> ExecutionCoordinator
+                 -> TaskExecutor
+                    -> execution.task.SourceTask / execution.task.SinkTask
 ```
 
 Do not add a second source/sink execution pipeline beside this path.
@@ -248,9 +321,9 @@ Use role names consistently. A suffix is a contract, not decoration.
 | `Compiler` | Translate one model/protocol into another normalized model. |
 | `Planner` | Produce an immutable physical graph without executing it. |
 | `Graph` | Describe a topology or state root for one lifecycle stage. Name the stage explicitly (`JobGraph`, `ExecutionGraph`). |
-| `Coordinator` | Coordinate lifecycle and outcomes across multiple runtime actors. |
-| `Scheduler` | Decide when/where executable work should run. Add only when this responsibility exists. |
-| `Executor` | Execute already-planned work. |
+| `Coordinator` | Coordinate lifecycle and outcomes across multiple actors at one hierarchy level. |
+| `Scheduler` | Decide when executable work is allowed to run and enforce concurrency policy. |
+| `Executor` | Execute already-selected/planned work without choosing scheduling policy. |
 | `Reader` | Read records from an external source. |
 | `Writer` | Write records to an external sink. |
 | `Enumerator` | Discover or enumerate source splits. |
@@ -271,7 +344,7 @@ Source
   -> SourceSplitEnumerator
 ```
 
-The physical/runtime split is now explicit, but split discovery is still transitional: `JobPlanner` invokes
+The physical/runtime split is explicit, but split discovery is still transitional: `JobPlanner` invokes
 `Source#createSplits(...)` during preparation/planning for compatibility. A later phase should make
 `SourceSplitEnumerator` / source coordination the standard split-discovery role.
 
@@ -304,9 +377,12 @@ Reject a change when it introduces any of the following without an explicit arch
 3. transport DTOs being used as mutable runtime state;
 4. planner code creating threads, channels, split queues, cancellation tokens, or runtime metrics;
 5. `SourceTaskPlan`, `PipelineGraph`, or `JobGraph` holding `SplitProvider` or other mutable execution ownership;
-6. a second `FactoryRegistry`, task hierarchy, or source execution path;
-7. a generic `common`, `core`, `helper`, or `utils` package used as a dumping ground;
-8. server HTTP code manipulating task/channel internals directly.
+6. `JobExecution` or `JobCoordinator` directly owning an `ExecutorService`;
+7. `PipelineScheduler` performing connector I/O or owning `ExecutionGraph` state;
+8. `PipelineExecutor` deciding job-level concurrency/failure policy;
+9. a second `FactoryRegistry`, task hierarchy, or source execution path;
+10. a generic `common`, `core`, `helper`, or `utils` package used as a dumping ground;
+11. server HTTP code manipulating task/channel internals directly.
 
 ## Completed architecture phases
 
@@ -319,19 +395,29 @@ Reject a change when it introduces any of the following without an explicit arch
 
 ### Phase 2: physical graph and runtime state
 
-- replace transitional `ExecutionPlan` with `JobGraph`;
-- replace `PipelinePlan` with `PipelineGraph`;
-- introduce `ExecutionGraph` as mutable state for one run;
-- remove `SplitProvider` from planner task models;
-- move `LocalSplitQueue` creation into `PipelineExecution`;
-- keep static/dynamic split semantics and external protocols unchanged.
+- replaced transitional `ExecutionPlan` with `JobGraph`;
+- replaced `PipelinePlan` with `PipelineGraph`;
+- introduced `ExecutionGraph` as mutable state for one run;
+- removed `SplitProvider` from planner task models;
+- moved `LocalSplitQueue` creation into `PipelineExecution`;
+- preserved source split enumeration order independently from task assignment;
+- kept static/dynamic split semantics and external protocols unchanged.
+
+### Phase 3: runtime role separation
+
+- reduced `JobExecution` to a public execution facade/handle;
+- introduced `JobCoordinator` for job lifecycle, failure policy, and result aggregation;
+- introduced `PipelineScheduler` / `LocalPipelineScheduler` for bounded pipeline concurrency;
+- introduced `PipelineExecutor` / `LocalPipelineExecutor` for single-pipeline execution;
+- preserved worker-thread log context at the executor boundary;
+- added focused scheduling and architecture-boundary tests.
 
 ## Next architecture steps
 
 The next phases should remain incremental:
 
-1. separate coordinator/scheduler/executor responsibilities where current classes still own multiple lifecycle stages;
-2. integrate `SourceSplitEnumerator` as the standard split-discovery/coordinator role;
-3. migrate connector package layouts toward the connector development template as connectors are touched;
-4. improve server application/domain/adapter boundaries without coupling them to execution internals;
+1. integrate `SourceSplitEnumerator` as the standard split-discovery/coordinator role;
+2. migrate connector package layouts toward the connector development template as connectors are touched;
+3. improve server application/domain/adapter boundaries without coupling them to execution internals;
+4. evaluate retry/recovery semantics only after execution-state ownership is stable;
 5. split Maven modules only if package boundaries prove insufficient.

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/JobCoordinator.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/JobCoordinator.java
@@ -1,0 +1,201 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.dirtydata.DirtyDataSummary;
+import com.link.up.api.sink.CommitScope;
+import com.link.up.framework.job.CommitSummary;
+import com.link.up.framework.job.JobResult;
+import com.link.up.framework.job.JobStatus;
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.planner.JobGraph;
+import org.apache.logging.log4j.CloseableThreadContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Coordinates the lifecycle of one {@link ExecutionGraph}.
+ *
+ * <p>The coordinator owns job-level lifecycle transitions, failure policy and
+ * result aggregation. Pipeline concurrency belongs to {@link PipelineScheduler}
+ * and pipeline execution belongs to {@link PipelineExecutor}.
+ */
+final class JobCoordinator {
+
+    private static final Logger LOG =
+            LogManager.getLogger(JobCoordinator.class);
+
+    private final ExecutionGraph executionGraph;
+    private final PipelineScheduler pipelineScheduler;
+    private final PipelineExecutor pipelineExecutor;
+
+    JobCoordinator(
+            ExecutionGraph executionGraph,
+            PipelineScheduler pipelineScheduler,
+            PipelineExecutor pipelineExecutor) {
+
+        this.executionGraph =
+                Objects.requireNonNull(
+                        executionGraph,
+                        "executionGraph must not be null");
+        this.pipelineScheduler =
+                Objects.requireNonNull(
+                        pipelineScheduler,
+                        "pipelineScheduler must not be null");
+        this.pipelineExecutor =
+                Objects.requireNonNull(
+                        pipelineExecutor,
+                        "pipelineExecutor must not be null");
+    }
+
+    JobResult execute() {
+        JobGraph jobGraph = executionGraph.getJobGraph();
+        String jobName = jobGraph.getJobName();
+        String runId = executionGraph.getRunId();
+        String jobLogFile = executionGraph.getJobLogFile();
+
+        executionGraph.markRunning();
+
+        try (CloseableThreadContext.Instance ignored =
+                     openJobLogContext(
+                             runId,
+                             jobName,
+                             jobLogFile)) {
+
+            LOG.info(
+                    "Job started: jobName={}, runId={}, jobLogFile={}",
+                    jobName,
+                    runId,
+                    jobLogFile);
+
+            PipelineScheduleResult scheduleResult =
+                    pipelineScheduler.schedule(
+                            jobGraph.getPipelineGraphs(),
+                            jobGraph
+                                    .getExecutionConfig()
+                                    .getPipelineParallelism(),
+                            executionGraph.getCancellationToken(),
+                            pipelineExecutor);
+
+            JobResult result =
+                    createJobResult(scheduleResult);
+
+            executionGraph.complete(result);
+            logResult(result);
+
+            return result;
+
+        } catch (RuntimeException failure) {
+            executionGraph.fail(failure);
+            throw failure;
+        } catch (Error failure) {
+            executionGraph.fail(failure);
+            throw failure;
+        }
+    }
+
+    private JobResult createJobResult(
+            PipelineScheduleResult scheduleResult) {
+
+        Objects.requireNonNull(
+                scheduleResult,
+                "scheduleResult must not be null");
+
+        JobGraph jobGraph = executionGraph.getJobGraph();
+        Throwable failure = scheduleResult.getFailure();
+        JobStatus status =
+                failure != null
+                        ? JobStatus.FAILED
+                        : executionGraph.isCancellationRequested()
+                        ? JobStatus.CANCELED
+                        : JobStatus.SUCCEEDED;
+
+        return new JobResult(
+                jobGraph.getJobName(),
+                status,
+                executionGraph.getStartTimeMillis(),
+                System.currentTimeMillis(),
+                executionGraph.getMetrics(),
+                failure,
+                merge(scheduleResult.getPipelineResults()),
+                DirtyDataSummary.empty(),
+                scheduleResult.getPipelineResults());
+    }
+
+    private void logResult(JobResult result) {
+        if (result.getStatus() == JobStatus.SUCCEEDED) {
+            LOG.info(
+                    "Job finished: status={}, durationMillis={}",
+                    result.getStatus(),
+                    result.getDurationMillis());
+        } else if (result.getFailure() != null) {
+            LOG.error(
+                    "Job finished: status={}, durationMillis={}",
+                    result.getStatus(),
+                    result.getDurationMillis(),
+                    result.getFailure());
+        } else {
+            LOG.warn(
+                    "Job finished: status={}, durationMillis={}",
+                    result.getStatus(),
+                    result.getDurationMillis());
+        }
+    }
+
+    private CommitSummary merge(
+            List<PipelineResult> results) {
+
+        int total = 0;
+        int finished = 0;
+        int committed = 0;
+        int empty = 0;
+        int failed = 0;
+        long attempted = 0L;
+        long written = 0L;
+        long committedRows = 0L;
+        long failedRows = 0L;
+        long unknown = 0L;
+
+        for (PipelineResult result : results) {
+            CommitSummary summary = result.getCommitSummary();
+
+            total += summary.getTotalTaskCount();
+            finished += summary.getFinishedTaskCount();
+            committed += summary.getCommittedTaskCount();
+            empty += summary.getEmptyCommittedTaskCount();
+            failed += summary.getFailedOrUncommittedTaskCount();
+            attempted += summary.getAttemptedRecordCount();
+            written += summary.getSuccessfullyWrittenRecordCount();
+            committedRows += summary.getSuccessfullyCommittedRecordCount();
+            failedRows += summary.getFailedRecordCount();
+            unknown += summary.getUnknownStateRecordCount();
+        }
+
+        return new CommitSummary(
+                total,
+                finished,
+                committed,
+                empty,
+                failed,
+                attempted,
+                written,
+                committedRows,
+                failedRows,
+                unknown,
+                CommitScope.TASK_LOCAL,
+                "This sink commits per task; inspect unknown batch states before retrying.");
+    }
+
+    private static CloseableThreadContext.Instance openJobLogContext(
+            String runId,
+            String jobName,
+            String jobLogFile) {
+
+        return CloseableThreadContext
+                .put("runId", runId)
+                .put("jobId", runId)
+                .put("jobName", jobName)
+                .put("jobLogFile", jobLogFile);
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/JobExecution.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/JobExecution.java
@@ -1,43 +1,22 @@
 package com.link.up.framework.execution;
 
-import com.link.up.api.dirtydata.DirtyDataSummary;
-import com.link.up.api.sink.CommitScope;
-import com.link.up.api.source.SourceSplit;
-import com.link.up.framework.job.CommitSummary;
 import com.link.up.framework.job.JobResult;
-import com.link.up.framework.job.JobStatus;
-import com.link.up.framework.job.PipelineResult;
 import com.link.up.framework.metrics.JobMetrics;
 import com.link.up.framework.planner.JobGraph;
-import com.link.up.framework.planner.PipelineGraph;
-import org.apache.logging.log4j.CloseableThreadContext;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletionService;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 /**
- * Coordinates one runtime execution of an immutable JobGraph.
+ * Public handle for one local execution of an immutable {@link JobGraph}.
  *
- * <p>Mutable state is owned by {@link ExecutionGraph}; this class only drives
- * pipeline execution and aggregates outcomes.
+ * <p>This class is intentionally a thin facade. Job lifecycle coordination is
+ * delegated to {@link JobCoordinator}; pipeline concurrency and pipeline work
+ * are owned by dedicated scheduler/executor roles.
  */
 public final class JobExecution {
 
-    private static final Logger LOG =
-            LogManager.getLogger(JobExecution.class);
-
     private final ExecutionGraph executionGraph;
-    private final ClassLoader classLoader;
+    private final JobCoordinator jobCoordinator;
 
     public JobExecution(
             JobGraph jobGraph,
@@ -83,248 +62,36 @@ public final class JobExecution {
             ExecutionGraph executionGraph,
             ClassLoader classLoader) {
 
+        this(
+                executionGraph,
+                new LocalPipelineScheduler(),
+                new LocalPipelineExecutor(
+                        executionGraph,
+                        classLoader));
+    }
+
+    JobExecution(
+            ExecutionGraph executionGraph,
+            PipelineScheduler pipelineScheduler,
+            PipelineExecutor pipelineExecutor) {
+
         this.executionGraph =
                 Objects.requireNonNull(
                         executionGraph,
                         "executionGraph must not be null");
-        this.classLoader =
-                Objects.requireNonNull(
-                        classLoader,
-                        "classLoader must not be null");
+        this.jobCoordinator =
+                new JobCoordinator(
+                        executionGraph,
+                        Objects.requireNonNull(
+                                pipelineScheduler,
+                                "pipelineScheduler must not be null"),
+                        Objects.requireNonNull(
+                                pipelineExecutor,
+                                "pipelineExecutor must not be null"));
     }
 
     public JobResult execute() {
-        JobGraph jobGraph = executionGraph.getJobGraph();
-        String jobName = jobGraph.getJobName();
-        String runId = executionGraph.getRunId();
-        String jobLogFile = executionGraph.getJobLogFile();
-
-        executionGraph.markRunning();
-
-        try (CloseableThreadContext.Instance ignored =
-                     openJobLogContext(
-                             runId,
-                             jobName,
-                             jobLogFile)) {
-
-            LOG.info(
-                    "Job started: jobName={}, runId={}, jobLogFile={}",
-                    jobName,
-                    runId,
-                    jobLogFile);
-
-            JobResult result = executeInternal();
-            executionGraph.complete(result);
-
-            if (result.getStatus() == JobStatus.SUCCEEDED) {
-                LOG.info(
-                        "Job finished: status={}, durationMillis={}",
-                        result.getStatus(),
-                        result.getDurationMillis());
-            } else if (result.getFailure() != null) {
-                LOG.error(
-                        "Job finished: status={}, durationMillis={}",
-                        result.getStatus(),
-                        result.getDurationMillis(),
-                        result.getFailure());
-            } else {
-                LOG.warn(
-                        "Job finished: status={}, durationMillis={}",
-                        result.getStatus(),
-                        result.getDurationMillis());
-            }
-
-            return result;
-
-        } catch (RuntimeException failure) {
-            executionGraph.fail(failure);
-            throw failure;
-        } catch (Error failure) {
-            executionGraph.fail(failure);
-            throw failure;
-        }
-    }
-
-    private JobResult executeInternal() {
-        final JobGraph jobGraph = executionGraph.getJobGraph();
-        final CancellationToken cancellationToken =
-                executionGraph.getCancellationToken();
-        final JobMetrics jobMetrics = executionGraph.getMetrics();
-        final long start = executionGraph.getStartTimeMillis();
-        final String currentRunId = executionGraph.getRunId();
-        final String currentJobLogFile = executionGraph.getJobLogFile();
-
-        List<PipelineResult> results =
-                new ArrayList<PipelineResult>();
-        Throwable first = null;
-
-        if (!jobGraph.isEmpty()) {
-            int threadCount = Math.min(
-                    jobGraph
-                            .getExecutionConfig()
-                            .getPipelineParallelism(),
-                    jobGraph
-                            .getPipelineGraphs()
-                            .size());
-
-            ExecutorService pool =
-                    Executors.newFixedThreadPool(threadCount);
-            CompletionService<PipelineResult> completionService =
-                    new ExecutorCompletionService<PipelineResult>(pool);
-            List<Future<PipelineResult>> submitted =
-                    new ArrayList<Future<PipelineResult>>();
-
-            try {
-                for (final PipelineGraph<?> pipelineGraph :
-                        jobGraph.getPipelineGraphs()) {
-
-                    submitted.add(
-                            completionService.submit(
-                                    new Callable<PipelineResult>() {
-                                        public PipelineResult call() {
-                                            try (CloseableThreadContext.Instance ignored =
-                                                         openJobLogContext(
-                                                                 currentRunId,
-                                                                 jobGraph.getJobName(),
-                                                                 currentJobLogFile)) {
-                                                return executePipeline(
-                                                        pipelineGraph,
-                                                        jobGraph,
-                                                        cancellationToken,
-                                                        jobMetrics,
-                                                        start);
-                                            }
-                                        }
-                                    }));
-                }
-
-                for (int index = 0;
-                     index < submitted.size();
-                     index++) {
-                    try {
-                        PipelineResult result =
-                                completionService
-                                        .take()
-                                        .get();
-                        results.add(result);
-
-                        if (result.getFailure() != null
-                                && first == null) {
-                            first = result.getFailure();
-                            cancellationToken.cancel(first);
-                        }
-
-                    } catch (Exception exception) {
-                        Throwable failure =
-                                exception instanceof ExecutionException
-                                        && exception.getCause() != null
-                                        ? exception.getCause()
-                                        : exception;
-
-                        if (first == null) {
-                            first = failure;
-                            cancellationToken.cancel(failure);
-                        }
-                    }
-                }
-
-            } finally {
-                pool.shutdownNow();
-            }
-        }
-
-        CommitSummary summary = merge(results);
-        JobStatus status =
-                first != null
-                        ? JobStatus.FAILED
-                        : cancellationToken.isCancelled()
-                        ? JobStatus.CANCELED
-                        : JobStatus.SUCCEEDED;
-
-        return new JobResult(
-                jobGraph.getJobName(),
-                status,
-                start,
-                System.currentTimeMillis(),
-                jobMetrics,
-                first,
-                summary,
-                DirtyDataSummary.empty(),
-                results);
-    }
-
-    private <SplitT extends SourceSplit> PipelineResult executePipeline(
-            PipelineGraph<SplitT> pipelineGraph,
-            JobGraph jobGraph,
-            CancellationToken cancellationToken,
-            JobMetrics jobMetrics,
-            long start) {
-
-        return new PipelineExecution<SplitT>(
-                pipelineGraph,
-                jobGraph.getExecutionConfig(),
-                cancellationToken,
-                jobMetrics,
-                classLoader,
-                jobGraph.getJobName(),
-                start)
-                .execute();
-    }
-
-    private static CloseableThreadContext.Instance openJobLogContext(
-            String currentRunId,
-            String jobName,
-            String currentJobLogFile) {
-
-        return CloseableThreadContext
-                .put("runId", currentRunId)
-                .put("jobId", currentRunId)
-                .put("jobName", jobName)
-                .put("jobLogFile", currentJobLogFile);
-    }
-
-    private CommitSummary merge(
-            List<PipelineResult> results) {
-
-        int total = 0;
-        int finished = 0;
-        int committed = 0;
-        int empty = 0;
-        int failed = 0;
-        long attempted = 0L;
-        long written = 0L;
-        long committedRows = 0L;
-        long failedRows = 0L;
-        long unknown = 0L;
-
-        for (PipelineResult result : results) {
-            CommitSummary summary = result.getCommitSummary();
-
-            total += summary.getTotalTaskCount();
-            finished += summary.getFinishedTaskCount();
-            committed += summary.getCommittedTaskCount();
-            empty += summary.getEmptyCommittedTaskCount();
-            failed += summary.getFailedOrUncommittedTaskCount();
-            attempted += summary.getAttemptedRecordCount();
-            written += summary.getSuccessfullyWrittenRecordCount();
-            committedRows += summary.getSuccessfullyCommittedRecordCount();
-            failedRows += summary.getFailedRecordCount();
-            unknown += summary.getUnknownStateRecordCount();
-        }
-
-        return new CommitSummary(
-                total,
-                finished,
-                committed,
-                empty,
-                failed,
-                attempted,
-                written,
-                committedRows,
-                failedRows,
-                unknown,
-                CommitScope.TASK_LOCAL,
-                "This sink commits per task; inspect unknown batch states before retrying.");
+        return jobCoordinator.execute();
     }
 
     public void cancel() {

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/LocalPipelineExecutor.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/LocalPipelineExecutor.java
@@ -1,0 +1,75 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.planner.JobGraph;
+import com.link.up.framework.planner.PipelineGraph;
+import org.apache.logging.log4j.CloseableThreadContext;
+
+import java.util.Objects;
+
+/**
+ * Materializes and executes one local {@link PipelineExecution} from an
+ * immutable {@link PipelineGraph}.
+ *
+ * <p>The executor also restores the job log context on the scheduler worker
+ * thread. Log4j thread context is thread-local and therefore must be opened at
+ * the execution boundary rather than assumed to propagate from the caller.
+ */
+final class LocalPipelineExecutor
+        implements PipelineExecutor {
+
+    private final ExecutionGraph executionGraph;
+    private final ClassLoader classLoader;
+
+    LocalPipelineExecutor(
+            ExecutionGraph executionGraph,
+            ClassLoader classLoader) {
+
+        this.executionGraph =
+                Objects.requireNonNull(
+                        executionGraph,
+                        "executionGraph must not be null");
+        this.classLoader =
+                Objects.requireNonNull(
+                        classLoader,
+                        "classLoader must not be null");
+    }
+
+    @Override
+    public PipelineResult execute(
+            PipelineGraph<?> pipelineGraph) {
+
+        Objects.requireNonNull(
+                pipelineGraph,
+                "pipelineGraph must not be null");
+
+        JobGraph jobGraph = executionGraph.getJobGraph();
+
+        try (CloseableThreadContext.Instance ignored =
+                     CloseableThreadContext
+                             .put("runId", executionGraph.getRunId())
+                             .put("jobId", executionGraph.getRunId())
+                             .put("jobName", jobGraph.getJobName())
+                             .put("jobLogFile", executionGraph.getJobLogFile())) {
+
+            return executeTyped(pipelineGraph);
+        }
+    }
+
+    private <SplitT extends SourceSplit> PipelineResult executeTyped(
+            PipelineGraph<SplitT> pipelineGraph) {
+
+        JobGraph jobGraph = executionGraph.getJobGraph();
+
+        return new PipelineExecution<SplitT>(
+                pipelineGraph,
+                jobGraph.getExecutionConfig(),
+                executionGraph.getCancellationToken(),
+                executionGraph.getMetrics(),
+                classLoader,
+                jobGraph.getJobName(),
+                executionGraph.getStartTimeMillis())
+                .execute();
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/LocalPipelineScheduler.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/LocalPipelineScheduler.java
@@ -1,0 +1,150 @@
+package com.link.up.framework.execution;
+
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.planner.PipelineGraph;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Local bounded-concurrency scheduler for {@link PipelineGraph} instances.
+ *
+ * <p>The scheduler decides how many pipelines may run concurrently and collects
+ * their outcomes in completion order. The actual pipeline work is delegated to
+ * {@link PipelineExecutor}.
+ */
+final class LocalPipelineScheduler
+        implements PipelineScheduler {
+
+    @Override
+    public PipelineScheduleResult schedule(
+            List<PipelineGraph<?>> pipelineGraphs,
+            int parallelism,
+            CancellationToken cancellationToken,
+            final PipelineExecutor pipelineExecutor) {
+
+        Objects.requireNonNull(
+                pipelineGraphs,
+                "pipelineGraphs must not be null");
+        Objects.requireNonNull(
+                cancellationToken,
+                "cancellationToken must not be null");
+        Objects.requireNonNull(
+                pipelineExecutor,
+                "pipelineExecutor must not be null");
+
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException(
+                    "parallelism must be greater than 0");
+        }
+
+        if (pipelineGraphs.isEmpty()) {
+            return PipelineScheduleResult.empty();
+        }
+
+        for (PipelineGraph<?> pipelineGraph : pipelineGraphs) {
+            Objects.requireNonNull(
+                    pipelineGraph,
+                    "pipelineGraphs must not contain null values");
+        }
+
+        int threadCount =
+                Math.min(
+                        parallelism,
+                        pipelineGraphs.size());
+
+        ExecutorService pool =
+                Executors.newFixedThreadPool(threadCount);
+        CompletionService<PipelineResult> completionService =
+                new ExecutorCompletionService<PipelineResult>(pool);
+        List<Future<PipelineResult>> submitted =
+                new ArrayList<Future<PipelineResult>>(
+                        pipelineGraphs.size());
+        List<PipelineResult> results =
+                new ArrayList<PipelineResult>();
+        Throwable firstFailure = null;
+
+        try {
+            for (final PipelineGraph<?> pipelineGraph : pipelineGraphs) {
+                submitted.add(
+                        completionService.submit(
+                                new java.util.concurrent.Callable<PipelineResult>() {
+                                    @Override
+                                    public PipelineResult call() {
+                                        return pipelineExecutor.execute(
+                                                pipelineGraph);
+                                    }
+                                }));
+            }
+
+            for (int index = 0;
+                 index < submitted.size();
+                 index++) {
+
+                try {
+                    PipelineResult result =
+                            completionService
+                                    .take()
+                                    .get();
+
+                    if (result == null) {
+                        throw new IllegalStateException(
+                                "PipelineExecutor returned a null result");
+                    }
+
+                    results.add(result);
+
+                    if (result.getFailure() != null
+                            && firstFailure == null) {
+                        firstFailure = result.getFailure();
+                        cancellationToken.cancel(firstFailure);
+                    }
+
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+
+                    if (firstFailure == null) {
+                        firstFailure = interrupted;
+                        cancellationToken.cancel(interrupted);
+                    }
+
+                    cancelSubmitted(submitted);
+                    break;
+
+                } catch (ExecutionException executionFailure) {
+                    Throwable failure =
+                            executionFailure.getCause() == null
+                                    ? executionFailure
+                                    : executionFailure.getCause();
+
+                    if (firstFailure == null) {
+                        firstFailure = failure;
+                        cancellationToken.cancel(failure);
+                    }
+                }
+            }
+
+        } finally {
+            pool.shutdownNow();
+        }
+
+        return new PipelineScheduleResult(
+                results,
+                firstFailure);
+    }
+
+    private void cancelSubmitted(
+            List<Future<PipelineResult>> submitted) {
+
+        for (Future<PipelineResult> future : submitted) {
+            future.cancel(true);
+        }
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineExecutor.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineExecutor.java
@@ -1,0 +1,15 @@
+package com.link.up.framework.execution;
+
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.planner.PipelineGraph;
+
+/**
+ * Executes one already-planned pipeline.
+ *
+ * <p>The executor does not decide when the pipeline runs or how many pipelines
+ * may run concurrently. Those decisions belong to {@link PipelineScheduler}.
+ */
+interface PipelineExecutor {
+
+    PipelineResult execute(PipelineGraph<?> pipelineGraph);
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineScheduleResult.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineScheduleResult.java
@@ -1,0 +1,55 @@
+package com.link.up.framework.execution;
+
+import com.link.up.framework.job.PipelineResult;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Immutable outcome returned by {@link PipelineScheduler}.
+ */
+final class PipelineScheduleResult {
+
+    private final List<PipelineResult> pipelineResults;
+    private final Throwable failure;
+
+    PipelineScheduleResult(
+            List<PipelineResult> pipelineResults,
+            Throwable failure) {
+
+        Objects.requireNonNull(
+                pipelineResults,
+                "pipelineResults must not be null");
+
+        List<PipelineResult> copy =
+                new ArrayList<PipelineResult>(
+                        pipelineResults.size());
+
+        for (PipelineResult result : pipelineResults) {
+            copy.add(
+                    Objects.requireNonNull(
+                            result,
+                            "pipelineResults must not contain null values"));
+        }
+
+        this.pipelineResults =
+                Collections.unmodifiableList(copy);
+        this.failure = failure;
+    }
+
+    static PipelineScheduleResult empty() {
+        return new PipelineScheduleResult(
+                Collections.<PipelineResult>emptyList(),
+                null);
+    }
+
+    List<PipelineResult> getPipelineResults() {
+        return pipelineResults;
+    }
+
+    Throwable getFailure() {
+        return failure;
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineScheduler.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineScheduler.java
@@ -1,0 +1,21 @@
+package com.link.up.framework.execution;
+
+import com.link.up.framework.planner.PipelineGraph;
+
+import java.util.List;
+
+/**
+ * Schedules physical pipelines for one local execution.
+ *
+ * <p>A scheduler owns concurrency and completion-order collection. It must not
+ * execute connector I/O itself; executable work is delegated to a
+ * {@link PipelineExecutor}.
+ */
+interface PipelineScheduler {
+
+    PipelineScheduleResult schedule(
+            List<PipelineGraph<?>> pipelineGraphs,
+            int parallelism,
+            CancellationToken cancellationToken,
+            PipelineExecutor pipelineExecutor);
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/package-info.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/package-info.java
@@ -1,11 +1,15 @@
 /**
- * Runtime lifecycle, execution state, cancellation, coordination, and task
+ * Runtime lifecycle, execution state, coordination, scheduling, and task
  * execution.
  *
  * <p>This package consumes immutable graphs produced by
  * {@code framework.planner}. Mutable per-run ownership belongs here, rooted at
- * {@link com.link.up.framework.execution.ExecutionGraph}. New executable
- * source/sink work belongs under {@code framework.execution.task}; do not
- * introduce a parallel processor/task hierarchy beside the active runtime.
+ * {@link com.link.up.framework.execution.ExecutionGraph}. Runtime roles are
+ * layered deliberately: {@code JobExecution} is the facade,
+ * {@code JobCoordinator} owns job lifecycle, {@code PipelineScheduler} owns
+ * pipeline concurrency, {@code PipelineExecutor} executes one pipeline, and
+ * {@code TaskExecutor} executes concrete tasks. New source/sink work belongs
+ * under {@code framework.execution.task}; do not introduce a parallel
+ * processor/task hierarchy beside the active runtime.
  */
 package com.link.up.framework.execution;

--- a/link-up-framework/src/test/java/com/link/up/framework/execution/ExecutionRoleBoundaryTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/execution/ExecutionRoleBoundaryTest.java
@@ -1,0 +1,84 @@
+package com.link.up.framework.execution;
+
+import com.link.up.framework.planner.JobGraph;
+import com.link.up.framework.planner.PipelineGraph;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Architecture guards for Phase 3 runtime role separation.
+ */
+public class ExecutionRoleBoundaryTest {
+
+    @Test
+    public void jobExecutionShouldRemainAThinFacade() {
+        Set<Class<?>> fieldTypes = instanceFieldTypes(
+                JobExecution.class);
+
+        assertTrue(fieldTypes.contains(ExecutionGraph.class));
+        assertTrue(fieldTypes.contains(JobCoordinator.class));
+        assertFalse(fieldTypes.contains(JobGraph.class));
+        assertFalse(fieldTypes.contains(PipelineGraph.class));
+        assertNoExecutorService(JobExecution.class);
+    }
+
+    @Test
+    public void jobCoordinatorShouldDependOnSchedulerAndExecutorRoles() {
+        Set<Class<?>> fieldTypes = instanceFieldTypes(
+                JobCoordinator.class);
+
+        assertTrue(fieldTypes.contains(ExecutionGraph.class));
+        assertTrue(fieldTypes.contains(PipelineScheduler.class));
+        assertTrue(fieldTypes.contains(PipelineExecutor.class));
+        assertFalse(fieldTypes.contains(ClassLoader.class));
+        assertNoExecutorService(JobCoordinator.class);
+    }
+
+    @Test
+    public void localPipelineSchedulerShouldNotOwnExecutionState() {
+        Set<Class<?>> fieldTypes = instanceFieldTypes(
+                LocalPipelineScheduler.class);
+
+        assertFalse(fieldTypes.contains(ExecutionGraph.class));
+        assertFalse(fieldTypes.contains(JobGraph.class));
+        assertFalse(fieldTypes.contains(PipelineGraph.class));
+    }
+
+    private static Set<Class<?>> instanceFieldTypes(
+            Class<?> type) {
+
+        Set<Class<?>> fieldTypes =
+                new HashSet<Class<?>>();
+
+        for (Field field : type.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) {
+                fieldTypes.add(field.getType());
+            }
+        }
+
+        return fieldTypes;
+    }
+
+    private static void assertNoExecutorService(
+            Class<?> type) {
+
+        for (Field field : type.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers())) {
+                assertFalse(
+                        type.getSimpleName()
+                                + " must not own ExecutorService field "
+                                + field.getName(),
+                        ExecutorService.class.isAssignableFrom(
+                                field.getType()));
+            }
+        }
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/execution/JobCoordinatorTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/execution/JobCoordinatorTest.java
@@ -1,0 +1,214 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.framework.job.CommitSummary;
+import com.link.up.framework.job.JobResult;
+import com.link.up.framework.job.JobStatus;
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.job.PipelineStatus;
+import com.link.up.framework.planner.JobGraph;
+import com.link.up.framework.planner.PipelineGraph;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class JobCoordinatorTest {
+
+    @Test
+    public void shouldOwnLifecycleAndAggregateScheduledResults() {
+        final PipelineGraph<?> first =
+                RuntimeRoleTestSupport.pipelineGraph("pipeline-first");
+        final PipelineGraph<?> second =
+                RuntimeRoleTestSupport.pipelineGraph("pipeline-second");
+        JobGraph jobGraph =
+                RuntimeRoleTestSupport.jobGraph(
+                        Arrays.<PipelineGraph<?>>asList(
+                                first,
+                                second),
+                        2);
+        final ExecutionGraph executionGraph =
+                new ExecutionGraph(
+                        jobGraph,
+                        100L,
+                        "run-phase-3",
+                        "phase-3.log");
+
+        final CommitSummary firstSummary =
+                new CommitSummary(
+                        1,
+                        1,
+                        1,
+                        0,
+                        0,
+                        10L,
+                        10L,
+                        10L,
+                        0L,
+                        0L,
+                        CommitScope.TASK_LOCAL,
+                        "first");
+        final CommitSummary secondSummary =
+                new CommitSummary(
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        0L,
+                        0L,
+                        0L,
+                        0L,
+                        0L,
+                        CommitScope.TASK_LOCAL,
+                        "second");
+
+        PipelineScheduler scheduler =
+                new PipelineScheduler() {
+                    @Override
+                    public PipelineScheduleResult schedule(
+                            List<PipelineGraph<?>> pipelineGraphs,
+                            int parallelism,
+                            CancellationToken cancellationToken,
+                            PipelineExecutor pipelineExecutor) {
+
+                        assertSame(
+                                executionGraph.getJobGraph().getPipelineGraphs(),
+                                pipelineGraphs);
+                        assertEquals(2, parallelism);
+                        assertSame(
+                                executionGraph.getCancellationToken(),
+                                cancellationToken);
+
+                        return new PipelineScheduleResult(
+                                Arrays.asList(
+                                        RuntimeRoleTestSupport.result(
+                                                first,
+                                                PipelineStatus.SUCCEEDED,
+                                                firstSummary,
+                                                null),
+                                        RuntimeRoleTestSupport.result(
+                                                second,
+                                                PipelineStatus.SUCCEEDED,
+                                                secondSummary,
+                                                null)),
+                                null);
+                    }
+                };
+
+        JobResult result =
+                new JobCoordinator(
+                        executionGraph,
+                        scheduler,
+                        unusedExecutor())
+                        .execute();
+
+        assertEquals(JobStatus.SUCCEEDED, result.getStatus());
+        assertEquals(JobStatus.SUCCEEDED, executionGraph.getStatus());
+        assertTrue(executionGraph.isTerminal());
+        assertSame(result, executionGraph.getResult());
+        assertEquals(2, result.getPipelineResults().size());
+        assertEquals(2, result.getCommitSummary().getTotalTaskCount());
+        assertEquals(2, result.getCommitSummary().getCommittedTaskCount());
+        assertEquals(1, result.getCommitSummary().getEmptyCommittedTaskCount());
+        assertEquals(10L, result.getCommitSummary().getSuccessfullyCommittedRecordCount());
+    }
+
+    @Test
+    public void shouldReturnCanceledWhenCancellationWasRequestedBeforeScheduling() {
+        ExecutionGraph executionGraph =
+                new ExecutionGraph(
+                        RuntimeRoleTestSupport.jobGraph(
+                                Collections.<PipelineGraph<?>>emptyList(),
+                                1),
+                        100L,
+                        "run-canceled",
+                        "canceled.log");
+
+        executionGraph.requestCancellation(
+                new CancellationException("cancel before run"));
+
+        JobResult result =
+                new JobCoordinator(
+                        executionGraph,
+                        emptyScheduler(),
+                        unusedExecutor())
+                        .execute();
+
+        assertEquals(JobStatus.CANCELED, result.getStatus());
+        assertEquals(JobStatus.CANCELED, executionGraph.getStatus());
+        assertNull(result.getFailure());
+    }
+
+    @Test
+    public void shouldFailExecutionGraphWhenSchedulerThrows() {
+        final RuntimeException failure =
+                new RuntimeException("scheduler failed");
+        ExecutionGraph executionGraph =
+                new ExecutionGraph(
+                        RuntimeRoleTestSupport.jobGraph(
+                                Collections.<PipelineGraph<?>>emptyList(),
+                                1),
+                        100L,
+                        "run-failed",
+                        "failed.log");
+
+        PipelineScheduler scheduler =
+                new PipelineScheduler() {
+                    @Override
+                    public PipelineScheduleResult schedule(
+                            List<PipelineGraph<?>> pipelineGraphs,
+                            int parallelism,
+                            CancellationToken cancellationToken,
+                            PipelineExecutor pipelineExecutor) {
+                        throw failure;
+                    }
+                };
+
+        try {
+            new JobCoordinator(
+                    executionGraph,
+                    scheduler,
+                    unusedExecutor())
+                    .execute();
+        } catch (RuntimeException actual) {
+            assertSame(failure, actual);
+        }
+
+        assertEquals(JobStatus.FAILED, executionGraph.getStatus());
+        assertSame(failure, executionGraph.getFailure());
+        assertTrue(executionGraph.isTerminal());
+        assertNull(executionGraph.getResult());
+    }
+
+    private static PipelineScheduler emptyScheduler() {
+        return new PipelineScheduler() {
+            @Override
+            public PipelineScheduleResult schedule(
+                    List<PipelineGraph<?>> pipelineGraphs,
+                    int parallelism,
+                    CancellationToken cancellationToken,
+                    PipelineExecutor pipelineExecutor) {
+                return PipelineScheduleResult.empty();
+            }
+        };
+    }
+
+    private static PipelineExecutor unusedExecutor() {
+        return new PipelineExecutor() {
+            @Override
+            public PipelineResult execute(
+                    PipelineGraph<?> pipelineGraph) {
+                throw new AssertionError(
+                        "PipelineExecutor should not be invoked by this test scheduler");
+            }
+        };
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/execution/LocalPipelineSchedulerTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/execution/LocalPipelineSchedulerTest.java
@@ -1,0 +1,165 @@
+package com.link.up.framework.execution;
+
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.planner.PipelineGraph;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class LocalPipelineSchedulerTest {
+
+    @Test
+    public void shouldRespectConfiguredPipelineParallelism() {
+        final List<PipelineGraph<?>> graphs =
+                Arrays.<PipelineGraph<?>>asList(
+                        RuntimeRoleTestSupport.pipelineGraph("pipeline-a"),
+                        RuntimeRoleTestSupport.pipelineGraph("pipeline-b"),
+                        RuntimeRoleTestSupport.pipelineGraph("pipeline-c"));
+        final CountDownLatch firstWave =
+                new CountDownLatch(2);
+        final AtomicInteger active =
+                new AtomicInteger();
+        final AtomicInteger maxActive =
+                new AtomicInteger();
+
+        PipelineExecutor executor =
+                new PipelineExecutor() {
+                    @Override
+                    public PipelineResult execute(
+                            PipelineGraph<?> pipelineGraph) {
+
+                        int running = active.incrementAndGet();
+                        updateMaximum(maxActive, running);
+                        firstWave.countDown();
+
+                        try {
+                            if (!firstWave.await(
+                                    3L,
+                                    TimeUnit.SECONDS)) {
+                                throw new AssertionError(
+                                        "Expected two pipelines to run concurrently");
+                            }
+                            return RuntimeRoleTestSupport.success(
+                                    pipelineGraph);
+                        } catch (InterruptedException interrupted) {
+                            Thread.currentThread().interrupt();
+                            throw new RuntimeException(interrupted);
+                        } finally {
+                            active.decrementAndGet();
+                        }
+                    }
+                };
+
+        CancellationToken token = new CancellationToken();
+        PipelineScheduleResult result =
+                new LocalPipelineScheduler().schedule(
+                        graphs,
+                        2,
+                        token,
+                        executor);
+
+        assertNull(result.getFailure());
+        assertEquals(3, result.getPipelineResults().size());
+        assertEquals(2, maxActive.get());
+        assertFalse(token.isCancelled());
+    }
+
+    @Test
+    public void shouldPropagateFirstPipelineFailureToCancellation() {
+        final PipelineGraph<?> failing =
+                RuntimeRoleTestSupport.pipelineGraph("pipeline-failing");
+        PipelineGraph<?> succeeding =
+                RuntimeRoleTestSupport.pipelineGraph("pipeline-succeeding");
+        final RuntimeException failure =
+                new RuntimeException("pipeline failed");
+
+        PipelineExecutor executor =
+                new PipelineExecutor() {
+                    @Override
+                    public PipelineResult execute(
+                            PipelineGraph<?> pipelineGraph) {
+                        if (pipelineGraph == failing) {
+                            throw failure;
+                        }
+                        return RuntimeRoleTestSupport.success(
+                                pipelineGraph);
+                    }
+                };
+
+        CancellationToken token = new CancellationToken();
+        PipelineScheduleResult result =
+                new LocalPipelineScheduler().schedule(
+                        Arrays.asList(failing, succeeding),
+                        1,
+                        token,
+                        executor);
+
+        assertSame(failure, result.getFailure());
+        assertTrue(token.isCancelled());
+        assertSame(failure, token.getCause());
+    }
+
+    @Test
+    public void shouldReturnEmptyWithoutInvokingExecutor() {
+        final AtomicInteger calls = new AtomicInteger();
+
+        PipelineScheduleResult result =
+                new LocalPipelineScheduler().schedule(
+                        Collections.<PipelineGraph<?>>emptyList(),
+                        1,
+                        new CancellationToken(),
+                        new PipelineExecutor() {
+                            @Override
+                            public PipelineResult execute(
+                                    PipelineGraph<?> pipelineGraph) {
+                                calls.incrementAndGet();
+                                return null;
+                            }
+                        });
+
+        assertEquals(0, calls.get());
+        assertTrue(result.getPipelineResults().isEmpty());
+        assertNull(result.getFailure());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldRejectNonPositiveParallelism() {
+        new LocalPipelineScheduler().schedule(
+                Collections.<PipelineGraph<?>>emptyList(),
+                0,
+                new CancellationToken(),
+                new PipelineExecutor() {
+                    @Override
+                    public PipelineResult execute(
+                            PipelineGraph<?> pipelineGraph) {
+                        return null;
+                    }
+                });
+    }
+
+    private static void updateMaximum(
+            AtomicInteger maximum,
+            int candidate) {
+
+        while (true) {
+            int current = maximum.get();
+            if (candidate <= current
+                    || maximum.compareAndSet(
+                            current,
+                            candidate)) {
+                return;
+            }
+        }
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/execution/RuntimeRoleTestSupport.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/execution/RuntimeRoleTestSupport.java
@@ -1,0 +1,218 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.framework.connector.PreparedSink;
+import com.link.up.framework.connector.PreparedSource;
+import com.link.up.framework.job.CommitSummary;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.job.PipelineStatus;
+import com.link.up.framework.job.SinkPartitionStrategy;
+import com.link.up.framework.job.SplitAssignmentMode;
+import com.link.up.framework.planner.JobGraph;
+import com.link.up.framework.planner.PipelineGraph;
+import com.link.up.framework.planner.SinkTaskPlan;
+import com.link.up.framework.planner.SourceTaskPlan;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class RuntimeRoleTestSupport {
+
+    private RuntimeRoleTestSupport() {
+    }
+
+    static PipelineGraph<TestSplit> pipelineGraph(
+            String pipelineId) {
+
+        TablePath path = TablePath.of(
+                "demo",
+                pipelineId.replace('-', '_'));
+        CatalogTable table = table(path);
+        Map<TablePath, CatalogTable> tables =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        tables.put(path, table);
+
+        PreparedSource<TestSplit> preparedSource =
+                preparedSource(tables);
+        TestSplit split =
+                new TestSplit(
+                        pipelineId + "-split",
+                        path.toString());
+
+        return new PipelineGraph<TestSplit>(
+                pipelineId,
+                path.toString(),
+                table,
+                Collections.singletonList(split),
+                Collections.singletonList(
+                        new SourceTaskPlan<TestSplit>(
+                                new TaskId(
+                                        pipelineId,
+                                        TaskType.SOURCE,
+                                        0,
+                                        1),
+                                preparedSource,
+                                Collections.singletonList(split),
+                                100)),
+                Collections.singletonList(
+                        new SinkTaskPlan(
+                                new TaskId(
+                                        pipelineId,
+                                        TaskType.SINK,
+                                        0,
+                                        1),
+                                preparedSink(tables))),
+                SplitAssignmentMode.STATIC_ROUND_ROBIN);
+    }
+
+    static JobGraph jobGraph(
+            List<PipelineGraph<?>> pipelines,
+            int pipelineParallelism) {
+
+        return new JobGraph(
+                "phase-3-test",
+                new ExecutionConfig(
+                        100,
+                        1,
+                        1,
+                        pipelineParallelism,
+                        32,
+                        -1L,
+                        -1L,
+                        -1L,
+                        -1L,
+                        SinkPartitionStrategy.TABLE_AFFINITY,
+                        SplitAssignmentMode.STATIC_ROUND_ROBIN),
+                pipelines);
+    }
+
+    static PipelineResult result(
+            PipelineGraph<?> graph,
+            PipelineStatus status,
+            CommitSummary summary,
+            Throwable failure) {
+
+        return new PipelineResult(
+                graph.getPipelineId(),
+                graph.getDataSetId(),
+                status,
+                summary,
+                failure);
+    }
+
+    static PipelineResult success(
+            PipelineGraph<?> graph) {
+
+        return result(
+                graph,
+                PipelineStatus.SUCCEEDED,
+                CommitSummary.empty(),
+                null);
+    }
+
+    private static CatalogTable table(
+            TablePath path) {
+
+        TableSchema schema = TableSchema.builder()
+                .column(
+                        Column.builder(
+                                "id",
+                                BasicType.LONG_TYPE)
+                                .nullable(false)
+                                .build())
+                .build();
+
+        return CatalogTable.builder(
+                path,
+                schema)
+                .build();
+    }
+
+    private static PreparedSource<TestSplit> preparedSource(
+            final Map<TablePath, CatalogTable> tables) {
+
+        Source<TestSplit> source = new Source<TestSplit>() {
+            @Override
+            public List<TestSplit> createSplits(
+                    Map<TablePath, CatalogTable> ignored) {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public SourceReader<FluxRow, TestSplit> createReader(
+                    Map<TablePath, CatalogTable> ignored,
+                    int batchSize) {
+                return null;
+            }
+        };
+
+        return new PreparedSource<TestSplit>(
+                "test-source",
+                source,
+                tables);
+    }
+
+    private static PreparedSink preparedSink(
+            Map<TablePath, CatalogTable> tables) {
+
+        SinkFactory factory = new SinkFactory() {
+            @Override
+            public String factoryIdentifier() {
+                return "test-sink";
+            }
+
+            @Override
+            public OptionRule optionRule() {
+                return null;
+            }
+        };
+
+        return new PreparedSink(
+                "test-sink",
+                factory,
+                ReadonlyConfig.fromMap(
+                        Collections.<String, Object>emptyMap()),
+                new PreparedSinkMetadata(tables));
+    }
+
+    static final class TestSplit
+            implements SourceSplit {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String splitId;
+        private final String dataSetId;
+
+        private TestSplit(
+                String splitId,
+                String dataSetId) {
+            this.splitId = splitId;
+            this.dataSetId = dataSetId;
+        }
+
+        @Override
+        public String splitId() {
+            return splitId;
+        }
+
+        @Override
+        public String dataSetId() {
+            return dataSetId;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes Phase 3 of the Link-Up architecture refactor on top of the merged Phase 2 baseline.

The goal is to separate runtime responsibilities that were still concentrated in `JobExecution`:

```text
JobExecution                 facade / execution handle
    |
    v
JobCoordinator               job lifecycle + failure policy + result aggregation
    |
    v
PipelineScheduler            pipeline concurrency + completion-order collection
    |
    v
PipelineExecutor             execute one selected PipelineGraph
    |
    v
PipelineExecution
    |
    v
ExecutionCoordinator
    |
    v
TaskExecutor
```

## What changed

### Thin `JobExecution` facade

- remove pipeline thread-pool management from `JobExecution`
- remove direct `PipelineGraph` iteration/execution from `JobExecution`
- remove commit/result aggregation from `JobExecution`
- preserve the public constructors, cancellation, metrics, run/log identity and `ExecutionGraph` accessors
- delegate `execute()` to the new `JobCoordinator`

### Job-level coordination

Introduce `JobCoordinator` to own:

- `ExecutionGraph` lifecycle transitions
- job-level log context and terminal logging
- invocation of the pipeline scheduler
- final `JobStatus` derivation
- `PipelineResult` / `CommitSummary` aggregation
- completion/failure of the `ExecutionGraph`

The coordinator deliberately does not own an `ExecutorService` and does not instantiate `PipelineExecution` directly.

### Pipeline scheduling

Introduce `PipelineScheduler` with local implementation `LocalPipelineScheduler`:

- enforce `runtime.pipelineParallelism`
- submit immutable `PipelineGraph` units to a bounded local pool
- collect `PipelineResult` values in completion order, preserving previous behavior
- propagate the first pipeline failure to the shared `CancellationToken`
- cancel submitted futures if the scheduling thread itself is interrupted

The scheduler does not own `ExecutionGraph` or connector/runtime I/O state.

### Pipeline execution

Introduce `PipelineExecutor` with `LocalPipelineExecutor`:

- execute one already-selected `PipelineGraph`
- materialize the existing `PipelineExecution` with current execution state and classloader
- restore Log4j thread context (`runId`, `jobId`, `jobName`, `jobLogFile`) on scheduler worker threads before pipeline execution

This preserves the per-pipeline logging context that previously lived inside the `JobExecution` worker callable.

### Tests / architecture guards

- add focused scheduler concurrency tests
- verify first-pipeline-failure cancellation propagation
- verify empty scheduling and invalid parallelism behavior
- test `JobCoordinator` lifecycle, cancellation, failure handling and commit-summary aggregation
- add reflection-based architecture guards so `JobExecution` stays a thin facade and `JobCoordinator` cannot regain thread-pool ownership

### Documentation

- add ADR-0003 for runtime role separation
- update the architecture lifecycle and runtime hierarchy
- update README with the coordinator/scheduler/executor chain

## Compatibility

This PR intentionally preserves:

- public `JobExecution` constructors and server integration
- `JobSpec` and connector APIs
- `ExecutionGraph` ownership semantics from Phase 2
- `runtime.pipelineParallelism`
- completion-order pipeline result collection
- first-failure cancellation propagation
- static/dynamic split behavior
- sink commit and result aggregation semantics
- per-pipeline MDC/log routing

## Non-goals

This phase does **not** introduce:

- distributed scheduling or remote placement
- retries/recovery/checkpoints/HA
- worker discovery/resource management
- `SourceSplitEnumerator` runtime integration
- server package restructuring

Those remain later phases.

## Validation

- branch is based directly on the Phase 2 merge commit on current `main`
- `main...refactor/phase3-runtime-roles`: 1 commit ahead, 0 behind
- `JobExecution` now owns only `ExecutionGraph` and `JobCoordinator` as runtime instance fields
- focused unit tests and architecture guards were added for the new roles
- GitHub currently reports no status checks and no Actions workflow runs for the branch head
- the execution container in this session cannot resolve `github.com`, so a local checkout/full Maven build could not be performed here

This PR therefore does not claim automated build success. Recommended before marking ready:

```bash
mvn --batch-mode clean verify
```
