### PR TITLE
refactor: persist Worker checkpoints and execution attempts (Phase 7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ target/
 /logs
 logs.zip
 
+# Link-Up local Worker state
+/data/worker-state/
+
 # Intellij Idea files
 .idea/
 *.iml

--- a/README.md
+++ b/README.md
@@ -59,8 +59,23 @@ HTTP / registration
     -> JobApplication
        -> JobApplicationService
           -> JobExecutionState
+             -> JobExecutionAttempt
           -> application ports
-             -> LocalJobRuntimeScheduler / LocalJobExecutor / InMemoryJobRepository
+             -> LocalJobRuntimeScheduler / LocalJobExecutor / FileJobRepository
+```
+
+Worker control-plane checkpoints are durable by default. A stable Job identity owns execution attempts, while a local
+versioned checkpoint records lifecycle/idempotency/attempt state. On process restart, any persisted non-terminal Job is
+recovered deterministically as `LOST`; it is not automatically retried.
+
+```text
+Job
+  -> Attempt #1
+      -> QUEUED -> RUNNING -> SUCCEEDED / FAILED / CANCELED / LOST
+
+state transition
+  -> JobRepository upsert
+      -> data/worker-state/<job>.job.json
 ```
 
 Built-in connectors use the same role vocabulary for their internal structure:
@@ -84,7 +99,8 @@ See [architecture](docs/architecture.md),
 [ADR-0003](docs/adr/0003-runtime-role-separation.md),
 [ADR-0004](docs/adr/0004-source-enumerator-coordination.md),
 [ADR-0005](docs/adr/0005-connector-package-roles.md),
-[ADR-0006](docs/adr/0006-server-control-plane-boundaries.md), and the
+[ADR-0006](docs/adr/0006-server-control-plane-boundaries.md),
+[ADR-0007](docs/adr/0007-worker-checkpoint-attempts.md), and the
 [connector development guide](docs/connector-development.md).
 
 ## Quick start
@@ -123,8 +139,9 @@ CREATED -> SUBMITTED -> QUEUED -> RUNNING
 ```
 
 The JSON submit protocol supports control-plane `externalExecutionId`, `idempotencyKey`, definition versioning,
-auditable state transitions, worker instance identity and deterministic duplicate submission handling. The previous
-HOCON body submission remains available for CLI and compatibility use.
+auditable state transitions, Worker instance identity, execution-attempt history and deterministic duplicate submission
+handling. Checkpoints default to `data/worker-state`; use `--state-dir` to override the directory. The previous HOCON body
+submission remains available for CLI and compatibility use.
 
 See [the single-node offline Worker protocol](docs/worker-protocol.md) for the complete API and state ownership contract.
 

--- a/docs/adr/0007-worker-checkpoint-attempts.md
+++ b/docs/adr/0007-worker-checkpoint-attempts.md
@@ -1,0 +1,184 @@
+# ADR-0007: Persist Worker checkpoints and model execution attempts
+
+- Status: Accepted
+- Date: 2026-08-24
+
+## Context
+
+Phase 6 separated the Worker control plane into application, domain, ports and infrastructure. The remaining reliability gap was process restart:
+
+- active job state existed only in `JobApplicationService` memory;
+- idempotency/external-execution indexes were rebuilt only from new submissions;
+- `InMemoryJobRepository` preserved terminal history only for the current process;
+- a process crash could leave the control plane unable to explain whether a previously RUNNING job finished;
+- the model had one Job lifecycle but no explicit execution-attempt identity for future retry/recovery work.
+
+Automatically rerunning an interrupted synchronization is not safe by default. A Sink may have committed some data before the Worker disappeared, and current commit/retry semantics differ by connector.
+
+## Decision
+
+Phase 7 introduces two foundations without automatic retry:
+
+```text
+Job identity
+    |
+    +--> Attempt #1
+            |
+            +--> QUEUED
+            +--> RUNNING
+            +--> SUCCEEDED / FAILED / CANCELED / LOST
+```
+
+and:
+
+```text
+JobApplicationService
+    |
+    +--> checkpoint after lifecycle changes
+    |
+    v
+JobRepository
+    |
+    v
+FileJobRepository
+    |
+    +--> versioned per-job JSON checkpoint
+    +--> fsync temporary file
+    +--> atomic replace when supported
+```
+
+### Attempt model
+
+`domain.JobExecutionAttempt` is the state of one concrete execution attempt. It records:
+
+- `attemptNumber` and stable `attemptId`;
+- attempt lifecycle status;
+- create/queue/start/end timestamps;
+- framework `runId` and job log path as values only;
+- terminal failure type/message;
+- connector/framework `retryAdvice` from the terminal `CommitSummary` when available.
+
+It does not own a Thread, Future, Semaphore, ExecutorService or framework `JobExecution` object.
+
+Phase 7 creates exactly one attempt. The job state stores a list intentionally so a later retry policy can append Attempt #2/#3 without changing the stable Job identity or REST resource.
+
+`JobAttemptMetadata` is the read-model representation exposed additively through `JobResponse.attempts` and `attemptCount`.
+
+### Checkpoint semantics
+
+The application upserts the same Job record after meaningful state changes:
+
+```text
+SUBMITTED
+QUEUED
+RUNNING
+job log identity bound
+cancellation requested
+terminal completion
+```
+
+If scheduling is rejected or fails before acceptance is complete, the partially persisted checkpoint is deleted together with the in-process idempotency registration.
+
+`JobRepository.save(...)` is therefore an upsert, not a terminal-only append.
+
+### Local durable repository
+
+The standalone Worker now composes `FileJobRepository` by default. `InMemoryJobRepository` remains available for tests and embedded use.
+
+Default state directory:
+
+```text
+data/worker-state
+```
+
+Override it with:
+
+```text
+--state-dir /path/to/link-up-state
+```
+
+Each Job is written to one versioned JSON file. Job IDs are URL-safe-base64 encoded before becoming file names. Writes use a temporary file, flush + file-descriptor sync, and atomic move where the file system supports it.
+
+A malformed or unsupported checkpoint fails repository initialization instead of being silently ignored, because silently losing idempotency/recovery state is more dangerous than failing startup.
+
+### Persisted boundary
+
+The durable format intentionally stores control-plane recovery information:
+
+- Job identity/name/status and top-level timestamps/errors;
+- external execution ID and idempotency key;
+- definition version/config digest;
+- lifecycle transition audit;
+- cancellation intent;
+- run/log identity;
+- attempt history.
+
+Detailed pipeline/task/channel metrics and Table-DDL views remain process-local in Phase 7. Terminal jobs keep the full rich snapshot while the process is alive; after restart they are reconstructed as a lifecycle/history view with empty detailed runtime metrics.
+
+This prevents the persistence layer from serializing framework runtime objects merely to make a historical dashboard richer.
+
+### Startup recovery
+
+`JobApplicationService` scans `JobRepository.listEntries()` during construction.
+
+For every persisted record it restores the external-execution/idempotency index. Terminal records remain terminal.
+
+Any non-terminal checkpoint is deterministically converted to `LOST`:
+
+```text
+CREATED / SUBMITTED / QUEUED / RUNNING
+                    |
+                    v
+                   LOST
+```
+
+Recovery appends an auditable `worker-restart-recovery` state transition and changes any non-terminal Attempt to `LOST` with a `WorkerRestartRecovery` reason.
+
+The interrupted execution is **not** automatically scheduled again.
+
+### Why no automatic retry yet
+
+Retry requires a safety decision, not only a retry count. For example:
+
+- a Sink may commit per batch;
+- a 2PC Sink may have prepared but uncommitted transactions;
+- a failure may occur before any write, after partial write, or during commit;
+- connector retry advice and commit summaries already expose useful evidence.
+
+Phase 7 records Attempt outcome/retry advice so the next phase can define retry eligibility deliberately.
+
+## Compatibility
+
+Phase 7 preserves:
+
+- existing Job IDs and REST routes;
+- existing lifecycle status names;
+- idempotency conflict rules;
+- queue/admission behavior;
+- cancellation behavior;
+- Framework `JobGraph` / `ExecutionGraph` semantics;
+- connector execution/commit behavior.
+
+REST changes are additive: `attempts` and `attemptCount` are new response properties.
+
+## Consequences
+
+Positive:
+
+- standalone Worker history/idempotency survives process restart;
+- interrupted jobs no longer disappear or remain ambiguously RUNNING after restart;
+- the stable Job identity is separated from execution-attempt identity;
+- future retries can append attempts instead of overwriting prior execution history;
+- persistence remains a control-plane concern rather than a framework-runtime serialization concern;
+- state writes are deterministic and inspectable JSON files.
+
+Trade-offs:
+
+- durable history after restart does not yet retain detailed pipeline/task/channel metrics or Table-DDL projections;
+- persistence is local-file based, not a distributed database;
+- active checkpoints are state-transition checkpoints, not continuous metrics snapshots;
+- no retry or resume is performed automatically.
+
+## Follow-up
+
+A later retry/recovery phase can use Attempt history plus `CommitSummary`/`retryAdvice` to decide whether a new attempt is safe. Durable detailed observability can be added independently through a purpose-built metrics/event store if it becomes necessary.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,7 +1,9 @@
 # 部署与运维指南
 
-Link-Up 当前以**本地批处理进程**运行：一个命令执行一个同步作业，进程退出即代表作业结束。它不提供常驻 Server，因此不应使用后台 `start/stop` 脚本；应由 systemd、Kubernetes Job
-或调度器负责重试、超时和退出码处理。
+Link-Up 有两种本地运行方式：
+
+- `link-up-launcher`：一个进程执行一个离线同步作业，适合 CLI / Kubernetes Job / 外部调度器；
+- `link-up-server`：常驻的单节点 Offline Worker，通过 REST 接收、排队、查询和取消作业，并向控制面动态注册。
 
 ## 构建与安装
 
@@ -9,12 +11,9 @@ Link-Up 当前以**本地批处理进程**运行：一个命令执行一个同�
 
 ```bash
 mvn --batch-mode clean verify
-
--- 跳过测试用例
-mvn --batch-mode clean verify -Dmaven.test.skip=true
 ```
 
-产物为 `link-up-dist/target/link-up-1.0.0.tar.gz` 和 `.zip`。解压后目录包含 `bin/`、`config/` 和运行时依赖 `lib/`：
+产物为 `link-up-dist/target/link-up-1.0.0.tar.gz` 和 `.zip`。Launcher 模式示例：
 
 ```bash
 tar -xzf link-up-dist/target/link-up-1.0.0.tar.gz
@@ -24,45 +23,109 @@ cp config/link-up.yaml config/orders-prod.yaml
 bin/link-up.sh --config config/orders-prod.yaml
 ```
 
-配置文件扩展名可为 `.yaml`，但内容是 HOCON（与现有作业解析器一致），不是 YAML。启动器默认读取 `config/link-up.yaml`，因此 `bin/link-up.sh`
-可直接执行示例配置。`--help` 和 `--version` 可用于探测安装是否完整。
+配置文件扩展名可为 `.yaml`，但内容是 HOCON，不是 YAML。
+
+## Offline Worker 状态目录
+
+Phase 7 起，Standalone Worker 默认把控制面 checkpoint 写入：
+
+```text
+data/worker-state
+```
+
+可以用启动参数指定持久目录：
+
+```bash
+java ... com.link.up.server.FluxServer \
+  --state-dir /var/lib/link-up/worker-state
+```
+
+生产环境必须把该目录放在**稳定本地磁盘或持久卷**上。容器重建时如果目录跟着消失，Worker 无法恢复上一实例的幂等索引和非终态 Job checkpoint。
+
+状态文件只包含恢复所需的控制面信息：Job 生命周期、幂等标识、状态转换、错误、run/log 身份和 Attempt 历史。它不持久化 Connector 密码/Token，也不把 Framework Thread、JobExecution 或持续变化的 Metrics 对象序列化到磁盘。
+
+Worker 启动时会扫描状态目录：历史终态继续保留；上一次进程留下的非终态记录会被恢复为 `LOST`，不会自动重新执行。是否重试必须结合 Sink 提交语义与 `retryAdvice` 判断。
+
+建议：
+
+- 目录只允许 Link-Up 运行账户读写；
+- 不要由多个 Worker 实例共享同一个 `state-dir`；
+- 将状态目录纳入磁盘容量和 inode 监控；
+- `--history-limit` 只裁剪终态历史，不会主动删除非终态 checkpoint；
+- 升级前备份状态目录；遇到无法识别/损坏的状态文件时 Worker 会 fail-fast，而不是静默丢弃恢复信息。
 
 ## 配置与机密
 
-`config/link-up.yaml` 包含 source/sink JDBC 示例、并行度和通道容量。复制后替换 `change-me`
-，并将配置设为仅运行账户可读（例如 `chmod 600 config/orders-prod.yaml`）。推荐在 CI/CD 中由 Secret 渲染临时配置文件，或把只读 Secret 挂载到容器；不要把密码放在命令行或提交到
-Git。可通过 `LINK_UP_CONF_DIR`、`LINK_UP_LOG_DIR`、`LINK_UP_HOME` 覆盖目录。
+`config/link-up.yaml` 包含 source/sink JDBC 示例、并行度和通道容量。复制后替换 `change-me`，并将配置设为仅运行账户可读，例如：
+
+```bash
+chmod 600 config/orders-prod.yaml
+```
+
+推荐在 CI/CD 中由 Secret 渲染临时配置文件，或把只读 Secret 挂载到容器；不要把密码放在命令行或提交到 Git。可通过 `LINK_UP_CONF_DIR`、`LINK_UP_LOG_DIR`、`LINK_UP_HOME` 覆盖目录。
 
 ## JVM 与日志
 
-默认 JVM 参数：`-Xms256m -Xmx1024m -XX:+ExitOnOutOfMemoryError -Dfile.encoding=UTF-8`。使用 `LINK_UP_JAVA_OPTS` 追加容器内存比例、GC
-或诊断参数，例如：
+默认 JVM 参数建议至少包括：
+
+```text
+-Xms256m -Xmx1024m -XX:+ExitOnOutOfMemoryError -Dfile.encoding=UTF-8
+```
+
+使用 `LINK_UP_JAVA_OPTS` 追加容器内存比例、GC 或诊断参数，例如：
 
 ```bash
 LINK_UP_JAVA_OPTS='-XX:+UseG1GC -XX:MaxRAMPercentage=70.0' bin/link-up.sh -c config/orders-prod.yaml
 ```
 
-`config/log4j2.xml` 同时输出控制台和 `${LINK_UP_LOG_DIR:-logs}/link-up.log`。日志按日或 100 MB 滚动，最多保留 14 个归档。每次作业执行还会为每个
-Source/Sink Task 创建独立日志，命名为 `job-<job-name>-<pipeline>-<task-type>-<subtask>-<run-id>.log`
-（例如 `job-orders_sync-pipeline_source.orders-source-0-128392984.log`）。文件名中的不安全字符会替换为下划线；同一作业运行的 `run-id` 相同，便于按批次检索。Task
-日志同样按 100 MB 滚动，最多保留 14 个归档。对容器运行，优先采集 stdout；需要落盘时挂载日志目录。
+Server/Launcher 日志通过 Log4j2 输出。每次 Framework Run 还会绑定独立 `runId` 和 Job 日志文件，控制面可通过 Job Logs API 增量读取。容器运行优先采集 stdout；需要长期日志审计时挂载日志目录或发送到集中日志系统。
 
-## Docker、上线与回滚
+## Docker
 
-先构建分发包，再从仓库根目录构建镜像：
+构建示例：
 
 ```bash
 mvn -pl link-up-dist -am package
 docker build -f deploy/docker/Dockerfile -t link-up:1.0.0 .
+```
+
+Launcher 模式：
+
+```bash
 docker run --rm \
   -v /secure/orders-prod.yaml:/opt/link-up/config/job.yaml:ro \
   link-up:1.0.0 --config /opt/link-up/config/job.yaml
 ```
 
-上线前应执行小表验证、确认目标端写入策略和重复运行行为、设置数据库连接/查询超时，并监控进程退出码、作业汇总指标与错误日志。批任务失败应由调度平台重试；对于非幂等 `APPEND_DATA`
-作业，先修复或清理目标数据再重试。回滚使用上一版本的不可变压缩包/镜像和与之匹配的已验证配置，而不是覆盖运行中的目录。
+Worker 模式部署时，还应挂载状态与日志目录，例如：
+
+```text
+/var/lib/link-up/worker-state  -> Worker --state-dir
+/var/log/link-up               -> LINK_UP_LOG_DIR
+```
+
+不要让两个同时运行的 Worker 使用同一状态目录。
+
+## 上线与回滚
+
+上线前应执行小表验证、确认目标端写入策略和重复运行行为、设置数据库连接/查询超时，并监控：
+
+- Worker 存活和 `instanceId` 变化；
+- `RUNNING / QUEUED / LOST` 数量；
+- 状态目录磁盘空间；
+- Job Attempt 失败原因和 `retryAdvice`；
+- Framework 任务指标与错误日志。
+
+对于非幂等 `APPEND_DATA` 或可能部分提交的任务，不要因为 Worker 重启/LOST 就自动重跑。先确认提交范围或使用 Connector 提供的安全事务语义。
+
+回滚使用上一版本的不可变压缩包/镜像，并保留 Worker 状态目录。若未来持久化格式发生不兼容升级，应按照对应版本的迁移说明处理，不能直接删除状态文件来规避升级问题。
 
 ## CI
 
-GitHub Actions 会在 push 和 PR 上用 JDK 8 执行 `mvn verify`，并解压发行包运行 `--help` 冒烟检查。发布流水线应额外保存 tar.gz/zip、生成 SHA-512
-校验和、对发布工件签名，并在部署前验证校验和。
+PR 合并前建议执行：
+
+```bash
+mvn --batch-mode clean verify
+```
+
+发布流水线还应保存 tar.gz/zip、生成 SHA-512 校验和、对发布工件签名，并在部署前验证校验和。

--- a/docs/worker-protocol.md
+++ b/docs/worker-protocol.md
@@ -1,6 +1,6 @@
 # Link-Up 单节点离线 Worker 执行协议
 
-Link-Up Server 是一个只执行离线批量同步任务的单节点 Worker。Yak Ops 等控制面负责任务定义、调度、执行历史、重试和告警；Link-Up 负责接收一次执行命令、排队、运行、取消并返回最终结果。
+Link-Up Server 是一个只执行离线批量同步任务的单节点 Worker。Yak Ops 等控制面负责任务定义、调度、执行历史、重试和告警；Link-Up 负责接收一次执行命令、排队、运行、取消、持久化控制面 checkpoint 并返回最终结果。
 
 ## Worker 身份
 
@@ -8,7 +8,7 @@ Link-Up Server 是一个只执行离线批量同步任务的单节点 Worker。Y
 GET /api/v1/node
 ```
 
-响应包含稳定的 `nodeId`、每次启动变化的 `instanceId`、容量、负载和完整生命周期。控制面必须保存提交时的 `workerInstanceId`。如果同一 `nodeId` 返回了新的 `instanceId`，控制面应将旧实例中仍处于非终态的任务标记为 `LOST`。
+响应包含稳定的 `nodeId`、每次启动变化的 `instanceId`、容量、负载和完整生命周期。控制面必须保存提交时的 `workerInstanceId`。如果同一 `nodeId` 返回新的 `instanceId`，控制面仍应将其视为 Worker 重启事件；Phase 7 起 Worker 自身也会在启动时把本地持久化的非终态 checkpoint 恢复为 `LOST`。
 
 ## 状态机
 
@@ -27,6 +27,36 @@ RUNNING
 ```
 
 终态不可再次转换。每次状态转换都会增加 `stateVersion`，并记录在 `transitions` 中。取消请求不会引入额外的 `CANCELLING` 业务状态；`cancellationRequested=true` 表示取消意图已被接收，实际状态仍保持 `QUEUED` 或 `RUNNING`，直到进入终态。
+
+## Job 与 Attempt
+
+`jobId` 是一次 Worker 执行资源的稳定身份，`Attempt` 表示该 Job 的一次具体执行尝试。Phase 7 每个新 Job 只创建 Attempt #1，但协议使用数组，为后续安全 Retry 预留模型空间。
+
+```json
+{
+  "jobId": "flux-1787540000000-1",
+  "status": "FAILED",
+  "attemptCount": 1,
+  "attempts": [
+    {
+      "attemptNumber": 1,
+      "attemptId": "flux-1787540000000-1-attempt-1",
+      "status": "FAILED",
+      "createTimeMillis": 1787540000000,
+      "queuedTimeMillis": 1787540000010,
+      "startTimeMillis": 1787540000020,
+      "endTimeMillis": 1787540009123,
+      "runId": "MYSQL_MYSQL_-1787540000030",
+      "jobLogFile": "...",
+      "failureType": "SQLException",
+      "failureMessage": "...",
+      "retryAdvice": "verify already committed data before retrying"
+    }
+  ]
+}
+```
+
+Attempt 状态为 `CREATED / QUEUED / RUNNING / SUCCEEDED / FAILED / CANCELED / LOST`。`retryAdvice` 是证据，不是自动重试指令；控制面不能仅凭 `FAILED` 或 `LOST` 自动重跑。
 
 ## 结构化 JSON 提交协议
 
@@ -71,9 +101,38 @@ Content-Type: application/json
 
 Worker 会对规范化后的 `jobSpec` 计算配置摘要。相同 `externalExecutionId`、`idempotencyKey`、`definitionVersion` 和配置摘要的重复请求返回同一个 `jobId`；复用相同标识但提交不同内容时返回 HTTP `409` 和错误码 `FLUX-JOB-IDEMPOTENCY-CONFLICT`。
 
+Phase 7 起幂等索引从本地 checkpoint 恢复，因此 Worker 正常重启后，同一幂等请求仍返回原 `jobId`，不会因为进程重启而静默创建第二个执行实例。
+
 JSON 请求必须且只能包含 `jobSpec` 或 `hocon` 其中一个。`hocon`、`application/hocon` 和 `text/plain` 仍保留给 CLI 与迁移场景，控制面必须使用结构化 `jobSpec`。完整字段说明见 `docs/job-spec.md`。
 
 提交入口只记录 `externalExecutionId`、定义版本、任务名称和 Connector 类型等摘要，不记录完整 JobSpec、用户名、密码、Token 或其他 Connector options。
+
+## Worker checkpoint 与重启恢复
+
+Standalone Worker 默认把控制面 checkpoint 写入：
+
+```text
+data/worker-state
+```
+
+可以通过启动参数覆盖：
+
+```bash
+--state-dir /var/lib/link-up/worker-state
+```
+
+checkpoint 在 `SUBMITTED / QUEUED / RUNNING / 日志身份绑定 / 取消请求 / 终态` 等关键生命周期节点 upsert。每个 Job 使用一个带 `formatVersion` 的 JSON 文件；写入采用临时文件 + flush/fsync + 原子替换（文件系统支持时）。
+
+启动时：
+
+1. 读取本地 checkpoint；
+2. 恢复 `externalExecutionId` 和 `idempotencyKey` 索引；
+3. 终态记录保持原终态；
+4. 任何非终态记录追加 `worker-restart-recovery` 转换并进入 `LOST`；
+5. 当前非终态 Attempt 同步进入 `LOST`，错误类型为 `WorkerRestartRecovery`；
+6. **不会自动重新执行**。
+
+持久化范围是控制面恢复状态。Phase 7 不持久化上一个进程里的完整 Pipeline/Task/Channel metrics 或 Table-DDL 详情；这些详细视图在同一进程内仍完整，重启后的历史记录保留生命周期、错误、幂等信息和 Attempt 历史。
 
 ## 查询与取消
 
@@ -102,17 +161,7 @@ DELETE /api/v1/jobs/{jobId}
   "jobId": "flux-1785977590967-1",
   "externalExecutionId": "yak-offline-21d1f420-c9e7-4d3b-a5c7-87e52899958c",
   "runId": "MYSQL_MYSQL_-1785977593842",
-  "items": [
-    {
-      "sequence": 0,
-      "timestampMillis": 1785977593855,
-      "source": "LINK_UP",
-      "level": "INFO",
-      "thread": "link-up-job-1",
-      "logger": "c.l.u.f.e.JobExecution",
-      "message": "Job started: jobName=MYSQL → MYSQL 离线同步"
-    }
-  ],
+  "items": [],
   "nextCursor": 226,
   "completed": false
 }
