### PR TITLE
refactor: apply Link-Up code style to connectors

### DIFF
--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/sink/DorisSinkWriter.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/sink/DorisSinkWriter.java
@@ -1,5 +1,6 @@
 package com.link.up.connector.doris.sink;
 
+import com.link.up.api.dirtydata.BoundedMemoryDirtyDataCollector;
 import com.link.up.api.dirtydata.DirtyDataCollector;
 import com.link.up.api.dirtydata.DirtyDataContext;
 import com.link.up.api.dirtydata.DirtyDataSummary;
@@ -19,73 +20,84 @@ import com.link.up.connector.doris.converter.DorisRowSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Doris SinkWriter。
+ * Writes FluxRow batches through Doris Stream Load.
  *
- * <p>通过 Stream Load 将数据批量写入 Doris。
- * 内部维护一个行缓冲区，达到 {@code doris.batch.size} 阈值时
- * 触发一次 Stream Load HTTP 请求。
- *
- * <p>支持两种事务模式：
- * <ul>
- *   <li><b>非 2PC 模式</b>（默认）：每次 flush 立即提交，at-least-once 语义。</li>
- *   <li><b>2PC 模式</b>（{@code sink.enable-2pc=true}）：每次 flush 产生一个 PREPARE 事务，
- *       所有数据写入完成后在 {@link #commit()} 中统一提交，实现 exactly-once 语义。</li>
- * </ul>
+ * <p>The writer owns buffering, serialization and dirty-data reporting.
+ * Task-local 2PC transaction state belongs to
+ * {@link DorisTwoPhaseCommitController}.</p>
  */
-public final class DorisSinkWriter implements SinkWriter<FluxRow>, DirtyDataAwareSinkWriter {
+public final class DorisSinkWriter
+        implements SinkWriter<FluxRow>, DirtyDataAwareSinkWriter {
 
     private static final Logger LOG =
             LoggerFactory.getLogger(DorisSinkWriter.class);
 
     private final DorisSinkConfig config;
-    private final PreparedSinkMetadata metadata;
     private final DorisStreamLoadClient client;
-    private final List<FluxRow> buffer = new ArrayList<>();
-    private final boolean enable2pc;
+    private final DorisTwoPhaseCommitController transactions;
+    private final List<FluxRow> buffer =
+            new ArrayList<FluxRow>();
+
     private TableSchema schema;
     private DorisRowSerializer serializer;
-
-    private final List<String> pendingTxnIds = new ArrayList<>();
-
-    private long totalWrittenRows = 0;
-    private long totalLoadRequests = 0;
-    private long totalFilteredRows = 0;
+    private long totalWrittenRows;
+    private long totalLoadRequests;
+    private long totalFilteredRows;
 
     private DirtyDataCollector dirtyDataCollector;
     private DirtyDataContext dirtyDataContext;
 
-    public DorisSinkWriter(DorisSinkConfig config, PreparedSinkMetadata metadata) {
-        this.config = Objects.requireNonNull(config, "config must not be null");
-        this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
+    public DorisSinkWriter(
+            DorisSinkConfig config,
+            PreparedSinkMetadata metadata) {
+
+        this.config = Objects.requireNonNull(
+                config,
+                "config must not be null");
+        Objects.requireNonNull(
+                metadata,
+                "metadata must not be null");
+
         this.client = new DorisStreamLoadClient(config);
-        this.enable2pc = config.isEnable2pc();
+        this.transactions =
+                new DorisTwoPhaseCommitController(
+                        client,
+                        config.isEnable2pc());
     }
 
     @Override
     public void open() throws Exception {
-        LOG.info("Doris SinkWriter opened: database={}, table={}, batchSize={}, format={}, 2pc={}",
-                config.getDatabase(), config.getTable(),
-                config.getBatchSize(), config.getLoadFormat(), enable2pc);
+        LOG.info(
+                "Doris SinkWriter opened: database={}, table={}, batchSize={}, format={}, 2pc={}",
+                config.getDatabase(),
+                config.getTable(),
+                config.getBatchSize(),
+                config.getLoadFormat(),
+                transactions.isEnabled());
+
         if (dirtyDataCollector != null) {
             dirtyDataCollector.open();
         }
     }
 
     @Override
-    public void write(RecordBatch<FluxRow> batch, CatalogTable sourceTable) throws Exception {
-        if (batch == null || batch.isEndOfInput() || batch.getRecords().isEmpty()) {
+    public void write(
+            RecordBatch<FluxRow> batch,
+            CatalogTable sourceTable)
+            throws Exception {
+
+        if (batch == null
+                || batch.isEndOfInput()
+                || batch.getRecords().isEmpty()) {
             return;
         }
 
-        if (schema == null && sourceTable != null && sourceTable.getTableSchema() != null) {
-            schema = sourceTable.getTableSchema();
-        }
+        initializeSchema(sourceTable);
 
         for (FluxRow row : batch.getRecords()) {
             buffer.add(row);
@@ -103,35 +115,23 @@ public final class DorisSinkWriter implements SinkWriter<FluxRow>, DirtyDataAwar
 
     @Override
     public void commit() throws Exception {
-        if (enable2pc && !pendingTxnIds.isEmpty()) {
-            LOG.info("Committing {} pending 2PC transactions...", pendingTxnIds.size());
-            try {
-                client.commitTransactions(pendingTxnIds);
-                LOG.info("All {} 2PC transactions committed successfully", pendingTxnIds.size());
-            } catch (IOException e) {
-                LOG.error("2PC commit failed, {} transactions may be in inconsistent state. "
-                        + "Committed transactions will not be rolled back.",
-                        pendingTxnIds.size(), e);
-                throw new IOException("Doris 2PC commit failed with " + pendingTxnIds.size()
-                        + " pending transactions. Some may have been committed. "
-                        + "Check Doris transaction state before retrying.", e);
-            }
-            pendingTxnIds.clear();
-        }
-        LOG.info("Doris SinkWriter commit: totalWrittenRows={}, totalLoadRequests={}, 2pc={}",
-                totalWrittenRows, totalLoadRequests, enable2pc);
+        transactions.commit();
+
+        LOG.info(
+                "Doris SinkWriter commit: totalWrittenRows={}, totalLoadRequests={}, 2pc={}",
+                totalWrittenRows,
+                totalLoadRequests,
+                transactions.isEnabled());
     }
 
     @Override
     public void abort() throws Exception {
         buffer.clear();
-        if (enable2pc && !pendingTxnIds.isEmpty()) {
-            LOG.warn("Aborting {} pending 2PC transactions...", pendingTxnIds.size());
-            client.abortTransactions(pendingTxnIds);
-            LOG.info("All {} 2PC transactions aborted", pendingTxnIds.size());
-            pendingTxnIds.clear();
-        }
-        LOG.warn("Doris SinkWriter aborted, buffer cleared. totalWrittenRows={}", totalWrittenRows);
+        transactions.abort();
+
+        LOG.warn(
+                "Doris SinkWriter aborted: totalWrittenRows={}",
+                totalWrittenRows);
     }
 
     @Override
@@ -141,39 +141,60 @@ public final class DorisSinkWriter implements SinkWriter<FluxRow>, DirtyDataAwar
 
     @Override
     public String getRetryAdvice() {
-        if (enable2pc) {
-            return "Doris 2PC mode: data is PREPARED but not committed. "
-                    + "Safe to retry — uncommitted transactions will be aborted.";
-        }
-        return "Doris Stream Load commits per batch; verify already loaded data before retrying.";
+        return transactions.retryAdvice();
     }
 
     @Override
     public void close() throws Exception {
         try {
-            if (enable2pc && !pendingTxnIds.isEmpty()) {
-                LOG.warn("Closing with {} uncommitted 2PC transactions, aborting...", pendingTxnIds.size());
-                client.abortTransactions(pendingTxnIds);
-                pendingTxnIds.clear();
-            }
-            if (!enable2pc && !buffer.isEmpty()) {
-                flush();
-            }
+            closePendingWork();
         } finally {
-            try {
-                client.close();
-            } finally {
-                if (dirtyDataCollector != null) {
-                    try {
-                        dirtyDataCollector.close(true);
-                    } catch (Exception e) {
-                        LOG.warn("Failed to close dirty data collector", e);
-                    }
-                }
-            }
+            closeResources();
         }
-        LOG.info("Doris SinkWriter closed: totalWrittenRows={}, totalLoadRequests={}, totalFilteredRows={}, 2pc={}",
-                totalWrittenRows, totalLoadRequests, totalFilteredRows, enable2pc);
+
+        LOG.info(
+                "Doris SinkWriter closed: totalWrittenRows={}, totalLoadRequests={}, "
+                        + "totalFilteredRows={}, 2pc={}",
+                totalWrittenRows,
+                totalLoadRequests,
+                totalFilteredRows,
+                transactions.isEnabled());
+    }
+
+    @Override
+    public void configureDirtyData(
+            DirtyDataContext context)
+            throws Exception {
+
+        dirtyDataContext = Objects.requireNonNull(
+                context,
+                "context must not be null");
+
+        dirtyDataCollector =
+                new BoundedMemoryDirtyDataCollector(
+                        context.getTaskId(),
+                        100,
+                        1000,
+                        0.1);
+    }
+
+    @Override
+    public DirtyDataSummary getDirtyDataSummary() {
+        return dirtyDataCollector == null
+                ? DirtyDataSummary.empty()
+                : dirtyDataCollector.summary();
+    }
+
+    private void initializeSchema(
+            CatalogTable sourceTable) {
+
+        if (schema != null
+                || sourceTable == null
+                || sourceTable.getTableSchema() == null) {
+            return;
+        }
+
+        schema = sourceTable.getTableSchema();
     }
 
     private void flush() throws Exception {
@@ -181,87 +202,133 @@ public final class DorisSinkWriter implements SinkWriter<FluxRow>, DirtyDataAwar
             return;
         }
 
-        if (schema == null) {
-            throw new IllegalStateException(
-                    "Cannot flush: table schema is not initialized. "
-                            + "Ensure at least one write() call provides a CatalogTable with schema.");
-        }
+        ensureSerializer();
 
-        if (serializer == null) {
-            serializer = new DorisRowSerializer(config, schema);
-        }
         String data = serializer.serialize(buffer);
 
-        LOG.debug("Flushing {} rows via Stream Load, data size={} bytes",
-                buffer.size(), data.length());
+        LOG.debug(
+                "Flushing {} rows via Doris Stream Load: payloadBytes={}",
+                buffer.size(),
+                data.length());
 
-        StreamLoadResponse response = client.load(data);
+        StreamLoadResponse response =
+                client.load(data);
+
         response.checkSuccess();
 
         totalWrittenRows += buffer.size();
         totalLoadRequests++;
 
-        LOG.debug("Stream Load success: label={}, loadedRows={}, txnId={}, txnState={}",
-                response.getLabel(), response.getNumberLoadedRows(),
-                response.getTxnId(), response.getTxnState());
+        LOG.debug(
+                "Doris Stream Load succeeded: label={}, loadedRows={}, txnId={}, txnState={}",
+                response.getLabel(),
+                response.getNumberLoadedRows(),
+                response.getTxnId(),
+                response.getTxnState());
 
-        if (response.getNumberFilteredRows() > 0) {
-            totalFilteredRows += response.getNumberFilteredRows();
-            LOG.warn("Stream Load filtered {} rows, message: {}",
-                    response.getNumberFilteredRows(), response.getMessage());
-
-            if (dirtyDataCollector != null) {
-                try {
-                    dirtyDataCollector.recordAttempt(buffer.size());
-                    String errorMsg = "Doris Stream Load filtered " + response.getNumberFilteredRows()
-                            + " rows: " + response.getMessage();
-                    if (response.getBody() != null && response.getBody().contains("ErrorURL")) {
-                        errorMsg += ", check ErrorURL for details";
-                    }
-                    DirtyRecord dirtyRecord = new DirtyRecord(
-                            "STREAM_LOAD_FILTERED",
-                            errorMsg,
-                            dirtyDataContext,
-                            System.currentTimeMillis());
-                    dirtyDataCollector.collect(dirtyRecord);
-                } catch (Exception e) {
-                    LOG.error("Failed to record dirty data", e);
-                }
-            }
-        }
-
-        if (enable2pc) {
-            String txnId = response.getTxnId();
-            if (txnId == null || txnId.isEmpty()) {
-                throw new IOException(
-                        "2PC enabled but Doris returned no TxnId. "
-                        + "Response: " + response.getBody());
-            }
-            if (!response.isPrepared()) {
-                throw new IOException(
-                        "2PC enabled but TxnState is not PREPARE: txnId=" + txnId
-                                + ", txnState=" + response.getTxnState()
-                                + ", response=" + response.getBody());
-            }
-            pendingTxnIds.add(txnId);
-            LOG.debug("Collected 2PC txnId={}, pending count={}", txnId, pendingTxnIds.size());
-        }
-
+        recordFilteredRows(response);
+        transactions.record(response);
         buffer.clear();
     }
 
-    @Override
-    public void configureDirtyData(DirtyDataContext context) throws Exception {
-        this.dirtyDataContext = context;
-        this.dirtyDataCollector = new com.link.up.api.dirtydata.BoundedMemoryDirtyDataCollector(
-                context.getTaskId(), 100, 1000, 0.1);
+    private void ensureSerializer() {
+        if (schema == null) {
+            throw new IllegalStateException(
+                    "Cannot flush: table schema is not initialized. "
+                            + "Ensure at least one write() call provides "
+                            + "a CatalogTable with schema.");
+        }
+
+        if (serializer == null) {
+            serializer =
+                    new DorisRowSerializer(
+                            config,
+                            schema);
+        }
     }
 
-    @Override
-    public DirtyDataSummary getDirtyDataSummary() {
-        if (dirtyDataCollector != null) {
-            return dirtyDataCollector.summary();
+    private void recordFilteredRows(
+            StreamLoadResponse response) {
+
+        if (response.getNumberFilteredRows() <= 0) {
+            return;
         }
-        return DirtyDataSummary.empty();
+
+        totalFilteredRows +=
+                response.getNumberFilteredRows();
+
+        LOG.warn(
+                "Doris Stream Load filtered {} rows: {}",
+                response.getNumberFilteredRows(),
+                response.getMessage());
+
+        if (dirtyDataCollector == null) {
+            return;
+        }
+
+        try {
+            dirtyDataCollector.recordAttempt(
+                    buffer.size());
+
+            String message =
+                    "Doris Stream Load filtered "
+                            + response.getNumberFilteredRows()
+                            + " rows: "
+                            + response.getMessage();
+
+            if (response.getBody() != null
+                    && response.getBody().contains("ErrorURL")) {
+                message += ", check ErrorURL for details";
+            }
+
+            dirtyDataCollector.collect(
+                    new DirtyRecord(
+                            "STREAM_LOAD_FILTERED",
+                            message,
+                            dirtyDataContext,
+                            System.currentTimeMillis()));
+
+        } catch (Exception failure) {
+            LOG.error(
+                    "Failed to record Doris dirty-data evidence",
+                    failure);
+        }
+    }
+
+    private void closePendingWork()
+            throws Exception {
+
+        if (transactions.isEnabled()) {
+            transactions.close();
+            return;
+        }
+
+        if (!buffer.isEmpty()) {
+            flush();
+        }
+    }
+
+    private void closeResources()
+            throws Exception {
+
+        try {
+            client.close();
+        } finally {
+            closeDirtyDataCollector();
+        }
+    }
+
+    private void closeDirtyDataCollector() {
+        if (dirtyDataCollector == null) {
+            return;
+        }
+
+        try {
+            dirtyDataCollector.close(true);
+        } catch (Exception failure) {
+            LOG.warn(
+                    "Failed to close dirty data collector",
+                    failure);
+        }
     }
 }

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/sink/DorisTwoPhaseCommitController.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/sink/DorisTwoPhaseCommitController.java
@@ -1,0 +1,153 @@
+package com.link.up.connector.doris.sink;
+
+import com.link.up.connector.doris.client.DorisStreamLoadClient;
+import com.link.up.connector.doris.client.DorisStreamLoadClient.StreamLoadResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Owns Doris task-local 2PC transaction state for one sink writer. */
+final class DorisTwoPhaseCommitController {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(
+                    DorisTwoPhaseCommitController.class);
+
+    private final DorisStreamLoadClient client;
+    private final boolean enabled;
+    private final List<String> pendingTransactionIds =
+            new ArrayList<String>();
+
+    DorisTwoPhaseCommitController(
+            DorisStreamLoadClient client,
+            boolean enabled) {
+
+        this.client = Objects.requireNonNull(
+                client,
+                "client must not be null");
+        this.enabled = enabled;
+    }
+
+    void record(StreamLoadResponse response)
+            throws IOException {
+
+        Objects.requireNonNull(
+                response,
+                "response must not be null");
+
+        if (!enabled) {
+            return;
+        }
+
+        String transactionId = response.getTxnId();
+
+        if (transactionId == null
+                || transactionId.trim().isEmpty()) {
+            throw new IOException(
+                    "2PC enabled but Doris returned no TxnId. Response: "
+                            + response.getBody());
+        }
+
+        if (!response.isPrepared()) {
+            throw new IOException(
+                    "2PC enabled but TxnState is not PREPARE: txnId="
+                            + transactionId
+                            + ", txnState="
+                            + response.getTxnState()
+                            + ", response="
+                            + response.getBody());
+        }
+
+        pendingTransactionIds.add(transactionId);
+
+        LOG.debug(
+                "Collected Doris 2PC transaction: txnId={}, pendingCount={}",
+                transactionId,
+                pendingTransactionIds.size());
+    }
+
+    void commit() throws IOException {
+        if (!enabled || pendingTransactionIds.isEmpty()) {
+            return;
+        }
+
+        int count = pendingTransactionIds.size();
+
+        LOG.info(
+                "Committing {} pending Doris 2PC transactions",
+                count);
+
+        try {
+            client.commitTransactions(pendingTransactionIds);
+        } catch (IOException failure) {
+            LOG.error(
+                    "Doris 2PC commit failed; {} transactions may be in an inconsistent state",
+                    count,
+                    failure);
+
+            throw new IOException(
+                    "Doris 2PC commit failed with "
+                            + count
+                            + " pending transactions. Some may have been committed. "
+                            + "Check Doris transaction state before retrying.",
+                    failure);
+        }
+
+        pendingTransactionIds.clear();
+
+        LOG.info(
+                "Committed {} Doris 2PC transactions",
+                count);
+    }
+
+    void abort() {
+        if (!enabled || pendingTransactionIds.isEmpty()) {
+            return;
+        }
+
+        int count = pendingTransactionIds.size();
+
+        LOG.warn(
+                "Aborting {} pending Doris 2PC transactions",
+                count);
+
+        client.abortTransactions(pendingTransactionIds);
+        pendingTransactionIds.clear();
+
+        LOG.info(
+                "Aborted {} Doris 2PC transactions",
+                count);
+    }
+
+    void close() {
+        if (!enabled || pendingTransactionIds.isEmpty()) {
+            return;
+        }
+
+        LOG.warn(
+                "Closing Doris sink with {} uncommitted 2PC transactions",
+                pendingTransactionIds.size());
+
+        abort();
+    }
+
+    String retryAdvice() {
+        return enabled
+                ? "Doris 2PC mode: data is PREPARED but not committed. "
+                        + "Safe to retry — uncommitted transactions will be aborted."
+                : "Doris Stream Load commits per batch; "
+                        + "verify already loaded data before retrying.";
+    }
+
+    boolean isEnabled() {
+        return enabled;
+    }
+
+    int pendingCount() {
+        return pendingTransactionIds.size();
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/DorisConnectorPackageBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/DorisConnectorPackageBoundaryTest.java
@@ -1,12 +1,15 @@
 package com.link.up.connector.doris;
 
 import com.link.up.connector.doris.converter.DorisRowSerializer;
+import com.link.up.connector.doris.sink.DorisSinkWriter;
 import org.junit.Test;
 
 import java.io.File;
+import java.lang.reflect.Field;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class DorisConnectorPackageBoundaryTest {
 
@@ -15,6 +18,22 @@ public class DorisConnectorPackageBoundaryTest {
         assertEquals(
                 "com.link.up.connector.doris.converter",
                 DorisRowSerializer.class.getPackage().getName());
+    }
+
+    @Test
+    public void sinkWriterDelegatesTwoPhaseCommitState() {
+        boolean found = false;
+
+        for (Field field : DorisSinkWriter.class.getDeclaredFields()) {
+            if ("com.link.up.connector.doris.sink.DorisTwoPhaseCommitController"
+                    .equals(field.getType().getName())) {
+                found = true;
+            }
+        }
+
+        assertTrue(
+                "DorisSinkWriter should delegate 2PC state to a focused role",
+                found);
     }
 
     @Test
@@ -35,7 +54,8 @@ public class DorisConnectorPackageBoundaryTest {
 
         for (String name : forbidden) {
             assertFalse(
-                    "Forbidden Doris connector root package exists: " + name,
+                    "Forbidden Doris connector root package exists: "
+                            + name,
                     new File(root, name).exists());
         }
     }

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpRequestFactory.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpRequestFactory.java
@@ -1,0 +1,211 @@
+package com.link.up.connector.http.client;
+
+import com.link.up.connector.http.config.HttpMethod;
+import com.link.up.connector.http.config.HttpSourceConfig;
+import okhttp3.FormBody;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+import java.net.URLEncoder;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Builds one OkHttp request from immutable source config and page overrides. */
+final class HttpRequestFactory {
+
+    private static final MediaType JSON_MEDIA_TYPE =
+            MediaType.parse(
+                    "application/json; charset=utf-8");
+
+    private final HttpSourceConfig config;
+
+    HttpRequestFactory(HttpSourceConfig config) {
+        this.config = Objects.requireNonNull(
+                config,
+                "config must not be null");
+    }
+
+    Request create(
+            Map<String, String> effectiveHeaders,
+            Map<String, String> effectiveParams,
+            String effectiveBody) {
+
+        String url =
+                buildUrl(effectiveParams);
+
+        Request.Builder builder =
+                new Request.Builder()
+                        .url(url);
+
+        applyHeaders(
+                builder,
+                effectiveHeaders);
+
+        if (config.getMethod() == HttpMethod.POST) {
+            builder.post(
+                    requestBody(
+                            effectiveHeaders,
+                            effectiveParams,
+                            effectiveBody));
+        } else {
+            builder.get();
+        }
+
+        return builder.build();
+    }
+
+    private void applyHeaders(
+            Request.Builder builder,
+            Map<String, String> headers) {
+
+        if (headers == null) {
+            return;
+        }
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            builder.header(
+                    entry.getKey(),
+                    entry.getValue());
+        }
+    }
+
+    private RequestBody requestBody(
+            Map<String, String> headers,
+            Map<String, String> params,
+            String effectiveBody) {
+
+        String body =
+                effectiveBody != null
+                        ? effectiveBody
+                        : config.getBody();
+
+        if (body == null || body.isEmpty()) {
+            return RequestBody.create(
+                    "{}",
+                    JSON_MEDIA_TYPE);
+        }
+
+        if ("application/x-www-form-urlencoded"
+                .equalsIgnoreCase(
+                        contentType(headers))) {
+            return formBody(
+                    body,
+                    params);
+        }
+
+        return RequestBody.create(
+                body,
+                JSON_MEDIA_TYPE);
+    }
+
+    private String buildUrl(
+            Map<String, String> effectiveParams) {
+
+        StringBuilder url =
+                new StringBuilder(
+                        config.getUrl());
+
+        Map<String, String> params =
+                new LinkedHashMap<String, String>();
+
+        if (config.getParams() != null) {
+            params.putAll(
+                    config.getParams());
+        }
+
+        if (effectiveParams != null) {
+            params.putAll(
+                    effectiveParams);
+        }
+
+        if (params.isEmpty()) {
+            return url.toString();
+        }
+
+        char separator =
+                config.getUrl().contains("?")
+                        ? '&'
+                        : '?';
+
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            url.append(separator)
+                    .append(
+                            encode(
+                                    entry.getKey()))
+                    .append('=')
+                    .append(
+                            encode(
+                                    entry.getValue()));
+
+            separator = '&';
+        }
+
+        return url.toString();
+    }
+
+    private RequestBody formBody(
+            String body,
+            Map<String, String> params) {
+
+        FormBody.Builder builder =
+                new FormBody.Builder();
+
+        for (String pair : body.split("&")) {
+            int separator =
+                    pair.indexOf('=');
+
+            if (separator <= 0) {
+                continue;
+            }
+
+            builder.add(
+                    pair.substring(
+                            0,
+                            separator)
+                            .trim(),
+                    pair.substring(
+                            separator + 1)
+                            .trim());
+        }
+
+        if (params != null) {
+            for (Map.Entry<String, String> entry : params.entrySet()) {
+                builder.add(
+                        entry.getKey(),
+                        entry.getValue());
+            }
+        }
+
+        return builder.build();
+    }
+
+    private static String contentType(
+            Map<String, String> headers) {
+
+        if (headers == null) {
+            return null;
+        }
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if ("content-type"
+                    .equalsIgnoreCase(
+                            entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+
+        return null;
+    }
+
+    private static String encode(String value) {
+        try {
+            return URLEncoder.encode(
+                    value,
+                    "UTF-8");
+        } catch (Exception ignored) {
+            return value;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpRetryPolicy.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpRetryPolicy.java
@@ -1,0 +1,79 @@
+package com.link.up.connector.http.client;
+
+import com.link.up.connector.http.config.HttpMethod;
+import com.link.up.connector.http.config.HttpSourceConfig;
+
+import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
+
+/** Retry decisions for one HTTP source client. */
+final class HttpRetryPolicy {
+
+    private final HttpSourceConfig config;
+
+    HttpRetryPolicy(HttpSourceConfig config) {
+        this.config = Objects.requireNonNull(
+                config,
+                "config must not be null");
+    }
+
+    int maxAttempts() {
+        return Math.max(
+                1,
+                config.getRetry() + 1);
+    }
+
+    boolean isMethodRetryable() {
+        return config.getMethod() == HttpMethod.GET;
+    }
+
+    boolean isStatusRetryable(int statusCode) {
+        return config.getRetryableStatusCodes()
+                .contains(statusCode);
+    }
+
+    long backoffMillis(int attempt) {
+        long multiplier =
+                config.getRetryBackoffMultiplierMs();
+
+        long exponential =
+                attempt >= 63
+                        ? Long.MAX_VALUE
+                        : safeMultiply(
+                                multiplier,
+                                1L << Math.max(0, attempt - 1));
+
+        long base =
+                Math.min(
+                        exponential,
+                        config.getRetryBackoffMaxMs());
+
+        int jitterMax =
+                config.getRetryJitterMs();
+
+        if (jitterMax <= 0) {
+            return base;
+        }
+
+        return base
+                + ThreadLocalRandom.current()
+                .nextLong(
+                        0L,
+                        (long) jitterMax + 1L);
+    }
+
+    private static long safeMultiply(
+            long left,
+            long right) {
+
+        if (left == 0L || right == 0L) {
+            return 0L;
+        }
+
+        if (left > Long.MAX_VALUE / right) {
+            return Long.MAX_VALUE;
+        }
+
+        return left * right;
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpSourceClient.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/client/HttpSourceClient.java
@@ -1,372 +1,328 @@
 package com.link.up.connector.http.client;
 
-import com.link.up.connector.http.config.HttpFormat;
-import com.link.up.connector.http.config.HttpMethod;
 import com.link.up.connector.http.config.HttpSourceConfig;
 import okhttp3.ConnectionPool;
-import okhttp3.FormBody;
-import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
 /**
- * HTTP 请求客户端。
+ * Executes HTTP source requests with connector-level retry semantics.
  *
- * <p>封装 OkHttp，提供带连接池和增强重试策略的 HTTP 请求执行能力。
- *
- * <h3>连接池</h3>
- * <p>通过 {@code pool.max_idle_connections} 和 {@code pool.keep_alive_duration_ms}
- * 显式配置 OkHttp {@link ConnectionPool}，避免高并发分页场景下频繁建立连接。
- *
- * <h3>重试策略</h3>
- * <ul>
- *     <li>指数退避：{@code backoff = multiplier * 2^(attempt-1)}，上限 {@code retry_backoff_max_ms}</li>
- *     <li>抖动因子：在退避时间上叠加 {@code [0, retry_jitter_ms)} 随机值，防止惊群</li>
- *     <li>可重试状态码：通过 {@code retryable_status_codes} 配置哪些 HTTP 状态码触发重试</li>
- *     <li>连接级异常（连接超时、连接拒绝等）：安全重试</li>
- *     <li>响应体读取异常：不重试，因为服务端可能已返回数据，重试会导致下游重复写入</li>
- *     <li>POST 请求：默认不重试，因为服务端可能已执行副作用</li>
- * </ul>
+ * <p>Request construction belongs to {@link HttpRequestFactory}; retry
+ * decisions belong to {@link HttpRetryPolicy}. This client owns OkHttp
+ * resources and response safety semantics.</p>
  */
-public final class HttpSourceClient implements AutoCloseable {
+public final class HttpSourceClient
+        implements AutoCloseable {
 
     private static final Logger LOG =
             LoggerFactory.getLogger(HttpSourceClient.class);
 
-    private static final MediaType JSON_MEDIA_TYPE =
-            MediaType.parse("application/json; charset=utf-8");
-
     private final HttpSourceConfig config;
     private final OkHttpClient httpClient;
+    private final HttpRequestFactory requestFactory;
+    private final HttpRetryPolicy retryPolicy;
 
     public HttpSourceClient(HttpSourceConfig config) {
-        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.config = Objects.requireNonNull(
+                config,
+                "config must not be null");
 
-        ConnectionPool connectionPool = new ConnectionPool(
-                config.getPoolMaxIdleConnections(),
-                config.getPoolKeepAliveDurationMs(),
-                TimeUnit.MILLISECONDS);
+        ConnectionPool connectionPool =
+                new ConnectionPool(
+                        config.getPoolMaxIdleConnections(),
+                        config.getPoolKeepAliveDurationMs(),
+                        TimeUnit.MILLISECONDS);
 
-        this.httpClient = new OkHttpClient.Builder()
-                .connectTimeout(config.getConnectTimeoutMs(), TimeUnit.MILLISECONDS)
-                .readTimeout(config.getSocketTimeoutMs(), TimeUnit.MILLISECONDS)
-                .writeTimeout(config.getSocketTimeoutMs(), TimeUnit.MILLISECONDS)
-                .connectionPool(connectionPool)
-                .build();
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(
+                                config.getConnectTimeoutMs(),
+                                TimeUnit.MILLISECONDS)
+                        .readTimeout(
+                                config.getSocketTimeoutMs(),
+                                TimeUnit.MILLISECONDS)
+                        .writeTimeout(
+                                config.getSocketTimeoutMs(),
+                                TimeUnit.MILLISECONDS)
+                        .connectionPool(
+                                connectionPool)
+                        .build();
+
+        this.requestFactory =
+                new HttpRequestFactory(config);
+        this.retryPolicy =
+                new HttpRetryPolicy(config);
     }
 
-    /**
-     * 执行一次 HTTP 请求，返回响应体字符串。
-     *
-     * <p>包含增强重试逻辑：
-     * <ul>
-     *     <li>连接级异常（连接超时、连接拒绝等）安全重试</li>
-     *     <li>响应体读取异常不重试（服务端可能已返回数据，重试导致下游重复写入）</li>
-     *     <li>POST 请求默认不重试（服务端可能已执行副作用）</li>
-     *     <li>可重试的 HTTP 状态码（如 429、500、502、503、504）重试</li>
-     *     <li>其他 4xx/5xx 状态码不重试，直接抛出异常</li>
-     *     <li>指数退避 + 随机抖动，避免惊群效应</li>
-     * </ul>
-     *
-     * @param effectiveHeaders 当前请求头（可能已替换分页占位符）
-     * @param effectiveParams  当前请求参数（可能已替换分页占位符）
-     * @param effectiveBody    当前请求体（可能已替换分页占位符）
-     * @return 响应体文本
-     */
     public String execute(
             Map<String, String> effectiveHeaders,
             Map<String, String> effectiveParams,
-            String effectiveBody) throws IOException {
+            String effectiveBody)
+            throws IOException {
 
-        IOException lastException = null;
-        int maxAttempts = Math.max(1, config.getRetry() + 1);
-        Set<Integer> retryableCodes = config.getRetryableStatusCodes();
+        IOException lastFailure = null;
+        int maxAttempts =
+                retryPolicy.maxAttempts();
 
-        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+        for (int attempt = 1;
+             attempt <= maxAttempts;
+             attempt++) {
+
             try {
-                return doExecute(effectiveHeaders, effectiveParams, effectiveBody);
+                return doExecute(
+                        effectiveHeaders,
+                        effectiveParams,
+                        effectiveBody);
+
             } catch (HttpRetryableException retryable) {
-                lastException = retryable;
-                if (attempt < maxAttempts && isRetryable(retryable.getStatusCode(), retryable, retryableCodes)) {
-                    long backoff = computeBackoff(attempt, maxAttempts);
-                    LOG.warn("HTTP request returned retryable status {} (attempt {}/{}), retrying in {} ms: {}",
-                            retryable.getStatusCode(), attempt, maxAttempts, backoff, retryable.getMessage());
-                    sleep(backoff);
-                } else {
+                lastFailure = retryable;
+
+                if (attempt >= maxAttempts
+                        || !retryPolicy.isStatusRetryable(
+                                retryable.getStatusCode())) {
                     throw retryable;
                 }
-            } catch (ResponseReadException e) {
-                /*
-                 * 响应体读取失败：服务端已处理请求并返回了数据，
-                 * 但客户端在读取响应体时网络中断。
-                 * 此时重试会导致相同数据被再次获取，造成下游重复写入。
-                 */
-                LOG.error("HTTP response read failed, server may have returned data. "
-                        + "Skipping retry to avoid duplicate downstream writes: {}", e.getMessage());
-                throw e;
-            } catch (IOException e) {
-                lastException = e;
-                if (attempt < maxAttempts && isMethodRetryable()) {
-                    long backoff = computeBackoff(attempt, maxAttempts);
-                    LOG.warn("HTTP request failed (attempt {}/{}), retrying in {} ms: {}",
-                            attempt, maxAttempts, backoff, e.getMessage());
-                    sleep(backoff);
-                } else if (!isMethodRetryable()) {
-                    LOG.warn("HTTP {} request failed, POST requests are not retried by default "
-                            + "to avoid duplicate side effects: {}", config.getMethod(), e.getMessage());
-                    throw e;
+
+                retry(
+                        attempt,
+                        maxAttempts,
+                        "HTTP request returned retryable status "
+                                + retryable.getStatusCode(),
+                        retryable);
+
+            } catch (ResponseReadException readFailure) {
+                LOG.error(
+                        "HTTP response read failed; skipping retry to avoid "
+                                + "duplicate downstream writes: {}",
+                        readFailure.getMessage());
+                throw readFailure;
+
+            } catch (IOException failure) {
+                lastFailure = failure;
+
+                if (!retryPolicy.isMethodRetryable()) {
+                    LOG.warn(
+                            "HTTP {} request failed; non-idempotent requests "
+                                    + "are not retried by default: {}",
+                            config.getMethod(),
+                            failure.getMessage());
+                    throw failure;
                 }
+
+                if (attempt >= maxAttempts) {
+                    throw failure;
+                }
+
+                retry(
+                        attempt,
+                        maxAttempts,
+                        "HTTP request failed",
+                        failure);
             }
         }
 
-        throw lastException;
+        throw lastFailure == null
+                ? new IOException(
+                        "HTTP request failed without an execution attempt")
+                : lastFailure;
     }
 
-    /**
-     * 判断当前请求方法是否允许重试。
-     *
-     * <p>GET 请求是幂等的，可以安全重试；
-     * POST 请求可能包含副作用，默认不重试以避免重复写入。
-     */
-    private boolean isMethodRetryable() {
-        return config.getMethod() == HttpMethod.GET;
-    }
-
-    /**
-     * 判断给定的 HTTP 状态码是否可重试。
-     */
-    private boolean isRetryable(int statusCode, HttpRetryableException exception, Set<Integer> retryableCodes) {
-        return retryableCodes.contains(statusCode);
-    }
-
-    /**
-     * 计算指数退避 + 抖动的等待时间。
-     *
-     * <p>公式：{@code min(multiplier * 2^(attempt-1), max_backoff) + random(0, jitter)}
-     */
-    private long computeBackoff(int attempt, int maxAttempts) {
-        long baseBackoff = Math.min(
-                (long) config.getRetryBackoffMultiplierMs() * (1L << (attempt - 1)),
-                config.getRetryBackoffMaxMs());
-
-        int jitterMax = config.getRetryJitterMs();
-        if (jitterMax > 0) {
-            long jitter = ThreadLocalRandom.current().nextLong(0, jitterMax + 1);
-            return baseBackoff + jitter;
-        }
-
-        return baseBackoff;
+    @Override
+    public void close() {
+        httpClient.dispatcher()
+                .executorService()
+                .shutdown();
+        httpClient.connectionPool()
+                .evictAll();
     }
 
     private String doExecute(
-            Map<String, String> effectiveHeaders,
-            Map<String, String> effectiveParams,
-            String effectiveBody) throws IOException {
+            Map<String, String> headers,
+            Map<String, String> params,
+            String body)
+            throws IOException {
 
-        String url = buildUrl(effectiveParams);
+        Request request =
+                requestFactory.create(
+                        headers,
+                        params,
+                        body);
 
-        Request.Builder requestBuilder = new Request.Builder().url(url);
+        String url =
+                request.url()
+                        .toString();
 
-        // 设置请求头
-        if (effectiveHeaders != null) {
-            for (Map.Entry<String, String> entry : effectiveHeaders.entrySet()) {
-                requestBuilder.header(entry.getKey(), entry.getValue());
-            }
-        }
+        LOG.debug(
+                "HTTP {} {}",
+                config.getMethod(),
+                url);
 
-        // 设置请求方法和请求体
-        HttpMethod method = config.getMethod();
-        if (method == HttpMethod.POST) {
-            String bodyContent = effectiveBody != null ? effectiveBody : config.getBody();
-            RequestBody requestBody;
-            if (bodyContent != null && !bodyContent.isEmpty()) {
-                String contentType = getContentType(effectiveHeaders);
-                if ("application/x-www-form-urlencoded".equalsIgnoreCase(contentType)) {
-                    requestBody = buildFormBody(bodyContent, effectiveParams);
-                } else {
-                    requestBody = RequestBody.create(bodyContent, JSON_MEDIA_TYPE);
-                }
-            } else {
-                // POST 无 body 时发送空 JSON
-                requestBody = RequestBody.create("{}", JSON_MEDIA_TYPE);
-            }
-            requestBuilder.post(requestBody);
-        } else {
-            requestBuilder.get();
-        }
+        try (Response response =
+                     httpClient.newCall(request)
+                             .execute()) {
 
-        LOG.debug("HTTP {} {}", method, url);
-
-        try (Response response = httpClient.newCall(requestBuilder.build()).execute()) {
             if (!response.isSuccessful()) {
-                int statusCode = response.code();
-                String message = "HTTP request failed with status " + statusCode + " for URL: " + url;
-
-                /*
-                 * 可重试的状态码包装为 HttpRetryableException，
-                 * 由上层 execute() 决定是否重试。
-                 */
-                if (config.getRetryableStatusCodes().contains(statusCode)) {
-                    ResponseBody errorBody = response.body();
-                    String errorDetail = errorBody != null ? errorBody.string() : "";
-                    throw new HttpRetryableException(statusCode, message + " (body: " + truncate(errorDetail, 500) + ")");
-                }
-
-                LOG.warn("HTTP request failed: status={}, url={}", statusCode, url);
-                throw new IOException(message);
+                throwHttpFailure(
+                        response,
+                        url);
             }
-            ResponseBody responseBody = response.body();
-            String body;
-            try {
-                body = responseBody != null ? responseBody.string() : "";
-            } catch (IOException e) {
-                /*
-                 * 响应体读取失败（如连接被重置、超时等）。
-                 * 服务端已处理请求并可能已返回了部分/全部数据，
-                 * 包装为 ResponseReadException 以阻止上层重试，
-                 * 避免下游重复写入。
-                 */
-                throw new ResponseReadException(
-                        "Failed to read HTTP response body for URL: " + url
-                                + ". Data may have been partially received.", e);
-            }
-            LOG.debug("HTTP response: status={}, bodyLength={}",
-                    response.code(), body.length());
-            return body;
+
+            String responseBody =
+                    readResponseBody(
+                            response,
+                            url);
+
+            LOG.debug(
+                    "HTTP response: status={}, bodyLength={}",
+                    response.code(),
+                    responseBody.length());
+
+            return responseBody;
         }
     }
 
-    private String buildUrl(Map<String, String> effectiveParams) {
-        StringBuilder urlBuilder = new StringBuilder(config.getUrl());
+    private void throwHttpFailure(
+            Response response,
+            String url)
+            throws IOException {
 
-        // 合并静态 params 和分页 params
-        Map<String, String> allParams = new LinkedHashMap<>();
-        if (config.getParams() != null) {
-            allParams.putAll(config.getParams());
-        }
-        if (effectiveParams != null) {
-            allParams.putAll(effectiveParams);
+        int statusCode =
+                response.code();
+
+        String message =
+                "HTTP request failed with status "
+                        + statusCode
+                        + " for URL: "
+                        + url;
+
+        if (retryPolicy.isStatusRetryable(statusCode)) {
+            ResponseBody errorBody =
+                    response.body();
+
+            String detail =
+                    errorBody == null
+                            ? ""
+                            : errorBody.string();
+
+            throw new HttpRetryableException(
+                    statusCode,
+                    message
+                            + " (body: "
+                            + truncate(
+                                    detail,
+                                    500)
+                            + ")");
         }
 
-        if (!allParams.isEmpty()) {
-            char separator = config.getUrl().contains("?") ? '&' : '?';
-            for (Map.Entry<String, String> entry : allParams.entrySet()) {
-                urlBuilder.append(separator)
-                        .append(urlEncode(entry.getKey()))
-                        .append('=')
-                        .append(urlEncode(entry.getValue()));
-                separator = '&';
-            }
-        }
+        LOG.warn(
+                "HTTP request failed: status={}, url={}",
+                statusCode,
+                url);
 
-        return urlBuilder.toString();
+        throw new IOException(message);
     }
 
-    private RequestBody buildFormBody(
-            String bodyContent,
-            Map<String, String> effectiveParams) {
-        FormBody.Builder formBuilder = new FormBody.Builder();
+    private String readResponseBody(
+            Response response,
+            String url)
+            throws IOException {
 
-        // 解析 body 中的 form 参数（简单 key=value&key2=value2 格式）
-        if (bodyContent != null && !bodyContent.isEmpty()) {
-            for (String pair : bodyContent.split("&")) {
-                int eq = pair.indexOf('=');
-                if (eq > 0) {
-                    formBuilder.add(
-                            pair.substring(0, eq).trim(),
-                            pair.substring(eq + 1).trim());
-                }
-            }
-        }
+        ResponseBody responseBody =
+                response.body();
 
-        // 追加 params
-        if (effectiveParams != null) {
-            for (Map.Entry<String, String> entry : effectiveParams.entrySet()) {
-                formBuilder.add(entry.getKey(), entry.getValue());
-            }
-        }
-
-        return formBuilder.build();
-    }
-
-    private String getContentType(Map<String, String> headers) {
-        if (headers == null) {
-            return null;
-        }
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-            if ("content-type".equalsIgnoreCase(entry.getKey())) {
-                return entry.getValue();
-            }
-        }
-        return null;
-    }
-
-    private static String urlEncode(String value) {
         try {
-            return URLEncoder.encode(value, "UTF-8");
-        } catch (Exception e) {
-            return value;
+            return responseBody == null
+                    ? ""
+                    : responseBody.string();
+
+        } catch (IOException failure) {
+            throw new ResponseReadException(
+                    "Failed to read HTTP response body for URL: "
+                            + url
+                            + ". Data may have been partially received.",
+                    failure);
         }
     }
 
-    private static String truncate(String value, int maxLength) {
+    private void retry(
+            int attempt,
+            int maxAttempts,
+            String reason,
+            IOException failure) {
+
+        long backoff =
+                retryPolicy.backoffMillis(
+                        attempt);
+
+        LOG.warn(
+                "{} (attempt {}/{}), retrying in {} ms: {}",
+                reason,
+                attempt,
+                maxAttempts,
+                backoff,
+                failure.getMessage());
+
+        sleep(backoff);
+    }
+
+    private static String truncate(
+            String value,
+            int maxLength) {
+
         if (value == null) {
             return "";
         }
-        return value.length() <= maxLength ? value : value.substring(0, maxLength) + "...";
+
+        return value.length() <= maxLength
+                ? value
+                : value.substring(
+                        0,
+                        maxLength)
+                        + "...";
     }
 
     private static void sleep(long millis) {
         try {
             Thread.sleep(millis);
-        } catch (InterruptedException e) {
+        } catch (InterruptedException interrupted) {
             Thread.currentThread().interrupt();
         }
     }
 
-    @Override
-    public void close() {
-        httpClient.dispatcher().executorService().shutdown();
-        httpClient.connectionPool().evictAll();
-    }
+    /** Response-body read failure. Retrying may duplicate downstream data. */
+    static final class ResponseReadException
+            extends IOException {
 
-    /**
-     * 响应体读取异常。
-     *
-     * <p>当 HTTP 响应头已接收但读取响应体失败时抛出。
-     * 此时服务端可能已处理请求并返回了数据，
-     * 重试会导致下游重复写入，因此上层不应重试此异常。
-     */
-    static final class ResponseReadException extends IOException {
-        ResponseReadException(String message, Throwable cause) {
-            super(message, cause);
+        ResponseReadException(
+                String message,
+                Throwable cause) {
+
+            super(
+                    message,
+                    cause);
         }
     }
 
-    /**
-     * 可重试的 HTTP 异常。
-     *
-     * <p>当服务端返回的状态码在 {@code retryable_status_codes} 列表中时，
-     * 抛出该异常以触发重试逻辑。
-     */
-    static final class HttpRetryableException extends IOException {
+    /** HTTP response that is eligible for connector-configured retry. */
+    static final class HttpRetryableException
+            extends IOException {
+
         private final int statusCode;
 
-        HttpRetryableException(int statusCode, String message) {
+        HttpRetryableException(
+                int statusCode,
+                String message) {
+
             super(message);
             this.statusCode = statusCode;
         }

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpPageRequest.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpPageRequest.java
@@ -1,0 +1,45 @@
+package com.link.up.connector.http.source;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable request values for one HTTP source page. */
+final class HttpPageRequest {
+
+    private final Map<String, String> headers;
+    private final Map<String, String> params;
+    private final String body;
+
+    HttpPageRequest(
+            Map<String, String> headers,
+            Map<String, String> params,
+            String body) {
+
+        this.headers = immutable(headers, "headers");
+        this.params = immutable(params, "params");
+        this.body = body;
+    }
+
+    Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    Map<String, String> getParams() {
+        return params;
+    }
+
+    String getBody() {
+        return body;
+    }
+
+    private static Map<String, String> immutable(
+            Map<String, String> values,
+            String name) {
+
+        Objects.requireNonNull(values, name + " must not be null");
+        return Collections.unmodifiableMap(
+                new LinkedHashMap<String, String>(values));
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpPaginationState.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpPaginationState.java
@@ -1,0 +1,248 @@
+package com.link.up.connector.http.source;
+
+import com.link.up.connector.http.config.HttpSourceConfig;
+import com.link.up.connector.http.config.PageType;
+import com.link.up.connector.http.converter.HttpResponseParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Owns mutable pagination state for one {@link HttpSourceReader}.
+ *
+ * <p>The reader asks this object for the current request values and reports
+ * each response back after parsing. HTTP transport remains in the client and
+ * response conversion remains in the converter package.</p>
+ */
+final class HttpPaginationState {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(HttpPaginationState.class);
+
+    private final HttpSourceConfig config;
+
+    private int currentPage;
+    private String currentCursor;
+    private boolean exhausted;
+
+    HttpPaginationState(HttpSourceConfig config) {
+        this.config = Objects.requireNonNull(
+                config,
+                "config must not be null");
+        this.currentPage = config.getStartPageNumber();
+        this.exhausted = false;
+    }
+
+    HttpPageRequest currentRequest() {
+        Map<String, String> headers =
+                new LinkedHashMap<String, String>(config.getHeaders());
+        Map<String, String> params =
+                new LinkedHashMap<String, String>();
+        String body = config.getBody();
+
+        if (!config.hasPagination()) {
+            return new HttpPageRequest(headers, params, body);
+        }
+
+        if (config.getPageType() == PageType.CURSOR) {
+            applyCursor(headers, params);
+        } else {
+            applyPageNumber(headers, params);
+        }
+
+        if (config.isUsePlaceholderReplacement() && body != null) {
+            body = replaceBodyPlaceholder(body);
+        }
+
+        return new HttpPageRequest(headers, params, body);
+    }
+
+    void advance(String responseBody, int rowCount) {
+        if (!config.hasPagination()) {
+            exhausted = true;
+            return;
+        }
+
+        if (config.getPageType() == PageType.CURSOR) {
+            advanceCursor(responseBody);
+        } else {
+            advancePageNumber(rowCount);
+        }
+    }
+
+    boolean isExhausted() {
+        return exhausted;
+    }
+
+    int getCurrentPage() {
+        return currentPage;
+    }
+
+    String getCurrentCursor() {
+        return currentCursor;
+    }
+
+    private void applyPageNumber(
+            Map<String, String> headers,
+            Map<String, String> params) {
+
+        String field = config.getPageField();
+        String value = String.valueOf(currentPage);
+
+        if (config.isUsePlaceholderReplacement()) {
+            replacePlaceholder(headers, field, value);
+            replacePlaceholder(params, field, value);
+            return;
+        }
+
+        params.put(field, value);
+    }
+
+    private void applyCursor(
+            Map<String, String> headers,
+            Map<String, String> params) {
+
+        if (currentCursor == null || config.getCursorField() == null) {
+            return;
+        }
+
+        if (config.isUsePlaceholderReplacement()) {
+            replacePlaceholder(
+                    headers,
+                    config.getCursorField(),
+                    currentCursor);
+            replacePlaceholder(
+                    params,
+                    config.getCursorField(),
+                    currentCursor);
+            return;
+        }
+
+        params.put(
+                config.getCursorField(),
+                currentCursor);
+    }
+
+    private void advancePageNumber(int rowCount) {
+        long totalPageSize = config.getTotalPageSize();
+
+        if (totalPageSize > 0) {
+            long lastPage =
+                    totalPageSize
+                            + config.getStartPageNumber()
+                            - 1L;
+
+            if (currentPage >= lastPage) {
+                LOG.info(
+                        "HTTP pagination finished: totalPages={}, currentPage={}",
+                        totalPageSize,
+                        currentPage);
+                exhausted = true;
+                return;
+            }
+        } else if (rowCount < config.getPageBatchSize()) {
+            LOG.info(
+                    "HTTP pagination finished: rowCount={} < pageBatchSize={}, currentPage={}",
+                    rowCount,
+                    config.getPageBatchSize(),
+                    currentPage);
+            exhausted = true;
+            return;
+        }
+
+        currentPage++;
+        LOG.debug("HTTP pagination advanced: page={}", currentPage);
+    }
+
+    private void advanceCursor(String responseBody) {
+        String responseField = config.getCursorResponseField();
+
+        if (responseField == null || responseField.isEmpty()) {
+            LOG.info(
+                    "HTTP cursor pagination finished: cursor response field is not configured");
+            exhausted = true;
+            return;
+        }
+
+        try {
+            String cursorValue =
+                    HttpResponseParser.extractSingleStringValue(
+                            responseBody,
+                            responseField);
+
+            if (cursorValue == null
+                    || cursorValue.isEmpty()
+                    || "null".equals(cursorValue)) {
+
+                LOG.info(
+                        "HTTP cursor pagination finished: response contains no cursor");
+                exhausted = true;
+                return;
+            }
+
+            currentCursor = cursorValue;
+            LOG.debug(
+                    "HTTP cursor pagination advanced: cursor={}",
+                    currentCursor);
+
+        } catch (Exception failure) {
+            LOG.warn(
+                    "HTTP cursor pagination stopped because cursor extraction failed: {}",
+                    failure.getMessage());
+            exhausted = true;
+        }
+    }
+
+    private String replaceBodyPlaceholder(String body) {
+        if (config.getPageType() == PageType.CURSOR) {
+            if (currentCursor == null || config.getCursorField() == null) {
+                return body;
+            }
+
+            return replace(
+                    body,
+                    config.getCursorField(),
+                    currentCursor);
+        }
+
+        return replace(
+                body,
+                config.getPageField(),
+                String.valueOf(currentPage));
+    }
+
+    private static void replacePlaceholder(
+            Map<String, String> values,
+            String field,
+            String replacement) {
+
+        if (field == null) {
+            return;
+        }
+
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            String value = entry.getValue();
+            if (value != null) {
+                entry.setValue(
+                        replace(
+                                value,
+                                field,
+                                replacement));
+            }
+        }
+    }
+
+    private static String replace(
+            String value,
+            String field,
+            String replacement) {
+
+        String placeholder = "${" + field + "}";
+        return value.contains(placeholder)
+                ? value.replace(placeholder, replacement)
+                : value;
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceReader.java
+++ b/link-up-connectors/link-up-connector-http/src/main/java/com/link/up/connector/http/source/HttpSourceReader.java
@@ -7,27 +7,23 @@ import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.type.FluxRow;
 import com.link.up.connector.http.client.HttpSourceClient;
 import com.link.up.connector.http.config.HttpSourceConfig;
-import com.link.up.connector.http.config.PageType;
 import com.link.up.connector.http.converter.HttpResponseParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 /**
- * HTTP 离线数据读取器。
+ * Reads one bounded HTTP source.
  *
- * <p>Reader 负责：
- * <ol>
- *   <li>执行 HTTP 请求</li>
- *   <li>解析响应数据为 FluxRow</li>
- *   <li>处理分页逻辑</li>
- * </ol>
+ * <p>The reader owns SourceReader lifecycle and row buffering only. Pagination
+ * state belongs to {@link HttpPaginationState}; transport belongs to
+ * {@link HttpSourceClient}; response conversion belongs to
+ * {@link HttpResponseParser}.</p>
  */
 public final class HttpSourceReader
         implements SourceReader<FluxRow, HttpSourceSplit> {
@@ -41,72 +37,86 @@ public final class HttpSourceReader
     private final HttpSourceClient client;
 
     private HttpSourceSplit currentSplit;
+    private HttpPaginationState pagination;
+    private List<FluxRow> buffer =
+            Collections.emptyList();
+    private int bufferIndex;
     private boolean opened;
     private boolean finished;
-
-    // 分页状态
-    private int currentPage;
-    private String currentCursor;
-    private boolean paginationExhausted;
-
-    // 缓冲：上一次请求解析出的行，尚未全部输出
-    private List<FluxRow> buffer = Collections.emptyList();
-    private int bufferIndex;
 
     public HttpSourceReader(
             HttpSourceConfig config,
             Map<TablePath, CatalogTable> tables,
             int batchSize) {
 
+        this.config = Objects.requireNonNull(
+                config,
+                "config must not be null");
+        this.catalogTable = firstTable(tables);
+
         if (batchSize <= 0) {
-            throw new IllegalArgumentException("batchSize must be greater than 0");
+            throw new IllegalArgumentException(
+                    "batchSize must be greater than 0");
         }
 
-        this.config = Objects.requireNonNull(config, "config must not be null");
-        this.catalogTable = tables.values().iterator().next();
         this.batchSize = batchSize;
         this.client = new HttpSourceClient(config);
     }
 
     @Override
-    public void open(List<HttpSourceSplit> splits) throws Exception {
-        if (opened) {
-            throw new IllegalStateException("HttpSourceReader has already been opened");
-        }
-        this.currentSplit = splits.isEmpty() ? new HttpSourceSplit() : splits.get(0);
-        this.currentPage = config.getStartPageNumber();
-        this.currentCursor = null;
-        this.paginationExhausted = !config.hasPagination();
-        this.buffer = Collections.emptyList();
-        this.bufferIndex = 0;
-        this.finished = false;
-        this.opened = true;
+    public void open(List<HttpSourceSplit> splits)
+            throws Exception {
 
-        LOG.info("HTTP Source Reader opened, url={}, method={}, format={}, pagination={}",
-                config.getUrl(), config.getMethod(), config.getFormat(),
-                config.hasPagination() ? config.getPageType() : "none");
+        if (opened) {
+            throw new IllegalStateException(
+                    "HttpSourceReader has already been opened");
+        }
+
+        Objects.requireNonNull(
+                splits,
+                "splits must not be null");
+
+        currentSplit = splits.isEmpty()
+                ? new HttpSourceSplit()
+                : Objects.requireNonNull(
+                        splits.get(0),
+                        "splits must not contain null values");
+
+        pagination = new HttpPaginationState(config);
+        buffer = Collections.emptyList();
+        bufferIndex = 0;
+        finished = false;
+        opened = true;
+
+        LOG.info(
+                "HTTP Source Reader opened: url={}, method={}, format={}, pagination={}",
+                config.getUrl(),
+                config.getMethod(),
+                config.getFormat(),
+                config.hasPagination()
+                        ? config.getPageType()
+                        : "none");
     }
 
     @Override
-    public RecordBatch<FluxRow> readBatch() throws Exception {
-        if (!opened) {
-            throw new IllegalStateException("HttpSourceReader has not been opened");
-        }
+    public RecordBatch<FluxRow> readBatch()
+            throws Exception {
+
+        checkOpened();
+
         if (finished) {
             return RecordBatch.endOfInput();
         }
 
         while (true) {
-            // 先从缓冲区取
-            while (bufferIndex < buffer.size()) {
-                int end = Math.min(bufferIndex + batchSize, buffer.size());
-                List<FluxRow> batch = new ArrayList<>(buffer.subList(bufferIndex, end));
-                bufferIndex = end;
-                return RecordBatch.of(currentSplit, batch);
+            RecordBatch<FluxRow> buffered =
+                    nextBufferedBatch();
+
+            if (buffered != null) {
+                return buffered;
             }
 
-            // 缓冲区耗尽，获取下一页
-            if (paginationExhausted) {
+            if (pagination.isExhausted()) {
                 finished = true;
                 return RecordBatch.endOfInput();
             }
@@ -115,189 +125,99 @@ public final class HttpSourceReader
         }
     }
 
-    private void fetchNextPage() throws Exception {
-        // 构建当前页的请求参数
-        Map<String, String> effectiveHeaders = new LinkedHashMap<>(config.getHeaders());
-        Map<String, String> effectiveParams = new LinkedHashMap<>();
-        String effectiveBody = config.getBody();
-
-        if (config.hasPagination()) {
-            applyPagination(effectiveHeaders, effectiveParams);
-
-            // 占位符模式下，同步替换 body 中的分页占位符
-            if (config.isUsePlaceholderReplacement() && effectiveBody != null) {
-                effectiveBody = replaceBodyPlaceholder(effectiveBody);
-            }
-        }
-
-        LOG.debug("HTTP request page={}, cursor={}", currentPage, currentCursor);
-
-        String responseBody = client.execute(effectiveHeaders, effectiveParams, effectiveBody);
-
-        // 解析响应
-        List<FluxRow> rows = HttpResponseParser.parseResponse(
-                responseBody, config, catalogTable.getTableSchema());
-
-        buffer = rows;
-        bufferIndex = 0;
-
-        // 判断分页是否结束
-        if (config.hasPagination()) {
-            advancePagination(responseBody, rows.size());
-        } else {
-            paginationExhausted = true;
-        }
-    }
-
-    private void applyPagination(
-            Map<String, String> headers,
-            Map<String, String> params) {
-
-        if (config.getPageType() == PageType.CURSOR) {
-            applyCursorPagination(headers, params);
-        } else {
-            applyPageNumberPagination(headers, params);
-        }
-    }
-
-    private void applyPageNumberPagination(
-            Map<String, String> headers,
-            Map<String, String> params) {
-
-        String pageField = config.getPageField();
-        String pageValue = String.valueOf(currentPage);
-
-        if (config.isUsePlaceholderReplacement()) {
-            // 占位符替换模式：替换 headers、params、body 中的 ${page}
-            replacePlaceholder(headers, pageField, pageValue);
-            replacePlaceholder(params, pageField, pageValue);
-        } else {
-            // key-based 模式：直接设置参数值
-            params.put(pageField, pageValue);
-        }
-    }
-
-    private void applyCursorPagination(
-            Map<String, String> headers,
-            Map<String, String> params) {
-
-        if (currentCursor != null && config.getCursorField() != null) {
-            if (config.isUsePlaceholderReplacement()) {
-                replacePlaceholder(headers, config.getCursorField(), currentCursor);
-                replacePlaceholder(params, config.getCursorField(), currentCursor);
-            } else {
-                params.put(config.getCursorField(), currentCursor);
-            }
-        }
-    }
-
-    private void advancePagination(String responseBody, int rowCount) {
-        if (config.getPageType() == PageType.CURSOR) {
-            advanceCursorPagination(responseBody);
-        } else {
-            advancePageNumberPagination(rowCount);
-        }
-    }
-
-    private void advancePageNumberPagination(int rowCount) {
-        long totalPageSize = config.getTotalPageSize();
-
-        if (totalPageSize > 0) {
-            if (currentPage >= totalPageSize + config.getStartPageNumber() - 1) {
-                LOG.info("分页结束：已达总页数={}, 当前页={}",
-                        totalPageSize, currentPage);
-                paginationExhausted = true;
-                return;
-            }
-        } else {
-            if (rowCount < config.getPageBatchSize()) {
-                LOG.info("分页结束：返回行数={} < batch_size={}, 当前页={}",
-                        rowCount, config.getPageBatchSize(), currentPage);
-                paginationExhausted = true;
-                return;
-            }
-        }
-
-        currentPage++;
-        LOG.debug("翻页至 page={}", currentPage);
-    }
-
-    private void advanceCursorPagination(String responseBody) {
-        if (config.getCursorResponseField() == null
-                || config.getCursorResponseField().isEmpty()) {
-            LOG.info("Cursor 分页结束：未配置 cursor_response_field");
-            paginationExhausted = true;
-            return;
-        }
-
-        try {
-            String cursorValue = HttpResponseParser.extractSingleStringValue(
-                    responseBody,
-                    config.getCursorResponseField());
-
-            if (cursorValue == null
-                    || cursorValue.isEmpty()
-                    || "null".equals(cursorValue)) {
-                LOG.info("Cursor 分页结束：响应中未找到有效游标值");
-                paginationExhausted = true;
-                return;
-            }
-
-            currentCursor = cursorValue;
-            LOG.debug("Cursor 更新为: {}", currentCursor);
-        } catch (Exception e) {
-            LOG.warn("提取游标值失败，分页结束: {}", e.getMessage());
-            paginationExhausted = true;
-        }
-    }
-
-    /**
-     * 替换 body 中的分页占位符（${page} 或 ${cursor}）。
-     */
-    private String replaceBodyPlaceholder(String body) {
-        String result = body;
-
-        if (config.getPageType() == PageType.CURSOR) {
-            if (currentCursor != null && config.getCursorField() != null) {
-                String placeholder = "${" + config.getCursorField() + "}";
-                if (result.contains(placeholder)) {
-                    result = result.replace(placeholder, currentCursor);
-                }
-            }
-        } else {
-            String pageField = config.getPageField();
-            String placeholder = "${" + pageField + "}";
-            if (result.contains(placeholder)) {
-                result = result.replace(placeholder, String.valueOf(currentPage));
-            }
-        }
-
-        return result;
-    }
-
-    private static void replacePlaceholder(
-            Map<String, String> map,
-            String field,
-            String value) {
-
-        if (map == null) {
-            return;
-        }
-        for (Map.Entry<String, String> entry : map.entrySet()) {
-            String v = entry.getValue();
-            if (v != null && v.contains("${" + field + "}")) {
-                entry.setValue(v.replace("${" + field + "}", value));
-            }
-        }
-    }
-
     @Override
     public void close() throws Exception {
         if (!opened) {
             return;
         }
-        client.close();
-        opened = false;
+
+        try {
+            client.close();
+        } finally {
+            opened = false;
+        }
+
         LOG.info("HTTP Source Reader closed");
+    }
+
+    private RecordBatch<FluxRow> nextBufferedBatch() {
+        if (bufferIndex >= buffer.size()) {
+            return null;
+        }
+
+        int end =
+                Math.min(
+                        bufferIndex + batchSize,
+                        buffer.size());
+
+        List<FluxRow> rows =
+                new ArrayList<FluxRow>(
+                        buffer.subList(
+                                bufferIndex,
+                                end));
+
+        bufferIndex = end;
+        return RecordBatch.of(
+                currentSplit,
+                rows);
+    }
+
+    private void fetchNextPage()
+            throws Exception {
+
+        HttpPageRequest request =
+                pagination.currentRequest();
+
+        LOG.debug(
+                "HTTP request page={}, cursor={}",
+                pagination.getCurrentPage(),
+                pagination.getCurrentCursor());
+
+        String responseBody =
+                client.execute(
+                        request.getHeaders(),
+                        request.getParams(),
+                        request.getBody());
+
+        List<FluxRow> rows =
+                HttpResponseParser.parseResponse(
+                        responseBody,
+                        config,
+                        catalogTable.getTableSchema());
+
+        buffer = rows;
+        bufferIndex = 0;
+        pagination.advance(
+                responseBody,
+                rows.size());
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException(
+                    "HttpSourceReader has not been opened");
+        }
+    }
+
+    private static CatalogTable firstTable(
+            Map<TablePath, CatalogTable> tables) {
+
+        Objects.requireNonNull(
+                tables,
+                "tables must not be null");
+
+        if (tables.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "tables must not be empty");
+        }
+
+        CatalogTable table =
+                tables.values()
+                        .iterator()
+                        .next();
+
+        return Objects.requireNonNull(
+                table,
+                "tables must not contain null values");
     }
 }

--- a/link-up-connectors/link-up-connector-http/src/test/java/com/link/up/connector/http/HttpConnectorPackageBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-http/src/test/java/com/link/up/connector/http/HttpConnectorPackageBoundaryTest.java
@@ -2,21 +2,22 @@ package com.link.up.connector.http;
 
 import com.link.up.api.source.SourceEnumeratorContext;
 import com.link.up.api.source.SourceSplitEnumerator;
-import com.link.up.api.table.catalog.CatalogTable;
-import com.link.up.api.table.catalog.TablePath;
 import com.link.up.connector.http.converter.HttpResponseParser;
 import com.link.up.connector.http.source.HttpSource;
+import com.link.up.connector.http.source.HttpSourceReader;
 import com.link.up.connector.http.source.HttpSourceSplit;
 import com.link.up.connector.http.source.HttpSourceSplitEnumerator;
 import org.junit.Test;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class HttpConnectorPackageBoundaryTest {
 
@@ -28,22 +29,48 @@ public class HttpConnectorPackageBoundaryTest {
     }
 
     @Test
-    public void sourceUsesNativeEnumeratorContract() throws Exception {
+    public void readerDelegatesMutablePaginationState() {
+        boolean found = false;
+
+        for (Field field : HttpSourceReader.class.getDeclaredFields()) {
+            if ("com.link.up.connector.http.source.HttpPaginationState"
+                    .equals(field.getType().getName())) {
+                found = true;
+            }
+        }
+
+        assertTrue(
+                "HttpSourceReader should delegate pagination state to a focused role",
+                found);
+    }
+
+    @Test
+    public void sourceUsesNativeEnumeratorContract()
+            throws Exception {
+
         Method method =
                 HttpSource.class.getDeclaredMethod(
                         "createEnumerator",
                         Map.class,
                         SourceEnumeratorContext.class);
 
-        assertEquals(HttpSource.class, method.getDeclaringClass());
+        assertEquals(
+                HttpSource.class,
+                method.getDeclaringClass());
 
         SourceSplitEnumerator<HttpSourceSplit> enumerator =
                 new HttpSourceSplitEnumerator();
-        List<HttpSourceSplit> splits = enumerator.enumerateSplits();
+
+        List<HttpSourceSplit> splits =
+                enumerator.enumerateSplits();
 
         assertEquals(1, splits.size());
-        assertEquals("http-split-0", splits.get(0).splitId());
-        assertEquals("default.default", splits.get(0).dataSetId());
+        assertEquals(
+                "http-split-0",
+                splits.get(0).splitId());
+        assertEquals(
+                "default.default",
+                splits.get(0).dataSetId());
     }
 
     @Test
@@ -58,14 +85,17 @@ public class HttpConnectorPackageBoundaryTest {
                 "utils");
     }
 
-    private void assertMissingRootPackages(String... names) {
+    private void assertMissingRootPackages(
+            String... names) {
+
         File root =
                 new File(
                         "src/main/java/com/link/up/connector/http");
 
         for (String name : names) {
             assertFalse(
-                    "Forbidden HTTP connector root package exists: " + name,
+                    "Forbidden HTTP connector root package exists: "
+                            + name,
                     new File(root, name).exists());
         }
     }

--- a/link-up-connectors/link-up-connector-http/src/test/java/com/link/up/connector/http/client/HttpRetryPolicyTest.java
+++ b/link-up-connectors/link-up-connector-http/src/test/java/com/link/up/connector/http/client/HttpRetryPolicyTest.java
@@ -1,0 +1,52 @@
+package com.link.up.connector.http.client;
+
+import com.link.up.connector.http.config.HttpMethod;
+import com.link.up.connector.http.config.HttpSourceConfig;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HttpRetryPolicyTest {
+
+    @Test
+    public void shouldTreatGetAsRetryableAndRespectConfiguredStatusCodes() {
+        HttpSourceConfig config =
+                new HttpSourceConfig.Builder()
+                        .url("http://localhost/items")
+                        .method(HttpMethod.GET)
+                        .retry(2)
+                        .retryableStatusCodes(
+                                Collections.singleton(503))
+                        .retryJitterMs(0)
+                        .retryBackoffMultiplierMs(100)
+                        .retryBackoffMaxMs(1000)
+                        .build();
+
+        HttpRetryPolicy policy =
+                new HttpRetryPolicy(config);
+
+        assertEquals(3, policy.maxAttempts());
+        assertTrue(policy.isMethodRetryable());
+        assertTrue(policy.isStatusRetryable(503));
+        assertFalse(policy.isStatusRetryable(400));
+        assertEquals(100L, policy.backoffMillis(1));
+        assertEquals(200L, policy.backoffMillis(2));
+    }
+
+    @Test
+    public void shouldNotRetryPostByDefault() {
+        HttpSourceConfig config =
+                new HttpSourceConfig.Builder()
+                        .url("http://localhost/items")
+                        .method(HttpMethod.POST)
+                        .build();
+
+        assertFalse(
+                new HttpRetryPolicy(config)
+                        .isMethodRetryable());
+    }
+}

--- a/link-up-connectors/link-up-connector-http/src/test/java/com/link/up/connector/http/source/HttpPaginationStateTest.java
+++ b/link-up-connectors/link-up-connector-http/src/test/java/com/link/up/connector/http/source/HttpPaginationStateTest.java
@@ -1,0 +1,95 @@
+package com.link.up.connector.http.source;
+
+import com.link.up.connector.http.config.HttpSourceConfig;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HttpPaginationStateTest {
+
+    @Test
+    public void shouldAllowExactlyOneRequestWithoutPagination() {
+        HttpSourceConfig config =
+                new HttpSourceConfig.Builder()
+                        .url("http://localhost/items")
+                        .build();
+
+        HttpPaginationState state =
+                new HttpPaginationState(config);
+
+        assertFalse(state.isExhausted());
+        assertTrue(
+                state.currentRequest()
+                        .getParams()
+                        .isEmpty());
+
+        state.advance("{}", 1);
+        assertTrue(state.isExhausted());
+    }
+
+    @Test
+    public void shouldAdvancePageNumberWithoutChangingRequestContract() {
+        HttpSourceConfig config =
+                new HttpSourceConfig.Builder()
+                        .url("http://localhost/items")
+                        .pageField("page")
+                        .pageBatchSize(2)
+                        .totalPageSize(2)
+                        .startPageNumber(1)
+                        .build();
+
+        HttpPaginationState state =
+                new HttpPaginationState(config);
+
+        HttpPageRequest first =
+                state.currentRequest();
+
+        assertEquals(
+                Collections.singletonMap("page", "1"),
+                first.getParams());
+        assertFalse(state.isExhausted());
+
+        state.advance("{}", 2);
+
+        HttpPageRequest second =
+                state.currentRequest();
+
+        assertEquals(
+                Collections.singletonMap("page", "2"),
+                second.getParams());
+
+        state.advance("{}", 2);
+        assertTrue(state.isExhausted());
+    }
+
+    @Test
+    public void shouldReplacePagePlaceholderInHeadersAndBody() {
+        HttpSourceConfig config =
+                new HttpSourceConfig.Builder()
+                        .url("http://localhost/items")
+                        .headers(
+                                Collections.singletonMap(
+                                        "X-Page",
+                                        "${page}"))
+                        .body("{\"page\":\"${page}\"}")
+                        .pageField("page")
+                        .usePlaceholderReplacement(true)
+                        .totalPageSize(1)
+                        .build();
+
+        HttpPageRequest request =
+                new HttpPaginationState(config)
+                        .currentRequest();
+
+        assertEquals(
+                "1",
+                request.getHeaders().get("X-Page"));
+        assertEquals(
+                "{\"page\":\"1\"}",
+                request.getBody());
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceSplitGenerator.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSourceSplitGenerator.java
@@ -5,32 +5,23 @@ import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogUtils;
 import com.link.up.connector.jdbc.config.JdbcSourceConfig;
-import com.link.up.connector.jdbc.config.SplitPlanningMode;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
-import com.link.up.connector.jdbc.core.split.JdbcSplitStatistics;
-import com.link.up.connector.jdbc.core.split.JdbcSplitStatisticsProvider;
-import com.link.up.connector.jdbc.core.split.JdbcSplitStatisticsRequest;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-/**
- * Prepares bounded JDBC split enumeration from a prepared source schema.
- */
+/** Prepares bounded JDBC split enumeration from prepared source metadata. */
 final class JdbcSourceSplitGenerator {
-    private static final Logger LOG = LoggerFactory.getLogger(JdbcSourceSplitGenerator.class);
 
     private JdbcSourceSplitGenerator() {
     }
 
     /**
-     * Compatibility helper for legacy callers that still request the split
-     * list directly.
+     * Compatibility helper for callers that still request the split list
+     * directly.
      */
     static List<JdbcSourceSplit> generate(
             JdbcSourceConfig config,
@@ -43,121 +34,46 @@ final class JdbcSourceSplitGenerator {
                              config,
                              tables,
                              parallelism)) {
+
             return enumerator.enumerateSplits();
         }
     }
 
-    /**
-     * Resolves the connector-specific table metadata/statistics needed by the
-     * JDBC enumerator, then returns the canonical bounded split enumerator.
-     */
     static SourceSplitEnumerator<JdbcSourceSplit> createEnumerator(
             JdbcSourceConfig config,
             Map<TablePath, CatalogTable> tables,
             int parallelism)
             throws Exception {
 
-        Objects.requireNonNull(config, "config must not be null");
-        Objects.requireNonNull(tables, "tables must not be null");
+        Objects.requireNonNull(
+                config,
+                "config must not be null");
+        Objects.requireNonNull(
+                tables,
+                "tables must not be null");
+
         if (parallelism <= 0) {
-            throw new IllegalArgumentException("parallelism must be greater than 0");
+            throw new IllegalArgumentException(
+                    "parallelism must be greater than 0");
         }
 
-        JdbcDialect dialect = JdbcDialectLoader.load(config.getConnectionConfig());
+        JdbcDialect dialect =
+                JdbcDialectLoader.load(
+                        config.getConnectionConfig());
+
         Map<TablePath, JdbcSourceTable> sourceTables =
                 reconcilePreparedTables(
-                        JdbcCatalogUtils.getTables(config, dialect),
+                        JdbcCatalogUtils.getTables(
+                                config,
+                                dialect),
                         tables);
 
         Map<TablePath, JdbcSourceTable> plannedTables =
-                new LinkedHashMap<TablePath, JdbcSourceTable>();
-        JdbcSplitStatisticsProvider statisticsProvider =
-                new JdbcSplitStatisticsProvider(
-                        config.getConnectionConfig(),
-                        dialect);
+                new JdbcSplitPlanningService(
+                        config,
+                        dialect)
+                        .plan(sourceTables);
 
-        for (JdbcSourceTable table : sourceTables.values()) {
-            JdbcSourceTable planned = table;
-            if (table.getPartitionColumn() != null
-                    && config.getSplitPlanningMode() != SplitPlanningMode.MANUAL) {
-                SplitPlanningMode mode = config.getSplitPlanningMode();
-                try {
-                    JdbcSplitStatistics statistics =
-                            statisticsProvider.collect(
-                                    new JdbcSplitStatisticsRequest(
-                                            table,
-                                            mode,
-                                            config.getStatisticsQueryTimeout(),
-                                            config.getSampleSize()));
-                    if (statistics.isEmpty()) {
-                        plannedTables.put(table.getTablePath(), null);
-                        continue;
-                    }
-                    if (statistics.isAllNull()) {
-                        if (!config.isNullPartitionSingleSplit()) {
-                            throw new IllegalArgumentException(
-                                    "Partition column is entirely NULL: "
-                                            + table.getTablePath());
-                        }
-                    } else {
-                        planned = JdbcSourceTable.builder()
-                                .tablePath(table.getTablePath())
-                                .query(table.getQuery())
-                                .partitionColumn(table.getPartitionColumn())
-                                .partitionNumber(table.getPartitionNumber())
-                                .partitionStart(
-                                        statistics.getLowerBound().orElse(null))
-                                .partitionEnd(
-                                        statistics.getUpperBound().orElse(null))
-                                .catalogTable(table.getCatalogTable())
-                                .build();
-                    }
-                } catch (UnsupportedOperationException e) {
-                    if (mode != SplitPlanningMode.AUTO_SAMPLE
-                            || !config.isAllowStatisticsFallback()) {
-                        throw e;
-                    }
-                    LOG.warn(
-                            "AUTO_SAMPLE statistics unsupported for table {}; falling back to AUTO_MIN_MAX",
-                            table.getTablePath());
-                    JdbcSplitStatistics statistics =
-                            statisticsProvider.collect(
-                                    new JdbcSplitStatisticsRequest(
-                                            table,
-                                            SplitPlanningMode.AUTO_MIN_MAX,
-                                            config.getStatisticsQueryTimeout(),
-                                            config.getSampleSize()));
-                    if (statistics.isEmpty()) {
-                        plannedTables.put(table.getTablePath(), null);
-                        continue;
-                    }
-                    planned = JdbcSourceTable.builder()
-                            .tablePath(table.getTablePath())
-                            .query(table.getQuery())
-                            .partitionColumn(table.getPartitionColumn())
-                            .partitionNumber(table.getPartitionNumber())
-                            .partitionStart(
-                                    statistics.getLowerBound().orElse(null))
-                            .partitionEnd(
-                                    statistics.getUpperBound().orElse(null))
-                            .catalogTable(table.getCatalogTable())
-                            .build();
-                } catch (Exception e) {
-                    if (config.isMultiTable()
-                            && config.getMultiTableFailurePolicy()
-                            .continueOtherTables()) {
-                        LOG.warn(
-                                "Split statistics failed for table {}; continuing according to multi-table policy",
-                                table.getTablePath());
-                        continue;
-                    }
-                    throw e;
-                }
-            }
-            plannedTables.put(planned.getTablePath(), planned);
-        }
-
-        plannedTables.values().removeIf(java.util.Objects::isNull);
         return new JdbcSourceSplitEnumerator(
                 config,
                 plannedTables,
@@ -165,16 +81,8 @@ final class JdbcSourceSplitGenerator {
     }
 
     /**
-     * Reconciles the connector's second metadata discovery with the metadata
-     * already prepared by the framework.
-     *
-     * <p>A JDBC catalog may normalize an unqualified configured path such as
-     * {@code sink_user_info} to {@code test1.sink_user_info}. The discovered
-     * {@link JdbcSourceTable} historically retained the unqualified path while
-     * its {@link CatalogTable} contained the normalized path. Using the former
-     * as the data-set identity made split planning fail with
-     * {@code No prepared table metadata} even though preparation and sink DDL
-     * had succeeded.</p>
+     * Reconciles connector metadata discovery with the table metadata already
+     * prepared by the framework.
      */
     static Map<TablePath, JdbcSourceTable> reconcilePreparedTables(
             Map<TablePath, JdbcSourceTable> discoveredTables,
@@ -190,7 +98,9 @@ final class JdbcSourceSplitGenerator {
         Map<TablePath, JdbcSourceTable> result =
                 new LinkedHashMap<TablePath, JdbcSourceTable>();
 
-        for (JdbcSourceTable discoveredTable : discoveredTables.values()) {
+        for (JdbcSourceTable discoveredTable :
+                discoveredTables.values()) {
+
             if (discoveredTable == null) {
                 throw new IllegalArgumentException(
                         "discoveredTables must not contain null values");
@@ -221,17 +131,26 @@ final class JdbcSourceSplitGenerator {
                     JdbcSourceTable.builder()
                             .tablePath(normalizedPath)
                             .query(discoveredTable.getQuery())
-                            .partitionColumn(discoveredTable.getPartitionColumn())
-                            .partitionNumber(discoveredTable.getPartitionNumber())
-                            .partitionStart(discoveredTable.getPartitionStart())
-                            .partitionEnd(discoveredTable.getPartitionEnd())
-                            .useSelectCount(discoveredTable.getUseSelectCount())
-                            .skipAnalyze(discoveredTable.getSkipAnalyze())
-                            .catalogTable(preparedCatalogTable)
+                            .partitionColumn(
+                                    discoveredTable.getPartitionColumn())
+                            .partitionNumber(
+                                    discoveredTable.getPartitionNumber())
+                            .partitionStart(
+                                    discoveredTable.getPartitionStart())
+                            .partitionEnd(
+                                    discoveredTable.getPartitionEnd())
+                            .useSelectCount(
+                                    discoveredTable.getUseSelectCount())
+                            .skipAnalyze(
+                                    discoveredTable.getSkipAnalyze())
+                            .catalogTable(
+                                    preparedCatalogTable)
                             .build();
 
             JdbcSourceTable previous =
-                    result.put(normalizedPath, normalizedTable);
+                    result.put(
+                            normalizedPath,
+                            normalizedTable);
 
             if (previous != null) {
                 throw new IllegalArgumentException(

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSplitPlanningService.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/source/JdbcSplitPlanningService.java
@@ -1,0 +1,191 @@
+package com.link.up.connector.jdbc.source;
+
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcSourceConfig;
+import com.link.up.connector.jdbc.config.SplitPlanningMode;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.split.JdbcSplitStatistics;
+import com.link.up.connector.jdbc.core.split.JdbcSplitStatisticsProvider;
+import com.link.up.connector.jdbc.core.split.JdbcSplitStatisticsRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Resolves bounded JDBC split statistics before enumeration. */
+final class JdbcSplitPlanningService {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(
+                    JdbcSplitPlanningService.class);
+
+    private final JdbcSourceConfig config;
+    private final JdbcSplitStatisticsProvider statisticsProvider;
+
+    JdbcSplitPlanningService(
+            JdbcSourceConfig config,
+            JdbcDialect dialect) {
+
+        this.config = Objects.requireNonNull(
+                config,
+                "config must not be null");
+
+        this.statisticsProvider =
+                new JdbcSplitStatisticsProvider(
+                        config.getConnectionConfig(),
+                        Objects.requireNonNull(
+                                dialect,
+                                "dialect must not be null"));
+    }
+
+    Map<TablePath, JdbcSourceTable> plan(
+            Map<TablePath, JdbcSourceTable> sourceTables)
+            throws Exception {
+
+        Objects.requireNonNull(
+                sourceTables,
+                "sourceTables must not be null");
+
+        Map<TablePath, JdbcSourceTable> planned =
+                new LinkedHashMap<TablePath, JdbcSourceTable>();
+
+        for (JdbcSourceTable table : sourceTables.values()) {
+            JdbcSourceTable plannedTable =
+                    planTable(
+                            Objects.requireNonNull(
+                                    table,
+                                    "sourceTables must not contain null values"));
+
+            if (plannedTable != null) {
+                planned.put(
+                        plannedTable.getTablePath(),
+                        plannedTable);
+            }
+        }
+
+        return planned;
+    }
+
+    private JdbcSourceTable planTable(
+            JdbcSourceTable table)
+            throws Exception {
+
+        if (table.getPartitionColumn() == null
+                || config.getSplitPlanningMode()
+                == SplitPlanningMode.MANUAL) {
+            return table;
+        }
+
+        SplitPlanningMode mode =
+                config.getSplitPlanningMode();
+
+        try {
+            JdbcSplitStatistics statistics =
+                    collect(table, mode);
+
+            return applyStatistics(
+                    table,
+                    statistics,
+                    true);
+
+        } catch (UnsupportedOperationException unsupported) {
+            if (mode != SplitPlanningMode.AUTO_SAMPLE
+                    || !config.isAllowStatisticsFallback()) {
+                throw unsupported;
+            }
+
+            LOG.warn(
+                    "AUTO_SAMPLE statistics unsupported for table {}; "
+                            + "falling back to AUTO_MIN_MAX",
+                    table.getTablePath());
+
+            JdbcSplitStatistics statistics =
+                    collect(
+                            table,
+                            SplitPlanningMode.AUTO_MIN_MAX);
+
+            return applyStatistics(
+                    table,
+                    statistics,
+                    false);
+
+        } catch (Exception failure) {
+            if (config.isMultiTable()
+                    && config.getMultiTableFailurePolicy()
+                    .continueOtherTables()) {
+
+                LOG.warn(
+                        "Split statistics failed for table {}; "
+                                + "continuing according to multi-table policy",
+                        table.getTablePath());
+                return null;
+            }
+
+            throw failure;
+        }
+    }
+
+    private JdbcSplitStatistics collect(
+            JdbcSourceTable table,
+            SplitPlanningMode mode)
+            throws Exception {
+
+        return statisticsProvider.collect(
+                new JdbcSplitStatisticsRequest(
+                        table,
+                        mode,
+                        config.getStatisticsQueryTimeout(),
+                        config.getSampleSize()));
+    }
+
+    private JdbcSourceTable applyStatistics(
+            JdbcSourceTable table,
+            JdbcSplitStatistics statistics,
+            boolean enforceAllNullPolicy) {
+
+        if (statistics.isEmpty()) {
+            return null;
+        }
+
+        if (statistics.isAllNull()) {
+            if (enforceAllNullPolicy
+                    && !config.isNullPartitionSingleSplit()) {
+                throw new IllegalArgumentException(
+                        "Partition column is entirely NULL: "
+                                + table.getTablePath());
+            }
+
+            if (enforceAllNullPolicy) {
+                return table;
+            }
+        }
+
+        return withBounds(
+                table,
+                statistics);
+    }
+
+    private JdbcSourceTable withBounds(
+            JdbcSourceTable table,
+            JdbcSplitStatistics statistics) {
+
+        return JdbcSourceTable.builder()
+                .tablePath(table.getTablePath())
+                .query(table.getQuery())
+                .partitionColumn(
+                        table.getPartitionColumn())
+                .partitionNumber(
+                        table.getPartitionNumber())
+                .partitionStart(
+                        statistics.getLowerBound()
+                                .orElse(null))
+                .partitionEnd(
+                        statistics.getUpperBound()
+                                .orElse(null))
+                .catalogTable(
+                        table.getCatalogTable())
+                .build();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/JdbcConnectorPackageBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/JdbcConnectorPackageBoundaryTest.java
@@ -26,6 +26,19 @@ public class JdbcConnectorPackageBoundaryTest {
     }
 
     @Test
+    public void splitStatisticsPlanningBelongsToSourceRole()
+            throws Exception {
+
+        Class<?> service =
+                Class.forName(
+                        "com.link.up.connector.jdbc.source.JdbcSplitPlanningService");
+
+        assertEquals(
+                "com.link.up.connector.jdbc.source",
+                service.getPackage().getName());
+    }
+
+    @Test
     public void genericUtilsRootPackageMustNotExist() {
         File root =
                 new File(
@@ -52,11 +65,16 @@ public class JdbcConnectorPackageBoundaryTest {
                         "src/main/java/com/link/up/connector/jdbc/core");
 
         assertTrue(
-                "The current legacy JDBC core directory is expected during incremental migration",
+                "The current legacy JDBC core directory is expected "
+                        + "during incremental migration",
                 core.isDirectory());
 
-        File[] children = core.listFiles(File::isDirectory);
-        Set<String> actual = new HashSet<String>();
+        File[] children =
+                core.listFiles(File::isDirectory);
+
+        Set<String> actual =
+                new HashSet<String>();
+
         if (children != null) {
             for (File child : children) {
                 actual.add(child.getName());
@@ -71,7 +89,8 @@ public class JdbcConnectorPackageBoundaryTest {
                                 "split"));
 
         assertEquals(
-                "Do not add new JDBC core subdomains; create a top-level role package instead",
+                "Do not add new JDBC core subdomains; "
+                        + "create a top-level role package instead",
                 allowed,
                 actual);
     }


### PR DESCRIPTION
## Summary

Applies the canonical `CODE_STYLE.md` to the Connector modules as the third repository-wide Link-Up style refactoring sample.

This is not a mechanical formatting pass. The focus is to make connector roles visible in code while preserving connector contracts and data semantics:

```text
清晰 / 笔直 / 显式 / 克制

Factory
  -> Config / Catalog / Client
  -> Source / Enumerator / Reader
  -> Sink / Writer
  -> Converter
```

The changes cover representative execution paths in HTTP, Doris and JDBC without attempting a high-risk rewrite of every connector algorithm.

## HTTP Source

The HTTP source previously concentrated pagination state, request construction, retry policy, transport and row buffering across two large classes.

The flow is now explicit:

```text
HttpSourceReader
  -> HttpPaginationState
     -> HttpPageRequest
  -> HttpSourceClient
     -> HttpRequestFactory
     -> HttpRetryPolicy
  -> HttpResponseParser
```

Responsibilities are now separated as follows:

- `HttpSourceReader`: SourceReader lifecycle and row buffering
- `HttpPaginationState`: page/cursor state and placeholder expansion
- `HttpPageRequest`: immutable per-page request values
- `HttpSourceClient`: OkHttp ownership, transport and response safety
- `HttpRequestFactory`: URL/header/body request construction
- `HttpRetryPolicy`: retry eligibility and backoff/jitter
- `HttpResponseParser`: response -> FluxRow conversion remains unchanged

Existing retry semantics are preserved:

- configured retryable HTTP status codes may retry
- connection-level IO failures retry only for idempotent GET requests
- POST is not retried by default
- response-body read failures are not retried because downstream duplication may otherwise occur
- interrupted retry sleep restores the thread interrupt flag

### HTTP no-pagination bug fix

This refactoring exposed an existing state bug in `HttpSourceReader`.

Previously `open()` initialized:

```text
paginationExhausted = !config.hasPagination()
```

so a source without pagination could return end-of-input before executing its first HTTP request.

The new state contract is:

```text
no pagination
  -> request is initially available
  -> execute exactly one request
  -> mark pagination exhausted
  -> EOF after buffered rows are consumed
```

`HttpPaginationStateTest#shouldAllowExactlyOneRequestWithoutPagination` locks this behavior.

## Doris Sink

`DorisSinkWriter` previously owned buffering, serialization, dirty-data handling and task-local 2PC transaction state in the same class.

It now reads as:

```text
DorisSinkWriter
  -> DorisRowSerializer
  -> DorisStreamLoadClient
  -> DorisTwoPhaseCommitController
```

`DorisTwoPhaseCommitController` is the explicit owner of:

- pending transaction IDs
- PREPARE response validation
- task-local 2PC commit
- abort on failure/close
- 2PC retry advice

`DorisSinkWriter` remains responsible for row buffering, serializer initialization, Stream Load calls and dirty-data evidence.

The existing safety semantics are preserved:

- non-2PC mode still commits per Stream Load batch
- 2PC mode validates TxnId and PREPARE state
- pending 2PC transactions are aborted during close
- commit failure still warns that some transactions may already be committed and requires Doris transaction-state verification before retry
- non-2PC close still flushes a remaining buffer

## JDBC Source split planning

JDBC has the largest historical surface and still contains the explicitly frozen legacy `core/{converter,dialect,split}` area. This PR deliberately does not move those classes in bulk.

Instead, the split-planning orchestration is made explicit:

```text
JdbcSourceSplitGenerator
  -> JdbcCatalogUtils
  -> JdbcSplitPlanningService
     -> JdbcSplitStatisticsProvider
  -> JdbcSourceSplitEnumerator
```

`JdbcSourceSplitGenerator` now coordinates metadata reconciliation and enumerator creation. Statistics collection, AUTO_SAMPLE fallback and multi-table failure policy live in `JdbcSplitPlanningService`.

The existing split-planning behavior is intentionally preserved:

- MANUAL planning bypasses statistics
- tables without partition columns remain unchanged
- empty statistics skip the table
- primary all-NULL statistics follow `nullPartitionSingleSplit`
- AUTO_SAMPLE may fall back to AUTO_MIN_MAX only when configured
- fallback behavior remains compatible with the previous implementation
- multi-table continue policy still skips a table when primary statistics collection fails
- insertion order and prepared-table normalization remain unchanged

## Package boundaries

The existing Phase 5 package guards remain in force.

HTTP and Doris still forbid generic root packages such as:

```text
common / core / helper / misc / parser / serializer / utils
```

JDBC still forbids generic utility roots while allowing only the frozen legacy core subdomains:

```text
core/converter
core/dialect
core/split
```

No new JDBC `core` subdomain is introduced.

The boundary tests now also verify that:

- `HttpSourceReader` delegates mutable pagination state to `HttpPaginationState`
- `DorisSinkWriter` delegates 2PC state to `DorisTwoPhaseCommitController`
- JDBC split-statistics planning belongs to the `source` role package

## Tests added

- `HttpPaginationStateTest`
  - exactly one request without pagination
  - page-number advancement and exhaustion
  - header/body placeholder replacement
- `HttpRetryPolicyTest`
  - GET retry semantics
  - configured status-code retry
  - deterministic backoff without jitter
  - POST no-retry default
- existing Connector package-boundary tests are extended for the new role ownership

## Deliberate non-goals

This PR intentionally does **not** rewrite:

```text
JdbcOutputFormat
JDBC core converters/dialects/split algorithms
DorisCatalog
DorisStreamLoadClient internals beyond its existing public use
HttpResponseParser
Catalog/type-mapping algorithms
```

Those are data-correctness, protocol or database-specific boundaries and should be refactored separately after these orchestration roles are stable.

This PR also does not change:

- Connector API contracts
- Factory identifiers
- Source/Sink public contracts
- Connector package names exposed to ServiceLoader
- JDBC split algorithm semantics
- Doris Stream Load protocol semantics
- server/worker protocol

## Validation

- based directly on current `main` after PR #76
- `main...refactor/link-up-connectors-style`: 1 commit ahead, 0 behind
- 15 changed files, all under `link-up-connectors`
- no `link-up-api`, `link-up-framework` or `link-up-server` files changed
- JDBC legacy `core` files are untouched
- HTTP no-pagination behavior has a dedicated regression test
- GitHub currently reports no status checks and no Actions workflow runs for the branch head

A real Maven checkout/build could not be run because the execution container currently cannot resolve `github.com` (`Could not resolve host: github.com`). This PR therefore intentionally does **not** claim Maven tests have passed.

Recommended locally before marking ready:

```bash
mvn --batch-mode -pl link-up-connectors -am test
mvn --batch-mode clean verify
```
