### PR TITLE
refactor: standardize Source enumerator coordination (Phase 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,23 @@ The rules are intentionally strict:
 - connector modules depend on `link-up-api`, not on framework internals.
 - `link-up-launcher` and `link-up-server` are composition roots that assemble the framework with concrete connectors.
 
-The runtime architecture is Flink-inspired at the role level (`Source`, `SourceReader`, `SourceSplit`, planner, task runtime),
-without copying Flink's distributed complexity. The model lifecycle is explicit:
+The runtime architecture is Flink-inspired at the role level without copying Flink's distributed complexity. The model
+lifecycle is explicit:
 
 ```text
 JobSpec -> JobDefinition -> PreparedJob -> JobGraph -> ExecutionGraph -> JobResult
 ```
 
-Runtime responsibilities are also separated by role:
+Bounded Source split discovery has its own role chain:
+
+```text
+JobPlanner
+  -> SourceCoordinator
+     -> Source#createEnumerator(...)
+        -> SourceSplitEnumerator
+```
+
+Runtime responsibilities are separated independently:
 
 ```text
 JobExecution
@@ -43,12 +52,16 @@ JobExecution
                  -> TaskExecutor
 ```
 
-`JobGraph` is the immutable physical plan; `ExecutionGraph` owns mutable state for one run. `JobCoordinator` owns the
-job lifecycle and result aggregation, while scheduler/executor roles own pipeline concurrency and execution separately.
+`JobGraph` is the immutable physical plan; `ExecutionGraph` owns mutable state for one run. `SourceCoordinator` owns the
+framework side of Enumerator lifecycle/validation, while `JobPlanner` only builds topology from validated splits.
+`JobCoordinator` owns the job lifecycle and result aggregation, while scheduler/executor roles own pipeline concurrency
+and execution separately.
+
 See [architecture](docs/architecture.md),
 [ADR-0001](docs/adr/0001-flink-inspired-runtime-roles.md),
 [ADR-0002](docs/adr/0002-jobgraph-executiongraph.md),
-[ADR-0003](docs/adr/0003-runtime-role-separation.md), and the
+[ADR-0003](docs/adr/0003-runtime-role-separation.md),
+[ADR-0004](docs/adr/0004-source-enumerator-coordination.md), and the
 [connector development guide](docs/connector-development.md).
 
 ## Quick start

--- a/docs/adr/0004-source-enumerator-coordination.md
+++ b/docs/adr/0004-source-enumerator-coordination.md
@@ -1,0 +1,140 @@
+# ADR-0004: Standardize Source split discovery with Enumerator and SourceCoordinator
+
+- Status: Accepted
+- Date: 2026-08-24
+
+## Context
+
+Phases 1-3 established role vocabulary, separated physical/runtime state, and split job coordination from scheduling and
+execution. One important boundary was still transitional: `JobPlanner` called `Source#createSplits(...)` directly.
+
+The API already contained both `SourceSplitEnumerator` and `SourceEnumeratorContext`, and JDBC already had a
+`JdbcSourceSplitEnumerator`, but these concepts were not part of the framework's canonical planning path. As a result:
+
+- `JobPlanner` owned a connector lifecycle concern in addition to topology planning;
+- enumerator creation/close semantics were not controlled by one framework role;
+- connector classloader scope during split discovery was implicit;
+- split validation differed between static planning and dynamic `LocalSplitQueue` execution;
+- new connectors had no meaningful reason to implement the existing Enumerator abstraction.
+
+## Decision
+
+Bounded split discovery is standardized on this path:
+
+```text
+JobPlanner
+    |
+    v
+SourceCoordinator                 framework lifecycle boundary
+    |
+    v
+Source#createEnumerator(...)
+    |
+    v
+SourceSplitEnumerator
+    |
+    v
+enumerateSplits()
+```
+
+### Source preparation vs Source coordination
+
+Connector configuration and connector-specific parallelism validation remain in `ConnectorPreparer`. This preserves the
+existing fail-fast ordering: unsupported Source modes are rejected before Sink preparation can perform metadata/DDL side
+effects.
+
+`SourceCoordinator` starts after a validated `PreparedSource` exists. It owns:
+
+- `SourceEnumeratorContext` creation;
+- connector thread-context classloader scope for Enumerator creation/enumeration/close;
+- `SourceSplitEnumerator` creation and close lifecycle;
+- validation and immutable copying of enumerated splits.
+
+It does not repeat connector-specific configuration/parallelism validation, assign splits to tasks, create readers, create
+runtime split queues, or schedule work.
+
+### JobPlanner
+
+`JobPlanner` no longer calls Source split-discovery methods directly. It receives validated splits from
+`SourceCoordinator` and remains responsible for:
+
+- grouping splits by `dataSetId`;
+- task parallelism/topology;
+- static round-robin assignment;
+- `JobGraph` / `PipelineGraph` construction.
+
+### Source API compatibility
+
+`Source#createEnumerator(Map, SourceEnumeratorContext)` becomes the canonical extension point.
+
+The legacy `createSplits(...)` overloads remain as deprecated compatibility hooks. The default `createEnumerator(...)`
+adapts an existing connector by calling its legacy split method, so connectors such as the current HTTP Source continue
+to work without immediate changes.
+
+The single-argument legacy method is changed from abstract to a default compatibility method. This allows a new connector
+to implement only `createEnumerator(...)` and `createReader(...)` without also implementing a dead legacy method.
+
+### JDBC migration
+
+JDBC is migrated in this phase as the first native implementation:
+
+```text
+JdbcSource#createEnumerator
+    |
+    v
+JdbcSourceSplitGenerator         prepare metadata/statistics
+    |
+    v
+JdbcSourceSplitEnumerator       calculate bounded JDBC splits
+```
+
+Its legacy `createSplits(...)` methods remain as compatibility bridges and delegate back through the Enumerator path.
+
+### Split contract
+
+`SourceCoordinator` accepts an empty split list, which represents a valid empty bounded input. For non-empty input it
+requires:
+
+- no null split values;
+- non-blank `splitId`;
+- non-blank `dataSetId`;
+- unique `splitId` values within each `dataSetId`.
+
+The same `splitId` may appear in different data sets because each data set becomes an independent `PipelineGraph`.
+
+## Consequences
+
+Positive:
+
+- split discovery has one canonical extension contract;
+- planner responsibilities are narrower and easier to test;
+- Enumerator lifecycle and connector classloader scope are deterministic;
+- static and dynamic execution consume the same validated split contract;
+- existing connectors can migrate independently;
+- connector-specific validation still fails before Sink preparation side effects;
+- future Source coordination can evolve without reintroducing split lifecycle code into `JobPlanner`.
+
+Trade-offs:
+
+- split enumeration still happens before `JobGraph` construction because the current local physical graph needs the full
+  bounded split set;
+- this is not Flink's distributed runtime `SplitEnumerator` protocol: there is no reader registration, asynchronous split
+  requests, checkpointed enumerator state, or remote coordinator;
+- legacy `createSplits(...)` methods remain in the API during the compatibility period.
+
+## Compatibility
+
+This phase does not change:
+
+- `JobSpec` or Worker submission protocols;
+- source/sink task parallelism semantics;
+- static/dynamic split assignment policy;
+- `SourceReader` behavior;
+- existing connector factories;
+- HTTP Source behavior through the legacy adapter;
+- JDBC split statistics/planning semantics.
+
+## Follow-up
+
+After connectors have migrated, a later compatibility cleanup may remove the legacy `createSplits(...)` hooks in a major
+API version. That cleanup is deliberately not part of this phase.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 This document is the architecture baseline for Link-Up. It describes the boundaries that new code must follow and the
 vocabulary used in reviews. The runtime design is inspired by Apache Flink's separation of connector contracts,
-planning, and runtime roles, but Link-Up remains a small local batch synchronization engine.
+planning, coordination, scheduling, and execution roles, but Link-Up remains a small local batch synchronization engine.
 
 ## Goals
 
@@ -11,10 +11,11 @@ The architecture is evolving incrementally instead of through a full rewrite:
 - one canonical implementation for each framework role;
 - explicit module and package dependency direction;
 - separate protocol, definition, physical-plan, runtime-state, and read-model lifecycles;
-- predictable naming for factories, planners, coordinators, schedulers, executors, readers, writers, and repositories;
+- predictable naming for factories, planners, coordinators, schedulers, executors, enumerators, readers, writers, and repositories;
 - a repeatable connector package template;
 - no mutable runtime ownership inside planner models;
-- no single runtime class owning lifecycle, scheduling, and execution at the same time.
+- no single runtime class owning lifecycle, scheduling, and execution at the same time;
+- one canonical Source split-discovery path based on `SourceSplitEnumerator`.
 
 Link-Up does not attempt to reproduce Flink's distributed scheduler, RPC stack, checkpoint subsystem, resource manager,
 or compatibility surface.
@@ -40,8 +41,9 @@ Forbidden dependencies: `link-up-framework`, `link-up-server`, `link-up-launcher
 
 ### `link-up-framework`
 
-Owns local engine internals: connector discovery/preparation, job compilation, physical planning, channels, routing,
-execution state, runtime coordination/scheduling, task execution, metrics, and connector classloader isolation.
+Owns local engine internals: connector discovery/preparation, Source coordination, job compilation, physical planning,
+channels, routing, execution state, runtime coordination/scheduling, task execution, metrics, and connector classloader
+isolation.
 
 It may depend on `link-up-api`. It must not import concrete connector implementations.
 
@@ -76,6 +78,10 @@ JobDefinition                validated internal definition
 PreparedJob                  resolved connector/schema resources
     |
     | JobPlanner
+    |    |
+    |    +--> SourceCoordinator
+    |             |
+    |             +--> SourceSplitEnumerator
     v
 JobGraph                     immutable physical graph
     |
@@ -103,14 +109,108 @@ JobSnapshot                  server-side read model
 
 The core distinctions are:
 
+- `SourceCoordinator` answers **how bounded Source splits are discovered and validated**;
+- `JobPlanner` answers **how validated work becomes an immutable physical topology**;
 - `JobGraph` answers **what should be executed**;
 - `ExecutionGraph` answers **what is happening in this run**;
 - `JobCoordinator` answers **how the run transitions and finishes**;
 - `PipelineScheduler` answers **when pipeline units are allowed to run**;
 - `PipelineExecutor` answers **how one selected pipeline is executed**.
 
-See [ADR-0002](adr/0002-jobgraph-executiongraph.md) and
-[ADR-0003](adr/0003-runtime-role-separation.md) for the decisions and consequences.
+See [ADR-0002](adr/0002-jobgraph-executiongraph.md),
+[ADR-0003](adr/0003-runtime-role-separation.md), and
+[ADR-0004](adr/0004-source-enumerator-coordination.md) for the decisions and consequences.
+
+## Source coordination
+
+Phase 4 makes `SourceSplitEnumerator` the canonical bounded split-discovery contract.
+
+```text
+PreparedSource
+    |
+    v
+SourceCoordinator
+    |
+    +--> SourceEnumeratorContext(sourceParallelism)
+    |
+    +--> connector ClassLoaderScope
+    |
+    v
+Source#createEnumerator(...)
+    |
+    v
+SourceSplitEnumerator
+    |
+    v
+enumerateSplits()
+    |
+    v
+validated immutable split list
+    |
+    v
+JobPlanner
+```
+
+### `Source`
+
+`Source` remains an immutable connector-level object. It creates per-planning Enumerators and per-task Readers; it must
+not itself become a scheduler or hold task-runtime ownership.
+
+New connectors should implement:
+
+```text
+Source#createEnumerator(preparedTables, SourceEnumeratorContext)
+Source#createReader(preparedTables, batchSize)
+```
+
+The legacy `Source#createSplits(...)` overloads are deprecated compatibility hooks. The default
+`Source#createEnumerator(...)` adapts existing connectors by invoking those legacy methods, so migration can happen one
+connector at a time. New connectors should not build new behavior around the legacy hooks.
+
+### Preparation validation
+
+`ConnectorPreparer` remains responsible for connector configuration and connector-specific source-parallelism validation.
+This is intentionally earlier than split enumeration so unsupported Source modes fail before Sink preparation can perform
+metadata/DDL side effects.
+
+### `SourceCoordinator`
+
+`framework.source.SourceCoordinator` starts from an already validated `PreparedSource` and owns the framework side of
+split discovery:
+
+- `SourceEnumeratorContext` construction;
+- connector thread-context classloader scope during Enumerator lifecycle;
+- Enumerator creation and close on success/failure;
+- validation and immutable copying of Enumerator output.
+
+An empty split list is valid and represents empty bounded input. Non-empty results must have non-null splits, non-blank
+`splitId`/`dataSetId`, and unique `splitId` values within each data set.
+
+`SourceCoordinator` does **not**:
+
+- repeat connector configuration/parallelism validation;
+- group splits into pipelines;
+- assign splits to SourceTasks;
+- create `LocalSplitQueue`;
+- create SourceReaders;
+- schedule execution.
+
+### Connector migration
+
+JDBC is the first native Enumerator implementation in the canonical path:
+
+```text
+JdbcSource#createEnumerator
+    |
+    v
+JdbcSourceSplitGenerator         resolve JDBC metadata/statistics
+    |
+    v
+JdbcSourceSplitEnumerator       calculate bounded JDBC splits
+```
+
+Its legacy `createSplits(...)` methods delegate through the Enumerator path. Existing connectors such as HTTP can remain
+on legacy `createSplits(...)` temporarily because the API default Enumerator adapts them.
 
 ## Physical planning
 
@@ -133,6 +233,17 @@ A `PipelineGraph` is the physical execution boundary for one logical data set. I
 The graph records the selected policy but does not instantiate a mutable split queue. The original source enumeration
 order is stored independently from round-robin task assignments so dynamic execution does not accidentally reorder
 split acquisition.
+
+### `JobPlanner`
+
+`JobPlanner` consumes validated splits from `SourceCoordinator`. It owns:
+
+- grouping by `dataSetId`;
+- source/sink task parallelism;
+- static round-robin split assignment;
+- `PipelineGraph` / `JobGraph` construction.
+
+`JobPlanner` must not call `Source#createSplits(...)` or own `SourceSplitEnumerator` lifecycle directly.
 
 ### `SourceTaskPlan` / `SinkTaskPlan`
 
@@ -258,6 +369,12 @@ Prepared connector objects live here because they are framework-owned resolved r
 
 This package may create/resolve connector instances. It must not schedule or execute tasks.
 
+### `framework.source`
+
+Owns framework-side Source split coordination. It may create and close `SourceSplitEnumerator` instances and validate
+enumerated split output. It must not repeat connector preparation validation, build task topology, create readers, or own
+execution scheduling/runtime queues.
+
 ### `framework.job`
 
 Normalized job definition, execution configuration, statuses, and result value objects. `JobSpecCompiler` translates the
@@ -267,11 +384,13 @@ This package must not create threads, open connector resources, or perform task 
 
 ### `framework.planner`
 
-Transforms prepared input into immutable `JobGraph` / `PipelineGraph` physical models. Planner code may calculate split
-assignment, parallelism, pipeline topology, and task plans.
+Transforms prepared input and validated Source splits into immutable `JobGraph` / `PipelineGraph` physical models.
+Planner code may calculate split assignment, parallelism, pipeline topology, and task plans.
 
 Planner code must not:
 
+- call legacy Source split-discovery methods directly;
+- own `SourceSplitEnumerator` lifecycle;
 - create threads or executor services;
 - create channels;
 - create `SplitProvider` / `LocalSplitQueue`;
@@ -308,7 +427,8 @@ Own runtime measurements only. Metrics observe execution; they must not become a
 
 ### `framework.classloading`
 
-Own connector classloader isolation and classloader scope management.
+Own connector classloader isolation and classloader scope management. Connector lifecycle callbacks that may load
+connector-specific classes must run inside the connector's classloader scope.
 
 ## Role vocabulary
 
@@ -324,31 +444,14 @@ Use role names consistently. A suffix is a contract, not decoration.
 | `Coordinator` | Coordinate lifecycle and outcomes across multiple actors at one hierarchy level. |
 | `Scheduler` | Decide when executable work is allowed to run and enforce concurrency policy. |
 | `Executor` | Execute already-selected/planned work without choosing scheduling policy. |
+| `Enumerator` | Discover bounded Source splits for one planning attempt. |
 | `Reader` | Read records from an external source. |
 | `Writer` | Write records to an external sink. |
-| `Enumerator` | Discover or enumerate source splits. |
 | `Repository` | Persist or retrieve state; no scheduling side effects. |
 | `Gateway` | Cross a process/system boundary behind a narrow interface. |
 | `Manager` | Reserved for a true top-level lifecycle owner; prefer a more precise role when possible. |
 
 Avoid catch-all names such as `Common`, `Helper`, `Misc`, and generic `Utils` when a domain role can be named.
-
-## Source roles
-
-The API exposes the core Flink-inspired concepts:
-
-```text
-Source
-  -> SourceSplit
-  -> SourceReader
-  -> SourceSplitEnumerator
-```
-
-The physical/runtime split is explicit, but split discovery is still transitional: `JobPlanner` invokes
-`Source#createSplits(...)` during preparation/planning for compatibility. A later phase should make
-`SourceSplitEnumerator` / source coordination the standard split-discovery role.
-
-Do not add another split abstraction to work around this transition.
 
 ## Server boundary
 
@@ -375,14 +478,16 @@ Reject a change when it introduces any of the following without an explicit arch
 1. a connector importing `com.link.up.framework.*`;
 2. framework code importing a concrete connector package;
 3. transport DTOs being used as mutable runtime state;
-4. planner code creating threads, channels, split queues, cancellation tokens, or runtime metrics;
-5. `SourceTaskPlan`, `PipelineGraph`, or `JobGraph` holding `SplitProvider` or other mutable execution ownership;
-6. `JobExecution` or `JobCoordinator` directly owning an `ExecutorService`;
-7. `PipelineScheduler` performing connector I/O or owning `ExecutionGraph` state;
-8. `PipelineExecutor` deciding job-level concurrency/failure policy;
-9. a second `FactoryRegistry`, task hierarchy, or source execution path;
-10. a generic `common`, `core`, `helper`, or `utils` package used as a dumping ground;
-11. server HTTP code manipulating task/channel internals directly.
+4. `JobPlanner` invoking `Source#createSplits(...)` or creating/closing a `SourceSplitEnumerator` directly;
+5. `SourceCoordinator` assigning tasks, creating Readers, or creating runtime split queues;
+6. planner code creating threads, channels, split queues, cancellation tokens, or runtime metrics;
+7. `SourceTaskPlan`, `PipelineGraph`, or `JobGraph` holding `SplitProvider` or other mutable execution ownership;
+8. `JobExecution` or `JobCoordinator` directly owning an `ExecutorService`;
+9. `PipelineScheduler` performing connector I/O or owning `ExecutionGraph` state;
+10. `PipelineExecutor` deciding job-level concurrency/failure policy;
+11. a second `FactoryRegistry`, task hierarchy, Source coordinator, or source execution path;
+12. a generic `common`, `core`, `helper`, or `utils` package used as a dumping ground;
+13. server HTTP code manipulating task/channel internals directly.
 
 ## Completed architecture phases
 
@@ -412,12 +517,22 @@ Reject a change when it introduces any of the following without an explicit arch
 - preserved worker-thread log context at the executor boundary;
 - added focused scheduling and architecture-boundary tests.
 
+### Phase 4: Source Enumerator coordination
+
+- made `Source#createEnumerator(...)` the canonical split-discovery extension point;
+- introduced `framework.source.SourceCoordinator` for Enumerator lifecycle, connector classloader scope, and split-output validation;
+- kept connector-specific validation in `ConnectorPreparer` so it remains fail-fast;
+- removed direct split discovery from `JobPlanner`;
+- retained deprecated `createSplits(...)` hooks through a compatibility adapter;
+- migrated JDBC to native `JdbcSourceSplitEnumerator` creation;
+- standardized split identity validation for static and dynamic execution paths.
+
 ## Next architecture steps
 
 The next phases should remain incremental:
 
-1. integrate `SourceSplitEnumerator` as the standard split-discovery/coordinator role;
-2. migrate connector package layouts toward the connector development template as connectors are touched;
+1. migrate remaining connectors to native `SourceSplitEnumerator` implementations as they are touched;
+2. migrate connector package layouts toward the connector development template;
 3. improve server application/domain/adapter boundaries without coupling them to execution internals;
 4. evaluate retry/recovery semantics only after execution-state ownership is stable;
 5. split Maven modules only if package boundaries prove insufficient.

--- a/docs/connector-development.md
+++ b/docs/connector-development.md
@@ -17,7 +17,7 @@ com.link.up.connector.<name>
 ├── source
 │   ├── <Name>Source.java
 │   ├── <Name>SourceSplit.java
-│   ├── <Name>SplitEnumerator.java
+│   ├── <Name>SourceSplitEnumerator.java
 │   └── <Name>SourceReader.java
 ├── sink
 │   ├── <Name>SinkWriter.java
@@ -52,17 +52,49 @@ Factory classes must not schedule tasks or create framework runtime objects.
 
 ### Source
 
-A source describes how readers and splits are created. Keep external I/O in reader/enumerator/client roles rather than in
-configuration objects.
+A Source is the immutable connector-level description used to create two per-execution roles:
+
+- `SourceSplitEnumerator`: discovers/calculates bounded units of work;
+- `SourceReader`: reads already-assigned splits and owns reader-side resources.
+
+New connectors should implement:
+
+```text
+Source#createEnumerator(preparedTables, SourceEnumeratorContext)
+Source#createReader(preparedTables, batchSize)
+```
 
 Use these concepts consistently:
 
 - `SourceSplit`: one independently readable unit of work;
-- `SourceReader`: owns the resource used to read assigned splits and is not shared between task threads;
-- `SplitEnumerator`: discovers or calculates splits when the connector needs a dedicated planning role.
+- `SourceSplitEnumerator`: owns split discovery/planning for one framework planning attempt;
+- `SourceEnumeratorContext`: supplies framework planning inputs such as source parallelism;
+- `SourceReader`: owns the resource used to read assigned splits and is not shared between task threads.
 
-The current runtime still supports `Source#createSplits(...)`; do not invent a connector-local execution framework around
-that compatibility method.
+The framework creates and closes the Enumerator through its `SourceCoordinator`. Connector code must not create
+framework coordinators, task plans, split queues, or executor services.
+
+#### Legacy `createSplits(...)` compatibility
+
+The `Source#createSplits(...)` overloads are deprecated compatibility hooks. Existing connectors may keep them while they
+migrate: the default `Source#createEnumerator(...)` adapts those methods automatically.
+
+New connectors should not implement split discovery only through `createSplits(...)`. Override `createEnumerator(...)`
+instead so split lifecycle, classloader scope, and validation flow through the canonical framework path.
+
+JDBC is the reference native implementation: `JdbcSource` creates `JdbcSourceSplitEnumerator`, while its old
+`createSplits(...)` methods delegate back through that Enumerator path.
+
+#### Split contract
+
+An Enumerator may return an empty list for an empty bounded source. Non-empty results must contain:
+
+- no null splits;
+- a non-blank `splitId`;
+- a non-blank `dataSetId`;
+- no duplicate `splitId` within the same `dataSetId`.
+
+Keep split objects immutable/serializable and do not attach open database/network resources to them.
 
 ### Sink
 
@@ -108,7 +140,7 @@ utils
 
 A narrowly named utility tied to one role is acceptable, but a growing generic utility package is a signal that domain
 roles need to be extracted. Existing JDBC `core`/`utils` packages are transitional and should be migrated when related
-code is substantially changed; Phase 1 does not move them solely for cosmetics.
+code is substantially changed; do not move them solely for cosmetics.
 
 ## ServiceLoader registration
 
@@ -128,12 +160,12 @@ At minimum, a connector should test the responsibilities it owns:
 
 - option/config validation;
 - schema/type conversion for supported types;
-- split planning when applicable;
+- Enumerator split planning, including parallelism-sensitive behavior when applicable;
 - reader/writer lifecycle and error handling;
 - factory discovery/schema export;
 - database-specific behavior using a lightweight integration fixture when practical.
 
-Framework task scheduling and channel behavior belong to framework tests, not connector tests.
+Framework Source coordination, task scheduling, and channel behavior belong to framework tests, not connector tests.
 
 ## Review checklist
 
@@ -141,7 +173,9 @@ Before merging a connector change, verify:
 
 - no `com.link.up.framework.*` import exists in the connector;
 - each new class has one obvious runtime role;
-- source and sink resources are owned by reader/writer/preparer roles;
-- no second factory registry, executor, thread pool, or job lifecycle is introduced;
+- new Sources implement `createEnumerator(...)` instead of introducing another split-planning entry point;
+- Enumerator results follow the split identity contract;
+- source and sink resources are owned by enumerator/reader/writer/preparer roles;
+- no second factory registry, coordinator, executor, thread pool, or job lifecycle is introduced;
 - configuration validation stays close to connector option contracts;
 - new packages follow role names rather than generic technical buckets.

--- a/link-up-api/src/main/java/com/link/up/api/source/Source.java
+++ b/link-up-api/src/main/java/com/link/up/api/source/Source.java
@@ -5,11 +5,18 @@ import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.type.FluxRow;
 
 import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * 离线数据源。
+ *
+ * <p>Split discovery is expressed through {@link SourceSplitEnumerator}. The
+ * legacy {@code createSplits(...)} methods remain as compatibility hooks so an
+ * existing connector can migrate independently from the framework runtime.</p>
  *
  * @param <SplitT> Source 分片类型
  */
@@ -17,20 +24,67 @@ public interface Source<SplitT extends SourceSplit>
         extends Serializable {
 
     /**
-     * 根据表结构生成读取分片。
+     * Creates the split enumerator for one planning attempt.
+     *
+     * <p>New connectors should override this method instead of adding split
+     * discovery logic directly to the Source object. The default adapter keeps
+     * existing connectors source-compatible by delegating to the legacy
+     * {@link #createSplits(Map, int)} method.</p>
      */
-    List<SplitT> createSplits(
-            Map<TablePath, CatalogTable> tables)
-            throws Exception;
+    default SourceSplitEnumerator<SplitT> createEnumerator(
+            Map<TablePath, CatalogTable> tables,
+            SourceEnumeratorContext context)
+            throws Exception {
+
+        Objects.requireNonNull(
+                tables,
+                "tables must not be null");
+        Objects.requireNonNull(
+                context,
+                "context must not be null");
+
+        final int parallelism = context.getParallelism();
+        final Map<TablePath, CatalogTable> preparedTables =
+                Collections.unmodifiableMap(
+                        new LinkedHashMap<TablePath, CatalogTable>(tables));
+
+        return new SourceSplitEnumerator<SplitT>() {
+            @Override
+            public List<SplitT> enumerateSplits()
+                    throws Exception {
+                return Source.this.createSplits(
+                        preparedTables,
+                        parallelism);
+            }
+        };
+    }
 
     /**
-     * Creates the splits for an execution with the supplied reader parallelism.
-     * <p>
-     * Connectors that can use the parallelism while planning (for example to
-     * cap JDBC range splits) should override this method. The default keeps
-     * existing connectors source-compatible and lets the framework distribute
-     * their returned splits among reader tasks.
+     * Legacy split discovery hook.
+     *
+     * @deprecated Implement {@link #createEnumerator(Map, SourceEnumeratorContext)}
+     * instead. Existing connectors may keep overriding this method during the
+     * migration period.
      */
+    @Deprecated
+    default List<SplitT> createSplits(
+            Map<TablePath, CatalogTable> tables)
+            throws Exception {
+
+        throw new UnsupportedOperationException(
+                "Source must implement createEnumerator(...) or legacy createSplits(...)");
+    }
+
+    /**
+     * Legacy split discovery hook with reader parallelism.
+     *
+     * <p>The default keeps older connectors that only implemented the
+     * single-argument method working unchanged.</p>
+     *
+     * @deprecated Implement {@link #createEnumerator(Map, SourceEnumeratorContext)}
+     * instead.
+     */
+    @Deprecated
     default List<SplitT> createSplits(
             Map<TablePath, CatalogTable> tables,
             int parallelism)
@@ -44,8 +98,9 @@ public interface Source<SplitT extends SourceSplit>
     }
 
     /**
-     * Validates execution reader parallelism before source tasks are created.
-     * Connectors may override this to reject unsupported execution modes.
+     * Validates execution reader parallelism before connector preparation
+     * continues. The framework invokes this during Source preparation so an
+     * unsupported mode fails before sink preparation side effects occur.
      */
     default void validateParallelism(int parallelism) {
         if (parallelism <= 0) {

--- a/link-up-api/src/main/java/com/link/up/api/source/SourceEnumeratorContext.java
+++ b/link-up-api/src/main/java/com/link/up/api/source/SourceEnumeratorContext.java
@@ -3,14 +3,18 @@ package com.link.up.api.source;
 import java.io.Serializable;
 
 /**
- * Source 分片生成上下文。
+ * Framework-provided context for one Source split-enumeration attempt.
+ *
+ * <p>The context is intentionally connector-neutral and may grow with stable
+ * planning inputs over time. Connector implementations should not depend on
+ * framework runtime classes.</p>
  */
 public final class SourceEnumeratorContext implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
     /**
-     * 当前 Source 配置的并行度。
+     * Configured Source reader parallelism for this job.
      */
     private final int parallelism;
 

--- a/link-up-api/src/main/java/com/link/up/api/source/SourceSplitEnumerator.java
+++ b/link-up-api/src/main/java/com/link/up/api/source/SourceSplitEnumerator.java
@@ -3,18 +3,23 @@ package com.link.up.api.source;
 import java.util.List;
 
 /**
- * 离线 Source 分片生成器。
+ * Discovers bounded splits for one Source planning attempt.
+ *
+ * <p>An enumerator is created by {@link Source#createEnumerator} and may own
+ * temporary split-planning resources. The framework closes it after
+ * enumeration, including when enumeration fails. It must not own SourceReader
+ * instances or task-runtime state.</p>
  */
 public interface SourceSplitEnumerator<SplitT extends SourceSplit>
         extends AutoCloseable {
 
     /**
-     * 生成当前 Source 的全部数据分片。
+     * Returns all splits represented by this bounded Source.
      */
     List<SplitT> enumerateSplits() throws Exception;
 
     @Override
     default void close() throws Exception {
-        // 默认没有需要关闭的资源。
+        // Default enumerators have no resources to release.
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSource.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSource.java
@@ -1,7 +1,9 @@
 package com.link.up.connector.jdbc.source;
 
 import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
 import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplitEnumerator;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.type.FluxRow;
@@ -19,7 +21,8 @@ import java.util.Objects;
 /**
  * JDBC 离线 Source。
  * <p>
- * Source 本身只保存不可变配置，不直接持有 JDBC 连接。
+ * Source 本身只保存不可变配置，不直接持有 JDBC 连接。Split discovery
+ * is delegated to a per-planning {@link SourceSplitEnumerator}.
  */
 public final class JdbcSource
         implements Source<JdbcSourceSplit> {
@@ -38,6 +41,26 @@ public final class JdbcSource
     }
 
     @Override
+    public SourceSplitEnumerator<JdbcSourceSplit> createEnumerator(
+            Map<TablePath, CatalogTable> tables,
+            SourceEnumeratorContext context)
+            throws Exception {
+
+        Objects.requireNonNull(
+                context,
+                "context must not be null");
+
+        return JdbcSourceSplitGenerator.createEnumerator(
+                config,
+                tables,
+                context.getParallelism());
+    }
+
+    /**
+     * Compatibility bridge for callers that still invoke the legacy Source API.
+     */
+    @Override
+    @Deprecated
     public List<JdbcSourceSplit> createSplits(
             Map<TablePath, CatalogTable> tables)
             throws Exception {
@@ -71,23 +94,22 @@ public final class JdbcSource
         }
     }
 
+    /**
+     * Compatibility bridge for callers that still invoke the legacy Source API.
+     */
     @Override
+    @Deprecated
     public List<JdbcSourceSplit> createSplits(
             Map<TablePath, CatalogTable> tables,
             int parallelism)
             throws Exception {
 
-        /*
-         * 这里替换成你现有的分片生成器。
-         *
-         * 例如：
-         * return new JdbcSourceSplitEnumerator(config, tables)
-         *         .enumerateSplits();
-         */
-        return JdbcSourceSplitGenerator.generate(
-                config,
-                tables,
-                parallelism);
+        try (SourceSplitEnumerator<JdbcSourceSplit> enumerator =
+                     createEnumerator(
+                             tables,
+                             new SourceEnumeratorContext(parallelism))) {
+            return enumerator.enumerateSplits();
+        }
     }
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceSplitEnumerator.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceSplitEnumerator.java
@@ -1,6 +1,5 @@
 package com.link.up.connector.jdbc.source;
 
-
 import com.link.up.api.source.SourceSplitEnumerator;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.connector.jdbc.config.JdbcSourceConfig;
@@ -10,18 +9,18 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * JDBC 静态分片生成器。
- * <p>
- * 任务启动时一次性计算所有分片，
- * 不再与 Reader 动态通信，也不保存 Checkpoint 状态。
+ * JDBC bounded split enumerator.
+ *
+ * <p>Connector-specific metadata/statistics are prepared before construction;
+ * this role owns the final deterministic split calculation for one planning
+ * attempt. It does not communicate with SourceReaders and does not own runtime
+ * task/checkpoint state.</p>
  */
 public final class JdbcSourceSplitEnumerator
         implements SourceSplitEnumerator<JdbcSourceSplit> {
 
     private final JdbcSourceConfig config;
-
     private final Map<TablePath, JdbcSourceTable> sourceTables;
-
     private final int parallelism;
 
     public JdbcSourceSplitEnumerator(
@@ -38,16 +37,6 @@ public final class JdbcSourceSplitEnumerator
     public List<JdbcSourceSplit> enumerateSplits()
             throws Exception {
 
-        /*
-         * SeaTunnel 原 JdbcSourceSplitEnumerator 中：
-         *
-         * 1. 查询最大值和最小值；
-         * 2. 根据 partition_num 计算区间；
-         * 3. 生成 splitQuery；
-         * 4. 处理多表；
-         *
-         * 这些纯分片计算逻辑可以迁移到 JdbcSplitPlanner。
-         */
         return JdbcSplitPlanner.plan(
                 config,
                 sourceTables,

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceSplitGenerator.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceSplitGenerator.java
@@ -1,5 +1,6 @@
 package com.link.up.connector.jdbc.source;
 
+import com.link.up.api.source.SourceSplitEnumerator;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.connector.jdbc.config.JdbcSourceConfig;
@@ -19,7 +20,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * Creates the bounded JDBC splits for a prepared source.
+ * Prepares bounded JDBC split enumeration from a prepared source schema.
  */
 final class JdbcSourceSplitGenerator {
     private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceSplitGenerator.class);
@@ -27,7 +28,30 @@ final class JdbcSourceSplitGenerator {
     private JdbcSourceSplitGenerator() {
     }
 
+    /**
+     * Compatibility helper for legacy callers that still request the split
+     * list directly.
+     */
     static List<JdbcSourceSplit> generate(
+            JdbcSourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            int parallelism)
+            throws Exception {
+
+        try (SourceSplitEnumerator<JdbcSourceSplit> enumerator =
+                     createEnumerator(
+                             config,
+                             tables,
+                             parallelism)) {
+            return enumerator.enumerateSplits();
+        }
+    }
+
+    /**
+     * Resolves the connector-specific table metadata/statistics needed by the
+     * JDBC enumerator, then returns the canonical bounded split enumerator.
+     */
+    static SourceSplitEnumerator<JdbcSourceSplit> createEnumerator(
             JdbcSourceConfig config,
             Map<TablePath, CatalogTable> tables,
             int parallelism)
@@ -45,35 +69,86 @@ final class JdbcSourceSplitGenerator {
                         JdbcCatalogUtils.getTables(config, dialect),
                         tables);
 
-        Map<TablePath, JdbcSourceTable> plannedTables = new LinkedHashMap<TablePath, JdbcSourceTable>();
-        JdbcSplitStatisticsProvider statisticsProvider = new JdbcSplitStatisticsProvider(config.getConnectionConfig(), dialect);
+        Map<TablePath, JdbcSourceTable> plannedTables =
+                new LinkedHashMap<TablePath, JdbcSourceTable>();
+        JdbcSplitStatisticsProvider statisticsProvider =
+                new JdbcSplitStatisticsProvider(
+                        config.getConnectionConfig(),
+                        dialect);
+
         for (JdbcSourceTable table : sourceTables.values()) {
             JdbcSourceTable planned = table;
-            if (table.getPartitionColumn() != null && config.getSplitPlanningMode() != SplitPlanningMode.MANUAL) {
+            if (table.getPartitionColumn() != null
+                    && config.getSplitPlanningMode() != SplitPlanningMode.MANUAL) {
                 SplitPlanningMode mode = config.getSplitPlanningMode();
                 try {
-                    JdbcSplitStatistics statistics = statisticsProvider.collect(new JdbcSplitStatisticsRequest(table, mode, config.getStatisticsQueryTimeout(), config.getSampleSize()));
+                    JdbcSplitStatistics statistics =
+                            statisticsProvider.collect(
+                                    new JdbcSplitStatisticsRequest(
+                                            table,
+                                            mode,
+                                            config.getStatisticsQueryTimeout(),
+                                            config.getSampleSize()));
                     if (statistics.isEmpty()) {
                         plannedTables.put(table.getTablePath(), null);
                         continue;
                     }
                     if (statistics.isAllNull()) {
-                        if (!config.isNullPartitionSingleSplit())
-                            throw new IllegalArgumentException("Partition column is entirely NULL: " + table.getTablePath());
-                    } else
-                        planned = JdbcSourceTable.builder().tablePath(table.getTablePath()).query(table.getQuery()).partitionColumn(table.getPartitionColumn()).partitionNumber(table.getPartitionNumber()).partitionStart(statistics.getLowerBound().orElse(null)).partitionEnd(statistics.getUpperBound().orElse(null)).catalogTable(table.getCatalogTable()).build();
+                        if (!config.isNullPartitionSingleSplit()) {
+                            throw new IllegalArgumentException(
+                                    "Partition column is entirely NULL: "
+                                            + table.getTablePath());
+                        }
+                    } else {
+                        planned = JdbcSourceTable.builder()
+                                .tablePath(table.getTablePath())
+                                .query(table.getQuery())
+                                .partitionColumn(table.getPartitionColumn())
+                                .partitionNumber(table.getPartitionNumber())
+                                .partitionStart(
+                                        statistics.getLowerBound().orElse(null))
+                                .partitionEnd(
+                                        statistics.getUpperBound().orElse(null))
+                                .catalogTable(table.getCatalogTable())
+                                .build();
+                    }
                 } catch (UnsupportedOperationException e) {
-                    if (mode != SplitPlanningMode.AUTO_SAMPLE || !config.isAllowStatisticsFallback()) throw e;
-                    LOG.warn("AUTO_SAMPLE statistics unsupported for table {}; falling back to AUTO_MIN_MAX", table.getTablePath());
-                    JdbcSplitStatistics statistics = statisticsProvider.collect(new JdbcSplitStatisticsRequest(table, SplitPlanningMode.AUTO_MIN_MAX, config.getStatisticsQueryTimeout(), config.getSampleSize()));
+                    if (mode != SplitPlanningMode.AUTO_SAMPLE
+                            || !config.isAllowStatisticsFallback()) {
+                        throw e;
+                    }
+                    LOG.warn(
+                            "AUTO_SAMPLE statistics unsupported for table {}; falling back to AUTO_MIN_MAX",
+                            table.getTablePath());
+                    JdbcSplitStatistics statistics =
+                            statisticsProvider.collect(
+                                    new JdbcSplitStatisticsRequest(
+                                            table,
+                                            SplitPlanningMode.AUTO_MIN_MAX,
+                                            config.getStatisticsQueryTimeout(),
+                                            config.getSampleSize()));
                     if (statistics.isEmpty()) {
                         plannedTables.put(table.getTablePath(), null);
                         continue;
                     }
-                    planned = JdbcSourceTable.builder().tablePath(table.getTablePath()).query(table.getQuery()).partitionColumn(table.getPartitionColumn()).partitionNumber(table.getPartitionNumber()).partitionStart(statistics.getLowerBound().orElse(null)).partitionEnd(statistics.getUpperBound().orElse(null)).catalogTable(table.getCatalogTable()).build();
+                    planned = JdbcSourceTable.builder()
+                            .tablePath(table.getTablePath())
+                            .query(table.getQuery())
+                            .partitionColumn(table.getPartitionColumn())
+                            .partitionNumber(table.getPartitionNumber())
+                            .partitionStart(
+                                    statistics.getLowerBound().orElse(null))
+                            .partitionEnd(
+                                    statistics.getUpperBound().orElse(null))
+                            .catalogTable(table.getCatalogTable())
+                            .build();
                 } catch (Exception e) {
-                    if (config.isMultiTable() && config.getMultiTableFailurePolicy().continueOtherTables()) {
-                        LOG.warn("Split statistics failed for table {}; continuing according to multi-table policy", table.getTablePath());
+                    if (config.isMultiTable()
+                            && config.getMultiTableFailurePolicy()
+                            .continueOtherTables()) {
+                        LOG.warn(
+                                "Split statistics failed for table {}; continuing according to multi-table policy",
+                                table.getTablePath());
                         continue;
                     }
                     throw e;
@@ -81,8 +156,12 @@ final class JdbcSourceSplitGenerator {
             }
             plannedTables.put(planned.getTablePath(), planned);
         }
+
         plannedTables.values().removeIf(java.util.Objects::isNull);
-        return new JdbcSourceSplitEnumerator(config, plannedTables, parallelism).enumerateSplits();
+        return new JdbcSourceSplitEnumerator(
+                config,
+                plannedTables,
+                parallelism);
     }
 
     /**
@@ -101,15 +180,20 @@ final class JdbcSourceSplitGenerator {
             Map<TablePath, JdbcSourceTable> discoveredTables,
             Map<TablePath, CatalogTable> preparedTables) {
 
-        Objects.requireNonNull(discoveredTables, "discoveredTables must not be null");
-        Objects.requireNonNull(preparedTables, "preparedTables must not be null");
+        Objects.requireNonNull(
+                discoveredTables,
+                "discoveredTables must not be null");
+        Objects.requireNonNull(
+                preparedTables,
+                "preparedTables must not be null");
 
         Map<TablePath, JdbcSourceTable> result =
                 new LinkedHashMap<TablePath, JdbcSourceTable>();
 
         for (JdbcSourceTable discoveredTable : discoveredTables.values()) {
             if (discoveredTable == null) {
-                throw new IllegalArgumentException("discoveredTables must not contain null values");
+                throw new IllegalArgumentException(
+                        "discoveredTables must not contain null values");
             }
 
             CatalogTable discoveredCatalogTable =

--- a/link-up-framework/src/main/java/com/link/up/framework/planner/JobPlanner.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planner/JobPlanner.java
@@ -9,6 +9,7 @@ import com.link.up.framework.connector.PreparedSource;
 import com.link.up.framework.execution.TaskId;
 import com.link.up.framework.execution.TaskType;
 import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.source.SourceCoordinator;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -19,19 +20,34 @@ import java.util.Objects;
 /**
  * Builds an immutable {@link JobGraph} grouped by SourceSplit.dataSetId.
  *
- * <p>The planner calculates topology and split assignment only. Runtime
- * ownership objects such as split queues are created later by the execution
- * layer.
+ * <p>The planner calculates topology and split assignment only. Source split
+ * discovery is delegated to {@link SourceCoordinator}; runtime ownership
+ * objects such as split queues are created later by the execution layer.</p>
  */
 public final class JobPlanner {
 
+    private final SourceCoordinator sourceCoordinator;
     private final SplitAssigner splitAssigner;
 
     public JobPlanner() {
-        this(new SplitAssigner());
+        this(
+                new SourceCoordinator(),
+                new SplitAssigner());
     }
 
     public JobPlanner(SplitAssigner splitAssigner) {
+        this(
+                new SourceCoordinator(),
+                splitAssigner);
+    }
+
+    public JobPlanner(
+            SourceCoordinator sourceCoordinator,
+            SplitAssigner splitAssigner) {
+
+        this.sourceCoordinator = Objects.requireNonNull(
+                sourceCoordinator,
+                "sourceCoordinator must not be null");
         this.splitAssigner = Objects.requireNonNull(
                 splitAssigner,
                 "splitAssigner must not be null");
@@ -50,36 +66,21 @@ public final class JobPlanner {
             throws Exception {
 
         ExecutionConfig config = job.getExecutionConfig();
-        List<SplitT> splits = preparedSource
-                .getSource()
-                .createSplits(
-                        preparedSource.getTables(),
+        List<SplitT> splits =
+                sourceCoordinator.enumerateSplits(
+                        preparedSource,
                         config.getSourceParallelism());
-
-        if (splits == null) {
-            throw new IllegalStateException(
-                    "Source returned null splits");
-        }
 
         Map<String, List<SplitT>> byDataSet =
                 new LinkedHashMap<String, List<SplitT>>();
 
         for (SplitT split : splits) {
-            if (split == null) {
-                throw new IllegalStateException(
-                        "Source returned a null split");
-            }
+            String dataSetId = split.dataSetId().trim();
 
-            String id = split.dataSetId();
-            if (id == null || id.trim().isEmpty()) {
-                throw new IllegalStateException(
-                        "SourceSplit dataSetId must not be blank");
-            }
-
-            List<SplitT> group = byDataSet.get(id);
+            List<SplitT> group = byDataSet.get(dataSetId);
             if (group == null) {
                 group = new ArrayList<SplitT>();
-                byDataSet.put(id, group);
+                byDataSet.put(dataSetId, group);
             }
             group.add(split);
         }

--- a/link-up-framework/src/main/java/com/link/up/framework/planner/package-info.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planner/package-info.java
@@ -1,11 +1,12 @@
 /**
  * Physical job planning for the local Link-Up runtime.
  *
- * <p>Planner components transform prepared connector/job inputs into immutable
- * {@link com.link.up.framework.planner.JobGraph} and
- * {@link com.link.up.framework.planner.PipelineGraph} models. They may
- * calculate topology, parallelism, and split assignment, but must not create
- * runtime ownership such as threads, channels, cancellation tokens, metrics,
- * or split providers.
+ * <p>Planner components transform prepared connector/job inputs and validated
+ * Source splits into immutable {@link com.link.up.framework.planner.JobGraph}
+ * and {@link com.link.up.framework.planner.PipelineGraph} models. They may
+ * calculate topology, parallelism, and split assignment, but Source Enumerator
+ * lifecycle belongs to {@code com.link.up.framework.source} and runtime
+ * ownership such as threads, channels, cancellation tokens, metrics, or split
+ * providers belongs to execution.</p>
  */
 package com.link.up.framework.planner;

--- a/link-up-framework/src/main/java/com/link/up/framework/source/SourceCoordinator.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/source/SourceCoordinator.java
@@ -1,0 +1,141 @@
+package com.link.up.framework.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.framework.classloading.ClassLoaderScope;
+import com.link.up.framework.connector.PreparedSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Coordinates bounded Source split discovery for the local planner.
+ *
+ * <p>This class owns the framework side of the enumerator lifecycle: it opens
+ * the connector classloader scope, creates one {@link SourceSplitEnumerator},
+ * validates its output and closes it on both success and failure. Connector
+ * configuration/parallelism validation happens earlier in ConnectorPreparer so
+ * unsupported modes fail before sink preparation side effects occur.</p>
+ *
+ * <p>The coordinator does not assign splits to tasks; that remains a planner
+ * responsibility.</p>
+ */
+public final class SourceCoordinator {
+
+    public <SplitT extends SourceSplit> List<SplitT> enumerateSplits(
+            PreparedSource<SplitT> preparedSource,
+            int parallelism)
+            throws Exception {
+
+        PreparedSource<SplitT> source =
+                Objects.requireNonNull(
+                        preparedSource,
+                        "preparedSource must not be null");
+
+        SourceEnumeratorContext context =
+                new SourceEnumeratorContext(parallelism);
+        Source<SplitT> connectorSource = source.getSource();
+
+        try (ClassLoaderScope ignored =
+                     ClassLoaderScope.open(source.getClassLoader())) {
+
+            SourceSplitEnumerator<SplitT> enumerator =
+                    connectorSource.createEnumerator(
+                            source.getTables(),
+                            context);
+
+            if (enumerator == null) {
+                throw new IllegalStateException(
+                        "Source '"
+                                + source.getFactoryIdentifier()
+                                + "' returned a null SourceSplitEnumerator");
+            }
+
+            try (SourceSplitEnumerator<SplitT> closeable = enumerator) {
+                return validateAndCopy(
+                        source.getFactoryIdentifier(),
+                        closeable.enumerateSplits());
+            }
+        }
+    }
+
+    private <SplitT extends SourceSplit> List<SplitT> validateAndCopy(
+            String sourceIdentifier,
+            List<SplitT> splits) {
+
+        if (splits == null) {
+            throw new IllegalStateException(
+                    "Source '"
+                            + sourceIdentifier
+                            + "' enumerator returned null splits");
+        }
+
+        List<SplitT> result =
+                new ArrayList<SplitT>(splits.size());
+        Map<String, Set<String>> splitIdsByDataSet =
+                new HashMap<String, Set<String>>();
+
+        for (SplitT split : splits) {
+            if (split == null) {
+                throw new IllegalStateException(
+                        "Source '"
+                                + sourceIdentifier
+                                + "' enumerator returned a null split");
+            }
+
+            String splitId = requireText(
+                    split.splitId(),
+                    "splitId",
+                    sourceIdentifier);
+            String dataSetId = requireText(
+                    split.dataSetId(),
+                    "dataSetId",
+                    sourceIdentifier);
+
+            Set<String> dataSetSplitIds =
+                    splitIdsByDataSet.get(dataSetId);
+            if (dataSetSplitIds == null) {
+                dataSetSplitIds = new HashSet<String>();
+                splitIdsByDataSet.put(dataSetId, dataSetSplitIds);
+            }
+
+            if (!dataSetSplitIds.add(splitId)) {
+                throw new IllegalStateException(
+                        "Source '"
+                                + sourceIdentifier
+                                + "' returned duplicate splitId '"
+                                + splitId
+                                + "' for dataSetId '"
+                                + dataSetId
+                                + "'");
+            }
+
+            result.add(split);
+        }
+
+        return Collections.unmodifiableList(result);
+    }
+
+    private String requireText(
+            String value,
+            String fieldName,
+            String sourceIdentifier) {
+
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalStateException(
+                    "Source '"
+                            + sourceIdentifier
+                            + "' returned a split with blank "
+                            + fieldName);
+        }
+        return value.trim();
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/source/package-info.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/source/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Framework-side Source coordination.
+ *
+ * <p>This package bridges prepared connector contracts and physical planning.
+ * It owns SourceSplitEnumerator lifecycle and validation, but not task split
+ * assignment, channels, readers, or runtime scheduling.</p>
+ */
+package com.link.up.framework.source;

--- a/link-up-framework/src/test/java/com/link/up/framework/planner/JobPlannerSourceCoordinatorTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planner/JobPlannerSourceCoordinatorTest.java
@@ -1,0 +1,167 @@
+package com.link.up.framework.planner;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.framework.connector.PreparedJob;
+import com.link.up.framework.connector.PreparedSink;
+import com.link.up.framework.connector.PreparedSource;
+import com.link.up.framework.job.ExecutionConfig;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class JobPlannerSourceCoordinatorTest {
+
+    @Test
+    public void plannerShouldUseNativeEnumeratorInsteadOfLegacyCreateSplits()
+            throws Exception {
+
+        final TablePath path = TablePath.of("demo", "users");
+        final CatalogTable table = table(path);
+        final Map<TablePath, CatalogTable> tables =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        tables.put(path, table);
+
+        final boolean[] enumeratorCreated = {false};
+        Source<TestSplit> source = new Source<TestSplit>() {
+            @Override
+            public SourceSplitEnumerator<TestSplit> createEnumerator(
+                    Map<TablePath, CatalogTable> preparedTables,
+                    SourceEnumeratorContext context) {
+
+                enumeratorCreated[0] = true;
+                assertSame(table, preparedTables.get(path));
+                assertEquals(2, context.getParallelism());
+
+                return new SourceSplitEnumerator<TestSplit>() {
+                    @Override
+                    public List<TestSplit> enumerateSplits() {
+                        return Collections.singletonList(
+                                new TestSplit(
+                                        "split-1",
+                                        path.toString()));
+                    }
+                };
+            }
+
+            @Override
+            public SourceReader<FluxRow, TestSplit> createReader(
+                    Map<TablePath, CatalogTable> preparedTables,
+                    int batchSize) {
+                return null;
+            }
+        };
+
+        PreparedSource<TestSplit> preparedSource =
+                new PreparedSource<TestSplit>(
+                        "native-source",
+                        source,
+                        tables);
+
+        PreparedSink preparedSink = preparedSink(tables);
+        Map<String, List<PreparedSink>> sinks =
+                new LinkedHashMap<String, List<PreparedSink>>();
+        sinks.put(
+                path.toString(),
+                Collections.singletonList(preparedSink));
+
+        PreparedJob preparedJob =
+                new PreparedJob(
+                        "phase-4-planner-test",
+                        preparedSource,
+                        sinks,
+                        new ExecutionConfig(
+                                100,
+                                2,
+                                1,
+                                32));
+
+        JobGraph graph = new JobPlanner().plan(preparedJob);
+
+        assertTrue(enumeratorCreated[0]);
+        assertEquals(1, graph.getPipelineGraphs().size());
+        PipelineGraph<?> pipeline = graph.getPipelineGraphs().get(0);
+        assertEquals(path.toString(), pipeline.getDataSetId());
+        assertEquals(1, pipeline.getSourceSplits().size());
+        assertEquals("split-1", pipeline.getSourceSplits().get(0).splitId());
+    }
+
+    private static CatalogTable table(TablePath path) {
+        TableSchema schema = TableSchema.builder()
+                .column(
+                        Column.builder(
+                                "id",
+                                BasicType.LONG_TYPE)
+                                .nullable(false)
+                                .build())
+                .build();
+        return CatalogTable.builder(path, schema).build();
+    }
+
+    private static PreparedSink preparedSink(
+            Map<TablePath, CatalogTable> tables) {
+
+        SinkFactory factory = new SinkFactory() {
+            @Override
+            public String factoryIdentifier() {
+                return "test-sink";
+            }
+
+            @Override
+            public OptionRule optionRule() {
+                return null;
+            }
+        };
+
+        return new PreparedSink(
+                "test-sink",
+                factory,
+                ReadonlyConfig.fromMap(
+                        Collections.<String, Object>emptyMap()),
+                new PreparedSinkMetadata(tables));
+    }
+
+    private static final class TestSplit implements SourceSplit {
+        private static final long serialVersionUID = 1L;
+
+        private final String splitId;
+        private final String dataSetId;
+
+        private TestSplit(
+                String splitId,
+                String dataSetId) {
+            this.splitId = splitId;
+            this.dataSetId = dataSetId;
+        }
+
+        @Override
+        public String splitId() {
+            return splitId;
+        }
+
+        @Override
+        public String dataSetId() {
+            return dataSetId;
+        }
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/planner/PlannerBoundaryTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planner/PlannerBoundaryTest.java
@@ -1,5 +1,6 @@
 package com.link.up.framework.planner;
 
+import com.link.up.framework.source.SourceCoordinator;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
@@ -60,5 +61,26 @@ public class PlannerBoundaryTest {
                         Modifier.isFinal(field.getModifiers()));
             }
         }
+    }
+
+    @Test
+    public void jobPlannerMustDelegateSourceDiscoveryToSourceCoordinator() {
+        boolean foundSourceCoordinator = false;
+
+        for (Field field : JobPlanner.class.getDeclaredFields()) {
+            if (SourceCoordinator.class.isAssignableFrom(field.getType())) {
+                foundSourceCoordinator = true;
+            }
+
+            String typeName = field.getGenericType().getTypeName();
+            assertFalse(
+                    "JobPlanner must not own SourceSplitEnumerator directly",
+                    typeName.contains(
+                            "com.link.up.api.source.SourceSplitEnumerator"));
+        }
+
+        assertTrue(
+                "JobPlanner must delegate split discovery to SourceCoordinator",
+                foundSourceCoordinator);
     }
 }

--- a/link-up-framework/src/test/java/com/link/up/framework/source/SourceCoordinatorTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/source/SourceCoordinatorTest.java
@@ -1,0 +1,277 @@
+package com.link.up.framework.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.framework.connector.PreparedSource;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class SourceCoordinatorTest {
+
+    @Test
+    public void shouldAdaptLegacyCreateSplitsSource() throws Exception {
+        final boolean[] legacyCalled = {false};
+        Source<TestSplit> source = new Source<TestSplit>() {
+            @Override
+            public List<TestSplit> createSplits(
+                    Map<TablePath, CatalogTable> tables) {
+                legacyCalled[0] = true;
+                return Collections.singletonList(
+                        new TestSplit("legacy-1", "default"));
+            }
+
+            @Override
+            public SourceReader<FluxRow, TestSplit> createReader(
+                    Map<TablePath, CatalogTable> tables,
+                    int batchSize) {
+                return null;
+            }
+        };
+
+        List<TestSplit> splits =
+                new SourceCoordinator().enumerateSplits(
+                        new PreparedSource<TestSplit>(
+                                "legacy",
+                                source,
+                                Collections.<TablePath, CatalogTable>emptyMap()),
+                        3);
+
+        assertTrue(legacyCalled[0]);
+        assertEquals(1, splits.size());
+        assertEquals("legacy-1", splits.get(0).splitId());
+    }
+
+    @Test
+    public void shouldUseNativeEnumeratorContextClassLoaderAndClose()
+            throws Exception {
+
+        final ClassLoader previous =
+                Thread.currentThread().getContextClassLoader();
+        final ClassLoader connectorLoader =
+                new ClassLoader(previous) {
+                };
+        final boolean[] enumeratorCreated = {false};
+        final boolean[] enumerated = {false};
+        final boolean[] closed = {false};
+
+        Source<TestSplit> source = new Source<TestSplit>() {
+            @Override
+            public SourceSplitEnumerator<TestSplit> createEnumerator(
+                    Map<TablePath, CatalogTable> tables,
+                    SourceEnumeratorContext context) {
+
+                enumeratorCreated[0] = true;
+                assertEquals(4, context.getParallelism());
+                assertSame(
+                        connectorLoader,
+                        Thread.currentThread().getContextClassLoader());
+
+                return new SourceSplitEnumerator<TestSplit>() {
+                    @Override
+                    public List<TestSplit> enumerateSplits() {
+                        enumerated[0] = true;
+                        assertSame(
+                                connectorLoader,
+                                Thread.currentThread()
+                                        .getContextClassLoader());
+                        return Arrays.asList(
+                                new TestSplit("s1", "demo.users"),
+                                new TestSplit("s2", "demo.users"));
+                    }
+
+                    @Override
+                    public void close() {
+                        closed[0] = true;
+                        assertSame(
+                                connectorLoader,
+                                Thread.currentThread()
+                                        .getContextClassLoader());
+                    }
+                };
+            }
+
+            @Override
+            public SourceReader<FluxRow, TestSplit> createReader(
+                    Map<TablePath, CatalogTable> tables,
+                    int batchSize) {
+                return null;
+            }
+        };
+
+        List<TestSplit> splits =
+                new SourceCoordinator().enumerateSplits(
+                        new PreparedSource<TestSplit>(
+                                "native",
+                                source,
+                                Collections.<TablePath, CatalogTable>emptyMap(),
+                                connectorLoader),
+                        4);
+
+        assertTrue(enumeratorCreated[0]);
+        assertTrue(enumerated[0]);
+        assertTrue(closed[0]);
+        assertSame(
+                previous,
+                Thread.currentThread().getContextClassLoader());
+        assertEquals(2, splits.size());
+
+        try {
+            splits.add(new TestSplit("s3", "demo.users"));
+            fail("enumerated split view must be immutable");
+        } catch (UnsupportedOperationException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void shouldCloseEnumeratorWhenEnumerationFails() {
+        final boolean[] closed = {false};
+        final RuntimeException failure =
+                new RuntimeException("enumeration failed");
+
+        Source<TestSplit> source = new Source<TestSplit>() {
+            @Override
+            public SourceSplitEnumerator<TestSplit> createEnumerator(
+                    Map<TablePath, CatalogTable> tables,
+                    SourceEnumeratorContext context) {
+                return new SourceSplitEnumerator<TestSplit>() {
+                    @Override
+                    public List<TestSplit> enumerateSplits() {
+                        throw failure;
+                    }
+
+                    @Override
+                    public void close() {
+                        closed[0] = true;
+                    }
+                };
+            }
+
+            @Override
+            public SourceReader<FluxRow, TestSplit> createReader(
+                    Map<TablePath, CatalogTable> tables,
+                    int batchSize) {
+                return null;
+            }
+        };
+
+        try {
+            new SourceCoordinator().enumerateSplits(
+                    new PreparedSource<TestSplit>(
+                            "failing",
+                            source,
+                            Collections.<TablePath, CatalogTable>emptyMap()),
+                    1);
+            fail("enumeration failure should be propagated");
+        } catch (Exception actual) {
+            assertSame(failure, actual);
+        }
+
+        assertTrue(closed[0]);
+    }
+
+    @Test
+    public void shouldRejectDuplicateSplitIdentityWithinDataSet() {
+        Source<TestSplit> source = sourceWithSplits(
+                Arrays.asList(
+                        new TestSplit("duplicate", "demo.users"),
+                        new TestSplit("duplicate", "demo.users")));
+
+        try {
+            new SourceCoordinator().enumerateSplits(
+                    new PreparedSource<TestSplit>(
+                            "duplicates",
+                            source,
+                            Collections.<TablePath, CatalogTable>emptyMap()),
+                    1);
+            fail("duplicate split identity should be rejected");
+        } catch (IllegalStateException expected) {
+            assertTrue(expected.getMessage().contains("duplicate splitId"));
+        } catch (Exception unexpected) {
+            throw new AssertionError(unexpected);
+        }
+    }
+
+    @Test
+    public void shouldAllowSameSplitIdAcrossDifferentDataSets() throws Exception {
+        Source<TestSplit> source = sourceWithSplits(
+                Arrays.asList(
+                        new TestSplit("split-1", "demo.users"),
+                        new TestSplit("split-1", "demo.orders")));
+
+        List<TestSplit> splits =
+                new SourceCoordinator().enumerateSplits(
+                        new PreparedSource<TestSplit>(
+                                "multi-dataset",
+                                source,
+                                Collections.<TablePath, CatalogTable>emptyMap()),
+                        1);
+
+        assertEquals(2, splits.size());
+        assertFalse(splits.isEmpty());
+    }
+
+    private static Source<TestSplit> sourceWithSplits(
+            final List<TestSplit> splits) {
+        return new Source<TestSplit>() {
+            @Override
+            public SourceSplitEnumerator<TestSplit> createEnumerator(
+                    Map<TablePath, CatalogTable> tables,
+                    SourceEnumeratorContext context) {
+                return new SourceSplitEnumerator<TestSplit>() {
+                    @Override
+                    public List<TestSplit> enumerateSplits() {
+                        return splits;
+                    }
+                };
+            }
+
+            @Override
+            public SourceReader<FluxRow, TestSplit> createReader(
+                    Map<TablePath, CatalogTable> tables,
+                    int batchSize) {
+                return null;
+            }
+        };
+    }
+
+    private static final class TestSplit implements SourceSplit {
+        private static final long serialVersionUID = 1L;
+
+        private final String splitId;
+        private final String dataSetId;
+
+        private TestSplit(
+                String splitId,
+                String dataSetId) {
+            this.splitId = splitId;
+            this.dataSetId = dataSetId;
+        }
+
+        @Override
+        public String splitId() {
+            return splitId;
+        }
+
+        @Override
+        public String dataSetId() {
+            return dataSetId;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Completes Phase 4 of the Link-Up architecture refactor on top of the merged Phase 3 baseline.

The goal is to make bounded Source split discovery a first-class role instead of a lifecycle concern hidden inside `JobPlanner`:

```text
PreparedJob
  -> JobPlanner
      -> SourceCoordinator
          -> Source#createEnumerator(...)
              -> SourceSplitEnumerator
                  -> enumerateSplits()
      -> split assignment / JobGraph construction
```

## What changed

### Canonical Source Enumerator API

- make `Source#createEnumerator(Map<TablePath, CatalogTable>, SourceEnumeratorContext)` the canonical split-discovery extension point
- keep both `Source#createSplits(...)` overloads as deprecated compatibility hooks
- provide a default Enumerator adapter that delegates to the legacy split methods so existing connectors can migrate independently
- change the legacy single-argument `createSplits(...)` from abstract to a default compatibility method, allowing new connectors to implement only `createEnumerator(...)` + `createReader(...)`
- clarify `SourceEnumeratorContext` / `SourceSplitEnumerator` lifecycle contracts

### Framework Source coordination

Introduce `framework.source.SourceCoordinator` to own the framework side of bounded split discovery:

- create `SourceEnumeratorContext` from configured source parallelism
- run Enumerator creation / enumeration / close inside the prepared connector classloader scope
- close the Enumerator on both success and failure
- reject null split lists / null split values
- require non-blank `splitId` and `dataSetId`
- reject duplicate `splitId` values within the same data set
- return an immutable validated split list

An empty split list remains valid and represents empty bounded input.

Connector-specific configuration and parallelism validation deliberately remain in `ConnectorPreparer`, preserving the existing fail-fast ordering before Sink preparation side effects.

### Narrower `JobPlanner`

- `JobPlanner` no longer invokes `Source#createSplits(...)`
- `JobPlanner` no longer owns Enumerator lifecycle
- it delegates discovery to `SourceCoordinator`
- it remains responsible for grouping validated splits by data set, round-robin assignment, task parallelism, and `PipelineGraph` / `JobGraph` construction
- preserve existing `JobPlanner()` and `JobPlanner(SplitAssigner)` constructors while adding an injectable coordinator constructor for focused testing

### JDBC native migration

JDBC becomes the first connector using the canonical Enumerator path natively:

```text
JdbcSource#createEnumerator
  -> JdbcSourceSplitGenerator#createEnumerator
      -> metadata/statistics preparation
      -> JdbcSourceSplitEnumerator
          -> JdbcSplitPlanner
```

- retain JDBC legacy `createSplits(...)` methods as deprecated compatibility bridges
- legacy calls delegate back through the Enumerator path
- preserve existing JDBC statistics, fallback and multi-table failure-policy behavior

### Backward compatibility

Connectors that still implement only legacy `createSplits(...)` continue to work through the default Enumerator adapter. The current HTTP Source intentionally remains unchanged in this phase to prove migration does not need to be all-at-once.

### Tests / architecture guards

- verify a legacy `createSplits(...)` Source works through `SourceCoordinator`
- verify a native Enumerator-only Source works without implementing `createSplits(...)`
- verify `SourceEnumeratorContext` parallelism propagation
- verify connector TCCL is active during Enumerator creation, enumeration and close, then restored
- verify Enumerator close runs when enumeration fails
- verify returned split views are immutable
- verify duplicate split identity validation and same split ID across different data sets
- verify `JobPlanner` consumes a native Enumerator-only Source
- extend planner architecture guards so split discovery must go through `SourceCoordinator`

### Documentation

- add ADR-0004 for Source Enumerator coordination
- update architecture docs with the `framework.source` boundary
- update connector development guidance to make Enumerator the default extension pattern
- update README architecture overview

## Compatibility

This PR intentionally preserves:

- public `JobSpec` / Worker submission protocols
- Source/Sink task parallelism semantics
- static and dynamic split-assignment policies
- `SourceReader` behavior
- existing connector factory contracts
- HTTP Source behavior through the legacy adapter
- JDBC split planning/statistics semantics
- `ConnectorPreparer` fail-fast parallelism validation

## Non-goals

This is **not** Flink's distributed SplitEnumerator runtime protocol. This phase does not introduce:

- reader registration / asynchronous split requests
- checkpointed Enumerator state
- remote SourceCoordinator RPC
- distributed scheduling / placement
- retry / recovery / HA
- removal of legacy `createSplits(...)` APIs

Legacy split hooks can be removed only in a future major API compatibility cleanup after connector migration.

## Validation

- branch is based directly on the Phase 3 merge commit on current `main`
- `main...refactor/phase4-source-coordination`: 1 commit ahead, 0 behind
- focused SourceCoordinator, Planner integration, and architecture-boundary tests were added
- branch `JobPlanner` contains no direct `Source#createSplits(...)` call
- JDBC legacy methods are compatibility bridges through its native Enumerator implementation
- GitHub currently reports no status checks and no Actions workflow runs for the branch head

A full Maven build could not be executed from this session's checkout environment, so this PR intentionally does not claim `mvn clean verify` has passed. Recommended before marking ready:

```bash
mvn --batch-mode clean verify
```