@@ -126,37 +175,7 @@ DELETE /api/v1/jobs/{jobId}
 
 ## 离线建表结果
 
-JDBC Sink 在准备每个数据集时会生成最终目标表的 `CREATE TABLE` 语句。单表任务包含一个 Pipeline，多表任务按数据集包含多个 Pipeline；两种模式使用相同结构：
-
-```json
-{
-  "pipelineId": "pipeline-orders",
-  "dataSetId": "source_db.orders",
-  "source": {
-    "table": "source_db.orders"
-  },
-  "sink": {
-    "table": "target_db.orders"
-  },
-  "tableDdl": {
-    "dialect": "MYSQL",
-    "sourceTable": "source_db.orders",
-    "targetTable": "target_db.orders",
-    "createTableSql": "CREATE TABLE `target_db`.`orders` (...);",
-    "executed": true,
-    "status": "SUCCEEDED",
-    "reason": "TARGET_TABLE_CREATED",
-    "durationMillis": 18
-  }
-}
-```
-
-`tableDdl` 只描述离线任务准备阶段生成的建表语句，不表示 CDC 或实时 Schema Change：
-
-- `executed=true` 表示本次确实执行了建表；
-- 目标表已经存在时，`executed=false`、`status=SKIPPED`、`reason=TARGET_TABLE_ALREADY_EXISTS`；
-- 即使本次未执行，仍返回按最终目标表结构生成的 `createTableSql`，供控制面查看和审计；
-- DDL 按 Pipeline 返回，因此多表任务不会把不同目标表的建表语句混在一起。
+JDBC Sink 在准备每个数据集时会生成最终目标表的 `CREATE TABLE` 语句。单表任务包含一个 Pipeline，多表任务按数据集包含多个 Pipeline；两种模式使用相同结构。`tableDdl` 只描述离线任务准备阶段生成的建表语句，不表示 CDC 或实时 Schema Change。
 
 ## LOST 处理
 
@@ -165,8 +184,9 @@ JDBC Sink 在准备每个数据集时会生成最终目标表的 `CREATE TABLE` 
 1. Worker 优雅关闭时先请求取消。
 2. 在关闭超时内完成的任务进入实际终态。
 3. 关闭超时后仍未完成的任务进入 `LOST`。
-4. 如果进程被直接杀死，控制面通过 `workerInstanceId` 变化或节点失联超时，将旧实例的非终态任务标记为 `LOST`。
-5. 对 `LOST` 的重试必须创建新的控制面执行实例和新的 `externalExecutionId`，不能修改原执行记录。
+4. 进程异常退出后，下一次启动会根据本地 checkpoint 把原非终态任务恢复为 `LOST`；控制面仍可用 `workerInstanceId` 变化作为交叉校验。
+5. `LOST` 不会由 Worker 自动重跑。
+6. 是否可以创建新的 Attempt/执行实例，必须结合 Sink 提交语义、CommitSummary 和 `retryAdvice` 判断。
 
 ## 控制面轮询建议
 

--- a/link-up-server/src/main/java/com/link/up/server/FluxServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/FluxServer.java
@@ -12,7 +12,7 @@ import com.link.up.server.config.FluxServerConfig;
 import com.link.up.server.http.JettyServer;
 import com.link.up.server.infrastructure.execution.LocalJobExecutor;
 import com.link.up.server.infrastructure.identity.LocalJobIdGenerator;
-import com.link.up.server.infrastructure.persistence.InMemoryJobRepository;
+import com.link.up.server.infrastructure.persistence.FileJobRepository;
 import com.link.up.server.infrastructure.runtime.LocalJobRuntimeScheduler;
 import com.link.up.server.registration.ControlPlaneRegistrationAgent;
 import com.link.up.server.registration.ControlPlaneRegistrationConfig;
