### PR TITLE
refactor: apply Link-Up code style to link-up-framework

### DIFF
--- a/link-up-framework/src/main/java/com/link/up/framework/execution/ExecutionCoordinator.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/ExecutionCoordinator.java
@@ -1,7 +1,6 @@
 package com.link.up.framework.execution;
 
 import com.link.up.framework.execution.task.ExecutionTask;
-import com.link.up.framework.execution.task.SinkTask;
 import com.link.up.framework.job.CommitSummary;
 import com.link.up.framework.metrics.JobMetrics;
 import com.link.up.framework.metrics.TaskMetrics;
@@ -14,28 +13,19 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 /**
- * Job Task 协调器。
+ * Coordinates local task execution for one pipeline.
  *
- * <p>任意一个 Task 失败时：
- *
- * <ol>
- *     <li>设置全局取消标记</li>
- *     <li>关闭或失败所有 Channel</li>
- *     <li>取消其他 Task</li>
- *     <li>中断执行线程</li>
- * </ol>
+ * <p>Sink tasks are submitted before source tasks. The first task failure
+ * cancels the shared runtime and interrupts outstanding tasks.</p>
  */
 public final class ExecutionCoordinator {
 
     private final TaskExecutor taskExecutor;
-
     private final CancellationToken cancellationToken;
-
     private final JobMetrics jobMetrics;
-
     private final ClassLoader classLoader;
-
     private final Runnable cancellationHook;
+    private final SinkCommitSummaryCollector commitSummaryCollector;
 
     public ExecutionCoordinator(
             TaskExecutor taskExecutor,
@@ -44,30 +34,23 @@ public final class ExecutionCoordinator {
             ClassLoader classLoader,
             Runnable cancellationHook) {
 
-        this.taskExecutor =
-                Objects.requireNonNull(
-                        taskExecutor,
-                        "taskExecutor must not be null");
-
-        this.cancellationToken =
-                Objects.requireNonNull(
-                        cancellationToken,
-                        "cancellationToken must not be null");
-
-        this.jobMetrics =
-                Objects.requireNonNull(
-                        jobMetrics,
-                        "jobMetrics must not be null");
-
-        this.classLoader =
-                Objects.requireNonNull(
-                        classLoader,
-                        "classLoader must not be null");
-
-        this.cancellationHook =
-                Objects.requireNonNull(
-                        cancellationHook,
-                        "cancellationHook must not be null");
+        this.taskExecutor = Objects.requireNonNull(
+                taskExecutor,
+                "taskExecutor must not be null");
+        this.cancellationToken = Objects.requireNonNull(
+                cancellationToken,
+                "cancellationToken must not be null");
+        this.jobMetrics = Objects.requireNonNull(
+                jobMetrics,
+                "jobMetrics must not be null");
+        this.classLoader = Objects.requireNonNull(
+                classLoader,
+                "classLoader must not be null");
+        this.cancellationHook = Objects.requireNonNull(
+                cancellationHook,
+                "cancellationHook must not be null");
+        this.commitSummaryCollector =
+                new SinkCommitSummaryCollector(jobMetrics);
     }
 
     public ExecutionOutcome execute(
@@ -77,133 +60,133 @@ public final class ExecutionCoordinator {
         Objects.requireNonNull(
                 sinkTasks,
                 "sinkTasks must not be null");
-
         Objects.requireNonNull(
                 sourceTasks,
                 "sourceTasks must not be null");
 
-        List<ExecutionTask> allTasks =
-                new ArrayList<ExecutionTask>();
+        List<ExecutionTask> orderedTasks =
+                orderedTasks(sinkTasks, sourceTasks);
 
-        /*
-         * 先启动 Sink，让消费者优先进入等待状态。
-         */
-        allTasks.addAll(sinkTasks);
-        allTasks.addAll(sourceTasks);
-
-        if (allTasks.isEmpty()) {
-            return new ExecutionOutcome(null, CommitSummary.empty());
+        if (orderedTasks.isEmpty()) {
+            return new ExecutionOutcome(
+                    null,
+                    CommitSummary.empty());
         }
 
         List<Future<TaskResult>> futures =
                 new ArrayList<Future<TaskResult>>(
-                        allTasks.size());
+                        orderedTasks.size());
 
         Throwable firstFailure = null;
 
         try {
-            for (ExecutionTask task : allTasks) {
-                TaskMetrics metrics =
-                        jobMetrics.registerTask(
-                                task.getTaskId());
-
-                TaskContext context =
-                        new TaskContext(
-                                task.getTaskId(),
-                                cancellationToken,
-                                metrics,
-                                classLoader);
-
-                futures.add(
-                        taskExecutor.submit(
-                                task,
-                                context));
-            }
-
-            for (int i = 0; i < allTasks.size(); i++) {
-                Future<TaskResult> completed =
-                        taskExecutor.takeCompleted();
-
-                try {
-                    TaskResult result =
-                            completed.get();
-
-                    if (result.isFailed()
-                            && firstFailure == null) {
-
-                        firstFailure =
-                                result.getFailure();
-
-                        cancelAll(
-                                allTasks,
-                                futures,
-                                firstFailure);
-                    }
-
-                } catch (CancellationException ignored) {
-                    // 由其他 Task 失败触发的取消。
-
-                } catch (ExecutionException exception) {
-                    if (firstFailure == null) {
-                        firstFailure =
-                                exception.getCause() == null
-                                        ? exception
-                                        : exception.getCause();
-
-                        cancelAll(
-                                allTasks,
-                                futures,
-                                firstFailure);
-                    }
-                }
-            }
-
+            submit(orderedTasks, futures);
+            firstFailure =
+                    awaitCompletion(
+                            orderedTasks,
+                            futures);
         } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
-
             firstFailure = interrupted;
-
             cancelAll(
-                    allTasks,
+                    orderedTasks,
                     futures,
                     interrupted);
-
-        } catch (Throwable throwable) {
-            firstFailure = throwable;
-
+        } catch (Throwable failure) {
+            firstFailure = failure;
             cancelAll(
-                    allTasks,
+                    orderedTasks,
                     futures,
-                    throwable);
+                    failure);
         }
 
-        return new ExecutionOutcome(firstFailure, summarizeCommits(sinkTasks));
+        return new ExecutionOutcome(
+                firstFailure,
+                commitSummaryCollector.collect(sinkTasks));
     }
 
-    private CommitSummary summarizeCommits(List<ExecutionTask> sinkTasks) {
-        int committed = 0, empty = 0, finished = 0;
-        long attempted = 0, written = 0, unknown = 0, failed = 0;
-        String retryAdvice = "This sink commits per task; verify already committed targets before retrying.";
-        com.link.up.api.sink.CommitScope scope = com.link.up.api.sink.CommitScope.TASK_LOCAL;
-        for (ExecutionTask task : sinkTasks)
-            if (task instanceof SinkTask) {
-                SinkTask sink = (SinkTask) task;
-                TaskMetrics m = jobMetrics.getTaskMetrics().get(sink.getTaskId());
-                long successful = m == null ? 0 : m.getSinkWriteSuccessRecordCount();
-                attempted += m == null ? 0 : m.getAttemptedRecordCount();
-                written += successful;
-                unknown += m == null ? 0 : m.getUnknownStateRecordCount();
-                failed += m == null ? 0 : m.getFailedRecordCount();
-                if (m != null && m.getState() == TaskState.FINISHED) finished++;
-                if (sink.isCommitted()) {
-                    committed++;
-                    if (successful == 0) empty++;
+    private List<ExecutionTask> orderedTasks(
+            List<ExecutionTask> sinkTasks,
+            List<ExecutionTask> sourceTasks) {
+
+        List<ExecutionTask> tasks =
+                new ArrayList<ExecutionTask>(
+                        sinkTasks.size()
+                                + sourceTasks.size());
+
+        tasks.addAll(sinkTasks);
+        tasks.addAll(sourceTasks);
+        return tasks;
+    }
+
+    private void submit(
+            List<ExecutionTask> tasks,
+            List<Future<TaskResult>> futures) {
+
+        for (ExecutionTask task : tasks) {
+            TaskMetrics metrics =
+                    jobMetrics.registerTask(
+                            task.getTaskId());
+
+            TaskContext context =
+                    new TaskContext(
+                            task.getTaskId(),
+                            cancellationToken,
+                            metrics,
+                            classLoader);
+
+            futures.add(
+                    taskExecutor.submit(
+                            task,
+                            context));
+        }
+    }
+
+    private Throwable awaitCompletion(
+            List<ExecutionTask> tasks,
+            List<Future<TaskResult>> futures)
+            throws InterruptedException {
+
+        Throwable firstFailure = null;
+
+        for (int index = 0;
+             index < tasks.size();
+             index++) {
+
+            Future<TaskResult> completed =
+                    taskExecutor.takeCompleted();
+
+            try {
+                TaskResult result = completed.get();
+
+                if (result.isFailed()
+                        && firstFailure == null) {
+                    firstFailure = result.getFailure();
+                    cancelAll(
+                            tasks,
+                            futures,
+                            firstFailure);
                 }
-                scope = sink.getCommitScope();
-                retryAdvice = sink.getRetryAdvice();
+            } catch (CancellationException ignored) {
+                // Cancellation was already initiated by another task.
+            } catch (ExecutionException executionFailure) {
+                if (firstFailure != null) {
+                    continue;
+                }
+
+                firstFailure =
+                        executionFailure.getCause() == null
+                                ? executionFailure
+                                : executionFailure.getCause();
+
+                cancelAll(
+                        tasks,
+                        futures,
+                        firstFailure);
             }
-        return new CommitSummary(sinkTasks.size(), finished, committed, empty, sinkTasks.size() - committed,
-                attempted, written, committed == 0 ? 0 : written, failed, unknown, scope, retryAdvice);
+        }
+
+        return firstFailure;
     }
 
     private void cancelAll(
@@ -216,16 +199,14 @@ public final class ExecutionCoordinator {
         try {
             cancellationHook.run();
         } catch (Throwable hookFailure) {
-            cause.addSuppressed(
-                    hookFailure);
+            cause.addSuppressed(hookFailure);
         }
 
         for (ExecutionTask task : tasks) {
             try {
                 task.cancel();
             } catch (Throwable cancelFailure) {
-                cause.addSuppressed(
-                        cancelFailure);
+                cause.addSuppressed(cancelFailure);
             }
         }
 
@@ -234,14 +215,16 @@ public final class ExecutionCoordinator {
         }
     }
 
-    /**
-     * Result of task coordination, including local sink commit observations.
-     */
+    /** Result of task coordination and local sink commit observations. */
     public static final class ExecutionOutcome {
+
         private final Throwable failure;
         private final CommitSummary commitSummary;
 
-        private ExecutionOutcome(Throwable failure, CommitSummary commitSummary) {
+        private ExecutionOutcome(
+                Throwable failure,
+                CommitSummary commitSummary) {
+
             this.failure = failure;
             this.commitSummary = commitSummary;
         }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/JobCommitSummaryMerger.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/JobCommitSummaryMerger.java
@@ -1,0 +1,69 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.framework.job.CommitSummary;
+import com.link.up.framework.job.PipelineResult;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Aggregates pipeline commit observations into one job-level summary. */
+final class JobCommitSummaryMerger {
+
+    private static final String RETRY_ADVICE =
+            "This sink commits per task; inspect unknown batch states before retrying.";
+
+    private JobCommitSummaryMerger() {
+    }
+
+    static CommitSummary merge(List<PipelineResult> results) {
+        Objects.requireNonNull(
+                results,
+                "results must not be null");
+
+        int total = 0;
+        int finished = 0;
+        int committed = 0;
+        int empty = 0;
+        int failed = 0;
+        long attempted = 0L;
+        long written = 0L;
+        long committedRecords = 0L;
+        long failedRecords = 0L;
+        long unknown = 0L;
+
+        for (PipelineResult result : results) {
+            CommitSummary summary =
+                    Objects.requireNonNull(
+                            result,
+                            "results must not contain null values")
+                            .getCommitSummary();
+
+            total += summary.getTotalTaskCount();
+            finished += summary.getFinishedTaskCount();
+            committed += summary.getCommittedTaskCount();
+            empty += summary.getEmptyCommittedTaskCount();
+            failed += summary.getFailedOrUncommittedTaskCount();
+            attempted += summary.getAttemptedRecordCount();
+            written += summary.getSuccessfullyWrittenRecordCount();
+            committedRecords +=
+                    summary.getSuccessfullyCommittedRecordCount();
+            failedRecords += summary.getFailedRecordCount();
+            unknown += summary.getUnknownStateRecordCount();
+        }
+
+        return new CommitSummary(
+                total,
+                finished,
+                committed,
+                empty,
+                failed,
+                attempted,
+                written,
+                committedRecords,
+                failedRecords,
+                unknown,
+                CommitScope.TASK_LOCAL,
+                RETRY_ADVICE);
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/JobCoordinator.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/JobCoordinator.java
@@ -1,25 +1,20 @@
 package com.link.up.framework.execution;
 
 import com.link.up.api.dirtydata.DirtyDataSummary;
-import com.link.up.api.sink.CommitScope;
-import com.link.up.framework.job.CommitSummary;
 import com.link.up.framework.job.JobResult;
 import com.link.up.framework.job.JobStatus;
-import com.link.up.framework.job.PipelineResult;
 import com.link.up.framework.planner.JobGraph;
 import org.apache.logging.log4j.CloseableThreadContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
  * Coordinates the lifecycle of one {@link ExecutionGraph}.
  *
- * <p>The coordinator owns job-level lifecycle transitions, failure policy and
- * result aggregation. Pipeline concurrency belongs to {@link PipelineScheduler}
- * and pipeline execution belongs to {@link PipelineExecutor}.
+ * <p>Pipeline concurrency belongs to {@link PipelineScheduler}; pipeline work
+ * belongs to {@link PipelineExecutor}.</p>
  */
 final class JobCoordinator {
 
@@ -35,55 +30,41 @@ final class JobCoordinator {
             PipelineScheduler pipelineScheduler,
             PipelineExecutor pipelineExecutor) {
 
-        this.executionGraph =
-                Objects.requireNonNull(
-                        executionGraph,
-                        "executionGraph must not be null");
-        this.pipelineScheduler =
-                Objects.requireNonNull(
-                        pipelineScheduler,
-                        "pipelineScheduler must not be null");
-        this.pipelineExecutor =
-                Objects.requireNonNull(
-                        pipelineExecutor,
-                        "pipelineExecutor must not be null");
+        this.executionGraph = Objects.requireNonNull(
+                executionGraph,
+                "executionGraph must not be null");
+        this.pipelineScheduler = Objects.requireNonNull(
+                pipelineScheduler,
+                "pipelineScheduler must not be null");
+        this.pipelineExecutor = Objects.requireNonNull(
+                pipelineExecutor,
+                "pipelineExecutor must not be null");
     }
 
     JobResult execute() {
         JobGraph jobGraph = executionGraph.getJobGraph();
-        String jobName = jobGraph.getJobName();
-        String runId = executionGraph.getRunId();
-        String jobLogFile = executionGraph.getJobLogFile();
-
         executionGraph.markRunning();
 
         try (CloseableThreadContext.Instance ignored =
-                     openJobLogContext(
-                             runId,
-                             jobName,
-                             jobLogFile)) {
+                     openJobLogContext(jobGraph)) {
 
-            LOG.info(
-                    "Job started: jobName={}, runId={}, jobLogFile={}",
-                    jobName,
-                    runId,
-                    jobLogFile);
+            logStarted(jobGraph);
 
             PipelineScheduleResult scheduleResult =
                     pipelineScheduler.schedule(
                             jobGraph.getPipelineGraphs(),
-                            jobGraph
-                                    .getExecutionConfig()
+                            jobGraph.getExecutionConfig()
                                     .getPipelineParallelism(),
                             executionGraph.getCancellationToken(),
                             pipelineExecutor);
 
             JobResult result =
-                    createJobResult(scheduleResult);
+                    createJobResult(
+                            jobGraph,
+                            scheduleResult);
 
             executionGraph.complete(result);
             logResult(result);
-
             return result;
 
         } catch (RuntimeException failure) {
@@ -96,31 +77,46 @@ final class JobCoordinator {
     }
 
     private JobResult createJobResult(
+            JobGraph jobGraph,
             PipelineScheduleResult scheduleResult) {
 
         Objects.requireNonNull(
                 scheduleResult,
                 "scheduleResult must not be null");
 
-        JobGraph jobGraph = executionGraph.getJobGraph();
         Throwable failure = scheduleResult.getFailure();
-        JobStatus status =
-                failure != null
-                        ? JobStatus.FAILED
-                        : executionGraph.isCancellationRequested()
-                        ? JobStatus.CANCELED
-                        : JobStatus.SUCCEEDED;
 
         return new JobResult(
                 jobGraph.getJobName(),
-                status,
+                resolveStatus(failure),
                 executionGraph.getStartTimeMillis(),
                 System.currentTimeMillis(),
                 executionGraph.getMetrics(),
                 failure,
-                merge(scheduleResult.getPipelineResults()),
+                JobCommitSummaryMerger.merge(
+                        scheduleResult.getPipelineResults()),
                 DirtyDataSummary.empty(),
                 scheduleResult.getPipelineResults());
+    }
+
+    private JobStatus resolveStatus(Throwable failure) {
+        if (failure != null) {
+            return JobStatus.FAILED;
+        }
+
+        if (executionGraph.isCancellationRequested()) {
+            return JobStatus.CANCELED;
+        }
+
+        return JobStatus.SUCCEEDED;
+    }
+
+    private void logStarted(JobGraph jobGraph) {
+        LOG.info(
+                "Job started: jobName={}, runId={}, jobLogFile={}",
+                jobGraph.getJobName(),
+                executionGraph.getRunId(),
+                executionGraph.getJobLogFile());
     }
 
     private void logResult(JobResult result) {
@@ -129,73 +125,31 @@ final class JobCoordinator {
                     "Job finished: status={}, durationMillis={}",
                     result.getStatus(),
                     result.getDurationMillis());
-        } else if (result.getFailure() != null) {
+            return;
+        }
+
+        if (result.getFailure() != null) {
             LOG.error(
                     "Job finished: status={}, durationMillis={}",
                     result.getStatus(),
                     result.getDurationMillis(),
                     result.getFailure());
-        } else {
-            LOG.warn(
-                    "Job finished: status={}, durationMillis={}",
-                    result.getStatus(),
-                    result.getDurationMillis());
-        }
-    }
-
-    private CommitSummary merge(
-            List<PipelineResult> results) {
-
-        int total = 0;
-        int finished = 0;
-        int committed = 0;
-        int empty = 0;
-        int failed = 0;
-        long attempted = 0L;
-        long written = 0L;
-        long committedRows = 0L;
-        long failedRows = 0L;
-        long unknown = 0L;
-
-        for (PipelineResult result : results) {
-            CommitSummary summary = result.getCommitSummary();
-
-            total += summary.getTotalTaskCount();
-            finished += summary.getFinishedTaskCount();
-            committed += summary.getCommittedTaskCount();
-            empty += summary.getEmptyCommittedTaskCount();
-            failed += summary.getFailedOrUncommittedTaskCount();
-            attempted += summary.getAttemptedRecordCount();
-            written += summary.getSuccessfullyWrittenRecordCount();
-            committedRows += summary.getSuccessfullyCommittedRecordCount();
-            failedRows += summary.getFailedRecordCount();
-            unknown += summary.getUnknownStateRecordCount();
+            return;
         }
 
-        return new CommitSummary(
-                total,
-                finished,
-                committed,
-                empty,
-                failed,
-                attempted,
-                written,
-                committedRows,
-                failedRows,
-                unknown,
-                CommitScope.TASK_LOCAL,
-                "This sink commits per task; inspect unknown batch states before retrying.");
+        LOG.warn(
+                "Job finished: status={}, durationMillis={}",
+                result.getStatus(),
+                result.getDurationMillis());
     }
 
-    private static CloseableThreadContext.Instance openJobLogContext(
-            String runId,
-            String jobName,
-            String jobLogFile) {
+    private CloseableThreadContext.Instance openJobLogContext(
+            JobGraph jobGraph) {
 
         return CloseableThreadContext
-                .put("runId", runId)
-                .put("jobId", runId)
-                .put("jobName", jobName)
-                .put("jobLogFile", jobLogFile);
+                .put("runId", executionGraph.getRunId())
+                .put("jobId", executionGraph.getRunId())
+                .put("jobName", jobGraph.getJobName())
+                .put("jobLogFile", executionGraph.getJobLogFile());
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/LocalFluxEngine.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/LocalFluxEngine.java
@@ -14,9 +14,7 @@ import org.apache.logging.log4j.Logger;
 import java.nio.file.Path;
 import java.util.Objects;
 
-/**
- * Local offline Link-Up execution engine.
- */
+/** Local offline Link-Up execution engine and composition boundary. */
 public final class LocalFluxEngine
         implements FluxEngine {
 
@@ -32,6 +30,7 @@ public final class LocalFluxEngine
             ClassLoader classLoader,
             ConnectorPreparer connectorPreparer,
             JobPlanner jobPlanner) {
+
         this(
                 classLoader,
                 connectorPreparer,
@@ -60,69 +59,47 @@ public final class LocalFluxEngine
     public static LocalFluxEngine create(
             ClassLoader classLoader) {
 
-        ClassLoader effectiveClassLoader =
-                classLoader == null
-                        ? Thread.currentThread()
-                                .getContextClassLoader()
-                        : classLoader;
+        ClassLoader effective =
+                effectiveClassLoader(classLoader);
 
-        FactoryRegistry registry =
-                FactoryRegistry.discover(
-                        effectiveClassLoader);
-        ConnectorPreparer preparer =
-                new ConnectorPreparer(
-                        registry,
-                        effectiveClassLoader);
-        JobPlanner planner = new JobPlanner();
-
-        return new LocalFluxEngine(
-                effectiveClassLoader,
-                preparer,
-                planner,
-                registry);
+        return assemble(
+                effective,
+                FactoryRegistry.discover(effective));
     }
 
     public static LocalFluxEngine create(
             ClassLoader classLoader,
             Path... pluginDirectories) {
 
-        ClassLoader effectiveClassLoader =
-                classLoader == null
-                        ? Thread.currentThread()
-                                .getContextClassLoader()
-                        : classLoader;
+        ClassLoader effective =
+                effectiveClassLoader(classLoader);
 
-        FactoryRegistry registry =
+        return assemble(
+                effective,
                 FactoryRegistry.discover(
-                        effectiveClassLoader,
-                        pluginDirectories);
-
-        return new LocalFluxEngine(
-                effectiveClassLoader,
-                new ConnectorPreparer(
-                        registry,
-                        effectiveClassLoader),
-                new JobPlanner(),
-                registry);
+                        effective,
+                        pluginDirectories));
     }
 
     @Override
-    public JobResult execute(
-            JobDefinition definition)
+    public JobResult execute(JobDefinition definition)
             throws Exception {
-        return execute(definition, null);
+
+        return execute(
+                definition,
+                null);
     }
 
     /**
-     * Exposes the active JobExecution to the local server so cancellation can
-     * be propagated after planning and before/during task execution.
+     * Executes one prepared job and exposes the active execution to an optional
+     * listener used by the local Worker control plane.
      */
     public JobResult execute(
             JobDefinition definition,
             JobExecutionListener listener)
             throws Exception {
 
-        Objects.requireNonNull(
+        JobDefinition job = Objects.requireNonNull(
                 definition,
                 "definition must not be null");
 
@@ -130,54 +107,30 @@ public final class LocalFluxEngine
                 System.currentTimeMillis();
         String runId =
                 JobLogFileName.createJobId(
-                        definition.getName(),
+                        job.getName(),
                         logIdentityTimeMillis);
         String jobLogFile =
                 JobLogFileName.create(
-                        definition.getName(),
+                        job.getName(),
                         logIdentityTimeMillis);
 
         try (CloseableThreadContext.Instance ignored =
-                     CloseableThreadContext
-                             .put("runId", runId)
-                             .put("jobId", runId)
-                             .put("jobName", definition.getName())
-                             .put("jobLogFile", jobLogFile)) {
+                     openLogContext(
+                             job,
+                             runId,
+                             jobLogFile)) {
 
-            if (listener != null) {
-                listener.onJobLogCreated(
-                        runId,
-                        jobLogFile);
-            }
+            notifyJobLogCreated(
+                    listener,
+                    runId,
+                    jobLogFile);
 
-            LOG.info(
-                    "Job preparation started: jobName={}, runId={}",
-                    definition.getName(),
-                    runId);
+            JobGraph jobGraph =
+                    prepareAndPlan(
+                            job,
+                            runId);
 
-            PreparedJob preparedJob;
-            JobGraph jobGraph;
-
-            try {
-                preparedJob = connectorPreparer.prepare(definition);
-                jobGraph = jobPlanner.plan(preparedJob);
-            } catch (Exception failure) {
-                LOG.error(
-                        "Job preparation failed: jobName={}, runId={}",
-                        definition.getName(),
-                        runId,
-                        failure);
-                throw failure;
-            } catch (Error failure) {
-                LOG.error(
-                        "Job preparation failed: jobName={}, runId={}",
-                        definition.getName(),
-                        runId,
-                        failure);
-                throw failure;
-            }
-
-            JobExecution jobExecution =
+            JobExecution execution =
                     new JobExecution(
                             jobGraph,
                             classLoader,
@@ -185,21 +138,113 @@ public final class LocalFluxEngine
                             runId,
                             jobLogFile);
 
-            if (listener != null) {
-                listener.onJobExecutionCreated(jobExecution);
-            }
+            notifyJobExecutionCreated(
+                    listener,
+                    execution);
 
-            return jobExecution.execute();
+            return execution.execute();
 
         } finally {
-            if (registry != null) {
-                registry.close();
-            }
+            closeRegistry();
         }
     }
 
     @Override
     public void close() {
+        closeRegistry();
+    }
+
+    private JobGraph prepareAndPlan(
+            JobDefinition definition,
+            String runId)
+            throws Exception {
+
+        LOG.info(
+                "Job preparation started: jobName={}, runId={}",
+                definition.getName(),
+                runId);
+
+        try {
+            PreparedJob preparedJob =
+                    connectorPreparer.prepare(
+                            definition);
+
+            return jobPlanner.plan(preparedJob);
+
+        } catch (Exception failure) {
+            LOG.error(
+                    "Job preparation failed: jobName={}, runId={}",
+                    definition.getName(),
+                    runId,
+                    failure);
+            throw failure;
+
+        } catch (Error failure) {
+            LOG.error(
+                    "Job preparation failed: jobName={}, runId={}",
+                    definition.getName(),
+                    runId,
+                    failure);
+            throw failure;
+        }
+    }
+
+    private static LocalFluxEngine assemble(
+            ClassLoader classLoader,
+            FactoryRegistry registry) {
+
+        return new LocalFluxEngine(
+                classLoader,
+                new ConnectorPreparer(
+                        registry,
+                        classLoader),
+                new JobPlanner(),
+                registry);
+    }
+
+    private static ClassLoader effectiveClassLoader(
+            ClassLoader classLoader) {
+
+        return classLoader == null
+                ? Thread.currentThread()
+                .getContextClassLoader()
+                : classLoader;
+    }
+
+    private static CloseableThreadContext.Instance openLogContext(
+            JobDefinition definition,
+            String runId,
+            String jobLogFile) {
+
+        return CloseableThreadContext
+                .put("runId", runId)
+                .put("jobId", runId)
+                .put("jobName", definition.getName())
+                .put("jobLogFile", jobLogFile);
+    }
+
+    private static void notifyJobLogCreated(
+            JobExecutionListener listener,
+            String runId,
+            String jobLogFile) {
+
+        if (listener != null) {
+            listener.onJobLogCreated(
+                    runId,
+                    jobLogFile);
+        }
+    }
+
+    private static void notifyJobExecutionCreated(
+            JobExecutionListener listener,
+            JobExecution execution) {
+
+        if (listener != null) {
+            listener.onJobExecutionCreated(execution);
+        }
+    }
+
+    private void closeRegistry() {
         if (registry != null) {
             registry.close();
         }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/LocalPipelineScheduler.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/LocalPipelineScheduler.java
@@ -6,6 +6,7 @@ import com.link.up.framework.planner.PipelineGraph;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
@@ -13,13 +14,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-/**
- * Local bounded-concurrency scheduler for {@link PipelineGraph} instances.
- *
- * <p>The scheduler decides how many pipelines may run concurrently and collects
- * their outcomes in completion order. The actual pipeline work is delegated to
- * {@link PipelineExecutor}.
- */
+/** Local bounded-concurrency scheduler for immutable pipeline graphs. */
 final class LocalPipelineScheduler
         implements PipelineScheduler {
 
@@ -28,7 +23,144 @@ final class LocalPipelineScheduler
             List<PipelineGraph<?>> pipelineGraphs,
             int parallelism,
             CancellationToken cancellationToken,
-            final PipelineExecutor pipelineExecutor) {
+            PipelineExecutor pipelineExecutor) {
+
+        validate(
+                pipelineGraphs,
+                parallelism,
+                cancellationToken,
+                pipelineExecutor);
+
+        if (pipelineGraphs.isEmpty()) {
+            return PipelineScheduleResult.empty();
+        }
+
+        int threadCount =
+                Math.min(
+                        parallelism,
+                        pipelineGraphs.size());
+
+        ExecutorService pool =
+                Executors.newFixedThreadPool(
+                        threadCount);
+
+        try {
+            CompletionService<PipelineResult> completionService =
+                    new ExecutorCompletionService<PipelineResult>(
+                            pool);
+
+            List<Future<PipelineResult>> submitted =
+                    submitAll(
+                            pipelineGraphs,
+                            pipelineExecutor,
+                            completionService);
+
+            return collect(
+                    submitted,
+                    completionService,
+                    cancellationToken);
+
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private PipelineScheduleResult collect(
+            List<Future<PipelineResult>> submitted,
+            CompletionService<PipelineResult> completionService,
+            CancellationToken cancellationToken) {
+
+        List<PipelineResult> results =
+                new ArrayList<PipelineResult>();
+        Throwable firstFailure = null;
+
+        for (int index = 0;
+             index < submitted.size();
+             index++) {
+
+            try {
+                PipelineResult result =
+                        completionService.take().get();
+
+                if (result == null) {
+                    throw new IllegalStateException(
+                            "PipelineExecutor returned a null result");
+                }
+
+                results.add(result);
+
+                if (result.getFailure() != null
+                        && firstFailure == null) {
+                    firstFailure = result.getFailure();
+                    cancellationToken.cancel(firstFailure);
+                }
+
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+
+                if (firstFailure == null) {
+                    firstFailure = interrupted;
+                    cancellationToken.cancel(interrupted);
+                }
+
+                cancelSubmitted(submitted);
+                break;
+
+            } catch (ExecutionException executionFailure) {
+                Throwable failure =
+                        executionFailure.getCause() == null
+                                ? executionFailure
+                                : executionFailure.getCause();
+
+                if (firstFailure == null) {
+                    firstFailure = failure;
+                    cancellationToken.cancel(failure);
+                }
+            }
+        }
+
+        return new PipelineScheduleResult(
+                results,
+                firstFailure);
+    }
+
+    private List<Future<PipelineResult>> submitAll(
+            List<PipelineGraph<?>> pipelineGraphs,
+            final PipelineExecutor pipelineExecutor,
+            CompletionService<PipelineResult> completionService) {
+
+        List<Future<PipelineResult>> submitted =
+                new ArrayList<Future<PipelineResult>>(
+                        pipelineGraphs.size());
+
+        for (final PipelineGraph<?> pipelineGraph : pipelineGraphs) {
+            submitted.add(
+                    completionService.submit(
+                            new Callable<PipelineResult>() {
+                                @Override
+                                public PipelineResult call() {
+                                    return pipelineExecutor.execute(
+                                            pipelineGraph);
+                                }
+                            }));
+        }
+
+        return submitted;
+    }
+
+    private void cancelSubmitted(
+            List<Future<PipelineResult>> submitted) {
+
+        for (Future<PipelineResult> future : submitted) {
+            future.cancel(true);
+        }
+    }
+
+    private void validate(
+            List<PipelineGraph<?>> pipelineGraphs,
+            int parallelism,
+            CancellationToken cancellationToken,
+            PipelineExecutor pipelineExecutor) {
 
         Objects.requireNonNull(
                 pipelineGraphs,
@@ -45,106 +177,10 @@ final class LocalPipelineScheduler
                     "parallelism must be greater than 0");
         }
 
-        if (pipelineGraphs.isEmpty()) {
-            return PipelineScheduleResult.empty();
-        }
-
         for (PipelineGraph<?> pipelineGraph : pipelineGraphs) {
             Objects.requireNonNull(
                     pipelineGraph,
                     "pipelineGraphs must not contain null values");
-        }
-
-        int threadCount =
-                Math.min(
-                        parallelism,
-                        pipelineGraphs.size());
-
-        ExecutorService pool =
-                Executors.newFixedThreadPool(threadCount);
-        CompletionService<PipelineResult> completionService =
-                new ExecutorCompletionService<PipelineResult>(pool);
-        List<Future<PipelineResult>> submitted =
-                new ArrayList<Future<PipelineResult>>(
-                        pipelineGraphs.size());
-        List<PipelineResult> results =
-                new ArrayList<PipelineResult>();
-        Throwable firstFailure = null;
-
-        try {
-            for (final PipelineGraph<?> pipelineGraph : pipelineGraphs) {
-                submitted.add(
-                        completionService.submit(
-                                new java.util.concurrent.Callable<PipelineResult>() {
-                                    @Override
-                                    public PipelineResult call() {
-                                        return pipelineExecutor.execute(
-                                                pipelineGraph);
-                                    }
-                                }));
-            }
-
-            for (int index = 0;
-                 index < submitted.size();
-                 index++) {
-
-                try {
-                    PipelineResult result =
-                            completionService
-                                    .take()
-                                    .get();
-
-                    if (result == null) {
-                        throw new IllegalStateException(
-                                "PipelineExecutor returned a null result");
-                    }
-
-                    results.add(result);
-
-                    if (result.getFailure() != null
-                            && firstFailure == null) {
-                        firstFailure = result.getFailure();
-                        cancellationToken.cancel(firstFailure);
-                    }
-
-                } catch (InterruptedException interrupted) {
-                    Thread.currentThread().interrupt();
-
-                    if (firstFailure == null) {
-                        firstFailure = interrupted;
-                        cancellationToken.cancel(interrupted);
-                    }
-
-                    cancelSubmitted(submitted);
-                    break;
-
-                } catch (ExecutionException executionFailure) {
-                    Throwable failure =
-                            executionFailure.getCause() == null
-                                    ? executionFailure
-                                    : executionFailure.getCause();
-
-                    if (firstFailure == null) {
-                        firstFailure = failure;
-                        cancellationToken.cancel(failure);
-                    }
-                }
-            }
-
-        } finally {
-            pool.shutdownNow();
-        }
-
-        return new PipelineScheduleResult(
-                results,
-                firstFailure);
-    }
-
-    private void cancelSubmitted(
-            List<Future<PipelineResult>> submitted) {
-
-        for (Future<PipelineResult> future : submitted) {
-            future.cancel(true);
         }
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineExecution.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineExecution.java
@@ -1,284 +1,140 @@
 package com.link.up.framework.execution;
 
-import com.link.up.api.sink.TableDdl;
 import com.link.up.api.source.SourceSplit;
-import com.link.up.api.table.catalog.CatalogTable;
-import com.link.up.api.table.type.FluxRow;
-import com.link.up.framework.channel.ChannelWriter;
-import com.link.up.framework.channel.DataChannel;
-import com.link.up.framework.channel.InputGate;
-import com.link.up.framework.channel.LocalDataChannel;
-import com.link.up.framework.channel.OutputGate;
-import com.link.up.framework.channel.RecordEnvelope;
-import com.link.up.framework.connector.PreparedSink;
-import com.link.up.framework.execution.split.LocalSplitQueue;
-import com.link.up.framework.execution.split.SplitProvider;
 import com.link.up.framework.execution.task.ExecutionTask;
-import com.link.up.framework.execution.task.SinkTask;
-import com.link.up.framework.execution.task.SourceTask;
-import com.link.up.framework.job.CommitSummary;
 import com.link.up.framework.job.ExecutionConfig;
 import com.link.up.framework.job.PipelineResult;
 import com.link.up.framework.job.PipelineStatus;
-import com.link.up.framework.job.SplitAssignmentMode;
 import com.link.up.framework.metrics.JobMetrics;
 import com.link.up.framework.planner.PipelineGraph;
-import com.link.up.framework.planner.SinkTaskPlan;
-import com.link.up.framework.planner.SourceTaskPlan;
-import com.link.up.framework.routing.Partitioner;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
- * Runtime execution of one immutable PipelineGraph.
+ * Executes one immutable {@link PipelineGraph}.
  *
- * <p>Mutable ownership state belongs here, not in the planner model. Dynamic
- * split assignment therefore creates one runtime-local SplitProvider shared by
- * the source tasks of this pipeline.
+ * <p>This class coordinates the pipeline workflow only. Mutable channels and
+ * split queues belong to {@link PipelineRuntimeResources}; task materialization
+ * belongs to {@link PipelineTaskFactory}.</p>
  */
 final class PipelineExecution<SplitT extends SourceSplit> {
 
     private final PipelineGraph<SplitT> graph;
     private final ExecutionConfig config;
-    private final CancellationToken token;
+    private final CancellationToken cancellationToken;
     private final JobMetrics metrics;
-    private final ClassLoader loader;
+    private final ClassLoader classLoader;
     private final String jobName;
     private final long runId;
-    private final SplitProvider<SplitT> splitProvider;
 
     PipelineExecution(
             PipelineGraph<SplitT> graph,
             ExecutionConfig config,
-            CancellationToken token,
+            CancellationToken cancellationToken,
             JobMetrics metrics,
-            ClassLoader loader,
+            ClassLoader classLoader,
             String jobName,
             long runId) {
 
-        this.graph = graph;
-        this.config = config;
-        this.token = token;
-        this.metrics = metrics;
-        this.loader = loader;
-        this.jobName = jobName;
-        this.runId = runId;
-        this.splitProvider =
-                graph.getSplitAssignmentMode()
-                        == SplitAssignmentMode.DYNAMIC
-                        ? new LocalSplitQueue<SplitT>(
-                                graph.getSourceSplits())
-                        : null;
-    }
+        this.graph = Objects.requireNonNull(
+                graph,
+                "graph must not be null");
+        this.config = Objects.requireNonNull(
+                config,
+                "config must not be null");
+        this.cancellationToken = Objects.requireNonNull(
+                cancellationToken,
+                "cancellationToken must not be null");
+        this.metrics = Objects.requireNonNull(
+                metrics,
+                "metrics must not be null");
+        this.classLoader = Objects.requireNonNull(
+                classLoader,
+                "classLoader must not be null");
+        this.jobName = Objects.requireNonNull(
+                jobName,
+                "jobName must not be null");
 
-    private static void fail(
-            List<DataChannel<RecordEnvelope<FluxRow>>> channels,
-            Throwable cause) {
-        for (DataChannel<RecordEnvelope<FluxRow>> channel : channels) {
-            channel.fail(
-                    cause == null
-                            ? new IllegalStateException(
-                                    "Pipeline cancelled")
-                            : cause);
+        if (runId < 0L) {
+            throw new IllegalArgumentException(
+                    "runId must not be negative");
         }
+        this.runId = runId;
     }
 
     PipelineResult execute() {
-        List<DataChannel<RecordEnvelope<FluxRow>>> channels =
-                new ArrayList<DataChannel<RecordEnvelope<FluxRow>>>();
+        try (PipelineRuntimeResources<SplitT> resources =
+                     PipelineRuntimeResources.open(
+                             graph,
+                             config,
+                             metrics)) {
 
-        try {
-            if (splitProvider != null) {
-                metrics.registerSplitProvider(splitProvider);
-            }
+            PipelineTaskFactory<SplitT> taskFactory =
+                    new PipelineTaskFactory<SplitT>(
+                            graph,
+                            resources.getChannels(),
+                            resources.getSplitProvider());
 
-            for (int i = 0;
-                 i < graph.getSinkTaskPlans().size();
-                 i++) {
+            List<ExecutionTask> sinkTasks =
+                    taskFactory.createSinkTasks();
+            List<ExecutionTask> sourceTasks =
+                    taskFactory.createSourceTasks();
 
-                LocalDataChannel<RecordEnvelope<FluxRow>> channel =
-                        new LocalDataChannel<RecordEnvelope<FluxRow>>(
-                                graph.getPipelineId()
-                                        + "-source-to-sink-"
-                                        + i,
-                                config.getMaxBufferedBatches(),
-                                config.getMaxBufferedRecords(),
-                                config.getMaxBufferedBytes(),
-                                config.getMaxRecordsPerSecond(),
-                                config.getMaxBytesPerSecond(),
-                                graph.getSourceTaskPlans().size());
+            ExecutionCoordinator.ExecutionOutcome outcome =
+                    executeTasks(
+                            sinkTasks,
+                            sourceTasks,
+                            resources);
 
-                channels.add(channel);
-                metrics.registerChannel(channel.getMetrics());
-            }
-
-            List<ExecutionTask> sinks =
-                    new ArrayList<ExecutionTask>();
-
-            for (int i = 0; i < channels.size(); i++) {
-                sinks.add(
-                        new SinkTask(
-                                graph.getSinkTaskPlans().get(i),
-                                new InputGate<RecordEnvelope<FluxRow>>(
-                                        channels.get(i).openReader())));
-            }
-
-            List<ExecutionTask> sources =
-                    new ArrayList<ExecutionTask>();
-
-            for (SourceTaskPlan<SplitT> source :
-                    graph.getSourceTaskPlans()) {
-                sources.add(
-                        createSource(
-                                source,
-                                channels));
-            }
-
-            try (TaskExecutor executor =
-                         new TaskExecutor(
-                                 sinks.size() + sources.size(),
-                                 "link-up-" + graph.getPipelineId(),
-                                 jobName,
-                                 runId)) {
-
-                ExecutionCoordinator outcomeCoordinator =
-                        new ExecutionCoordinator(
-                                executor,
-                                token,
-                                metrics,
-                                loader,
-                                new Runnable() {
-                                    public void run() {
-                                        fail(
-                                                channels,
-                                                token.getCause());
-                                        cancelSplitProvider();
-                                    }
-                                });
-
-                ExecutionCoordinator.ExecutionOutcome outcome =
-                        outcomeCoordinator.execute(
-                                sinks,
-                                sources);
-
-                if (outcome.getFailure() != null) {
-                    return createPipelineResult(
-                            token.isCancelled()
-                                    ? PipelineStatus.CANCELED
-                                    : PipelineStatus.FAILED,
-                            outcome.getCommitSummary(),
-                            outcome.getFailure());
-                }
-
-                return createPipelineResult(
-                        PipelineStatus.SUCCEEDED,
-                        outcome.getCommitSummary(),
-                        null);
-            }
-
-        } finally {
-            for (DataChannel<RecordEnvelope<FluxRow>> channel :
-                    channels) {
-                try {
-                    channel.close();
-                } catch (Throwable ignored) {
-                    // Best-effort close after execution outcome is known.
-                }
-            }
+            return PipelineResultFactory.create(
+                    graph,
+                    statusOf(outcome),
+                    outcome.getCommitSummary(),
+                    outcome.getFailure());
         }
     }
 
-    private PipelineResult createPipelineResult(
-            PipelineStatus status,
-            CommitSummary commitSummary,
-            Throwable failure) {
+    private ExecutionCoordinator.ExecutionOutcome executeTasks(
+            List<ExecutionTask> sinkTasks,
+            List<ExecutionTask> sourceTasks,
+            final PipelineRuntimeResources<SplitT> resources) {
 
-        SourceTaskPlan<SplitT> sourceTaskPlan =
-                graph.getSourceTaskPlans().get(0);
-        SinkTaskPlan sinkTaskPlan =
-                graph.getSinkTaskPlans().get(0);
+        try (TaskExecutor taskExecutor =
+                     new TaskExecutor(
+                             sinkTasks.size() + sourceTasks.size(),
+                             "link-up-" + graph.getPipelineId(),
+                             jobName,
+                             runId)) {
 
-        String sourceIdentifier =
-                sourceTaskPlan
-                        .getPreparedSource()
-                        .getFactoryIdentifier();
+            ExecutionCoordinator coordinator =
+                    new ExecutionCoordinator(
+                            taskExecutor,
+                            cancellationToken,
+                            metrics,
+                            classLoader,
+                            new Runnable() {
+                                @Override
+                                public void run() {
+                                    resources.cancel(
+                                            cancellationToken.getCause());
+                                }
+                            });
 
-        PreparedSink preparedSink =
-                sinkTaskPlan.getPreparedSink();
-        String sinkIdentifier =
-                preparedSink.getFactoryIdentifier();
-
-        CatalogTable targetTable =
-                preparedSink
-                        .getMetadata()
-                        .getTargetTable(
-                                graph.getDataSetPath());
-        TableDdl tableDdl =
-                preparedSink
-                        .getMetadata()
-                        .getTableDdl(
-                                graph.getDataSetPath());
-
-        String sinkTablePath = "-";
-        if (targetTable != null
-                && targetTable.getTablePath() != null) {
-            sinkTablePath =
-                    targetTable.getTablePath().toString();
-        }
-
-        return new PipelineResult(
-                graph.getPipelineId(),
-                graph.getDataSetId(),
-                sourceIdentifier,
-                graph.getDataSetPath().toString(),
-                graph.getSourceTaskPlans().size(),
-                sinkIdentifier,
-                sinkTablePath,
-                graph.getSinkTaskPlans().size(),
-                tableDdl,
-                status,
-                commitSummary,
-                failure);
-    }
-
-    private void cancelSplitProvider() {
-        if (splitProvider != null) {
-            splitProvider.cancel(token.getCause());
+            return coordinator.execute(
+                    sinkTasks,
+                    sourceTasks);
         }
     }
 
-    private ExecutionTask createSource(
-            SourceTaskPlan<SplitT> source,
-            List<DataChannel<RecordEnvelope<FluxRow>>> channels) {
-
-        List<ChannelWriter<RecordEnvelope<FluxRow>>> writers =
-                new ArrayList<ChannelWriter<RecordEnvelope<FluxRow>>>();
-
-        for (DataChannel<RecordEnvelope<FluxRow>> channel : channels) {
-            writers.add(channel.openWriter());
+    private PipelineStatus statusOf(
+            ExecutionCoordinator.ExecutionOutcome outcome) {
+        if (outcome.getFailure() == null) {
+            return PipelineStatus.SUCCEEDED;
         }
 
-        Partitioner<RecordEnvelope<FluxRow>> partitioner =
-                new Partitioner<RecordEnvelope<FluxRow>>() {
-                    public int selectChannel(
-                            RecordEnvelope<FluxRow> value,
-                            int count) {
-                        return count == 1
-                                ? 0
-                                : Math.floorMod(
-                                        value.getBatch()
-                                                .getSplitId()
-                                                .hashCode(),
-                                        count);
-                    }
-                };
-
-        return new SourceTask<SplitT>(
-                source,
-                new OutputGate<RecordEnvelope<FluxRow>>(
-                        writers,
-                        partitioner),
-                splitProvider);
+        return cancellationToken.isCancelled()
+                ? PipelineStatus.CANCELED
+                : PipelineStatus.FAILED;
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineResultFactory.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineResultFactory.java
@@ -1,0 +1,71 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.sink.TableDdl;
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.framework.connector.PreparedSink;
+import com.link.up.framework.job.CommitSummary;
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.job.PipelineStatus;
+import com.link.up.framework.planner.PipelineGraph;
+import com.link.up.framework.planner.SinkTaskPlan;
+import com.link.up.framework.planner.SourceTaskPlan;
+
+import java.util.Objects;
+
+/** Converts one pipeline execution outcome into the stable result model. */
+final class PipelineResultFactory {
+
+    private PipelineResultFactory() {
+    }
+
+    static <SplitT extends SourceSplit> PipelineResult create(
+            PipelineGraph<SplitT> graph,
+            PipelineStatus status,
+            CommitSummary commitSummary,
+            Throwable failure) {
+
+        Objects.requireNonNull(graph, "graph must not be null");
+        Objects.requireNonNull(status, "status must not be null");
+        Objects.requireNonNull(
+                commitSummary,
+                "commitSummary must not be null");
+
+        SourceTaskPlan<SplitT> sourceTaskPlan =
+                graph.getSourceTaskPlans().get(0);
+        SinkTaskPlan sinkTaskPlan =
+                graph.getSinkTaskPlans().get(0);
+        PreparedSink preparedSink =
+                sinkTaskPlan.getPreparedSink();
+
+        CatalogTable targetTable =
+                preparedSink.getMetadata()
+                        .getTargetTable(graph.getDataSetPath());
+        TableDdl tableDdl =
+                preparedSink.getMetadata()
+                        .getTableDdl(graph.getDataSetPath());
+
+        return new PipelineResult(
+                graph.getPipelineId(),
+                graph.getDataSetId(),
+                sourceTaskPlan.getPreparedSource()
+                        .getFactoryIdentifier(),
+                graph.getDataSetPath().toString(),
+                graph.getSourceTaskPlans().size(),
+                preparedSink.getFactoryIdentifier(),
+                targetTablePath(targetTable),
+                graph.getSinkTaskPlans().size(),
+                tableDdl,
+                status,
+                commitSummary,
+                failure);
+    }
+
+    private static String targetTablePath(CatalogTable targetTable) {
+        if (targetTable == null || targetTable.getTablePath() == null) {
+            return "-";
+        }
+
+        return targetTable.getTablePath().toString();
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineRuntimeResources.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineRuntimeResources.java
@@ -1,0 +1,138 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.framework.channel.DataChannel;
+import com.link.up.framework.channel.LocalDataChannel;
+import com.link.up.framework.channel.RecordEnvelope;
+import com.link.up.framework.execution.split.LocalSplitQueue;
+import com.link.up.framework.execution.split.SplitProvider;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.SplitAssignmentMode;
+import com.link.up.framework.metrics.JobMetrics;
+import com.link.up.framework.planner.PipelineGraph;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Owns mutable resources for one local pipeline execution.
+ *
+ * <p>Channels and dynamic split queues are created here and released with the
+ * pipeline lifecycle. Planner models remain immutable data only.</p>
+ */
+final class PipelineRuntimeResources<SplitT extends SourceSplit>
+        implements AutoCloseable {
+
+    private final List<DataChannel<RecordEnvelope<FluxRow>>> channels;
+    private final SplitProvider<SplitT> splitProvider;
+
+    private PipelineRuntimeResources(
+            List<DataChannel<RecordEnvelope<FluxRow>>> channels,
+            SplitProvider<SplitT> splitProvider) {
+
+        this.channels = Collections.unmodifiableList(
+                new ArrayList<DataChannel<RecordEnvelope<FluxRow>>>(channels));
+        this.splitProvider = splitProvider;
+    }
+
+    static <SplitT extends SourceSplit> PipelineRuntimeResources<SplitT> open(
+            PipelineGraph<SplitT> graph,
+            ExecutionConfig config,
+            JobMetrics metrics) {
+
+        Objects.requireNonNull(graph, "graph must not be null");
+        Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(metrics, "metrics must not be null");
+
+        SplitProvider<SplitT> splitProvider = createSplitProvider(graph);
+        if (splitProvider != null) {
+            metrics.registerSplitProvider(splitProvider);
+        }
+
+        List<DataChannel<RecordEnvelope<FluxRow>>> channels =
+                createChannels(graph, config, metrics);
+
+        return new PipelineRuntimeResources<SplitT>(
+                channels,
+                splitProvider);
+    }
+
+    List<DataChannel<RecordEnvelope<FluxRow>>> getChannels() {
+        return channels;
+    }
+
+    SplitProvider<SplitT> getSplitProvider() {
+        return splitProvider;
+    }
+
+    void cancel(Throwable cause) {
+        Throwable failure = cause == null
+                ? new IllegalStateException("Pipeline cancelled")
+                : cause;
+
+        for (DataChannel<RecordEnvelope<FluxRow>> channel : channels) {
+            channel.fail(failure);
+        }
+
+        if (splitProvider != null) {
+            splitProvider.cancel(cause);
+        }
+    }
+
+    @Override
+    public void close() {
+        for (DataChannel<RecordEnvelope<FluxRow>> channel : channels) {
+            try {
+                channel.close();
+            } catch (Throwable ignored) {
+                // Best-effort close after the pipeline outcome is known.
+            }
+        }
+    }
+
+    private static <SplitT extends SourceSplit> SplitProvider<SplitT>
+    createSplitProvider(PipelineGraph<SplitT> graph) {
+
+        if (graph.getSplitAssignmentMode() != SplitAssignmentMode.DYNAMIC) {
+            return null;
+        }
+
+        return new LocalSplitQueue<SplitT>(graph.getSourceSplits());
+    }
+
+    private static <SplitT extends SourceSplit>
+    List<DataChannel<RecordEnvelope<FluxRow>>> createChannels(
+            PipelineGraph<SplitT> graph,
+            ExecutionConfig config,
+            JobMetrics metrics) {
+
+        List<DataChannel<RecordEnvelope<FluxRow>>> channels =
+                new ArrayList<DataChannel<RecordEnvelope<FluxRow>>>(
+                        graph.getSinkTaskPlans().size());
+
+        for (int index = 0;
+             index < graph.getSinkTaskPlans().size();
+             index++) {
+
+            LocalDataChannel<RecordEnvelope<FluxRow>> channel =
+                    new LocalDataChannel<RecordEnvelope<FluxRow>>(
+                            graph.getPipelineId()
+                                    + "-source-to-sink-"
+                                    + index,
+                            config.getMaxBufferedBatches(),
+                            config.getMaxBufferedRecords(),
+                            config.getMaxBufferedBytes(),
+                            config.getMaxRecordsPerSecond(),
+                            config.getMaxBytesPerSecond(),
+                            graph.getSourceTaskPlans().size());
+
+            channels.add(channel);
+            metrics.registerChannel(channel.getMetrics());
+        }
+
+        return channels;
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineRuntimeResources.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineRuntimeResources.java
@@ -84,13 +84,7 @@ final class PipelineRuntimeResources<SplitT extends SourceSplit>
 
     @Override
     public void close() {
-        for (DataChannel<RecordEnvelope<FluxRow>> channel : channels) {
-            try {
-                channel.close();
-            } catch (Throwable ignored) {
-                // Best-effort close after the pipeline outcome is known.
-            }
-        }
+        closeChannels(channels);
     }
 
     private static <SplitT extends SourceSplit> SplitProvider<SplitT>
@@ -113,26 +107,47 @@ final class PipelineRuntimeResources<SplitT extends SourceSplit>
                 new ArrayList<DataChannel<RecordEnvelope<FluxRow>>>(
                         graph.getSinkTaskPlans().size());
 
-        for (int index = 0;
-             index < graph.getSinkTaskPlans().size();
-             index++) {
+        try {
+            for (int index = 0;
+                 index < graph.getSinkTaskPlans().size();
+                 index++) {
 
-            LocalDataChannel<RecordEnvelope<FluxRow>> channel =
-                    new LocalDataChannel<RecordEnvelope<FluxRow>>(
-                            graph.getPipelineId()
-                                    + "-source-to-sink-"
-                                    + index,
-                            config.getMaxBufferedBatches(),
-                            config.getMaxBufferedRecords(),
-                            config.getMaxBufferedBytes(),
-                            config.getMaxRecordsPerSecond(),
-                            config.getMaxBytesPerSecond(),
-                            graph.getSourceTaskPlans().size());
+                LocalDataChannel<RecordEnvelope<FluxRow>> channel =
+                        new LocalDataChannel<RecordEnvelope<FluxRow>>(
+                                graph.getPipelineId()
+                                        + "-source-to-sink-"
+                                        + index,
+                                config.getMaxBufferedBatches(),
+                                config.getMaxBufferedRecords(),
+                                config.getMaxBufferedBytes(),
+                                config.getMaxRecordsPerSecond(),
+                                config.getMaxBytesPerSecond(),
+                                graph.getSourceTaskPlans().size());
 
-            channels.add(channel);
-            metrics.registerChannel(channel.getMetrics());
+                channels.add(channel);
+                metrics.registerChannel(channel.getMetrics());
+            }
+
+            return channels;
+
+        } catch (RuntimeException failure) {
+            closeChannels(channels);
+            throw failure;
+        } catch (Error failure) {
+            closeChannels(channels);
+            throw failure;
         }
+    }
 
-        return channels;
+    private static void closeChannels(
+            List<DataChannel<RecordEnvelope<FluxRow>>> channels) {
+
+        for (DataChannel<RecordEnvelope<FluxRow>> channel : channels) {
+            try {
+                channel.close();
+            } catch (Throwable ignored) {
+                // Best-effort cleanup; the primary outcome is preserved.
+            }
+        }
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineTaskFactory.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/PipelineTaskFactory.java
@@ -1,0 +1,112 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.framework.channel.ChannelWriter;
+import com.link.up.framework.channel.DataChannel;
+import com.link.up.framework.channel.InputGate;
+import com.link.up.framework.channel.OutputGate;
+import com.link.up.framework.channel.RecordEnvelope;
+import com.link.up.framework.execution.split.SplitProvider;
+import com.link.up.framework.execution.task.ExecutionTask;
+import com.link.up.framework.execution.task.SinkTask;
+import com.link.up.framework.execution.task.SourceTask;
+import com.link.up.framework.planner.PipelineGraph;
+import com.link.up.framework.planner.SourceTaskPlan;
+import com.link.up.framework.routing.Partitioner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Materializes runtime tasks from one immutable pipeline graph. */
+final class PipelineTaskFactory<SplitT extends SourceSplit> {
+
+    private final PipelineGraph<SplitT> graph;
+    private final List<DataChannel<RecordEnvelope<FluxRow>>> channels;
+    private final SplitProvider<SplitT> splitProvider;
+
+    PipelineTaskFactory(
+            PipelineGraph<SplitT> graph,
+            List<DataChannel<RecordEnvelope<FluxRow>>> channels,
+            SplitProvider<SplitT> splitProvider) {
+
+        this.graph = Objects.requireNonNull(
+                graph,
+                "graph must not be null");
+        this.channels = Objects.requireNonNull(
+                channels,
+                "channels must not be null");
+        this.splitProvider = splitProvider;
+    }
+
+    List<ExecutionTask> createSinkTasks() {
+        if (channels.size() != graph.getSinkTaskPlans().size()) {
+            throw new IllegalStateException(
+                    "Channel count must match sink task count");
+        }
+
+        List<ExecutionTask> sinkTasks =
+                new ArrayList<ExecutionTask>(channels.size());
+
+        for (int index = 0; index < channels.size(); index++) {
+            sinkTasks.add(
+                    new SinkTask(
+                            graph.getSinkTaskPlans().get(index),
+                            new InputGate<RecordEnvelope<FluxRow>>(
+                                    channels.get(index).openReader())));
+        }
+
+        return sinkTasks;
+    }
+
+    List<ExecutionTask> createSourceTasks() {
+        List<ExecutionTask> sourceTasks =
+                new ArrayList<ExecutionTask>(
+                        graph.getSourceTaskPlans().size());
+
+        for (SourceTaskPlan<SplitT> sourceTaskPlan :
+                graph.getSourceTaskPlans()) {
+            sourceTasks.add(createSourceTask(sourceTaskPlan));
+        }
+
+        return sourceTasks;
+    }
+
+    private ExecutionTask createSourceTask(
+            SourceTaskPlan<SplitT> sourceTaskPlan) {
+
+        List<ChannelWriter<RecordEnvelope<FluxRow>>> writers =
+                new ArrayList<ChannelWriter<RecordEnvelope<FluxRow>>>(
+                        channels.size());
+
+        for (DataChannel<RecordEnvelope<FluxRow>> channel : channels) {
+            writers.add(channel.openWriter());
+        }
+
+        return new SourceTask<SplitT>(
+                sourceTaskPlan,
+                new OutputGate<RecordEnvelope<FluxRow>>(
+                        writers,
+                        splitPartitioner()),
+                splitProvider);
+    }
+
+    private Partitioner<RecordEnvelope<FluxRow>> splitPartitioner() {
+        return new Partitioner<RecordEnvelope<FluxRow>>() {
+            @Override
+            public int selectChannel(
+                    RecordEnvelope<FluxRow> value,
+                    int count) {
+
+                if (count == 1) {
+                    return 0;
+                }
+
+                return Math.floorMod(
+                        value.getBatch().getSplitId().hashCode(),
+                        count);
+            }
+        };
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/SinkCommitSummaryCollector.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/SinkCommitSummaryCollector.java
@@ -1,0 +1,101 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.framework.execution.task.ExecutionTask;
+import com.link.up.framework.execution.task.SinkTask;
+import com.link.up.framework.job.CommitSummary;
+import com.link.up.framework.metrics.JobMetrics;
+import com.link.up.framework.metrics.TaskMetrics;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Collects sink commit observations after task coordination finishes. */
+final class SinkCommitSummaryCollector {
+
+    private static final String DEFAULT_RETRY_ADVICE =
+            "This sink commits per task; verify already committed targets before retrying.";
+
+    private final JobMetrics jobMetrics;
+
+    SinkCommitSummaryCollector(JobMetrics jobMetrics) {
+        this.jobMetrics = Objects.requireNonNull(
+                jobMetrics,
+                "jobMetrics must not be null");
+    }
+
+    CommitSummary collect(List<ExecutionTask> sinkTasks) {
+        Objects.requireNonNull(
+                sinkTasks,
+                "sinkTasks must not be null");
+
+        int finished = 0;
+        int committed = 0;
+        int emptyCommitted = 0;
+        long attempted = 0L;
+        long written = 0L;
+        long failed = 0L;
+        long unknown = 0L;
+        CommitScope scope = CommitScope.TASK_LOCAL;
+        String retryAdvice = DEFAULT_RETRY_ADVICE;
+
+        for (ExecutionTask task : sinkTasks) {
+            if (!(task instanceof SinkTask)) {
+                continue;
+            }
+
+            SinkTask sinkTask = (SinkTask) task;
+            TaskMetrics metrics =
+                    jobMetrics.getTaskMetrics()
+                            .get(sinkTask.getTaskId());
+
+            long successful =
+                    metrics == null
+                            ? 0L
+                            : metrics.getSinkWriteSuccessRecordCount();
+
+            attempted +=
+                    metrics == null
+                            ? 0L
+                            : metrics.getAttemptedRecordCount();
+            written += successful;
+            unknown +=
+                    metrics == null
+                            ? 0L
+                            : metrics.getUnknownStateRecordCount();
+            failed +=
+                    metrics == null
+                            ? 0L
+                            : metrics.getFailedRecordCount();
+
+            if (metrics != null
+                    && metrics.getState() == TaskState.FINISHED) {
+                finished++;
+            }
+
+            if (sinkTask.isCommitted()) {
+                committed++;
+                if (successful == 0L) {
+                    emptyCommitted++;
+                }
+            }
+
+            scope = sinkTask.getCommitScope();
+            retryAdvice = sinkTask.getRetryAdvice();
+        }
+
+        return new CommitSummary(
+                sinkTasks.size(),
+                finished,
+                committed,
+                emptyCommitted,
+                sinkTasks.size() - committed,
+                attempted,
+                written,
+                committed == 0 ? 0L : written,
+                failed,
+                unknown,
+                scope,
+                retryAdvice);
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/TaskExecutor.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/TaskExecutor.java
@@ -16,28 +16,21 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/**
- * 本地 Task 线程执行器。
- */
+/** Owns local worker threads that execute already-planned tasks. */
 public final class TaskExecutor
         implements AutoCloseable {
 
     private static final Logger LOG =
-            LogManager.getLogger(
-                    TaskExecutor.class);
+            LogManager.getLogger(TaskExecutor.class);
 
     private final ExecutorService executorService;
-
-    private final ExecutorCompletionService<TaskResult>
-            completionService;
-
+    private final ExecutorCompletionService<TaskResult> completionService;
     private final String jobName;
-
     private final long runId;
 
     public TaskExecutor(
             int threadCount,
-            final String threadPrefix) {
+            String threadPrefix) {
 
         this(
                 threadCount,
@@ -48,7 +41,7 @@ public final class TaskExecutor
 
     public TaskExecutor(
             int threadCount,
-            final String threadPrefix,
+            String threadPrefix,
             String jobName,
             long runId) {
 
@@ -56,46 +49,23 @@ public final class TaskExecutor
             throw new IllegalArgumentException(
                     "threadCount must be greater than 0");
         }
-
-        this.jobName =
-                Objects.requireNonNull(
-                        jobName,
-                        "jobName must not be null");
-
         if (runId < 0L) {
             throw new IllegalArgumentException(
                     "runId must not be negative");
         }
 
+        this.jobName = Objects.requireNonNull(
+                jobName,
+                "jobName must not be null");
         this.runId = runId;
-
-        final AtomicInteger sequence =
-                new AtomicInteger();
-
-        ThreadFactory threadFactory =
-                new ThreadFactory() {
-                    @Override
-                    public Thread newThread(
-                            Runnable runnable) {
-
-                        Thread thread =
-                                new Thread(
-                                        runnable,
-                                        threadPrefix
-                                                + "-"
-                                                + sequence
-                                                .getAndIncrement());
-
-                        thread.setDaemon(false);
-
-                        return thread;
-                    }
-                };
 
         this.executorService =
                 Executors.newFixedThreadPool(
                         threadCount,
-                        threadFactory);
+                        threadFactory(
+                                Objects.requireNonNull(
+                                        threadPrefix,
+                                        "threadPrefix must not be null")));
 
         this.completionService =
                 new ExecutorCompletionService<TaskResult>(
@@ -109,7 +79,6 @@ public final class TaskExecutor
         Objects.requireNonNull(
                 task,
                 "task must not be null");
-
         Objects.requireNonNull(
                 context,
                 "context must not be null");
@@ -118,7 +87,6 @@ public final class TaskExecutor
                 JobLogFileName.createJobId(
                         jobName,
                         runId);
-
         final String jobLogFile =
                 JobLogFileName.create(
                         jobName,
@@ -130,15 +98,10 @@ public final class TaskExecutor
                     public TaskResult call() {
                         try (CloseableThreadContext.Instance ignored =
                                      CloseableThreadContext
-                                             .put(
-                                                     "jobId",
-                                                     jobId)
-                                             .put(
-                                                     "jobName",
-                                                     jobName)
-                                             .put(
-                                                     "jobLogFile",
-                                                     jobLogFile)) {
+                                             .put("runId", jobId)
+                                             .put("jobId", jobId)
+                                             .put("jobName", jobName)
+                                             .put("jobLogFile", jobLogFile)) {
 
                             return executeTask(
                                     task,
@@ -146,104 +109,6 @@ public final class TaskExecutor
                         }
                     }
                 });
-    }
-
-    private TaskResult executeTask(
-            ExecutionTask task,
-            TaskContext context) {
-
-        TaskMetrics metrics =
-                context.getMetrics();
-
-        if (context
-                .getCancellationToken()
-                .isCancelled()) {
-
-            metrics.markFinished(
-                    TaskState.CANCELED);
-
-            LOG.info(
-                    "Task cancelled before execution: {}",
-                    task.getTaskId());
-
-            return TaskResult.canceled(
-                    task.getTaskId(),
-                    context
-                            .getCancellationToken()
-                            .getCause());
-        }
-
-        metrics.markStarted();
-
-        LOG.info(
-                "Task started: {}",
-                task.getTaskId());
-
-        try {
-            task.execute(context);
-
-            if (context
-                    .getCancellationToken()
-                    .isCancelled()) {
-
-                metrics.markFinished(
-                        TaskState.CANCELED);
-
-                LOG.info(
-                        "Task cancelled: {}",
-                        task.getTaskId());
-
-                return TaskResult.canceled(
-                        task.getTaskId(),
-                        context
-                                .getCancellationToken()
-                                .getCause());
-            }
-
-            metrics.markFinished(
-                    TaskState.FINISHED);
-
-            LOG.info(
-                    "Task finished: {}",
-                    task.getTaskId());
-
-            return TaskResult.finished(
-                    task.getTaskId());
-
-        } catch (Throwable throwable) {
-            if (context
-                    .getCancellationToken()
-                    .isCancelled()
-                    && throwable
-                    instanceof InterruptedException) {
-
-                Thread.currentThread()
-                        .interrupt();
-
-                metrics.markFinished(
-                        TaskState.CANCELED);
-
-                LOG.info(
-                        "Task cancelled: {}",
-                        task.getTaskId());
-
-                return TaskResult.canceled(
-                        task.getTaskId(),
-                        throwable);
-            }
-
-            metrics.markFinished(
-                    TaskState.FAILED);
-
-            LOG.error(
-                    "Task failed: "
-                            + task.getTaskId(),
-                    throwable);
-
-            return TaskResult.failed(
-                    task.getTaskId(),
-                    throwable);
-        }
     }
 
     public Future<TaskResult> takeCompleted()
@@ -260,14 +125,144 @@ public final class TaskExecutor
             if (!executorService.awaitTermination(
                     5L,
                     TimeUnit.SECONDS)) {
-
                 executorService.shutdownNow();
             }
         } catch (InterruptedException interrupted) {
-            Thread.currentThread()
-                    .interrupt();
-
+            Thread.currentThread().interrupt();
             executorService.shutdownNow();
         }
+    }
+
+    private TaskResult executeTask(
+            ExecutionTask task,
+            TaskContext context) {
+
+        if (context.getCancellationToken().isCancelled()) {
+            return cancelBeforeExecution(
+                    task,
+                    context);
+        }
+
+        TaskMetrics metrics = context.getMetrics();
+        metrics.markStarted();
+
+        LOG.info(
+                "Task started: {}",
+                task.getTaskId());
+
+        try {
+            task.execute(context);
+
+            if (context.getCancellationToken().isCancelled()) {
+                return cancelAfterExecution(
+                        task,
+                        context);
+            }
+
+            metrics.markFinished(TaskState.FINISHED);
+
+            LOG.info(
+                    "Task finished: {}",
+                    task.getTaskId());
+
+            return TaskResult.finished(
+                    task.getTaskId());
+
+        } catch (Throwable failure) {
+            return handleFailure(
+                    task,
+                    context,
+                    failure);
+        }
+    }
+
+    private TaskResult cancelBeforeExecution(
+            ExecutionTask task,
+            TaskContext context) {
+
+        context.getMetrics()
+                .markFinished(TaskState.CANCELED);
+
+        LOG.info(
+                "Task cancelled before execution: {}",
+                task.getTaskId());
+
+        return TaskResult.canceled(
+                task.getTaskId(),
+                context.getCancellationToken()
+                        .getCause());
+    }
+
+    private TaskResult cancelAfterExecution(
+            ExecutionTask task,
+            TaskContext context) {
+
+        context.getMetrics()
+                .markFinished(TaskState.CANCELED);
+
+        LOG.info(
+                "Task cancelled: {}",
+                task.getTaskId());
+
+        return TaskResult.canceled(
+                task.getTaskId(),
+                context.getCancellationToken()
+                        .getCause());
+    }
+
+    private TaskResult handleFailure(
+            ExecutionTask task,
+            TaskContext context,
+            Throwable failure) {
+
+        if (context.getCancellationToken().isCancelled()
+                && failure instanceof InterruptedException) {
+
+            Thread.currentThread().interrupt();
+            context.getMetrics()
+                    .markFinished(TaskState.CANCELED);
+
+            LOG.info(
+                    "Task cancelled: {}",
+                    task.getTaskId());
+
+            return TaskResult.canceled(
+                    task.getTaskId(),
+                    failure);
+        }
+
+        context.getMetrics()
+                .markFinished(TaskState.FAILED);
+
+        LOG.error(
+                "Task failed: {}",
+                task.getTaskId(),
+                failure);
+
+        return TaskResult.failed(
+                task.getTaskId(),
+                failure);
+    }
+
+    private static ThreadFactory threadFactory(
+            final String threadPrefix) {
+
+        final AtomicInteger sequence =
+                new AtomicInteger();
+
+        return new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable runnable) {
+                Thread thread =
+                        new Thread(
+                                runnable,
+                                threadPrefix
+                                        + "-"
+                                        + sequence.getAndIncrement());
+
+                thread.setDaemon(false);
+                return thread;
+            }
+        };
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/job/CommitSummary.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/CommitSummary.java
@@ -5,38 +5,96 @@ import com.link.up.api.sink.CommitScope;
 import java.util.Objects;
 
 /**
- * Immutable distinction between task-local transactions and confirmed data commits.
+ * Immutable summary of task-local sink commit observations.
  */
 public final class CommitSummary {
-    private final int totalTaskCount, finishedTaskCount, committedTaskCount, emptyCommittedTaskCount, failedOrUncommittedTaskCount;
-    private final long attemptedRecordCount, successfullyWrittenRecordCount, successfullyCommittedRecordCount, failedRecordCount, unknownStateRecordCount;
+
+    private final int totalTaskCount;
+    private final int finishedTaskCount;
+    private final int committedTaskCount;
+    private final int emptyCommittedTaskCount;
+    private final int failedOrUncommittedTaskCount;
+
+    private final long attemptedRecordCount;
+    private final long successfullyWrittenRecordCount;
+    private final long successfullyCommittedRecordCount;
+    private final long failedRecordCount;
+    private final long unknownStateRecordCount;
+
     private final CommitScope commitScope;
     private final String retryAdvice;
 
-    public CommitSummary(int total, int finished, int committed, int empty, int failed, long attempted, long written, long committedRecords, long failedRecords, long unknown, CommitScope scope, String advice) {
-        totalTaskCount = total;
-        finishedTaskCount = finished;
-        committedTaskCount = committed;
-        emptyCommittedTaskCount = empty;
-        failedOrUncommittedTaskCount = failed;
-        attemptedRecordCount = attempted;
-        successfullyWrittenRecordCount = written;
-        successfullyCommittedRecordCount = committedRecords;
-        failedRecordCount = failedRecords;
-        unknownStateRecordCount = unknown;
-        commitScope = Objects.requireNonNull(scope, "commitScope");
-        retryAdvice = Objects.requireNonNull(advice, "retryAdvice");
+    public CommitSummary(
+            int total,
+            int finished,
+            int committed,
+            int empty,
+            int failed,
+            long attempted,
+            long written,
+            long committedRecords,
+            long failedRecords,
+            long unknown,
+            CommitScope scope,
+            String advice) {
+
+        this.totalTaskCount = total;
+        this.finishedTaskCount = finished;
+        this.committedTaskCount = committed;
+        this.emptyCommittedTaskCount = empty;
+        this.failedOrUncommittedTaskCount = failed;
+        this.attemptedRecordCount = attempted;
+        this.successfullyWrittenRecordCount = written;
+        this.successfullyCommittedRecordCount = committedRecords;
+        this.failedRecordCount = failedRecords;
+        this.unknownStateRecordCount = unknown;
+        this.commitScope = Objects.requireNonNull(
+                scope,
+                "commitScope");
+        this.retryAdvice = Objects.requireNonNull(
+                advice,
+                "retryAdvice");
     }
 
     /**
-     * Compatibility constructor: committed tasks are conservatively treated as empty.
+     * Compatibility constructor: committed tasks are conservatively treated as
+     * empty commits because record-level evidence is unavailable.
      */
-    public CommitSummary(int committed, int failed, CommitScope scope, String advice) {
-        this(committed + failed, committed, committed, committed, failed, 0, 0, 0, 0, 0, scope, advice);
+    public CommitSummary(
+            int committed,
+            int failed,
+            CommitScope scope,
+            String advice) {
+
+        this(
+                committed + failed,
+                committed,
+                committed,
+                committed,
+                failed,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                scope,
+                advice);
     }
 
     public static CommitSummary empty() {
-        return new CommitSummary(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, CommitScope.TASK_LOCAL, "No sink tasks were executed.");
+        return new CommitSummary(
+                0,
+                0,
+                0,
+                0,
+                0,
+                0L,
+                0L,
+                0L,
+                0L,
+                0L,
+                CommitScope.TASK_LOCAL,
+                "No sink tasks were executed.");
     }
 
     public int getTotalTaskCount() {
@@ -56,7 +114,8 @@ public final class CommitSummary {
     }
 
     public int getDataCommittedTaskCount() {
-        return committedTaskCount - emptyCommittedTaskCount;
+        return committedTaskCount
+                - emptyCommittedTaskCount;
     }
 
     public int getFailedOrUncommittedTaskCount() {
@@ -84,11 +143,13 @@ public final class CommitSummary {
     }
 
     public boolean isPartialTaskCommit() {
-        return committedTaskCount > 0 && failedOrUncommittedTaskCount > 0;
+        return committedTaskCount > 0
+                && failedOrUncommittedTaskCount > 0;
     }
 
     public boolean isPartialDataCommit() {
-        return successfullyCommittedRecordCount > 0 && failedOrUncommittedTaskCount > 0;
+        return successfullyCommittedRecordCount > 0
+                && failedOrUncommittedTaskCount > 0;
     }
 
     public boolean isPartialCommit() {
@@ -104,6 +165,10 @@ public final class CommitSummary {
     }
 
     public String getWarning() {
-        return isPartialDataCommit() ? "Partial data commit detected; task-local commits cannot be rolled back globally." : "";
+        if (!isPartialDataCommit()) {
+            return "";
+        }
+
+        return "Partial data commit detected; task-local commits cannot be rolled back globally.";
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/planner/DataSetSplitGrouper.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planner/DataSetSplitGrouper.java
@@ -1,0 +1,45 @@
+package com.link.up.framework.planner;
+
+import com.link.up.api.source.SourceSplit;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Groups enumerated source splits by data set while preserving source order. */
+final class DataSetSplitGrouper {
+
+    private DataSetSplitGrouper() {
+    }
+
+    static <SplitT extends SourceSplit> Map<String, List<SplitT>> group(
+            List<SplitT> splits) {
+
+        Objects.requireNonNull(
+                splits,
+                "splits must not be null");
+
+        Map<String, List<SplitT>> byDataSet =
+                new LinkedHashMap<String, List<SplitT>>();
+
+        for (SplitT split : splits) {
+            Objects.requireNonNull(
+                    split,
+                    "splits must not contain null values");
+
+            String dataSetId = split.dataSetId().trim();
+            List<SplitT> group = byDataSet.get(dataSetId);
+
+            if (group == null) {
+                group = new ArrayList<SplitT>();
+                byDataSet.put(dataSetId, group);
+            }
+
+            group.add(split);
+        }
+
+        return byDataSet;
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/planner/JobPlanner.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planner/JobPlanner.java
@@ -1,33 +1,26 @@
 package com.link.up.framework.planner;
 
 import com.link.up.api.source.SourceSplit;
-import com.link.up.api.table.catalog.CatalogTable;
-import com.link.up.api.table.catalog.TablePath;
 import com.link.up.framework.connector.PreparedJob;
-import com.link.up.framework.connector.PreparedSink;
 import com.link.up.framework.connector.PreparedSource;
-import com.link.up.framework.execution.TaskId;
-import com.link.up.framework.execution.TaskType;
 import com.link.up.framework.job.ExecutionConfig;
 import com.link.up.framework.source.SourceCoordinator;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 /**
- * Builds an immutable {@link JobGraph} grouped by SourceSplit.dataSetId.
+ * Builds immutable job topology from prepared connectors.
  *
- * <p>The planner calculates topology and split assignment only. Source split
- * discovery is delegated to {@link SourceCoordinator}; runtime ownership
- * objects such as split queues are created later by the execution layer.</p>
+ * <p>Split discovery belongs to {@link SourceCoordinator}; per-data-set physical
+ * planning belongs to {@link PipelinePlanner}.</p>
  */
 public final class JobPlanner {
 
     private final SourceCoordinator sourceCoordinator;
-    private final SplitAssigner splitAssigner;
+    private final PipelinePlanner pipelinePlanner;
 
     public JobPlanner() {
         this(
@@ -48,16 +41,23 @@ public final class JobPlanner {
         this.sourceCoordinator = Objects.requireNonNull(
                 sourceCoordinator,
                 "sourceCoordinator must not be null");
-        this.splitAssigner = Objects.requireNonNull(
-                splitAssigner,
-                "splitAssigner must not be null");
+        this.pipelinePlanner =
+                new PipelinePlanner(
+                        Objects.requireNonNull(
+                                splitAssigner,
+                                "splitAssigner must not be null"));
     }
 
-    public JobGraph plan(PreparedJob preparedJob) throws Exception {
+    public JobGraph plan(PreparedJob preparedJob)
+            throws Exception {
+
         PreparedJob job = Objects.requireNonNull(
                 preparedJob,
                 "preparedJob must not be null");
-        return createGraph(job, job.getSource());
+
+        return createGraph(
+                job,
+                job.getSource());
     }
 
     private <SplitT extends SourceSplit> JobGraph createGraph(
@@ -66,94 +66,28 @@ public final class JobPlanner {
             throws Exception {
 
         ExecutionConfig config = job.getExecutionConfig();
+
         List<SplitT> splits =
                 sourceCoordinator.enumerateSplits(
                         preparedSource,
                         config.getSourceParallelism());
 
         Map<String, List<SplitT>> byDataSet =
-                new LinkedHashMap<String, List<SplitT>>();
-
-        for (SplitT split : splits) {
-            String dataSetId = split.dataSetId().trim();
-
-            List<SplitT> group = byDataSet.get(dataSetId);
-            if (group == null) {
-                group = new ArrayList<SplitT>();
-                byDataSet.put(dataSetId, group);
-            }
-            group.add(split);
-        }
+                DataSetSplitGrouper.group(splits);
 
         List<PipelineGraph<?>> pipelines =
-                new ArrayList<PipelineGraph<?>>();
+                new ArrayList<PipelineGraph<?>>(
+                        byDataSet.size());
 
         for (Map.Entry<String, List<SplitT>> entry :
                 byDataSet.entrySet()) {
 
-            String dataSetId = entry.getKey();
-            TablePath path = TablePath.parse(dataSetId);
-            CatalogTable table =
-                    preparedSource.getOutputTables().get(path);
-
-            if (table == null) {
-                throw new IllegalStateException(
-                        "No output catalog table for data set: "
-                                + dataSetId);
-            }
-
-            List<List<SplitT>> assignments =
-                    splitAssigner.assign(
-                            entry.getValue(),
-                            config.getSourceParallelism());
-
-            String pipelineId = "pipeline-" + dataSetId;
-            List<SourceTaskPlan<SplitT>> sources =
-                    new ArrayList<SourceTaskPlan<SplitT>>();
-
-            for (int i = 0; i < assignments.size(); i++) {
-                sources.add(
-                        new SourceTaskPlan<SplitT>(
-                                new TaskId(
-                                        pipelineId,
-                                        TaskType.SOURCE,
-                                        i,
-                                        assignments.size()),
-                                preparedSource,
-                                assignments.get(i),
-                                config.getBatchSize()));
-            }
-
-            List<PreparedSink> sinks = job.getSinks(dataSetId);
-            int sinkCount = Math.min(
-                    Math.min(
-                            config.getSinkParallelism(),
-                            sinks.size()),
-                    Math.max(1, entry.getValue().size()));
-
-            List<SinkTaskPlan> sinkPlans =
-                    new ArrayList<SinkTaskPlan>();
-
-            for (int i = 0; i < sinkCount; i++) {
-                sinkPlans.add(
-                        new SinkTaskPlan(
-                                new TaskId(
-                                        pipelineId,
-                                        TaskType.SINK,
-                                        i,
-                                        sinkCount),
-                                sinks.get(i)));
-            }
-
             pipelines.add(
-                    new PipelineGraph<SplitT>(
-                            pipelineId,
-                            dataSetId,
-                            table,
+                    pipelinePlanner.plan(
+                            entry.getKey(),
                             entry.getValue(),
-                            sources,
-                            sinkPlans,
-                            config.getSplitAssignmentMode()));
+                            job,
+                            preparedSource));
         }
 
         return new JobGraph(

--- a/link-up-framework/src/main/java/com/link/up/framework/planner/PipelinePlanner.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planner/PipelinePlanner.java
@@ -1,0 +1,150 @@
+package com.link.up.framework.planner;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.framework.connector.PreparedJob;
+import com.link.up.framework.connector.PreparedSink;
+import com.link.up.framework.connector.PreparedSource;
+import com.link.up.framework.execution.TaskId;
+import com.link.up.framework.execution.TaskType;
+import com.link.up.framework.job.ExecutionConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Builds one immutable physical pipeline for a single logical data set. */
+final class PipelinePlanner {
+
+    private final SplitAssigner splitAssigner;
+
+    PipelinePlanner(SplitAssigner splitAssigner) {
+        this.splitAssigner = Objects.requireNonNull(
+                splitAssigner,
+                "splitAssigner must not be null");
+    }
+
+    <SplitT extends SourceSplit> PipelineGraph<SplitT> plan(
+            String dataSetId,
+            List<SplitT> splits,
+            PreparedJob job,
+            PreparedSource<SplitT> preparedSource) {
+
+        Objects.requireNonNull(
+                dataSetId,
+                "dataSetId must not be null");
+        Objects.requireNonNull(
+                splits,
+                "splits must not be null");
+        Objects.requireNonNull(
+                job,
+                "job must not be null");
+        Objects.requireNonNull(
+                preparedSource,
+                "preparedSource must not be null");
+
+        ExecutionConfig config = job.getExecutionConfig();
+        TablePath dataSetPath = TablePath.parse(dataSetId);
+        CatalogTable table =
+                preparedSource.getOutputTables()
+                        .get(dataSetPath);
+
+        if (table == null) {
+            throw new IllegalStateException(
+                    "No output catalog table for data set: "
+                            + dataSetId);
+        }
+
+        String pipelineId = "pipeline-" + dataSetId;
+
+        return new PipelineGraph<SplitT>(
+                pipelineId,
+                dataSetId,
+                table,
+                splits,
+                createSourceTaskPlans(
+                        pipelineId,
+                        splits,
+                        preparedSource,
+                        config),
+                createSinkTaskPlans(
+                        pipelineId,
+                        dataSetId,
+                        splits.size(),
+                        job,
+                        config),
+                config.getSplitAssignmentMode());
+    }
+
+    private <SplitT extends SourceSplit>
+    List<SourceTaskPlan<SplitT>> createSourceTaskPlans(
+            String pipelineId,
+            List<SplitT> splits,
+            PreparedSource<SplitT> preparedSource,
+            ExecutionConfig config) {
+
+        List<List<SplitT>> assignments =
+                splitAssigner.assign(
+                        splits,
+                        config.getSourceParallelism());
+
+        List<SourceTaskPlan<SplitT>> sourcePlans =
+                new ArrayList<SourceTaskPlan<SplitT>>(
+                        assignments.size());
+
+        for (int index = 0;
+             index < assignments.size();
+             index++) {
+
+            sourcePlans.add(
+                    new SourceTaskPlan<SplitT>(
+                            new TaskId(
+                                    pipelineId,
+                                    TaskType.SOURCE,
+                                    index,
+                                    assignments.size()),
+                            preparedSource,
+                            assignments.get(index),
+                            config.getBatchSize()));
+        }
+
+        return sourcePlans;
+    }
+
+    private List<SinkTaskPlan> createSinkTaskPlans(
+            String pipelineId,
+            String dataSetId,
+            int splitCount,
+            PreparedJob job,
+            ExecutionConfig config) {
+
+        List<PreparedSink> sinks = job.getSinks(dataSetId);
+
+        int sinkCount =
+                Math.min(
+                        Math.min(
+                                config.getSinkParallelism(),
+                                sinks.size()),
+                        Math.max(1, splitCount));
+
+        List<SinkTaskPlan> sinkPlans =
+                new ArrayList<SinkTaskPlan>(sinkCount);
+
+        for (int index = 0;
+             index < sinkCount;
+             index++) {
+
+            sinkPlans.add(
+                    new SinkTaskPlan(
+                            new TaskId(
+                                    pipelineId,
+                                    TaskType.SINK,
+                                    index,
+                                    sinkCount),
+                            sinks.get(index)));
+        }
+
+        return sinkPlans;
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/execution/ExecutionRoleBoundaryTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/execution/ExecutionRoleBoundaryTest.java
@@ -13,43 +13,84 @@ import java.util.concurrent.ExecutorService;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Architecture guards for Phase 3 runtime role separation.
- */
+/** Architecture guards for Link-Up runtime ownership roles. */
 public class ExecutionRoleBoundaryTest {
 
     @Test
     public void jobExecutionShouldRemainAThinFacade() {
-        Set<Class<?>> fieldTypes = instanceFieldTypes(
-                JobExecution.class);
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(JobExecution.class);
 
-        assertTrue(fieldTypes.contains(ExecutionGraph.class));
-        assertTrue(fieldTypes.contains(JobCoordinator.class));
-        assertFalse(fieldTypes.contains(JobGraph.class));
-        assertFalse(fieldTypes.contains(PipelineGraph.class));
-        assertNoExecutorService(JobExecution.class);
+        assertTrue(
+                fieldTypes.contains(
+                        ExecutionGraph.class));
+        assertTrue(
+                fieldTypes.contains(
+                        JobCoordinator.class));
+        assertFalse(
+                fieldTypes.contains(
+                        JobGraph.class));
+        assertFalse(
+                fieldTypes.contains(
+                        PipelineGraph.class));
+
+        assertNoExecutorService(
+                JobExecution.class);
     }
 
     @Test
     public void jobCoordinatorShouldDependOnSchedulerAndExecutorRoles() {
-        Set<Class<?>> fieldTypes = instanceFieldTypes(
-                JobCoordinator.class);
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        JobCoordinator.class);
 
-        assertTrue(fieldTypes.contains(ExecutionGraph.class));
-        assertTrue(fieldTypes.contains(PipelineScheduler.class));
-        assertTrue(fieldTypes.contains(PipelineExecutor.class));
-        assertFalse(fieldTypes.contains(ClassLoader.class));
-        assertNoExecutorService(JobCoordinator.class);
+        assertTrue(
+                fieldTypes.contains(
+                        ExecutionGraph.class));
+        assertTrue(
+                fieldTypes.contains(
+                        PipelineScheduler.class));
+        assertTrue(
+                fieldTypes.contains(
+                        PipelineExecutor.class));
+        assertFalse(
+                fieldTypes.contains(
+                        ClassLoader.class));
+
+        assertNoExecutorService(
+                JobCoordinator.class);
     }
 
     @Test
     public void localPipelineSchedulerShouldNotOwnExecutionState() {
-        Set<Class<?>> fieldTypes = instanceFieldTypes(
-                LocalPipelineScheduler.class);
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        LocalPipelineScheduler.class);
 
-        assertFalse(fieldTypes.contains(ExecutionGraph.class));
-        assertFalse(fieldTypes.contains(JobGraph.class));
-        assertFalse(fieldTypes.contains(PipelineGraph.class));
+        assertFalse(
+                fieldTypes.contains(
+                        ExecutionGraph.class));
+        assertFalse(
+                fieldTypes.contains(
+                        JobGraph.class));
+        assertFalse(
+                fieldTypes.contains(
+                        PipelineGraph.class));
+    }
+
+    @Test
+    public void pipelineExecutionShouldDelegateMutableResources() {
+        assertNoFieldTypeName(
+                PipelineExecution.class,
+                "com.link.up.framework.channel.DataChannel",
+                "com.link.up.framework.execution.split.SplitProvider");
+
+        assertHasFieldTypeName(
+                PipelineRuntimeResources.class,
+                "com.link.up.framework.channel.DataChannel");
+        assertHasFieldTypeName(
+                PipelineRuntimeResources.class,
+                "com.link.up.framework.execution.split.SplitProvider");
     }
 
     private static Set<Class<?>> instanceFieldTypes(
@@ -59,7 +100,8 @@ public class ExecutionRoleBoundaryTest {
                 new HashSet<Class<?>>();
 
         for (Field field : type.getDeclaredFields()) {
-            if (!Modifier.isStatic(field.getModifiers())) {
+            if (!Modifier.isStatic(
+                    field.getModifiers())) {
                 fieldTypes.add(field.getType());
             }
         }
@@ -71,14 +113,56 @@ public class ExecutionRoleBoundaryTest {
             Class<?> type) {
 
         for (Field field : type.getDeclaredFields()) {
-            if (!Modifier.isStatic(field.getModifiers())) {
+            if (Modifier.isStatic(
+                    field.getModifiers())) {
+                continue;
+            }
+
+            assertFalse(
+                    type.getSimpleName()
+                            + " must not own ExecutorService field "
+                            + field.getName(),
+                    ExecutorService.class.isAssignableFrom(
+                            field.getType()));
+        }
+    }
+
+    private static void assertNoFieldTypeName(
+            Class<?> type,
+            String... forbiddenTypes) {
+
+        for (Field field : type.getDeclaredFields()) {
+            String typeName =
+                    field.getGenericType()
+                            .getTypeName();
+
+            for (String forbidden : forbiddenTypes) {
                 assertFalse(
                         type.getSimpleName()
-                                + " must not own ExecutorService field "
-                                + field.getName(),
-                        ExecutorService.class.isAssignableFrom(
-                                field.getType()));
+                                + "."
+                                + field.getName()
+                                + " must not own "
+                                + forbidden,
+                        typeName.contains(forbidden));
             }
         }
+    }
+
+    private static void assertHasFieldTypeName(
+            Class<?> type,
+            String expectedType) {
+
+        for (Field field : type.getDeclaredFields()) {
+            if (field.getGenericType()
+                    .getTypeName()
+                    .contains(expectedType)) {
+                return;
+            }
+        }
+
+        throw new AssertionError(
+                type.getSimpleName()
+                        + " must own "
+                        + expectedType);
     }
 }

--- a/link-up-framework/src/test/java/com/link/up/framework/execution/JobCommitSummaryMergerTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/execution/JobCommitSummaryMergerTest.java
@@ -1,0 +1,80 @@
+package com.link.up.framework.execution;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.framework.job.CommitSummary;
+import com.link.up.framework.job.PipelineResult;
+import com.link.up.framework.job.PipelineStatus;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+
+public class JobCommitSummaryMergerTest {
+
+    @Test
+    public void shouldAggregatePipelineCommitEvidence() {
+        CommitSummary first =
+                new CommitSummary(
+                        2,
+                        2,
+                        1,
+                        0,
+                        1,
+                        100L,
+                        90L,
+                        90L,
+                        5L,
+                        5L,
+                        CommitScope.TASK_LOCAL,
+                        "first");
+
+        CommitSummary second =
+                new CommitSummary(
+                        1,
+                        1,
+                        1,
+                        1,
+                        0,
+                        20L,
+                        0L,
+                        0L,
+                        0L,
+                        0L,
+                        CommitScope.TASK_LOCAL,
+                        "second");
+
+        CommitSummary merged =
+                JobCommitSummaryMerger.merge(
+                        Arrays.asList(
+                                pipeline(
+                                        "pipeline-a",
+                                        first),
+                                pipeline(
+                                        "pipeline-b",
+                                        second)));
+
+        assertEquals(3, merged.getTotalTaskCount());
+        assertEquals(3, merged.getFinishedTaskCount());
+        assertEquals(2, merged.getCommittedTaskCount());
+        assertEquals(1, merged.getEmptyCommittedTaskCount());
+        assertEquals(1, merged.getFailedOrUncommittedTaskCount());
+        assertEquals(120L, merged.getAttemptedRecordCount());
+        assertEquals(90L, merged.getSuccessfullyWrittenRecordCount());
+        assertEquals(90L, merged.getSuccessfullyCommittedRecordCount());
+        assertEquals(5L, merged.getFailedRecordCount());
+        assertEquals(5L, merged.getUnknownStateRecordCount());
+    }
+
+    private static PipelineResult pipeline(
+            String pipelineId,
+            CommitSummary summary) {
+
+        return new PipelineResult(
+                pipelineId,
+                "db.table",
+                PipelineStatus.SUCCEEDED,
+                summary,
+                null);
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/planner/DataSetSplitGrouperTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planner/DataSetSplitGrouperTest.java
@@ -1,0 +1,75 @@
+package com.link.up.framework.planner;
+
+import com.link.up.api.source.SourceSplit;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class DataSetSplitGrouperTest {
+
+    @Test
+    public void shouldPreserveDataSetAndSplitEnumerationOrder() {
+        TestSplit firstA =
+                new TestSplit(
+                        "a-1",
+                        "db.a");
+        TestSplit firstB =
+                new TestSplit(
+                        "b-1",
+                        "db.b");
+        TestSplit secondA =
+                new TestSplit(
+                        "a-2",
+                        "db.a");
+
+        Map<String, List<TestSplit>> grouped =
+                DataSetSplitGrouper.group(
+                        Arrays.asList(
+                                firstA,
+                                firstB,
+                                secondA));
+
+        assertEquals(
+                Arrays.asList(
+                        "db.a",
+                        "db.b"),
+                new ArrayList<String>(
+                        grouped.keySet()));
+
+        assertEquals(
+                Arrays.asList(
+                        firstA,
+                        secondA),
+                grouped.get("db.a"));
+    }
+
+    private static final class TestSplit
+            implements SourceSplit {
+
+        private final String splitId;
+        private final String dataSetId;
+
+        private TestSplit(
+                String splitId,
+                String dataSetId) {
+
+            this.splitId = splitId;
+            this.dataSetId = dataSetId;
+        }
+
+        @Override
+        public String splitId() {
+            return splitId;
+        }
+
+        @Override
+        public String dataSetId() {
+            return dataSetId;
+        }
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/planner/PlannerBoundaryTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planner/PlannerBoundaryTest.java
@@ -9,9 +9,7 @@ import java.lang.reflect.Modifier;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/**
- * Architecture guards for the planner/runtime boundary.
- */
+/** Architecture guards for the planner/runtime boundary. */
 public class PlannerBoundaryTest {
 
     private static final Class<?>[] PLANNER_MODELS = {
@@ -19,6 +17,12 @@ public class PlannerBoundaryTest {
             PipelineGraph.class,
             SourceTaskPlan.class,
             SinkTaskPlan.class
+    };
+
+    private static final Class<?>[] PLANNER_SERVICES = {
+            JobPlanner.class,
+            PipelinePlanner.class,
+            DataSetSplitGrouper.class
     };
 
     private static final String[] FORBIDDEN_RUNTIME_TYPES = {
@@ -32,21 +36,12 @@ public class PlannerBoundaryTest {
 
     @Test
     public void plannerModelsMustNotOwnRuntimeState() {
-        for (Class<?> model : PLANNER_MODELS) {
-            for (Field field : model.getDeclaredFields()) {
-                String typeName = field.getGenericType().getTypeName();
+        assertNoRuntimeFields(PLANNER_MODELS);
+    }
 
-                for (String forbidden : FORBIDDEN_RUNTIME_TYPES) {
-                    assertFalse(
-                            model.getSimpleName()
-                                    + "."
-                                    + field.getName()
-                                    + " must not reference runtime ownership type "
-                                    + forbidden,
-                            typeName.contains(forbidden));
-                }
-            }
-        }
+    @Test
+    public void plannerServicesMustNotOwnRuntimeState() {
+        assertNoRuntimeFields(PLANNER_SERVICES);
     }
 
     @Test
@@ -58,29 +53,64 @@ public class PlannerBoundaryTest {
                                 + "."
                                 + field.getName()
                                 + " must be final",
-                        Modifier.isFinal(field.getModifiers()));
+                        Modifier.isFinal(
+                                field.getModifiers()));
             }
         }
     }
 
     @Test
-    public void jobPlannerMustDelegateSourceDiscoveryToSourceCoordinator() {
+    public void jobPlannerMustDelegateDiscoveryAndPipelinePlanning() {
         boolean foundSourceCoordinator = false;
+        boolean foundPipelinePlanner = false;
 
         for (Field field : JobPlanner.class.getDeclaredFields()) {
-            if (SourceCoordinator.class.isAssignableFrom(field.getType())) {
+            if (SourceCoordinator.class.isAssignableFrom(
+                    field.getType())) {
                 foundSourceCoordinator = true;
             }
 
-            String typeName = field.getGenericType().getTypeName();
+            if (PipelinePlanner.class.isAssignableFrom(
+                    field.getType())) {
+                foundPipelinePlanner = true;
+            }
+
             assertFalse(
                     "JobPlanner must not own SourceSplitEnumerator directly",
-                    typeName.contains(
-                            "com.link.up.api.source.SourceSplitEnumerator"));
+                    field.getGenericType()
+                            .getTypeName()
+                            .contains(
+                                    "com.link.up.api.source.SourceSplitEnumerator"));
         }
 
         assertTrue(
                 "JobPlanner must delegate split discovery to SourceCoordinator",
                 foundSourceCoordinator);
+        assertTrue(
+                "JobPlanner must delegate per-data-set planning to PipelinePlanner",
+                foundPipelinePlanner);
+    }
+
+    private static void assertNoRuntimeFields(
+            Class<?>[] types) {
+
+        for (Class<?> type : types) {
+            for (Field field : type.getDeclaredFields()) {
+                String typeName =
+                        field.getGenericType()
+                                .getTypeName();
+
+                for (String forbidden :
+                        FORBIDDEN_RUNTIME_TYPES) {
+                    assertFalse(
+                            type.getSimpleName()
+                                    + "."
+                                    + field.getName()
+                                    + " must not reference runtime ownership type "
+                                    + forbidden,
+                            typeName.contains(forbidden));
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Applies the canonical `CODE_STYLE.md` to `link-up-framework` as the second repository-wide Link-Up style refactoring sample.

This is not a mechanical formatting pass. The focus is Link-Up's runtime-specific rules:

```text
清晰 / 笔直 / 显式 / 克制

straight-line workflow
explicit runtime ownership
small role-focused collaborators
planner/runtime separation
```

## Scope

This PR preserves the existing Framework architecture introduced by the earlier phases:

```text
JobGraph
  -> ExecutionGraph
  -> JobExecution
  -> JobCoordinator
  -> PipelineScheduler
  -> PipelineExecutor
  -> PipelineExecution
  -> ExecutionCoordinator
  -> TaskExecutor
```

The goal is to make those roles visible in the code itself instead of allowing orchestration details to accumulate back into a few large classes.

## Pipeline runtime ownership

`PipelineExecution` previously owned and materialized all of the following directly:

- dynamic `SplitProvider`
- channels
- Source/Sink task creation
- partitioner wiring
- `TaskExecutor`
- cancellation hook
- `PipelineResult` mapping
- resource cleanup

It is now a straight-line orchestration facade:

```text
PipelineExecution
  -> PipelineRuntimeResources
     -> channels
     -> dynamic SplitProvider
  -> PipelineTaskFactory
     -> SinkTask
     -> SourceTask
  -> ExecutionCoordinator
  -> PipelineResultFactory
```

`PipelineRuntimeResources` is now the explicit owner of mutable pipeline-scoped channels and the dynamic split queue. `PipelineExecution` no longer stores either `DataChannel` or `SplitProvider` fields.

Resource cleanup preserves the old behavior, including best-effort cleanup of channels already created when initialization fails partway through.

## Task coordination

`ExecutionCoordinator` remains responsible for:

- submitting Sink tasks before Source tasks
- creating task contexts/metrics
- waiting for task completion
- first-failure propagation
- shared cancellation
- task/future cancellation

Sink commit evidence aggregation has been moved out to:

```text
SinkCommitSummaryCollector
```

The existing commit semantics are intentionally preserved, including committed/empty task counts, attempted/written/unknown/failed record counts, commit scope and retry advice.

## Job coordination

`JobCoordinator` now reads as the job lifecycle flow:

```text
mark running
-> schedule pipelines
-> create JobResult
-> complete ExecutionGraph
-> log result
```

Job-level `CommitSummary` aggregation has moved to `JobCommitSummaryMerger`.

The existing job status priority remains unchanged:

```text
schedule failure -> FAILED
else cancellation requested -> CANCELED
else -> SUCCEEDED
```

## Planner

`JobPlanner#createGraph` previously combined split discovery, data-set grouping, catalog lookup, source task planning, sink task planning and PipelineGraph construction.

It now delegates explicit planner roles:

```text
JobPlanner
  -> SourceCoordinator
  -> DataSetSplitGrouper
  -> PipelinePlanner
     -> SplitAssigner
     -> SourceTaskPlan
     -> SinkTaskPlan
  -> JobGraph
```

Planner services still produce immutable planning data only. They do not own Channel, SplitProvider, Metrics, Future, Executor or CancellationToken objects.

Split enumeration order, data-set insertion order, source round-robin assignment and sink-count calculation are preserved.

## Straight-line runtime cleanup

Also refactored without intended behavior changes:

- `TaskExecutor`
  - explicit lifecycle helpers
  - early-return cancellation paths
  - parameterized failure logging
  - task-thread MDC includes `runId`
  - interrupt restoration preserved
- `LocalPipelineScheduler`
  - validation, submission and completion collection are separate steps
  - completion-order results and first-failure cancellation preserved
- `LocalFluxEngine`
  - composition, prepare/plan, listener notification and execution are explicit workflow steps
  - existing FactoryRegistry lifecycle is preserved
- `CommitSummary`
  - class layout/readability cleanup only; constructors and semantics remain compatible

## Deliberate non-goals

This PR intentionally does **not** modify the algorithms inside:

```text
SourceTask
SinkTask
LocalDataChannel
FactoryRegistry plugin discovery
```

Those are hot-path/data-correctness or classloader boundaries and should be refactored separately after the orchestration ownership changes are stable.

This PR also does not change:

- Connector contracts
- JobGraph / PipelineGraph public model semantics
- Source split discovery semantics
- channel backpressure/rate limiting
- source reading or sink commit algorithms
- server/worker protocol

## Architecture guards and tests

Added/extended coverage:

- `DataSetSplitGrouperTest`
  - preserves data-set insertion order
  - preserves Source split enumeration order within each data set
- `JobCommitSummaryMergerTest`
  - verifies job-level commit evidence aggregation
- `ExecutionRoleBoundaryTest`
  - `PipelineExecution` must not own `DataChannel` / `SplitProvider`
  - `PipelineRuntimeResources` must own those runtime resources
  - existing JobExecution/Coordinator/Scheduler role guards remain
- `PlannerBoundaryTest`
  - planner models and planner services must not own runtime resource types
  - JobPlanner must delegate Source discovery to SourceCoordinator
  - JobPlanner must delegate per-data-set planning to PipelinePlanner

## Validation

- based directly on current `main` after PR #75
- `main...refactor/link-up-framework-style`: 2 commits ahead, 0 behind
- 19 changed files, all under `link-up-framework`
- no `link-up-api`, Connector or Server files changed
- public `JobPlanner`, `LocalFluxEngine`, `TaskExecutor` and `ExecutionCoordinator` entry signatures are preserved
- SourceTask/SinkTask/LocalDataChannel algorithms are untouched
- GitHub currently reports no status checks and no Actions workflow runs for the branch head

A full Maven checkout/build is not available from the current execution environment, so this PR intentionally does **not** claim Maven tests have passed.

Recommended locally before marking ready:

```bash
mvn --batch-mode -pl link-up-framework -am test
mvn --batch-mode clean verify
```