@@ -27,20 +27,16 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * Link-Up single-node offline Worker composition root.
- */
+/** Link-Up single-node offline Worker composition root. */
 public final class FluxServer {
 
-    private static final String LOG_FILE_PROPERTY =
-            "link.up.log.file";
+    private static final String LOG_FILE_PROPERTY = "link.up.log.file";
 
     static {
         configureDefaultLogFile();
     }
 
-    private static final Logger LOG =
-            LogManager.getLogger(FluxServer.class);
+    private static final Logger LOG = LogManager.getLogger(FluxServer.class);
 
     private FluxServer() {
     }
@@ -48,27 +44,20 @@ public final class FluxServer {
     public static void main(String[] args)
             throws Exception {
 
-        final FluxServerConfig config =
-                FluxServerConfig.fromArgs(args);
+        final FluxServerConfig config = FluxServerConfig.fromArgs(args);
 
-        List<Path> pluginDirectories =
-                config.getPluginDirectories();
-        ClassLoader classLoader =
-                Thread.currentThread()
-                        .getContextClassLoader();
-        Path[] pluginPaths =
-                pluginDirectories.toArray(
-                        new Path[pluginDirectories.size()]);
+        List<Path> pluginDirectories = config.getPluginDirectories();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        Path[] pluginPaths = pluginDirectories.toArray(
+                new Path[pluginDirectories.size()]);
 
         JobExecutor jobExecutor =
-                new LocalJobExecutor(
-                        classLoader,
-                        pluginPaths);
+                new LocalJobExecutor(classLoader, pluginPaths);
         JobRepository repository =
-                new InMemoryJobRepository(
+                new FileJobRepository(
+                        config.getStateDirectory(),
                         config.getHistoryLimit());
-        JobIdGenerator jobIdGenerator =
-                new LocalJobIdGenerator();
+        JobIdGenerator jobIdGenerator = new LocalJobIdGenerator();
         JobRuntimeScheduler runtimeScheduler =
                 new LocalJobRuntimeScheduler(
                         config.getMaxQueuedJobs(),
@@ -95,22 +84,16 @@ public final class FluxServer {
                         config.getMaxQueuedJobs());
 
         final FactoryRegistry connectorRegistry =
-                FactoryRegistry.discover(
-                        classLoader,
-                        pluginPaths);
+                FactoryRegistry.discover(classLoader, pluginPaths);
         ConnectorSchemaCatalog connectorCatalog =
-                ConnectorSchemaCatalog.fromRegistry(
-                        connectorRegistry);
+                ConnectorSchemaCatalog.fromRegistry(connectorRegistry);
         ConnectorRestService connectorService =
                 new ConnectorRestService(
                         connectorCatalog,
                         connectorRegistry);
 
         final JettyServer server =
-                new JettyServer(
-                        config,
-                        jobService,
-                        connectorService);
+                new JettyServer(config, jobService, connectorService);
 
         final ControlPlaneRegistrationConfig registrationConfig =
                 ControlPlaneRegistrationConfig.load();
@@ -119,8 +102,7 @@ public final class FluxServer {
                         registrationConfig,
                         jobService,
                         connectorCatalog);
-        final AtomicBoolean shutdown =
-                new AtomicBoolean(false);
+        final AtomicBoolean shutdown = new AtomicBoolean(false);
 
         final Runnable shutdownAction =
                 new Runnable() {
@@ -129,7 +111,6 @@ public final class FluxServer {
                         if (!shutdown.compareAndSet(false, true)) {
                             return;
                         }
-
                         try {
                             registrationAgent.close();
                         } catch (RuntimeException exception) {
@@ -137,7 +118,6 @@ public final class FluxServer {
                                     "Failed to close control-plane registration agent",
                                     exception);
                         }
-
                         try {
                             server.stop();
                         } catch (Exception exception) {
@@ -145,9 +125,7 @@ public final class FluxServer {
                                     "Failed to stop HTTP server",
                                     exception);
                         }
-
                         jobApplication.close();
-
                         try {
                             connectorRegistry.close();
                         } catch (RuntimeException exception) {
@@ -159,9 +137,7 @@ public final class FluxServer {
                 };
 
         Thread shutdownHook =
-                new Thread(
-                        shutdownAction,
-                        "link-up-shutdown");
+                new Thread(shutdownAction, "link-up-shutdown");
         Runtime.getRuntime().addShutdownHook(shutdownHook);
 
         try {
@@ -169,24 +145,22 @@ public final class FluxServer {
             registrationAgent.start();
 
             LOG.info(
-                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, host={}, port={}, jobThreads={}, connectorSchemas={}, pluginDirectories={}, dynamicRegistration={}",
+                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, host={}, port={}, jobThreads={}, stateDirectory={}, connectorSchemas={}, pluginDirectories={}, dynamicRegistration={}",
                     workerIdentity.getNodeId(),
                     workerIdentity.getInstanceId(),
                     config.getHost(),
                     server.getLocalPort(),
                     config.getJobThreads(),
+                    config.getStateDirectory(),
                     connectorCatalog.list().size(),
                     config.getPluginDirectories(),
                     registrationConfig.isEnabled());
 
             server.join();
-
         } finally {
             shutdownAction.run();
-
             try {
-                Runtime.getRuntime()
-                        .removeShutdownHook(shutdownHook);
+                Runtime.getRuntime().removeShutdownHook(shutdownHook);
             } catch (IllegalStateException ignored) {
                 // JVM shutdown already started.
             }
@@ -198,26 +172,19 @@ public final class FluxServer {
                 || hasText(System.getenv("LOGFILE"))) {
             return;
         }
-
-        String logDirectory =
-                System.getProperty("link.up.log.dir");
+        String logDirectory = System.getProperty("link.up.log.dir");
         if (!hasText(logDirectory)) {
             logDirectory = System.getenv("LINK_UP_LOG_DIR");
         }
         if (!hasText(logDirectory)) {
             logDirectory = "logs";
         }
-
         System.setProperty(
                 LOG_FILE_PROPERTY,
-                Paths.get(
-                                logDirectory,
-                                "link-up-server.log")
-                        .toString());
+                Paths.get(logDirectory, "link-up-server.log").toString());
     }
 
     private static boolean hasText(String value) {
-        return value != null
-                && !value.trim().isEmpty();
+        return value != null && !value.trim().isEmpty();
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/application/JobApplicationService.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobApplicationService.java
@@ -5,10 +5,12 @@ import com.link.up.framework.job.JobResult;
 import com.link.up.framework.job.JobStatus;
 import com.link.up.server.application.port.JobIdGenerator;
 import com.link.up.server.application.port.JobRepository;
+import com.link.up.server.application.port.JobRepositoryEntry;
 import com.link.up.server.application.port.JobRuntimeScheduler;
 import com.link.up.server.domain.JobExecutionState;
 import com.link.up.server.domain.JobSubmission;
 import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobRecoverySnapshotFactory;
 import com.link.up.server.runtime.JobSnapshot;
 import com.link.up.server.runtime.JobSnapshotFactory;
 import com.link.up.server.runtime.JobStateConflictException;
@@ -25,15 +27,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/**
- * Single-node Worker application service.
- *
- * <p>Owns use-case orchestration and idempotency semantics. Local admission,
- * threads and framework execution bindings are delegated to
- * {@link JobRuntimeScheduler}.</p>
- */
+/** Single-node Worker application service with durable control-plane checkpoints. */
 public final class JobApplicationService
         implements JobApplication {
+
+    private static final String RESTART_LOST_REASON =
+            "Worker restarted before the job reached a terminal state";
 
     private final JobRuntimeScheduler runtimeScheduler;
     private final JobRepository repository;
@@ -41,8 +40,7 @@ public final class JobApplicationService
     private final JobSubmissionRegistry submissionRegistry;
     private final ConcurrentMap<String, JobExecutionState> activeJobs =
             new ConcurrentHashMap<String, JobExecutionState>();
-    private final AtomicBoolean closed =
-            new AtomicBoolean(false);
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     public JobApplicationService(
             JobRuntimeScheduler runtimeScheduler,
@@ -59,6 +57,8 @@ public final class JobApplicationService
                 jobIdGenerator,
                 "jobIdGenerator must not be null");
         this.submissionRegistry = new JobSubmissionRegistry();
+
+        recoverPersistedJobs();
     }
 
     @Override
@@ -94,6 +94,7 @@ public final class JobApplicationService
         try {
             submissionRegistry.register(jobId, submission);
             state.markSubmitted();
+            checkpoint(state);
             runtimeScheduler.schedule(
                     jobId,
                     submission.getDefinition(),
@@ -101,6 +102,7 @@ public final class JobApplicationService
         } catch (RuntimeException failure) {
             activeJobs.remove(jobId, state);
             submissionRegistry.unregister(jobId, submission);
+            repository.delete(jobId);
             throw failure;
         }
 
@@ -114,11 +116,16 @@ public final class JobApplicationService
             @Override
             public void onQueued() {
                 state.markQueued();
+                checkpoint(state);
             }
 
             @Override
             public boolean onStarting() {
-                return state.markRunning();
+                boolean started = state.markRunning();
+                if (started) {
+                    checkpoint(state);
+                }
+                return started;
             }
 
             @Override
@@ -126,6 +133,7 @@ public final class JobApplicationService
                     String runId,
                     String jobLogFile) {
                 state.bindLogIdentity(runId, jobLogFile);
+                checkpoint(state);
             }
 
             @Override
@@ -158,6 +166,40 @@ public final class JobApplicationService
                         null);
             }
         };
+    }
+
+    private void recoverPersistedJobs() {
+        List<JobRepositoryEntry> persisted =
+                repository.listEntries();
+
+        for (JobRepositoryEntry entry : persisted) {
+            JobSnapshot snapshot = entry.getSnapshot();
+            JobExecutionMetadata metadata = entry.getMetadata();
+
+            if (metadata != null) {
+                submissionRegistry.restore(
+                        snapshot.getJobId(),
+                        metadata);
+            }
+
+            if (!snapshot.getStatus().isTerminal()) {
+                long recoveryTimeMillis =
+                        System.currentTimeMillis();
+                JobSnapshot lost =
+                        JobRecoverySnapshotFactory.recoverLost(
+                                snapshot,
+                                recoveryTimeMillis,
+                                RESTART_LOST_REASON);
+                JobExecutionMetadata recoveredMetadata =
+                        metadata == null
+                                ? null
+                                : metadata.recoverLost(
+                                        snapshot.getStatus(),
+                                        recoveryTimeMillis,
+                                        RESTART_LOST_REASON);
+                repository.save(lost, recoveredMetadata);
+            }
+        }
     }
 
     private JobSnapshot findExistingSubmission(
@@ -240,15 +282,19 @@ public final class JobApplicationService
             return;
         }
 
-        JobSnapshot snapshot = snapshot(state);
-        JobExecutionMetadata metadata =
-                JobSnapshotFactory.metadata(state);
-        repository.save(snapshot, metadata);
+        repository.save(
+                snapshot(state),
+                JobExecutionMetadata.fromState(state));
         activeJobs.remove(state.getJobId(), state);
     }
 
-    private JobSnapshot snapshot(
-            JobExecutionState state) {
+    private void checkpoint(JobExecutionState state) {
+        repository.save(
+                snapshot(state),
+                JobExecutionMetadata.fromState(state));
+    }
+
+    private JobSnapshot snapshot(JobExecutionState state) {
         return JobSnapshotFactory.create(
                 state,
                 runtimeScheduler.getMetrics(
@@ -273,10 +319,9 @@ public final class JobApplicationService
     public JobSnapshot getJobByExternalExecutionId(
             String externalExecutionId) {
 
-        String externalId =
-                requireText(
-                        externalExecutionId,
-                        "externalExecutionId");
+        String externalId = requireText(
+                externalExecutionId,
+                "externalExecutionId");
         String jobId =
                 submissionRegistry.findByExternalExecutionId(
                         externalId);
@@ -291,7 +336,7 @@ public final class JobApplicationService
         requireText(jobId, "jobId");
         JobExecutionState active = activeJobs.get(jobId);
         if (active != null) {
-            return JobSnapshotFactory.metadata(active);
+            return JobExecutionMetadata.fromState(active);
         }
         return repository.getMetadata(jobId);
     }
@@ -338,6 +383,7 @@ public final class JobApplicationService
             throw new JobNotFoundException(jobId);
         }
         state.requestCancellation();
+        checkpoint(state);
         runtimeScheduler.cancel(jobId);
         return getJob(jobId);
     }

--- a/link-up-server/src/main/java/com/link/up/server/application/JobSubmissionRegistry.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobSubmissionRegistry.java
@@ -1,22 +1,17 @@
 package com.link.up.server.application;
 
 import com.link.up.server.domain.JobSubmission;
+import com.link.up.server.runtime.JobExecutionMetadata;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-/**
- * In-process identity index for idempotent submission lookup.
- *
- * <p>The registry owns only index mechanics. Content equivalence is checked by
- * the application service against persisted execution metadata.</p>
- */
+/** In-process identity index for idempotent submission lookup. */
 final class JobSubmissionRegistry {
 
     private final ConcurrentMap<String, String>
             jobIdsByIdempotencyKey =
             new ConcurrentHashMap<String, String>();
-
     private final ConcurrentMap<String, String>
             jobIdsByExternalExecutionId =
             new ConcurrentHashMap<String, String>();
@@ -32,14 +27,12 @@ final class JobSubmissionRegistry {
         if (byIdempotency == null && byExternal == null) {
             return null;
         }
-
         if (byIdempotency != null
                 && byExternal != null
                 && !byIdempotency.equals(byExternal)) {
             throw new JobSubmissionConflictException(
                     "idempotencyKey and externalExecutionId reference different jobs");
         }
-
         return byIdempotency != null
                 ? byIdempotency
                 : byExternal;
@@ -48,13 +41,35 @@ final class JobSubmissionRegistry {
     void register(
             String jobId,
             JobSubmission submission) {
+        register(
+                jobId,
+                submission.getIdempotencyKey(),
+                submission.getExternalExecutionId());
+    }
+
+    void restore(
+            String jobId,
+            JobExecutionMetadata metadata) {
+        if (metadata == null) {
+            return;
+        }
+        register(
+                jobId,
+                metadata.getIdempotencyKey(),
+                metadata.getExternalExecutionId());
+    }
+
+    private void register(
+            String jobId,
+            String idempotencyKey,
+            String externalExecutionId) {
 
         String existingByIdempotency =
                 jobIdsByIdempotencyKey.putIfAbsent(
-                        submission.getIdempotencyKey(),
+                        idempotencyKey,
                         jobId);
-
-        if (existingByIdempotency != null) {
+        if (existingByIdempotency != null
+                && !existingByIdempotency.equals(jobId)) {
             throw new JobSubmissionConflictException(
                     "idempotencyKey already belongs to job "
                             + existingByIdempotency);
@@ -62,12 +77,12 @@ final class JobSubmissionRegistry {
 
         String existingByExternal =
                 jobIdsByExternalExecutionId.putIfAbsent(
-                        submission.getExternalExecutionId(),
+                        externalExecutionId,
                         jobId);
-
-        if (existingByExternal != null) {
+        if (existingByExternal != null
+                && !existingByExternal.equals(jobId)) {
             jobIdsByIdempotencyKey.remove(
-                    submission.getIdempotencyKey(),
+                    idempotencyKey,
                     jobId);
             throw new JobSubmissionConflictException(
                     "externalExecutionId already belongs to job "
@@ -78,7 +93,6 @@ final class JobSubmissionRegistry {
     void unregister(
             String jobId,
             JobSubmission submission) {
-
         jobIdsByIdempotencyKey.remove(
                 submission.getIdempotencyKey(),
                 jobId);

--- a/link-up-server/src/main/java/com/link/up/server/application/port/JobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/port/JobRepository.java
@@ -3,10 +3,15 @@ package com.link.up.server.application.port;
 import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobSnapshot;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Application persistence port for terminal Worker read models.
+ * Application persistence port for Worker checkpoints and terminal history.
+ *
+ * <p>Save is an upsert: non-terminal checkpoints and terminal snapshots share
+ * the same job identity. Implementations may persist a reduced recovery view
+ * as long as lifecycle/idempotency/attempt information survives restart.</p>
  */
 public interface JobRepository {
 
@@ -26,4 +31,20 @@ public interface JobRepository {
     }
 
     List<JobSnapshot> list();
+
+    default List<JobRepositoryEntry> listEntries() {
+        List<JobRepositoryEntry> result =
+                new ArrayList<JobRepositoryEntry>();
+        for (JobSnapshot snapshot : list()) {
+            result.add(
+                    new JobRepositoryEntry(
+                            snapshot,
+                            getMetadata(snapshot.getJobId())));
+        }
+        return result;
+    }
+
+    default void delete(String jobId) {
+        // Optional for legacy adapters. Durable/checkpoint adapters override.
+    }
 }

--- a/link-up-server/src/main/java/com/link/up/server/application/port/JobRepositoryEntry.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/port/JobRepositoryEntry.java
@@ -1,0 +1,30 @@
+package com.link.up.server.application.port;
+
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+
+import java.util.Objects;
+
+/** Immutable persisted Worker job record returned through the repository port. */
+public final class JobRepositoryEntry {
+
+    private final JobSnapshot snapshot;
+    private final JobExecutionMetadata metadata;
+
+    public JobRepositoryEntry(
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata) {
+        this.snapshot = Objects.requireNonNull(
+                snapshot,
+                "snapshot must not be null");
+        this.metadata = metadata;
+    }
+
+    public JobSnapshot getSnapshot() {
+        return snapshot;
+    }
+
+    public JobExecutionMetadata getMetadata() {
+        return metadata;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/config/FluxServerConfig.java
+++ b/link-up-server/src/main/java/com/link/up/server/config/FluxServerConfig.java
@@ -6,9 +6,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * Link-Up Server 启动参数。
- */
+/** Link-Up Server startup configuration. */
 public final class FluxServerConfig {
 
     public static final String DEFAULT_HOST = "0.0.0.0";
@@ -20,6 +18,7 @@ public final class FluxServerConfig {
     public static final long DEFAULT_SHUTDOWN_TIMEOUT_MILLIS = 10_000L;
     public static final String DEFAULT_NODE_ID = "link-up-node-1";
     public static final String DEFAULT_NODE_NAME = "Link-Up Offline Worker";
+    public static final String DEFAULT_STATE_DIRECTORY = "data/worker-state";
 
     private final String host;
     private final int port;
@@ -32,6 +31,7 @@ public final class FluxServerConfig {
     private final List<Path> pluginDirectories;
     private final String nodeId;
     private final String nodeName;
+    private final Path stateDirectory;
 
     public FluxServerConfig(
             String host,
@@ -55,7 +55,8 @@ public final class FluxServerConfig {
                 shutdownTimeoutMillis,
                 pluginDirectories,
                 DEFAULT_NODE_ID,
-                DEFAULT_NODE_NAME);
+                DEFAULT_NODE_NAME,
+                defaultStateDirectory());
     }
 
     public FluxServerConfig(
@@ -71,6 +72,35 @@ public final class FluxServerConfig {
             String nodeId,
             String nodeName) {
 
+        this(
+                host,
+                port,
+                jobThreads,
+                httpThreads,
+                maxQueuedJobs,
+                historyLimit,
+                maxRequestBytes,
+                shutdownTimeoutMillis,
+                pluginDirectories,
+                nodeId,
+                nodeName,
+                defaultStateDirectory());
+    }
+
+    public FluxServerConfig(
+            String host,
+            int port,
+            int jobThreads,
+            int httpThreads,
+            int maxQueuedJobs,
+            int historyLimit,
+            int maxRequestBytes,
+            long shutdownTimeoutMillis,
+            List<Path> pluginDirectories,
+            String nodeId,
+            String nodeName,
+            Path stateDirectory) {
+
         this.host = requireText(host, "host");
         this.port = requireRange(port, 1, 65535, "port");
         this.jobThreads = requireRange(jobThreads, 1, Integer.MAX_VALUE, "jobThreads");
@@ -83,24 +113,26 @@ public final class FluxServerConfig {
             throw new IllegalArgumentException(
                     "shutdownTimeoutMillis must not be negative");
         }
+        if (stateDirectory == null) {
+            throw new IllegalArgumentException(
+                    "stateDirectory must not be null");
+        }
 
         this.shutdownTimeoutMillis = shutdownTimeoutMillis;
-
         List<Path> directories =
                 pluginDirectories == null
                         ? Collections.<Path>emptyList()
                         : pluginDirectories;
-
-        this.pluginDirectories =
-                Collections.unmodifiableList(
-                        new ArrayList<Path>(directories));
+        this.pluginDirectories = Collections.unmodifiableList(
+                new ArrayList<Path>(directories));
         this.nodeId = requireText(nodeId, "nodeId");
         this.nodeName = requireText(nodeName, "nodeName");
+        this.stateDirectory =
+                stateDirectory.toAbsolutePath().normalize();
     }
 
     public static FluxServerConfig defaults() {
         int processors = Runtime.getRuntime().availableProcessors();
-
         return new FluxServerConfig(
                 DEFAULT_HOST,
                 DEFAULT_PORT,
@@ -112,7 +144,8 @@ public final class FluxServerConfig {
                 DEFAULT_SHUTDOWN_TIMEOUT_MILLIS,
                 Collections.<Path>emptyList(),
                 DEFAULT_NODE_ID,
-                DEFAULT_NODE_NAME);
+                DEFAULT_NODE_NAME,
+                defaultStateDirectory());
     }
 
     public static FluxServerConfig fromArgs(String[] args) {
@@ -128,12 +161,12 @@ public final class FluxServerConfig {
         long shutdownTimeout = defaults.getShutdownTimeoutMillis();
         String nodeId = defaults.getNodeId();
         String nodeName = defaults.getNodeName();
+        Path stateDirectory = defaults.getStateDirectory();
 
         List<Path> pluginDirectories = new ArrayList<Path>();
 
         for (int index = 0; index < args.length; index++) {
             String argument = args[index];
-
             if (argument == null || !argument.startsWith("--")) {
                 throw new IllegalArgumentException(
                         "Unknown argument: " + argument);
@@ -142,18 +175,15 @@ public final class FluxServerConfig {
             String option;
             String value;
             int equalIndex = argument.indexOf('=');
-
             if (equalIndex > 0) {
                 option = argument.substring(0, equalIndex);
                 value = argument.substring(equalIndex + 1);
             } else {
                 option = argument;
-
                 if (index + 1 >= args.length) {
                     throw new IllegalArgumentException(
                             "Missing value for " + option);
                 }
-
                 value = args[++index];
             }
 
@@ -179,6 +209,8 @@ public final class FluxServerConfig {
                 nodeId = value;
             } else if ("--node-name".equals(option)) {
                 nodeName = value;
+            } else if ("--state-dir".equals(option)) {
+                stateDirectory = path(option, value);
             } else {
                 throw new IllegalArgumentException(
                         "Unknown option: " + option);
@@ -196,23 +228,33 @@ public final class FluxServerConfig {
                 shutdownTimeout,
                 pluginDirectories,
                 nodeId,
-                nodeName);
+                nodeName,
+                stateDirectory);
+    }
+
+    private static Path defaultStateDirectory() {
+        return Paths.get(DEFAULT_STATE_DIRECTORY)
+                .toAbsolutePath()
+                .normalize();
+    }
+
+    private static Path path(String option, String value) {
+        String normalized = requireText(value, option);
+        return Paths.get(normalized)
+                .toAbsolutePath()
+                .normalize();
     }
 
     private static void addPluginDirectories(
             List<Path> directories,
             String value) {
-
         if (value == null || value.trim().isEmpty()) {
             throw new IllegalArgumentException(
                     "plugin directory must not be blank");
         }
-
         String[] paths = value.split(",");
-
         for (String path : paths) {
             String normalized = path.trim();
-
             if (!normalized.isEmpty()) {
                 directories.add(
                         Paths.get(normalized)
@@ -245,7 +287,6 @@ public final class FluxServerConfig {
             throw new IllegalArgumentException(
                     name + " must not be blank");
         }
-
         return value.trim();
     }
 
@@ -254,12 +295,10 @@ public final class FluxServerConfig {
             int minimum,
             int maximum,
             String name) {
-
         if (value < minimum || value > maximum) {
             throw new IllegalArgumentException(
                     name + " must be between " + minimum + " and " + maximum);
         }
-
         return value;
     }
 
@@ -274,4 +313,5 @@ public final class FluxServerConfig {
     public List<Path> getPluginDirectories() { return pluginDirectories; }
     public String getNodeId() { return nodeId; }
     public String getNodeName() { return nodeName; }
+    public Path getStateDirectory() { return stateDirectory; }
 }

--- a/link-up-server/src/main/java/com/link/up/server/domain/JobAttemptStatus.java
+++ b/link-up-server/src/main/java/com/link/up/server/domain/JobAttemptStatus.java
@@ -1,0 +1,22 @@
+package com.link.up.server.domain;
+
+/** Lifecycle of one concrete execution attempt of a Worker job. */
+public enum JobAttemptStatus {
+    CREATED(false),
+    QUEUED(false),
+    RUNNING(false),
+    SUCCEEDED(true),
+    FAILED(true),
+    CANCELED(true),
+    LOST(true);
+
+    private final boolean terminal;
+
+    JobAttemptStatus(boolean terminal) {
+        this.terminal = terminal;
+    }
+
+    public boolean isTerminal() {
+        return terminal;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/domain/JobExecutionAttempt.java
+++ b/link-up-server/src/main/java/com/link/up/server/domain/JobExecutionAttempt.java
@@ -1,0 +1,217 @@
+package com.link.up.server.domain;
+
+import com.link.up.framework.job.CommitSummary;
+import com.link.up.framework.job.JobResult;
+import com.link.up.server.runtime.ServerJobStatus;
+
+/**
+ * Domain state for one concrete execution attempt.
+ *
+ * <p>An attempt contains no thread, future, scheduler or framework execution
+ * handle. Phase 7 records one attempt; later retry policy may append more
+ * attempts without changing the job identity.</p>
+ */
+public final class JobExecutionAttempt {
+
+    private final int attemptNumber;
+    private final String attemptId;
+    private final long createTimeMillis;
+
+    private volatile JobAttemptStatus status =
+            JobAttemptStatus.CREATED;
+    private volatile long queuedTimeMillis;
+    private volatile long startTimeMillis;
+    private volatile long endTimeMillis;
+    private volatile String runId;
+    private volatile String jobLogFile;
+    private volatile String failureType;
+    private volatile String failureMessage;
+    private volatile String retryAdvice;
+
+    JobExecutionAttempt(
+            String jobId,
+            int attemptNumber) {
+
+        if (attemptNumber <= 0) {
+            throw new IllegalArgumentException(
+                    "attemptNumber must be greater than 0");
+        }
+        if (jobId == null || jobId.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "jobId must not be blank");
+        }
+
+        this.attemptNumber = attemptNumber;
+        this.attemptId =
+                jobId.trim()
+                        + "-attempt-"
+                        + attemptNumber;
+        this.createTimeMillis =
+                System.currentTimeMillis();
+    }
+
+    synchronized void markQueued() {
+        requireStatus(JobAttemptStatus.CREATED);
+        queuedTimeMillis = System.currentTimeMillis();
+        status = JobAttemptStatus.QUEUED;
+    }
+
+    synchronized void markRunning() {
+        requireStatus(JobAttemptStatus.QUEUED);
+        startTimeMillis = System.currentTimeMillis();
+        status = JobAttemptStatus.RUNNING;
+    }
+
+    synchronized void bindLogIdentity(
+            String runId,
+            String jobLogFile) {
+
+        this.runId = requireText(runId, "runId");
+        this.jobLogFile = requireText(
+                jobLogFile,
+                "jobLogFile");
+    }
+
+    synchronized void complete(
+            ServerJobStatus finalStatus,
+            JobResult result,
+            Throwable failure) {
+
+        if (status.isTerminal()) {
+            return;
+        }
+
+        status = attemptStatus(finalStatus);
+        endTimeMillis = System.currentTimeMillis();
+
+        Throwable terminalFailure =
+                failure != null
+                        ? failure
+                        : result == null
+                        ? null
+                        : result.getFailure();
+
+        if (terminalFailure != null) {
+            failureType =
+                    terminalFailure.getClass()
+                            .getSimpleName();
+            failureMessage = safeMessage(
+                    terminalFailure);
+        }
+
+        CommitSummary summary =
+                result == null
+                        ? null
+                        : result.getCommitSummary();
+        if (summary != null) {
+            retryAdvice = normalize(
+                    summary.getRetryAdvice());
+        }
+    }
+
+    private void requireStatus(JobAttemptStatus expected) {
+        if (status != expected) {
+            throw new IllegalStateException(
+                    "Illegal attempt state transition: "
+                            + status
+                            + " -> expected "
+                            + expected);
+        }
+    }
+
+    private static JobAttemptStatus attemptStatus(
+            ServerJobStatus status) {
+
+        if (status == ServerJobStatus.SUCCEEDED) {
+            return JobAttemptStatus.SUCCEEDED;
+        }
+        if (status == ServerJobStatus.CANCELED) {
+            return JobAttemptStatus.CANCELED;
+        }
+        if (status == ServerJobStatus.LOST) {
+            return JobAttemptStatus.LOST;
+        }
+        return JobAttemptStatus.FAILED;
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+        return normalized;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty()
+                ? null
+                : normalized;
+    }
+
+    private static String safeMessage(Throwable failure) {
+        String message = normalize(failure.getMessage());
+        if (message == null) {
+            message = failure.getClass().getSimpleName();
+        }
+        message = message.replace('\r', ' ')
+                .replace('\n', ' ');
+        return message.length() <= 500
+                ? message
+                : message.substring(0, 500);
+    }
+
+    public int getAttemptNumber() {
+        return attemptNumber;
+    }
+
+    public String getAttemptId() {
+        return attemptId;
+    }
+
+    public JobAttemptStatus getStatus() {
+        return status;
+    }
+
+    public long getCreateTimeMillis() {
+        return createTimeMillis;
+    }
+
+    public long getQueuedTimeMillis() {
+        return queuedTimeMillis;
+    }
+
+    public long getStartTimeMillis() {
+        return startTimeMillis;
+    }
+
+    public long getEndTimeMillis() {
+        return endTimeMillis;
+    }
+
+    public String getRunId() {
+        return runId;
+    }
+
+    public String getJobLogFile() {
+        return jobLogFile;
+    }
+
+    public String getFailureType() {
+        return failureType;
+    }
+
+    public String getFailureMessage() {
+        return failureMessage;
+    }
+
+    public String getRetryAdvice() {
+        return retryAdvice;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/domain/JobExecutionState.java
+++ b/link-up-server/src/main/java/com/link/up/server/domain/JobExecutionState.java
@@ -11,13 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-/**
- * Mutable control-plane state for one Worker job execution.
- *
- * <p>This aggregate owns lifecycle state, timestamps, cancellation intent and
- * terminal result only. It deliberately does not own Thread, Future,
- * ExecutorService, Semaphore, or framework JobExecution instances.</p>
- */
+/** Mutable control-plane state for one Worker job and its execution attempts. */
 public final class JobExecutionState {
 
     private final String jobId;
@@ -25,14 +19,16 @@ public final class JobExecutionState {
     private final long createTimeMillis;
     private final List<JobStateTransition> transitions =
             new ArrayList<JobStateTransition>();
+    private final List<JobExecutionAttempt> attempts =
+            new ArrayList<JobExecutionAttempt>();
 
     private volatile long submittedTimeMillis;
     private volatile long queuedTimeMillis;
     private volatile long startTimeMillis;
     private volatile long endTimeMillis;
     private volatile long stateVersion;
-    private volatile ServerJobStatus status =
-            ServerJobStatus.CREATED;
+    private volatile long checkpointVersion;
+    private volatile ServerJobStatus status = ServerJobStatus.CREATED;
     private volatile boolean cancellationRequested;
     private volatile JobResult result;
     private volatile Throwable failure;
@@ -48,6 +44,7 @@ public final class JobExecutionState {
                 submission,
                 "submission must not be null");
         this.createTimeMillis = System.currentTimeMillis();
+        this.attempts.add(new JobExecutionAttempt(this.jobId, 1));
 
         transitions.add(
                 new JobStateTransition(
@@ -60,16 +57,13 @@ public final class JobExecutionState {
 
     public synchronized void markSubmitted() {
         submittedTimeMillis = System.currentTimeMillis();
-        transition(
-                ServerJobStatus.SUBMITTED,
-                "submission-accepted");
+        transition(ServerJobStatus.SUBMITTED, "submission-accepted");
     }
 
     public synchronized void markQueued() {
+        currentAttempt().markQueued();
         queuedTimeMillis = System.currentTimeMillis();
-        transition(
-                ServerJobStatus.QUEUED,
-                "worker-queue-accepted");
+        transition(ServerJobStatus.QUEUED, "worker-queue-accepted");
     }
 
     public synchronized boolean markRunning() {
@@ -77,11 +71,9 @@ public final class JobExecutionState {
                 || cancellationRequested) {
             return false;
         }
-
+        currentAttempt().markRunning();
         startTimeMillis = System.currentTimeMillis();
-        transition(
-                ServerJobStatus.RUNNING,
-                "execution-started");
+        transition(ServerJobStatus.RUNNING, "execution-started");
         return true;
     }
 
@@ -90,18 +82,19 @@ public final class JobExecutionState {
             String jobLogFile) {
         this.runId = requireText(runId, "runId");
         this.jobLogFile = requireText(jobLogFile, "jobLogFile");
+        currentAttempt().bindLogIdentity(this.runId, this.jobLogFile);
+        checkpointVersion++;
     }
 
     public synchronized boolean requestCancellation() {
         if (status.isTerminal()) {
-            throw new JobStateConflictException(
-                    jobId,
-                    status);
+            throw new JobStateConflictException(jobId, status);
         }
         if (cancellationRequested) {
             return false;
         }
         cancellationRequested = true;
+        checkpointVersion++;
         return true;
     }
 
@@ -110,8 +103,7 @@ public final class JobExecutionState {
             JobResult result,
             Throwable failure) {
 
-        if (finalStatus == null
-                || !finalStatus.isTerminal()) {
+        if (finalStatus == null || !finalStatus.isTerminal()) {
             throw new IllegalArgumentException(
                     "finalStatus must be terminal");
         }
@@ -119,24 +111,25 @@ public final class JobExecutionState {
             return false;
         }
 
+        currentAttempt().complete(finalStatus, result, failure);
         this.result = result;
         this.failure = failure;
         this.endTimeMillis = System.currentTimeMillis();
-        transition(
-                finalStatus,
-                terminalReason(
-                        finalStatus,
-                        failure));
+        transition(finalStatus, terminalReason(finalStatus, failure));
         return true;
+    }
+
+    private JobExecutionAttempt currentAttempt() {
+        return attempts.get(attempts.size() - 1);
     }
 
     private void transition(
             ServerJobStatus target,
             String reason) {
-
         ServerJobStatus previous = status;
         JobStateMachine.requireTransition(previous, target);
         stateVersion++;
+        checkpointVersion++;
         status = target;
         transitions.add(
                 new JobStateTransition(
@@ -165,83 +158,38 @@ public final class JobExecutionState {
                 + failure.getClass().getSimpleName();
     }
 
-    private static String requireText(
-            String value,
-            String name) {
+    private static String requireText(String value, String name) {
         if (value == null || value.trim().isEmpty()) {
-            throw new IllegalArgumentException(
-                    name + " must not be blank");
+            throw new IllegalArgumentException(name + " must not be blank");
         }
         return value.trim();
     }
 
-    public String getJobId() {
-        return jobId;
-    }
-
-    public String getJobName() {
-        return submission.getDefinition().getName();
-    }
-
-    public JobSubmission getSubmission() {
-        return submission;
-    }
-
-    public JobDefinition getDefinition() {
-        return submission.getDefinition();
-    }
-
-    public long getCreateTimeMillis() {
-        return createTimeMillis;
-    }
-
-    public long getSubmittedTimeMillis() {
-        return submittedTimeMillis;
-    }
-
-    public long getQueuedTimeMillis() {
-        return queuedTimeMillis;
-    }
-
-    public long getStartTimeMillis() {
-        return startTimeMillis;
-    }
-
-    public long getEndTimeMillis() {
-        return endTimeMillis;
-    }
-
-    public long getStateVersion() {
-        return stateVersion;
-    }
-
-    public ServerJobStatus getStatus() {
-        return status;
-    }
-
-    public boolean isCancellationRequested() {
-        return cancellationRequested;
-    }
-
-    public JobResult getResult() {
-        return result;
-    }
-
-    public Throwable getFailure() {
-        return failure;
-    }
-
-    public String getRunId() {
-        return runId;
-    }
-
-    public String getJobLogFile() {
-        return jobLogFile;
-    }
+    public String getJobId() { return jobId; }
+    public String getJobName() { return submission.getDefinition().getName(); }
+    public JobSubmission getSubmission() { return submission; }
+    public JobDefinition getDefinition() { return submission.getDefinition(); }
+    public long getCreateTimeMillis() { return createTimeMillis; }
+    public long getSubmittedTimeMillis() { return submittedTimeMillis; }
+    public long getQueuedTimeMillis() { return queuedTimeMillis; }
+    public long getStartTimeMillis() { return startTimeMillis; }
+    public long getEndTimeMillis() { return endTimeMillis; }
+    public long getStateVersion() { return stateVersion; }
+    public long getCheckpointVersion() { return checkpointVersion; }
+    public ServerJobStatus getStatus() { return status; }
+    public boolean isCancellationRequested() { return cancellationRequested; }
+    public JobResult getResult() { return result; }
+    public Throwable getFailure() { return failure; }
+    public String getRunId() { return runId; }
+    public String getJobLogFile() { return jobLogFile; }
 
     public synchronized List<JobStateTransition> getTransitions() {
         return Collections.unmodifiableList(
-                new ArrayList<JobStateTransition>(
-                        transitions));
+                new ArrayList<JobStateTransition>(transitions));
+    }
+
+    public synchronized List<JobExecutionAttempt> getAttempts() {
+        return Collections.unmodifiableList(
+                new ArrayList<JobExecutionAttempt>(attempts));
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobResponse.java
@@ -1,6 +1,7 @@
 package com.link.up.server.dto;
 
 import com.link.up.api.sink.TableDdl;
+import com.link.up.server.runtime.JobAttemptMetadata;
 import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobSnapshot;
 import com.link.up.server.runtime.JobStateTransition;
@@ -11,9 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * 对控制面稳定输出的离线作业协议视图。
- */
+/** Stable offline-job protocol view returned to the control plane. */
 public final class JobResponse {
 
     private final JobSnapshot snapshot;
@@ -24,133 +23,62 @@ public final class JobResponse {
             JobSnapshot snapshot,
             JobExecutionMetadata metadata,
             WorkerIdentity worker) {
-
         this.snapshot = snapshot;
         this.metadata = metadata;
         this.worker = worker;
     }
 
-    public JobSnapshot.Summary toSummary() {
-        return snapshot.toSummary();
-    }
+    public JobSnapshot.Summary toSummary() { return snapshot.toSummary(); }
+    public String getJobId() { return snapshot.getJobId(); }
+    public String getExternalExecutionId() { return metadata == null ? null : metadata.getExternalExecutionId(); }
+    public String getIdempotencyKey() { return metadata == null ? null : metadata.getIdempotencyKey(); }
+    public String getJobName() { return snapshot.getJobName(); }
+    public int getDefinitionVersion() { return metadata == null ? 1 : metadata.getDefinitionVersion(); }
+    public String getWorkerNodeId() { return worker.getNodeId(); }
+    public String getWorkerInstanceId() { return worker.getInstanceId(); }
+    public ServerJobStatus getStatus() { return snapshot.getStatus(); }
+    public long getStateVersion() { return metadata == null ? 0L : metadata.getStateVersion(); }
+    public boolean isCancellationRequested() { return metadata != null && metadata.isCancellationRequested(); }
+    public long getCreateTimeMillis() { return snapshot.getCreateTimeMillis(); }
+    public long getSubmittedTimeMillis() { return metadata == null ? 0L : metadata.getSubmittedTimeMillis(); }
+    public long getQueuedTimeMillis() { return metadata == null ? 0L : metadata.getQueuedTimeMillis(); }
+    public long getStartTimeMillis() { return snapshot.getStartTimeMillis(); }
+    public long getEndTimeMillis() { return snapshot.getEndTimeMillis(); }
+    public long getDurationMillis() { return snapshot.getDurationMillis(); }
+    public JobSnapshot.Metrics getMetrics() { return snapshot.getMetrics(); }
+    public JobSnapshot.Commit getCommitSummary() { return snapshot.getCommitSummary(); }
 
-    public String getJobId() {
-        return snapshot.getJobId();
-    }
-
-    public String getExternalExecutionId() {
+    /** Additive Phase-7 protocol field: immutable execution-attempt history. */
+    public List<JobAttemptMetadata> getAttempts() {
         return metadata == null
-                ? null
-                : metadata.getExternalExecutionId();
+                ? Collections.<JobAttemptMetadata>emptyList()
+                : metadata.getAttempts();
     }
 
-    public String getIdempotencyKey() {
+    public int getAttemptCount() {
         return metadata == null
-                ? null
-                : metadata.getIdempotencyKey();
-    }
-
-    public String getJobName() {
-        return snapshot.getJobName();
-    }
-
-    public int getDefinitionVersion() {
-        return metadata == null
-                ? 1
-                : metadata.getDefinitionVersion();
-    }
-
-    public String getWorkerNodeId() {
-        return worker.getNodeId();
-    }
-
-    public String getWorkerInstanceId() {
-        return worker.getInstanceId();
-    }
-
-    public ServerJobStatus getStatus() {
-        return snapshot.getStatus();
-    }
-
-    public long getStateVersion() {
-        return metadata == null
-                ? 0L
-                : metadata.getStateVersion();
-    }
-
-    public boolean isCancellationRequested() {
-        return metadata != null
-                && metadata.isCancellationRequested();
-    }
-
-    public long getCreateTimeMillis() {
-        return snapshot.getCreateTimeMillis();
-    }
-
-    public long getSubmittedTimeMillis() {
-        return metadata == null
-                ? 0L
-                : metadata.getSubmittedTimeMillis();
-    }
-
-    public long getQueuedTimeMillis() {
-        return metadata == null
-                ? 0L
-                : metadata.getQueuedTimeMillis();
-    }
-
-    public long getStartTimeMillis() {
-        return snapshot.getStartTimeMillis();
-    }
-
-    public long getEndTimeMillis() {
-        return snapshot.getEndTimeMillis();
-    }
-
-    public long getDurationMillis() {
-        return snapshot.getDurationMillis();
-    }
-
-    public JobSnapshot.Metrics getMetrics() {
-        return snapshot.getMetrics();
-    }
-
-    public JobSnapshot.Commit getCommitSummary() {
-        return snapshot.getCommitSummary();
+                ? 0
+                : metadata.getAttemptCount();
     }
 
     public List<PipelineResponse> getPipelines() {
         List<PipelineResponse> result =
                 new ArrayList<PipelineResponse>();
-
-        for (JobSnapshot.Pipeline pipeline :
-                snapshot.getPipelines()) {
+        for (JobSnapshot.Pipeline pipeline : snapshot.getPipelines()) {
             TableDdl tableDdl = metadata == null
                     ? null
-                    : metadata.getTableDdl(
-                            pipeline.getPipelineId());
-
-            result.add(
-                    new PipelineResponse(
-                            pipeline,
-                            tableDdl));
+                    : metadata.getTableDdl(pipeline.getPipelineId());
+            result.add(new PipelineResponse(pipeline, tableDdl));
         }
-
         return Collections.unmodifiableList(result);
     }
 
     public List<JobStateTransition> getTransitions() {
         return metadata == null
-                ? Collections
-                .<JobStateTransition>emptyList()
+                ? Collections.<JobStateTransition>emptyList()
                 : metadata.getTransitions();
     }
 
-    public String getErrorCode() {
-        return snapshot.getErrorCode();
-    }
-
-    public String getErrorMessage() {
-        return snapshot.getErrorMessage();
-    }
+    public String getErrorCode() { return snapshot.getErrorCode(); }
+    public String getErrorMessage() { return snapshot.getErrorMessage(); }
 }

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/FileJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/FileJobRepository.java
@@ -1,0 +1,526 @@
+package com.link.up.server.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.server.application.port.JobRepository;
+import com.link.up.server.application.port.JobRepositoryEntry;
+import com.link.up.server.domain.JobAttemptStatus;
+import com.link.up.server.runtime.JobAttemptMetadata;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobRecoverySnapshotFactory;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobStateTransition;
+import com.link.up.server.runtime.ServerJobStatus;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ConcurrentMap;
+
+/** Local durable Worker checkpoint repository using versioned per-job JSON files. */
+public final class FileJobRepository
+        implements JobRepository {
+
+    private static final int FORMAT_VERSION = 1;
+    private static final String FILE_SUFFIX = ".job.json";
+
+    private final Path stateDirectory;
+    private final int historyLimit;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ConcurrentMap<String, JobSnapshot> snapshots =
+            new ConcurrentHashMap<String, JobSnapshot>();
+    private final ConcurrentMap<String, JobExecutionMetadata> metadata =
+            new ConcurrentHashMap<String, JobExecutionMetadata>();
+    private final ConcurrentLinkedDeque<String> orderedJobIds =
+            new ConcurrentLinkedDeque<String>();
+
+    public FileJobRepository(
+            Path stateDirectory,
+            int historyLimit) {
+
+        if (stateDirectory == null) {
+            throw new IllegalArgumentException(
+                    "stateDirectory must not be null");
+        }
+        if (historyLimit <= 0) {
+            throw new IllegalArgumentException(
+                    "historyLimit must be greater than 0");
+        }
+
+        this.stateDirectory = stateDirectory.toAbsolutePath().normalize();
+        this.historyLimit = historyLimit;
+
+        try {
+            Files.createDirectories(this.stateDirectory);
+            loadExisting();
+            trimTerminalHistory();
+        } catch (IOException failure) {
+            throw persistenceFailure(
+                    "Could not initialize Worker state directory "
+                            + this.stateDirectory,
+                    failure);
+        }
+    }
+
+    @Override
+    public synchronized void save(JobSnapshot snapshot) {
+        save(snapshot, null);
+    }
+
+    @Override
+    public synchronized void save(
+            JobSnapshot snapshot,
+            JobExecutionMetadata executionMetadata) {
+
+        if (snapshot == null) {
+            throw new IllegalArgumentException(
+                    "snapshot must not be null");
+        }
+
+        JobExecutionMetadata current =
+                metadata.get(snapshot.getJobId());
+        if (isStale(current, executionMetadata)) {
+            return;
+        }
+
+        JobSnapshot previous = snapshots.put(
+                snapshot.getJobId(),
+                snapshot);
+        if (executionMetadata != null) {
+            metadata.put(snapshot.getJobId(), executionMetadata);
+        }
+        if (previous == null) {
+            orderedJobIds.addFirst(snapshot.getJobId());
+        }
+
+        writeAtomically(
+                StoredJobRecord.from(
+                        snapshot,
+                        metadata.get(snapshot.getJobId())));
+        trimTerminalHistory();
+    }
+
+    @Override
+    public JobSnapshot get(String jobId) {
+        return snapshots.get(jobId);
+    }
+
+    @Override
+    public JobExecutionMetadata getMetadata(String jobId) {
+        return metadata.get(jobId);
+    }
+
+    @Override
+    public List<JobSnapshot> list() {
+        List<JobSnapshot> result = new ArrayList<JobSnapshot>();
+        for (String jobId : orderedJobIds) {
+            JobSnapshot snapshot = snapshots.get(jobId);
+            if (snapshot != null) {
+                result.add(snapshot);
+            }
+        }
+        Collections.sort(
+                result,
+                new Comparator<JobSnapshot>() {
+                    @Override
+                    public int compare(
+                            JobSnapshot left,
+                            JobSnapshot right) {
+                        return Long.compare(
+                                right.getCreateTimeMillis(),
+                                left.getCreateTimeMillis());
+                    }
+                });
+        return result;
+    }
+
+    @Override
+    public synchronized void delete(String jobId) {
+        if (jobId == null) {
+            return;
+        }
+        snapshots.remove(jobId);
+        metadata.remove(jobId);
+        orderedJobIds.remove(jobId);
+        try {
+            Files.deleteIfExists(fileFor(jobId));
+        } catch (IOException failure) {
+            throw persistenceFailure(
+                    "Could not delete Worker checkpoint for " + jobId,
+                    failure);
+        }
+    }
+
+    public Path getStateDirectory() {
+        return stateDirectory;
+    }
+
+    private static boolean isStale(
+            JobExecutionMetadata current,
+            JobExecutionMetadata candidate) {
+        return current != null
+                && candidate != null
+                && candidate.getCheckpointVersion()
+                < current.getCheckpointVersion();
+    }
+
+    private void loadExisting() throws IOException {
+        List<JobRepositoryEntry> loaded = new ArrayList<JobRepositoryEntry>();
+
+        try (DirectoryStream<Path> stream =
+                     Files.newDirectoryStream(
+                             stateDirectory,
+                             "*" + FILE_SUFFIX)) {
+            for (Path file : stream) {
+                StoredJobRecord record;
+                try {
+                    record = mapper.readValue(
+                            file.toFile(),
+                            StoredJobRecord.class);
+                } catch (Exception failure) {
+                    throw new IOException(
+                            "Invalid Worker state file: " + file,
+                            failure);
+                }
+                if (record.formatVersion != FORMAT_VERSION) {
+                    throw new IOException(
+                            "Unsupported Worker state formatVersion="
+                                    + record.formatVersion
+                                    + " in "
+                                    + file);
+                }
+                loaded.add(record.toEntry());
+            }
+        }
+
+        Collections.sort(
+                loaded,
+                new Comparator<JobRepositoryEntry>() {
+                    @Override
+                    public int compare(
+                            JobRepositoryEntry left,
+                            JobRepositoryEntry right) {
+                        return Long.compare(
+                                right.getSnapshot().getCreateTimeMillis(),
+                                left.getSnapshot().getCreateTimeMillis());
+                    }
+                });
+
+        for (JobRepositoryEntry entry : loaded) {
+            String jobId = entry.getSnapshot().getJobId();
+            snapshots.put(jobId, entry.getSnapshot());
+            if (entry.getMetadata() != null) {
+                metadata.put(jobId, entry.getMetadata());
+            }
+            orderedJobIds.addLast(jobId);
+        }
+    }
+
+    private void writeAtomically(StoredJobRecord record) {
+        Path target = fileFor(record.jobId);
+        Path temporary = null;
+        try {
+            byte[] bytes = mapper.writerWithDefaultPrettyPrinter()
+                    .writeValueAsBytes(record);
+            temporary = Files.createTempFile(
+                    stateDirectory,
+                    ".job-state-",
+                    ".tmp");
+
+            try (FileOutputStream output =
+                         new FileOutputStream(temporary.toFile())) {
+                output.write(bytes);
+                output.flush();
+                output.getFD().sync();
+            }
+
+            try {
+                Files.move(
+                        temporary,
+                        target,
+                        StandardCopyOption.REPLACE_EXISTING,
+                        StandardCopyOption.ATOMIC_MOVE);
+            } catch (AtomicMoveNotSupportedException unsupported) {
+                Files.move(
+                        temporary,
+                        target,
+                        StandardCopyOption.REPLACE_EXISTING);
+            }
+        } catch (IOException failure) {
+            throw persistenceFailure(
+                    "Could not persist Worker checkpoint for " + record.jobId,
+                    failure);
+        } finally {
+            if (temporary != null) {
+                try {
+                    Files.deleteIfExists(temporary);
+                } catch (IOException ignored) {
+                    // Best-effort cleanup.
+                }
+            }
+        }
+    }
+
+    private Path fileFor(String jobId) {
+        String encoded = Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(
+                        jobId.getBytes(StandardCharsets.UTF_8));
+        return stateDirectory.resolve(encoded + FILE_SUFFIX);
+    }
+
+    private void trimTerminalHistory() {
+        while (terminalCount() > historyLimit) {
+            String oldestTerminal = null;
+            Iterator<String> iterator = orderedJobIds.descendingIterator();
+            while (iterator.hasNext()) {
+                String jobId = iterator.next();
+                JobSnapshot snapshot = snapshots.get(jobId);
+                if (snapshot != null && snapshot.getStatus().isTerminal()) {
+                    oldestTerminal = jobId;
+                    break;
+                }
+            }
+            if (oldestTerminal == null) {
+                return;
+            }
+            delete(oldestTerminal);
+        }
+    }
+
+    private int terminalCount() {
+        int count = 0;
+        for (JobSnapshot snapshot : snapshots.values()) {
+            if (snapshot.getStatus().isTerminal()) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static IllegalStateException persistenceFailure(
+            String message,
+            Exception failure) {
+        return new IllegalStateException(message, failure);
+    }
+
+    public static final class StoredJobRecord {
+        public int formatVersion;
+        public String jobId;
+        public String jobName;
+        public String status;
+        public long createTimeMillis;
+        public long startTimeMillis;
+        public long endTimeMillis;
+        public String errorCode;
+        public String errorMessage;
+        public StoredMetadata metadata;
+
+        public StoredJobRecord() {
+        }
+
+        static StoredJobRecord from(
+                JobSnapshot snapshot,
+                JobExecutionMetadata metadata) {
+            StoredJobRecord record = new StoredJobRecord();
+            record.formatVersion = FORMAT_VERSION;
+            record.jobId = snapshot.getJobId();
+            record.jobName = snapshot.getJobName();
+            record.status = snapshot.getStatus().name();
+            record.createTimeMillis = snapshot.getCreateTimeMillis();
+            record.startTimeMillis = snapshot.getStartTimeMillis();
+            record.endTimeMillis = snapshot.getEndTimeMillis();
+            record.errorCode = snapshot.getErrorCode();
+            record.errorMessage = snapshot.getErrorMessage();
+            record.metadata = StoredMetadata.from(metadata);
+            return record;
+        }
+
+        JobRepositoryEntry toEntry() {
+            JobSnapshot restoredSnapshot =
+                    JobRecoverySnapshotFactory.restoreBasic(
+                            jobId,
+                            jobName,
+                            ServerJobStatus.valueOf(status),
+                            createTimeMillis,
+                            startTimeMillis,
+                            endTimeMillis,
+                            errorCode,
+                            errorMessage);
+            return new JobRepositoryEntry(
+                    restoredSnapshot,
+                    metadata == null ? null : metadata.toMetadata());
+        }
+    }
+
+    public static final class StoredMetadata {
+        public String externalExecutionId;
+        public String idempotencyKey;
+        public int definitionVersion;
+        public String configDigest;
+        public long submittedTimeMillis;
+        public long queuedTimeMillis;
+        public long stateVersion;
+        public long checkpointVersion;
+        public boolean cancellationRequested;
+        public String runId;
+        public String jobLogFile;
+        public List<StoredTransition> transitions =
+                new ArrayList<StoredTransition>();
+        public List<StoredAttempt> attempts =
+                new ArrayList<StoredAttempt>();
+
+        public StoredMetadata() {
+        }
+
+        static StoredMetadata from(JobExecutionMetadata metadata) {
+            if (metadata == null) {
+                return null;
+            }
+            StoredMetadata stored = new StoredMetadata();
+            stored.externalExecutionId = metadata.getExternalExecutionId();
+            stored.idempotencyKey = metadata.getIdempotencyKey();
+            stored.definitionVersion = metadata.getDefinitionVersion();
+            stored.configDigest = metadata.getConfigDigest();
+            stored.submittedTimeMillis = metadata.getSubmittedTimeMillis();
+            stored.queuedTimeMillis = metadata.getQueuedTimeMillis();
+            stored.stateVersion = metadata.getStateVersion();
+            stored.checkpointVersion = metadata.getCheckpointVersion();
+            stored.cancellationRequested = metadata.isCancellationRequested();
+            stored.runId = metadata.getRunId();
+            stored.jobLogFile = metadata.getJobLogFile();
+            for (JobStateTransition transition : metadata.getTransitions()) {
+                stored.transitions.add(StoredTransition.from(transition));
+            }
+            for (JobAttemptMetadata attempt : metadata.getAttempts()) {
+                stored.attempts.add(StoredAttempt.from(attempt));
+            }
+            return stored;
+        }
+
+        JobExecutionMetadata toMetadata() {
+            List<JobStateTransition> restoredTransitions =
+                    new ArrayList<JobStateTransition>();
+            for (StoredTransition transition : transitions) {
+                restoredTransitions.add(transition.toTransition());
+            }
+            List<JobAttemptMetadata> restoredAttempts =
+                    new ArrayList<JobAttemptMetadata>();
+            for (StoredAttempt attempt : attempts) {
+                restoredAttempts.add(attempt.toAttempt());
+            }
+            return new JobExecutionMetadata(
+                    externalExecutionId,
+                    idempotencyKey,
+                    definitionVersion,
+                    configDigest,
+                    submittedTimeMillis,
+                    queuedTimeMillis,
+                    stateVersion,
+                    checkpointVersion,
+                    cancellationRequested,
+                    restoredTransitions,
+                    Collections.<String, com.link.up.api.sink.TableDdl>emptyMap(),
+                    runId,
+                    jobLogFile,
+                    restoredAttempts);
+        }
+    }
+
+    public static final class StoredTransition {
+        public long version;
+        public String fromStatus;
+        public String toStatus;
+        public long transitionTimeMillis;
+        public String reason;
+
+        public StoredTransition() {
+        }
+
+        static StoredTransition from(JobStateTransition transition) {
+            StoredTransition stored = new StoredTransition();
+            stored.version = transition.getVersion();
+            stored.fromStatus = transition.getFromStatus() == null
+                    ? null
+                    : transition.getFromStatus().name();
+            stored.toStatus = transition.getToStatus().name();
+            stored.transitionTimeMillis = transition.getTransitionTimeMillis();
+            stored.reason = transition.getReason();
+            return stored;
+        }
+
+        JobStateTransition toTransition() {
+            return new JobStateTransition(
+                    version,
+                    fromStatus == null
+                            ? null
+                            : ServerJobStatus.valueOf(fromStatus),
+                    ServerJobStatus.valueOf(toStatus),
+                    transitionTimeMillis,
+                    reason);
+        }
+    }
+
+    public static final class StoredAttempt {
+        public int attemptNumber;
+        public String attemptId;
+        public String status;
+        public long createTimeMillis;
+        public long queuedTimeMillis;
+        public long startTimeMillis;
+        public long endTimeMillis;
+        public String runId;
+        public String jobLogFile;
+        public String failureType;
+        public String failureMessage;
+        public String retryAdvice;
+
+        public StoredAttempt() {
+        }
+
+        static StoredAttempt from(JobAttemptMetadata attempt) {
+            StoredAttempt stored = new StoredAttempt();
+            stored.attemptNumber = attempt.getAttemptNumber();
+            stored.attemptId = attempt.getAttemptId();
+            stored.status = attempt.getStatus().name();
+            stored.createTimeMillis = attempt.getCreateTimeMillis();
+            stored.queuedTimeMillis = attempt.getQueuedTimeMillis();
+            stored.startTimeMillis = attempt.getStartTimeMillis();
+            stored.endTimeMillis = attempt.getEndTimeMillis();
+            stored.runId = attempt.getRunId();
+            stored.jobLogFile = attempt.getJobLogFile();
+            stored.failureType = attempt.getFailureType();
+            stored.failureMessage = attempt.getFailureMessage();
+            stored.retryAdvice = attempt.getRetryAdvice();
+            return stored;
+        }
+
+        JobAttemptMetadata toAttempt() {
+            return new JobAttemptMetadata(
+                    attemptNumber,
+                    attemptId,
+                    JobAttemptStatus.valueOf(status),
+                    createTimeMillis,
+                    queuedTimeMillis,
+                    startTimeMillis,
+                    endTimeMillis,
+                    runId,
+                    jobLogFile,
+                    failureType,
+                    failureMessage,
+                    retryAdvice);
+        }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/InMemoryJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/InMemoryJobRepository.java
@@ -7,14 +7,13 @@ import com.link.up.server.runtime.JobSnapshot;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 
-/**
- * Bounded in-memory terminal history adapter.
- */
+/** Bounded in-memory checkpoint/history adapter used by tests and embeddings. */
 public final class InMemoryJobRepository
         implements JobRepository {
 
@@ -40,27 +39,26 @@ public final class InMemoryJobRepository
     }
 
     @Override
-    public void save(
+    public synchronized void save(
             JobSnapshot snapshot,
             JobExecutionMetadata executionMetadata) {
 
-        JobSnapshot previous =
-                snapshots.put(
-                        snapshot.getJobId(),
-                        snapshot);
+        JobExecutionMetadata current =
+                metadata.get(snapshot.getJobId());
+        if (isStale(current, executionMetadata)) {
+            return;
+        }
 
+        JobSnapshot previous = snapshots.put(
+                snapshot.getJobId(),
+                snapshot);
         if (executionMetadata != null) {
-            metadata.put(
-                    snapshot.getJobId(),
-                    executionMetadata);
+            metadata.put(snapshot.getJobId(), executionMetadata);
         }
-
         if (previous == null) {
-            orderedJobIds.addFirst(
-                    snapshot.getJobId());
+            orderedJobIds.addFirst(snapshot.getJobId());
         }
-
-        trim();
+        trimTerminalHistory();
     }
 
     @Override
@@ -75,16 +73,13 @@ public final class InMemoryJobRepository
 
     @Override
     public List<JobSnapshot> list() {
-        List<JobSnapshot> result =
-                new ArrayList<JobSnapshot>();
-
+        List<JobSnapshot> result = new ArrayList<JobSnapshot>();
         for (String jobId : orderedJobIds) {
             JobSnapshot snapshot = snapshots.get(jobId);
             if (snapshot != null) {
                 result.add(snapshot);
             }
         }
-
         Collections.sort(
                 result,
                 new Comparator<JobSnapshot>() {
@@ -97,18 +92,51 @@ public final class InMemoryJobRepository
                                 left.getCreateTimeMillis());
                     }
                 });
-
         return result;
     }
 
-    private void trim() {
-        while (snapshots.size() > historyLimit) {
-            String oldestJobId = orderedJobIds.pollLast();
-            if (oldestJobId == null) {
+    @Override
+    public synchronized void delete(String jobId) {
+        snapshots.remove(jobId);
+        metadata.remove(jobId);
+        orderedJobIds.remove(jobId);
+    }
+
+    private static boolean isStale(
+            JobExecutionMetadata current,
+            JobExecutionMetadata candidate) {
+        return current != null
+                && candidate != null
+                && candidate.getCheckpointVersion()
+                < current.getCheckpointVersion();
+    }
+
+    private void trimTerminalHistory() {
+        while (terminalCount() > historyLimit) {
+            String oldestTerminal = null;
+            Iterator<String> iterator = orderedJobIds.descendingIterator();
+            while (iterator.hasNext()) {
+                String jobId = iterator.next();
+                JobSnapshot snapshot = snapshots.get(jobId);
+                if (snapshot != null && snapshot.getStatus().isTerminal()) {
+                    oldestTerminal = jobId;
+                    break;
+                }
+            }
+            if (oldestTerminal == null) {
                 return;
             }
-            snapshots.remove(oldestJobId);
-            metadata.remove(oldestJobId);
+            delete(oldestTerminal);
         }
+    }
+
+    private int terminalCount() {
+        int count = 0;
+        for (JobSnapshot snapshot : snapshots.values()) {
+            if (snapshot.getStatus().isTerminal()) {
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobAttemptMetadata.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobAttemptMetadata.java
@@ -1,0 +1,108 @@
+package com.link.up.server.runtime;
+
+import com.link.up.server.domain.JobAttemptStatus;
+import com.link.up.server.domain.JobExecutionAttempt;
+
+import java.util.Objects;
+
+/** Stable Worker read model for one execution attempt. */
+public final class JobAttemptMetadata {
+
+    private final int attemptNumber;
+    private final String attemptId;
+    private final JobAttemptStatus status;
+    private final long createTimeMillis;
+    private final long queuedTimeMillis;
+    private final long startTimeMillis;
+    private final long endTimeMillis;
+    private final String runId;
+    private final String jobLogFile;
+    private final String failureType;
+    private final String failureMessage;
+    private final String retryAdvice;
+
+    public JobAttemptMetadata(
+            int attemptNumber,
+            String attemptId,
+            JobAttemptStatus status,
+            long createTimeMillis,
+            long queuedTimeMillis,
+            long startTimeMillis,
+            long endTimeMillis,
+            String runId,
+            String jobLogFile,
+            String failureType,
+            String failureMessage,
+            String retryAdvice) {
+
+        this.attemptNumber = attemptNumber;
+        this.attemptId = Objects.requireNonNull(
+                attemptId,
+                "attemptId must not be null");
+        this.status = Objects.requireNonNull(
+                status,
+                "status must not be null");
+        this.createTimeMillis = createTimeMillis;
+        this.queuedTimeMillis = queuedTimeMillis;
+        this.startTimeMillis = startTimeMillis;
+        this.endTimeMillis = endTimeMillis;
+        this.runId = runId;
+        this.jobLogFile = jobLogFile;
+        this.failureType = failureType;
+        this.failureMessage = failureMessage;
+        this.retryAdvice = retryAdvice;
+    }
+
+    public static JobAttemptMetadata from(
+            JobExecutionAttempt attempt) {
+        return new JobAttemptMetadata(
+                attempt.getAttemptNumber(),
+                attempt.getAttemptId(),
+                attempt.getStatus(),
+                attempt.getCreateTimeMillis(),
+                attempt.getQueuedTimeMillis(),
+                attempt.getStartTimeMillis(),
+                attempt.getEndTimeMillis(),
+                attempt.getRunId(),
+                attempt.getJobLogFile(),
+                attempt.getFailureType(),
+                attempt.getFailureMessage(),
+                attempt.getRetryAdvice());
+    }
+
+    public JobAttemptMetadata recoverLost(
+            long endTimeMillis,
+            String reason) {
+
+        if (status.isTerminal()) {
+            return this;
+        }
+
+        return new JobAttemptMetadata(
+                attemptNumber,
+                attemptId,
+                JobAttemptStatus.LOST,
+                createTimeMillis,
+                queuedTimeMillis,
+                startTimeMillis,
+                endTimeMillis,
+                runId,
+                jobLogFile,
+                "WorkerRestartRecovery",
+                reason,
+                retryAdvice);
+    }
+
+    public int getAttemptNumber() { return attemptNumber; }
+    public String getAttemptId() { return attemptId; }
+    public JobAttemptStatus getStatus() { return status; }
+    public long getCreateTimeMillis() { return createTimeMillis; }
+    public long getQueuedTimeMillis() { return queuedTimeMillis; }
+    public long getStartTimeMillis() { return startTimeMillis; }
+    public long getEndTimeMillis() { return endTimeMillis; }
+    public String getRunId() { return runId; }
+    public String getJobLogFile() { return jobLogFile; }
+    public String getFailureType() { return failureType; }
+    public String getFailureMessage() { return failureMessage; }
+    public String getRetryAdvice() { return retryAdvice; }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionMetadata.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionMetadata.java
@@ -1,6 +1,11 @@
 package com.link.up.server.runtime;
 
 import com.link.up.api.sink.TableDdl;
+import com.link.up.framework.job.JobResult;
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.server.domain.JobExecutionAttempt;
+import com.link.up.server.domain.JobExecutionState;
+import com.link.up.server.domain.JobSubmission;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -8,9 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * 作业协议元数据和状态机快照。
- */
+/** Worker protocol metadata, lifecycle audit and execution-attempt history. */
 public final class JobExecutionMetadata {
 
     private final String externalExecutionId;
@@ -20,11 +23,13 @@ public final class JobExecutionMetadata {
     private final long submittedTimeMillis;
     private final long queuedTimeMillis;
     private final long stateVersion;
+    private final long checkpointVersion;
     private final boolean cancellationRequested;
     private final List<JobStateTransition> transitions;
     private final Map<String, TableDdl> tableDdlsByPipelineId;
     private final String runId;
     private final String jobLogFile;
+    private final List<JobAttemptMetadata> attempts;
 
     public JobExecutionMetadata(
             String externalExecutionId,
@@ -36,7 +41,6 @@ public final class JobExecutionMetadata {
             long stateVersion,
             boolean cancellationRequested,
             List<JobStateTransition> transitions) {
-
         this(
                 externalExecutionId,
                 idempotencyKey,
@@ -45,11 +49,13 @@ public final class JobExecutionMetadata {
                 submittedTimeMillis,
                 queuedTimeMillis,
                 stateVersion,
+                stateVersion,
                 cancellationRequested,
                 transitions,
                 Collections.<String, TableDdl>emptyMap(),
                 null,
-                null);
+                null,
+                Collections.<JobAttemptMetadata>emptyList());
     }
 
     public JobExecutionMetadata(
@@ -63,7 +69,6 @@ public final class JobExecutionMetadata {
             boolean cancellationRequested,
             List<JobStateTransition> transitions,
             Map<String, TableDdl> tableDdlsByPipelineId) {
-
         this(
                 externalExecutionId,
                 idempotencyKey,
@@ -72,11 +77,13 @@ public final class JobExecutionMetadata {
                 submittedTimeMillis,
                 queuedTimeMillis,
                 stateVersion,
+                stateVersion,
                 cancellationRequested,
                 transitions,
                 tableDdlsByPipelineId,
                 null,
-                null);
+                null,
+                Collections.<JobAttemptMetadata>emptyList());
     }
 
     public JobExecutionMetadata(
@@ -92,6 +99,38 @@ public final class JobExecutionMetadata {
             Map<String, TableDdl> tableDdlsByPipelineId,
             String runId,
             String jobLogFile) {
+        this(
+                externalExecutionId,
+                idempotencyKey,
+                definitionVersion,
+                configDigest,
+                submittedTimeMillis,
+                queuedTimeMillis,
+                stateVersion,
+                stateVersion,
+                cancellationRequested,
+                transitions,
+                tableDdlsByPipelineId,
+                runId,
+                jobLogFile,
+                Collections.<JobAttemptMetadata>emptyList());
+    }
+
+    public JobExecutionMetadata(
+            String externalExecutionId,
+            String idempotencyKey,
+            int definitionVersion,
+            String configDigest,
+            long submittedTimeMillis,
+            long queuedTimeMillis,
+            long stateVersion,
+            long checkpointVersion,
+            boolean cancellationRequested,
+            List<JobStateTransition> transitions,
+            Map<String, TableDdl> tableDdlsByPipelineId,
+            String runId,
+            String jobLogFile,
+            List<JobAttemptMetadata> attempts) {
 
         this.externalExecutionId = externalExecutionId;
         this.idempotencyKey = idempotencyKey;
@@ -100,68 +139,115 @@ public final class JobExecutionMetadata {
         this.submittedTimeMillis = submittedTimeMillis;
         this.queuedTimeMillis = queuedTimeMillis;
         this.stateVersion = stateVersion;
+        this.checkpointVersion = checkpointVersion;
         this.cancellationRequested = cancellationRequested;
-        this.transitions =
-                Collections.unmodifiableList(
-                        new ArrayList<JobStateTransition>(
-                                transitions));
-        this.tableDdlsByPipelineId =
-                Collections.unmodifiableMap(
-                        new LinkedHashMap<String, TableDdl>(
-                                tableDdlsByPipelineId));
+        this.transitions = Collections.unmodifiableList(
+                new ArrayList<JobStateTransition>(transitions));
+        this.tableDdlsByPipelineId = Collections.unmodifiableMap(
+                new LinkedHashMap<String, TableDdl>(tableDdlsByPipelineId));
         this.runId = runId;
         this.jobLogFile = jobLogFile;
+        this.attempts = Collections.unmodifiableList(
+                new ArrayList<JobAttemptMetadata>(attempts));
     }
 
-    public String getExternalExecutionId() {
-        return externalExecutionId;
+    public static JobExecutionMetadata fromState(
+            JobExecutionState state) {
+
+        Map<String, TableDdl> tableDdls =
+                new LinkedHashMap<String, TableDdl>();
+        JobResult result = state.getResult();
+        if (result != null) {
+            for (PipelineResult pipelineResult : result.getPipelineResults()) {
+                if (pipelineResult.getTableDdl() != null) {
+                    tableDdls.put(
+                            pipelineResult.getPipelineId(),
+                            pipelineResult.getTableDdl());
+                }
+            }
+        }
+
+        List<JobAttemptMetadata> attempts =
+                new ArrayList<JobAttemptMetadata>();
+        for (JobExecutionAttempt attempt : state.getAttempts()) {
+            attempts.add(JobAttemptMetadata.from(attempt));
+        }
+
+        JobSubmission submission = state.getSubmission();
+        return new JobExecutionMetadata(
+                submission.getExternalExecutionId(),
+                submission.getIdempotencyKey(),
+                submission.getDefinitionVersion(),
+                submission.getConfigDigest(),
+                state.getSubmittedTimeMillis(),
+                state.getQueuedTimeMillis(),
+                state.getStateVersion(),
+                state.getCheckpointVersion(),
+                state.isCancellationRequested(),
+                state.getTransitions(),
+                tableDdls,
+                state.getRunId(),
+                state.getJobLogFile(),
+                attempts);
     }
 
-    public String getIdempotencyKey() {
-        return idempotencyKey;
+    public JobExecutionMetadata recoverLost(
+            ServerJobStatus previousStatus,
+            long recoveryTimeMillis,
+            String reason) {
+
+        if (previousStatus == null || previousStatus.isTerminal()) {
+            return this;
+        }
+
+        List<JobStateTransition> recoveredTransitions =
+                new ArrayList<JobStateTransition>(transitions);
+        recoveredTransitions.add(
+                new JobStateTransition(
+                        stateVersion + 1L,
+                        previousStatus,
+                        ServerJobStatus.LOST,
+                        recoveryTimeMillis,
+                        "worker-restart-recovery"));
+
+        List<JobAttemptMetadata> recoveredAttempts =
+                new ArrayList<JobAttemptMetadata>(attempts.size());
+        for (JobAttemptMetadata attempt : attempts) {
+            recoveredAttempts.add(
+                    attempt.recoverLost(recoveryTimeMillis, reason));
+        }
+
+        return new JobExecutionMetadata(
+                externalExecutionId,
+                idempotencyKey,
+                definitionVersion,
+                configDigest,
+                submittedTimeMillis,
+                queuedTimeMillis,
+                stateVersion + 1L,
+                checkpointVersion + 1L,
+                cancellationRequested,
+                recoveredTransitions,
+                tableDdlsByPipelineId,
+                runId,
+                jobLogFile,
+                recoveredAttempts);
     }
 
-    public int getDefinitionVersion() {
-        return definitionVersion;
-    }
-
-    public String getConfigDigest() {
-        return configDigest;
-    }
-
-    public long getSubmittedTimeMillis() {
-        return submittedTimeMillis;
-    }
-
-    public long getQueuedTimeMillis() {
-        return queuedTimeMillis;
-    }
-
-    public long getStateVersion() {
-        return stateVersion;
-    }
-
-    public boolean isCancellationRequested() {
-        return cancellationRequested;
-    }
-
-    public List<JobStateTransition> getTransitions() {
-        return transitions;
-    }
-
-    public Map<String, TableDdl> getTableDdlsByPipelineId() {
-        return tableDdlsByPipelineId;
-    }
-
-    public TableDdl getTableDdl(String pipelineId) {
-        return tableDdlsByPipelineId.get(pipelineId);
-    }
-
-    public String getRunId() {
-        return runId;
-    }
-
-    public String getJobLogFile() {
-        return jobLogFile;
-    }
+    public String getExternalExecutionId() { return externalExecutionId; }
+    public String getIdempotencyKey() { return idempotencyKey; }
+    public int getDefinitionVersion() { return definitionVersion; }
+    public String getConfigDigest() { return configDigest; }
+    public long getSubmittedTimeMillis() { return submittedTimeMillis; }
+    public long getQueuedTimeMillis() { return queuedTimeMillis; }
+    public long getStateVersion() { return stateVersion; }
+    public long getCheckpointVersion() { return checkpointVersion; }
+    public boolean isCancellationRequested() { return cancellationRequested; }
+    public List<JobStateTransition> getTransitions() { return transitions; }
+    public Map<String, TableDdl> getTableDdlsByPipelineId() { return tableDdlsByPipelineId; }
+    public TableDdl getTableDdl(String pipelineId) { return tableDdlsByPipelineId.get(pipelineId); }
+    public String getRunId() { return runId; }
+    public String getJobLogFile() { return jobLogFile; }
+    public List<JobAttemptMetadata> getAttempts() { return attempts; }
+    public int getAttemptCount() { return attempts.size(); }
 }

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobRecoverySnapshotFactory.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobRecoverySnapshotFactory.java
@@ -1,0 +1,93 @@
+package com.link.up.server.runtime;
+
+import java.util.Collections;
+
+/** Helpers for restoring persisted control-plane checkpoints after restart. */
+public final class JobRecoverySnapshotFactory {
+
+    private JobRecoverySnapshotFactory() {
+    }
+
+    public static JobSnapshot restoreBasic(
+            String jobId,
+            String jobName,
+            ServerJobStatus status,
+            long createTimeMillis,
+            long startTimeMillis,
+            long endTimeMillis,
+            String errorCode,
+            String errorMessage) {
+
+        return new JobSnapshot(
+                jobId,
+                jobName,
+                status,
+                createTimeMillis,
+                startTimeMillis,
+                endTimeMillis,
+                duration(startTimeMillis, endTimeMillis),
+                emptyMetrics(),
+                emptyCommit(),
+                Collections.<JobSnapshot.Pipeline>emptyList(),
+                errorCode,
+                errorMessage);
+    }
+
+    public static JobSnapshot recoverLost(
+            JobSnapshot checkpoint,
+            long recoveryTimeMillis,
+            String reason) {
+
+        if (checkpoint.getStatus().isTerminal()) {
+            return checkpoint;
+        }
+
+        return new JobSnapshot(
+                checkpoint.getJobId(),
+                checkpoint.getJobName(),
+                ServerJobStatus.LOST,
+                checkpoint.getCreateTimeMillis(),
+                checkpoint.getStartTimeMillis(),
+                recoveryTimeMillis,
+                duration(
+                        checkpoint.getStartTimeMillis(),
+                        recoveryTimeMillis),
+                checkpoint.getMetrics(),
+                checkpoint.getCommitSummary(),
+                checkpoint.getPipelines(),
+                "FLUX-JOB-LOST",
+                reason);
+    }
+
+    private static JobSnapshot.Metrics emptyMetrics() {
+        return new JobSnapshot.Metrics(
+                0L, 0L, 0L, 0D,
+                0L, 0L, 0L, 0L, 0D,
+                0L, 0L, 0L, 0L,
+                0L, 0L, 0L, 0L, 0L,
+                0L, 0L,
+                0D, 0D, 0D);
+    }
+
+    private static JobSnapshot.Commit emptyCommit() {
+        return new JobSnapshot.Commit(
+                0, 0, 0, 0, 0, 0,
+                0L, 0L, 0L, 0L, 0L,
+                false,
+                false,
+                null,
+                null);
+    }
+
+    private static long duration(
+            long startTimeMillis,
+            long endTimeMillis) {
+        if (startTimeMillis <= 0L
+                || endTimeMillis <= 0L) {
+            return 0L;
+        }
+        return Math.max(
+                0L,
+                endTimeMillis - startTimeMillis);
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/ServerControlPlaneBoundaryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/ServerControlPlaneBoundaryTest.java
@@ -1,6 +1,7 @@
 package com.link.up.server;
 
 import com.link.up.server.application.JobApplicationService;
+import com.link.up.server.domain.JobExecutionAttempt;
 import com.link.up.server.domain.JobExecutionState;
 import com.link.up.server.service.JobRestService;
 import org.junit.Test;
@@ -9,15 +10,20 @@ import java.lang.reflect.Field;
 
 import static org.junit.Assert.assertFalse;
 
-/**
- * Architecture guards for the Phase 6 control-plane boundaries.
- */
+/** Architecture guards for Server control-plane boundaries. */
 public class ServerControlPlaneBoundaryTest {
 
     @Test
     public void domainStateMustNotOwnLocalRuntimeObjects() {
         assertNoFieldType(
                 JobExecutionState.class,
+                "java.lang.Thread",
+                "java.util.concurrent.Future",
+                "java.util.concurrent.Executor",
+                "java.util.concurrent.Semaphore",
+                "com.link.up.framework.execution.JobExecution");
+        assertNoFieldType(
+                JobExecutionAttempt.class,
                 "java.lang.Thread",
                 "java.util.concurrent.Future",
                 "java.util.concurrent.Executor",
@@ -47,10 +53,8 @@ public class ServerControlPlaneBoundaryTest {
     private static void assertNoFieldType(
             Class<?> type,
             String... forbiddenTypes) {
-
         for (Field field : type.getDeclaredFields()) {
-            String fieldType =
-                    field.getGenericType().getTypeName();
+            String fieldType = field.getGenericType().getTypeName();
             for (String forbidden : forbiddenTypes) {
                 assertFalse(
                         type.getSimpleName()

--- a/link-up-server/src/test/java/com/link/up/server/application/JobApplicationRecoveryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/application/JobApplicationRecoveryTest.java
@@ -1,0 +1,114 @@
+package com.link.up.server.application;
+
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.metrics.JobMetrics;
+import com.link.up.server.application.port.JobIdGenerator;
+import com.link.up.server.application.port.JobRuntimeScheduler;
+import com.link.up.server.domain.JobAttemptStatus;
+import com.link.up.server.domain.JobExecutionState;
+import com.link.up.server.domain.JobSubmission;
+import com.link.up.server.infrastructure.persistence.InMemoryJobRepository;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobSnapshotFactory;
+import com.link.up.server.runtime.ServerJobStatus;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+
+public class JobApplicationRecoveryTest {
+
+    @Test
+    public void shouldRecoverInterruptedCheckpointAsLostAndRestoreIdempotency() {
+        InMemoryJobRepository repository =
+                new InMemoryJobRepository(20);
+        JobSubmission submission =
+                JobApplicationServiceProtocolTest.submission(
+                        "external-recovery",
+                        "key-recovery",
+                        "digest-recovery");
+
+        JobExecutionState interrupted =
+                new JobExecutionState(
+                        "job-recovery",
+                        submission);
+        interrupted.markSubmitted();
+        interrupted.markQueued();
+        interrupted.markRunning();
+
+        repository.save(
+                JobSnapshotFactory.create(interrupted, null),
+                JobExecutionMetadata.fromState(interrupted));
+
+        RecordingScheduler scheduler =
+                new RecordingScheduler();
+        JobApplicationService application =
+                new JobApplicationService(
+                        scheduler,
+                        repository,
+                        new JobIdGenerator() {
+                            @Override
+                            public String nextId() {
+                                return "unexpected-new-job";
+                            }
+                        });
+
+        try {
+            JobSnapshot recovered =
+                    application.getJob("job-recovery");
+            assertEquals(
+                    ServerJobStatus.LOST,
+                    recovered.getStatus());
+            assertEquals(
+                    "FLUX-JOB-LOST",
+                    recovered.getErrorCode());
+
+            JobExecutionMetadata metadata =
+                    application.getMetadata("job-recovery");
+            assertEquals(1, metadata.getAttemptCount());
+            assertEquals(
+                    JobAttemptStatus.LOST,
+                    metadata.getAttempts().get(0).getStatus());
+            assertEquals(
+                    ServerJobStatus.LOST,
+                    metadata.getTransitions()
+                            .get(metadata.getTransitions().size() - 1)
+                            .getToStatus());
+
+            assertEquals(
+                    "job-recovery",
+                    application.getJobByExternalExecutionId(
+                            "external-recovery")
+                            .getJobId());
+            assertEquals(
+                    "job-recovery",
+                    application.submit(submission).getJobId());
+            assertEquals(0, scheduler.scheduleCount.get());
+        } finally {
+            application.close();
+        }
+    }
+
+    private static final class RecordingScheduler
+            implements JobRuntimeScheduler {
+
+        private final AtomicInteger scheduleCount =
+                new AtomicInteger();
+        private boolean closed;
+
+        @Override
+        public void schedule(
+                String jobId,
+                JobDefinition definition,
+                Listener listener) {
+            scheduleCount.incrementAndGet();
+        }
+
+        @Override public void cancel(String jobId) { }
+        @Override public JobMetrics getMetrics(String jobId) { return null; }
+        @Override public boolean isClosed() { return closed; }
+        @Override public void close() { closed = true; }
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/application/JobApplicationServiceProtocolTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/application/JobApplicationServiceProtocolTest.java
@@ -10,8 +10,10 @@ import com.link.up.framework.job.SourceDefinition;
 import com.link.up.framework.metrics.JobMetrics;
 import com.link.up.server.application.port.JobIdGenerator;
 import com.link.up.server.application.port.JobRuntimeScheduler;
+import com.link.up.server.domain.JobAttemptStatus;
 import com.link.up.server.domain.JobSubmission;
 import com.link.up.server.infrastructure.persistence.InMemoryJobRepository;
+import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobSnapshot;
 import org.junit.Test;
 
@@ -26,11 +28,10 @@ public class JobApplicationServiceProtocolTest {
     public void shouldReturnSameJobForSameIdempotentSubmission() {
         JobApplicationService application = application();
         try {
-            JobSubmission submission =
-                    submission(
-                            "external-100",
-                            "key-100",
-                            "digest-100");
+            JobSubmission submission = submission(
+                    "external-100",
+                    "key-100",
+                    "digest-100");
 
             JobSnapshot first = application.submit(submission);
             JobSnapshot second = application.submit(submission);
@@ -38,9 +39,15 @@ public class JobApplicationServiceProtocolTest {
             assertEquals(first.getJobId(), second.getJobId());
             assertEquals(
                     first.getJobId(),
-                    application.getJobByExternalExecutionId(
-                            "external-100")
+                    application.getJobByExternalExecutionId("external-100")
                             .getJobId());
+
+            JobExecutionMetadata metadata =
+                    application.getMetadata(first.getJobId());
+            assertEquals(1, metadata.getAttemptCount());
+            assertEquals(
+                    JobAttemptStatus.SUCCEEDED,
+                    metadata.getAttempts().get(0).getStatus());
         } finally {
             application.close();
         }
@@ -50,17 +57,14 @@ public class JobApplicationServiceProtocolTest {
     public void shouldRejectReusedIdempotencyKeyWithDifferentContent() {
         JobApplicationService application = application();
         try {
-            application.submit(
-                    submission(
-                            "external-200",
-                            "key-200",
-                            "digest-a"));
-
-            application.submit(
-                    submission(
-                            "external-200",
-                            "key-200",
-                            "digest-b"));
+            application.submit(submission(
+                    "external-200",
+                    "key-200",
+                    "digest-a"));
+            application.submit(submission(
+                    "external-200",
+                    "key-200",
+                    "digest-b"));
         } finally {
             application.close();
         }
@@ -82,14 +86,13 @@ public class JobApplicationServiceProtocolTest {
                 idGenerator);
     }
 
-    private static JobSubmission submission(
+    static JobSubmission submission(
             String externalExecutionId,
             String idempotencyKey,
             String digest) {
 
-        ReadonlyConfig options =
-                ReadonlyConfig.fromMap(
-                        Collections.<String, Object>emptyMap());
+        ReadonlyConfig options = ReadonlyConfig.fromMap(
+                Collections.<String, Object>emptyMap());
         JobDefinition definition =
                 new JobDefinition(
                         "protocol-test",
@@ -115,13 +118,11 @@ public class JobApplicationServiceProtocolTest {
                 String jobId,
                 JobDefinition definition,
                 Listener listener) {
-
             listener.onQueued();
             if (!listener.onStarting()) {
                 listener.onCompleted(null, null, true);
                 return;
             }
-
             long now = System.currentTimeMillis();
             listener.onCompleted(
                     new JobResult(
@@ -135,23 +136,9 @@ public class JobApplicationServiceProtocolTest {
                     false);
         }
 
-        @Override
-        public void cancel(String jobId) {
-        }
-
-        @Override
-        public JobMetrics getMetrics(String jobId) {
-            return null;
-        }
-
-        @Override
-        public boolean isClosed() {
-            return closed;
-        }
-
-        @Override
-        public void close() {
-            closed = true;
-        }
+        @Override public void cancel(String jobId) { }
+        @Override public JobMetrics getMetrics(String jobId) { return null; }
+        @Override public boolean isClosed() { return closed; }
+        @Override public void close() { closed = true; }
     }
 }

--- a/link-up-server/src/test/java/com/link/up/server/config/FluxServerConfigTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/config/FluxServerConfigTest.java
@@ -1,0 +1,26 @@
+package com.link.up.server.config;
+
+import org.junit.Test;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertEquals;
+
+public class FluxServerConfigTest {
+
+    @Test
+    public void shouldParseWorkerStateDirectory() {
+        Path expected = Paths.get("target", "phase7-state")
+                .toAbsolutePath()
+                .normalize();
+
+        FluxServerConfig config = FluxServerConfig.fromArgs(
+                new String[] {
+                        "--state-dir",
+                        expected.toString()
+                });
+
+        assertEquals(expected, config.getStateDirectory());
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/domain/JobExecutionStateTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/domain/JobExecutionStateTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.assertTrue;
 public class JobExecutionStateTest {
 
     @Test
-    public void shouldRecordLifecycleWithoutRuntimeOwnership() {
+    public void shouldRecordLifecycleAndAttemptWithoutRuntimeOwnership() {
         JobExecutionState state =
                 new JobExecutionState(
                         "job-1",
@@ -32,26 +32,28 @@ public class JobExecutionStateTest {
                 null,
                 null));
 
-        List<JobStateTransition> transitions =
-                state.getTransitions();
+        List<JobStateTransition> transitions = state.getTransitions();
         assertEquals(5, transitions.size());
-        assertEquals(ServerJobStatus.CREATED,
-                transitions.get(0).getToStatus());
-        assertEquals(ServerJobStatus.SUBMITTED,
-                transitions.get(1).getToStatus());
-        assertEquals(ServerJobStatus.QUEUED,
-                transitions.get(2).getToStatus());
-        assertEquals(ServerJobStatus.RUNNING,
-                transitions.get(3).getToStatus());
-        assertEquals(ServerJobStatus.LOST,
-                transitions.get(4).getToStatus());
+        assertEquals(ServerJobStatus.CREATED, transitions.get(0).getToStatus());
+        assertEquals(ServerJobStatus.SUBMITTED, transitions.get(1).getToStatus());
+        assertEquals(ServerJobStatus.QUEUED, transitions.get(2).getToStatus());
+        assertEquals(ServerJobStatus.RUNNING, transitions.get(3).getToStatus());
+        assertEquals(ServerJobStatus.LOST, transitions.get(4).getToStatus());
         assertEquals(4L, state.getStateVersion());
+
+        assertEquals(1, state.getAttempts().size());
+        JobExecutionAttempt attempt = state.getAttempts().get(0);
+        assertEquals(1, attempt.getAttemptNumber());
+        assertEquals("job-1-attempt-1", attempt.getAttemptId());
+        assertEquals(JobAttemptStatus.LOST, attempt.getStatus());
+        assertTrue(attempt.getQueuedTimeMillis() > 0L);
+        assertTrue(attempt.getStartTimeMillis() > 0L);
+        assertTrue(attempt.getEndTimeMillis() > 0L);
     }
 
     private static JobSubmission submission(String digest) {
-        ReadonlyConfig options =
-                ReadonlyConfig.fromMap(
-                        Collections.<String, Object>emptyMap());
+        ReadonlyConfig options = ReadonlyConfig.fromMap(
+                Collections.<String, Object>emptyMap());
         JobDefinition definition =
                 new JobDefinition(
                         "protocol-test",

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryTest.java
@@ -1,0 +1,110 @@
+package com.link.up.server.infrastructure.persistence;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.SinkDefinition;
+import com.link.up.framework.job.SourceDefinition;
+import com.link.up.server.domain.JobAttemptStatus;
+import com.link.up.server.domain.JobExecutionState;
+import com.link.up.server.domain.JobSubmission;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobSnapshotFactory;
+import com.link.up.server.runtime.ServerJobStatus;
+import org.junit.Test;
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+public class FileJobRepositoryTest {
+
+    @Test
+    public void shouldReloadCheckpointAndRejectOlderRevision() throws Exception {
+        Path directory = Files.createTempDirectory("link-up-state-");
+        try {
+            FileJobRepository first = new FileJobRepository(directory, 20);
+            JobExecutionState state =
+                    new JobExecutionState("job-file-1", submission());
+            state.markSubmitted();
+            state.markQueued();
+            state.markRunning();
+
+            first.save(
+                    JobSnapshotFactory.create(state, null),
+                    JobExecutionMetadata.fromState(state));
+
+            JobExecutionState stale =
+                    new JobExecutionState("job-file-1", submission());
+            stale.markSubmitted();
+            first.save(
+                    JobSnapshotFactory.create(stale, null),
+                    JobExecutionMetadata.fromState(stale));
+
+            assertEquals(
+                    ServerJobStatus.RUNNING,
+                    first.get("job-file-1").getStatus());
+
+            FileJobRepository reopened =
+                    new FileJobRepository(directory, 20);
+            JobSnapshot snapshot = reopened.get("job-file-1");
+            assertNotNull(snapshot);
+            assertEquals(ServerJobStatus.RUNNING, snapshot.getStatus());
+
+            JobExecutionMetadata metadata =
+                    reopened.getMetadata("job-file-1");
+            assertEquals("external-file", metadata.getExternalExecutionId());
+            assertEquals("key-file", metadata.getIdempotencyKey());
+            assertEquals(1, metadata.getAttemptCount());
+            assertEquals(
+                    JobAttemptStatus.RUNNING,
+                    metadata.getAttempts().get(0).getStatus());
+            assertEquals(3L, metadata.getCheckpointVersion());
+
+            reopened.delete("job-file-1");
+            assertNull(reopened.get("job-file-1"));
+
+            FileJobRepository afterDelete =
+                    new FileJobRepository(directory, 20);
+            assertNull(afterDelete.get("job-file-1"));
+        } finally {
+            deleteDirectory(directory);
+        }
+    }
+
+    private static JobSubmission submission() {
+        ReadonlyConfig options = ReadonlyConfig.fromMap(
+                Collections.<String, Object>emptyMap());
+        JobDefinition definition =
+                new JobDefinition(
+                        "file-repository-test",
+                        new SourceDefinition("test-source", options),
+                        new SinkDefinition("test-sink", options),
+                        new ExecutionConfig(100, 1, 1, 1));
+        return new JobSubmission(
+                "external-file",
+                "key-file",
+                1,
+                "digest-file",
+                definition);
+    }
+
+    private static void deleteDirectory(Path directory) throws Exception {
+        if (directory == null || !Files.exists(directory)) {
+            return;
+        }
+        try (DirectoryStream<Path> stream =
+                     Files.newDirectoryStream(directory)) {
+            for (Path path : stream) {
+                Files.deleteIfExists(path);
+            }
+        }
+        Files.deleteIfExists(directory);
+    }
+}


### PR DESCRIPTION
## Summary

Completes Phase 7 of the Link-Up architecture refactor on top of the merged Phase 6 control-plane boundary.

This phase moves the standalone Worker from **process-memory-only control-plane state** to a durable, restart-explainable model, and introduces an explicit execution-attempt identity without enabling unsafe automatic retry.

```text
Job identity
    |
    +--> Attempt #1
            |
            +--> CREATED / QUEUED / RUNNING
            +--> SUCCEEDED / FAILED / CANCELED / LOST

JobApplicationService
    |
    +--> lifecycle checkpoint upsert
            |
            v
       JobRepository
            |
            v
       FileJobRepository
```

## What changed

### Explicit Job Attempt model

Introduce:

- `JobAttemptStatus`
- `JobExecutionAttempt`
- `JobAttemptMetadata`

A Job now owns execution-attempt history. Phase 7 creates exactly one attempt, but the model deliberately uses a list so a later safe-retry phase can append Attempt #2/#3 without replacing the stable `jobId`.

Each attempt records:

- `attemptNumber` / `attemptId`
- lifecycle status
- create / queue / start / end timestamps
- framework `runId` and job log file as values only
- failure type/message
- terminal `CommitSummary.retryAdvice` when available

Attempt state remains a pure domain model: it owns no Thread, Future, Semaphore, ExecutorService or framework `JobExecution` object.

### Additive Worker protocol fields

`JobResponse` now exposes:

```text
attemptCount
attempts[]
```

This is additive; existing Worker REST fields and routes are unchanged.

### Durable checkpoint repository

Add `FileJobRepository` and make it the default repository composed by standalone `FluxServer`.

Default state location:

```text
data/worker-state
```

Override with:

```text
--state-dir /var/lib/link-up/worker-state
```

`InMemoryJobRepository` remains available for unit tests and embedded scenarios.

The file repository uses:

- one versioned JSON checkpoint per Job
- URL-safe Base64 Job IDs for file names
- temporary-file writes
- flush + file-descriptor sync
- atomic move where supported, replace-move fallback otherwise
- fail-fast startup for malformed or unsupported checkpoint formats

The default local state directory is also ignored by Git.

### Checkpoint lifecycle

The application now persists/upserts control-plane state after meaningful changes:

```text
SUBMITTED
QUEUED
RUNNING
log identity bound
cancellation requested
terminal completion
```

If scheduling fails before the submission is fully accepted, the partial checkpoint and in-process idempotency registration are both rolled back.

### Monotonic checkpoint revision

Add an internal `checkpointVersion` separate from REST `stateVersion`.

- `stateVersion` continues to mean **business state transition version**.
- `checkpointVersion` increments for every persistable state mutation, including log binding and cancellation intent.
- repositories reject older checkpoint revisions.

This prevents an earlier asynchronously-computed RUNNING/log checkpoint from overwriting a newer terminal checkpoint.

### Startup recovery

`JobApplicationService` now scans repository entries during construction.

It restores persisted `externalExecutionId` / `idempotencyKey` indexes so a Worker restart does not silently create a duplicate Job for the same idempotent request.

Any persisted non-terminal Job is deterministically recovered as `LOST`:

```text
CREATED / SUBMITTED / QUEUED / RUNNING
                    |
                    v
                   LOST
```

Recovery:

- appends an auditable `worker-restart-recovery` transition
- changes the current non-terminal Attempt to `LOST`
- records `WorkerRestartRecovery` as the attempt failure type
- preserves the original Job identity and idempotency mapping
- does **not** automatically reschedule execution

### Why this PR does not auto-retry

A Worker restart does not prove that a retry is safe. A Sink may have:

- committed per batch
- partially committed data
- prepared but uncommitted a 2PC transaction
- failed before any write
- failed during final commit

Phase 7 records Attempt outcome and retry advice so a later phase can make an explicit retry-eligibility decision instead of equating `FAILED/LOST` with “run again”.

### Persistence boundary

The durable JSON format intentionally stores recovery/control-plane data only:

- Job identity/name/status/timestamps/errors
- external execution ID and idempotency key
- definition version and config digest
- cancellation intent
- lifecycle transition audit
- run/log identity
- execution-attempt history

It deliberately does **not** persist:

- `JobDefinition` / JobSpec
- Connector options, passwords or tokens
- Thread/Future/framework `JobExecution`
- continuously changing framework `JobMetrics`
- detailed Pipeline/Task/Channel metrics
- Table-DDL projections

Rich pipeline/task/channel views remain available in the current process. After restart, historical records are reconstructed as lifecycle/attempt history views with empty detailed runtime metrics.

### History retention

`historyLimit` now trims terminal history only. Non-terminal checkpoints are never removed merely because terminal history reached the retention limit.

### Tests / architecture guards

Add or extend tests for:

- Job lifecycle and Attempt #1 lifecycle staying aligned
- normal execution producing one SUCCEEDED Attempt
- restart recovery converting RUNNING checkpoint to LOST
- restored idempotency/external-execution lookup after recovery
- duplicate idempotent submit after restart returning the original Job without scheduling a second execution
- file repository reopen/reload
- stale checkpoint revision rejection
- checkpoint deletion
- `--state-dir` parsing
- Attempt domain state remaining free of local runtime ownership

## Compatibility

This PR preserves:

- existing `jobId` identity semantics
- Worker REST routes
- existing lifecycle status names
- queue/admission behavior
- cancellation behavior
- idempotency conflict rules
- Framework `JobGraph` / `ExecutionGraph` behavior
- Connector execution and commit behavior
- existing application/domain/infrastructure dependency direction

REST changes are additive (`attempts`, `attemptCount`).

## Non-goals

Phase 7 does not introduce:

- automatic retry
- automatic resume from a split/checkpoint position
- distributed/shared persistence
- multi-Worker failover
- durable detailed runtime metrics
- connector transaction recovery
- changes to source/sink execution algorithms

## Documentation

- add ADR-0007 for Worker checkpoints and execution attempts
- update Worker protocol documentation
- update deployment/operations guidance for persistent state directories
- update README architecture overview
- ignore the default local Worker state directory

## Validation

- branch is based directly on the Phase 6 merge commit on current `main`
- `main...refactor/phase7-attempt-recovery`: 2 commits ahead, 0 behind
- actual diff is scoped to Server control-plane reliability/docs; no Framework or Connector execution algorithm is changed
- standalone `FluxServer` composes `FileJobRepository`; `InMemoryJobRepository` remains for tests/embedding
- persisted DTO contains no `JobDefinition`, JobSpec, Connector options, passwords or tokens
- repository writes reject older `checkpointVersion` revisions
- recovery path never invokes `JobRuntimeScheduler.schedule(...)`
- GitHub currently reports no status checks and no Actions workflow runs for the branch head

A full Maven build was not available from the current execution environment, so this PR intentionally does **not** claim `mvn clean verify` has passed.

Recommended before marking ready:

```bash
mvn --batch-mode clean verify
```
