### PR TITLE
refactor: apply Link-Up code style to link-up-server

### DIFF
--- a/link-up-server/src/main/java/com/link/up/server/application/ActiveJobRegistry.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/ActiveJobRegistry.java
@@ -1,0 +1,72 @@
+package com.link.up.server.application;
+
+import com.link.up.server.domain.JobExecutionState;
+import com.link.up.server.runtime.ServerJobStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/** Owns the in-process index of active job execution states. */
+final class ActiveJobRegistry {
+
+    private final ConcurrentMap<String, JobExecutionState> jobs =
+            new ConcurrentHashMap<String, JobExecutionState>();
+
+    JobExecutionState putIfAbsent(JobExecutionState state) {
+        return jobs.putIfAbsent(
+                state.getJobId(),
+                state);
+    }
+
+    JobExecutionState get(String jobId) {
+        return jobs.get(jobId);
+    }
+
+    boolean contains(String jobId) {
+        return jobs.containsKey(jobId);
+    }
+
+    boolean remove(
+            String jobId,
+            JobExecutionState state) {
+        return jobs.remove(jobId, state);
+    }
+
+    List<JobExecutionState> snapshot() {
+        return new ArrayList<JobExecutionState>(jobs.values());
+    }
+
+    int size() {
+        return jobs.size();
+    }
+
+    int count(ServerJobStatus status) {
+        int count = 0;
+
+        for (JobExecutionState state : jobs.values()) {
+            if (state.getStatus() == status) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    int countQueued() {
+        int count = 0;
+
+        for (JobExecutionState state : jobs.values()) {
+            ServerJobStatus status = state.getStatus();
+
+            if (status == ServerJobStatus.CREATED
+                    || status == ServerJobStatus.SUBMITTED
+                    || status == ServerJobStatus.QUEUED) {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/application/JobApplicationService.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobApplicationService.java
@@ -1,20 +1,15 @@
 package com.link.up.server.application;
 
 import com.link.up.framework.job.JobDefinition;
-import com.link.up.framework.job.JobResult;
-import com.link.up.framework.job.JobStatus;
 import com.link.up.server.application.port.JobIdGenerator;
 import com.link.up.server.application.port.JobRepository;
-import com.link.up.server.application.port.JobRepositoryEntry;
 import com.link.up.server.application.port.JobRuntimeScheduler;
 import com.link.up.server.domain.JobExecutionAttempt;
 import com.link.up.server.domain.JobExecutionState;
 import com.link.up.server.domain.JobSubmission;
 import com.link.up.server.runtime.JobAttemptMetadata;
 import com.link.up.server.runtime.JobExecutionMetadata;
-import com.link.up.server.runtime.JobRecoverySnapshotFactory;
 import com.link.up.server.runtime.JobSnapshot;
-import com.link.up.server.runtime.JobSnapshotFactory;
 import com.link.up.server.runtime.JobStateConflictException;
 import com.link.up.server.runtime.ServerJobStatus;
 
@@ -25,24 +20,27 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-/** Single-node Worker application service with durable checkpoints and safe manual retry. */
-public final class JobApplicationService implements JobApplication {
-
-    private static final String RESTART_LOST_REASON =
-            "Worker restarted before the job reached a terminal state";
+/**
+ * Single-node Worker application facade.
+ *
+ * <p>The service owns use-case sequencing only. Active state indexing,
+ * runtime-event lifecycle handling and startup recovery are delegated to
+ * focused application collaborators.</p>
+ */
+public final class JobApplicationService
+        implements JobApplication {
 
     private final JobRuntimeScheduler runtimeScheduler;
     private final JobRepository repository;
     private final JobIdGenerator jobIdGenerator;
     private final JobSubmissionRegistry submissionRegistry;
-    private final JobRetryPolicy retryPolicy = new JobRetryPolicy();
-    private final ConcurrentMap<String, JobExecutionState> activeJobs =
-            new ConcurrentHashMap<String, JobExecutionState>();
-    private final AtomicBoolean closed = new AtomicBoolean(false);
+    private final JobRetryPolicy retryPolicy;
+    private final ActiveJobRegistry activeJobs;
+    private final JobRuntimeLifecycle lifecycle;
+    private final AtomicBoolean closed =
+            new AtomicBoolean(false);
 
     public JobApplicationService(
             JobRuntimeScheduler runtimeScheduler,
@@ -58,8 +56,20 @@ public final class JobApplicationService implements JobApplication {
         this.jobIdGenerator = Objects.requireNonNull(
                 jobIdGenerator,
                 "jobIdGenerator must not be null");
+
         this.submissionRegistry = new JobSubmissionRegistry();
-        recoverPersistedJobs();
+        this.retryPolicy = new JobRetryPolicy();
+        this.activeJobs = new ActiveJobRegistry();
+        this.lifecycle =
+                new JobRuntimeLifecycle(
+                        runtimeScheduler,
+                        repository,
+                        activeJobs);
+
+        new JobRecoveryService(
+                repository,
+                submissionRegistry)
+                .recover();
     }
 
     @Override
@@ -68,39 +78,50 @@ public final class JobApplicationService implements JobApplication {
     }
 
     @Override
-    public synchronized JobSnapshot submit(final JobSubmission submission) {
-        ensureOpen();
-        Objects.requireNonNull(submission, "submission must not be null");
+    public synchronized JobSnapshot submit(
+            final JobSubmission submission) {
 
-        JobSnapshot existing = findExistingSubmission(submission);
+        ensureOpen();
+        Objects.requireNonNull(
+                submission,
+                "submission must not be null");
+
+        JobSnapshot existing =
+                findExistingSubmission(submission);
+
         if (existing != null) {
             return existing;
         }
 
-        final String jobId = jobIdGenerator.nextId();
-        final JobExecutionState state = new JobExecutionState(jobId, submission);
+        final JobExecutionState state =
+                new JobExecutionState(
+                        jobIdGenerator.nextId(),
+                        submission);
 
-        JobExecutionState previous = activeJobs.putIfAbsent(jobId, state);
+        JobExecutionState previous =
+                activeJobs.putIfAbsent(state);
+
         if (previous != null) {
-            throw new IllegalStateException("Duplicate jobId: " + jobId);
+            throw new IllegalStateException(
+                    "Duplicate jobId: "
+                            + state.getJobId());
         }
 
         try {
-            submissionRegistry.register(jobId, submission);
+            submissionRegistry.register(
+                    state.getJobId(),
+                    submission);
             state.markSubmitted();
-            checkpoint(state);
-            runtimeScheduler.schedule(
-                    jobId,
-                    submission.getDefinition(),
-                    listener(state));
+            lifecycle.checkpoint(state);
+            schedule(state, submission);
         } catch (RuntimeException failure) {
-            activeJobs.remove(jobId, state);
-            submissionRegistry.unregister(jobId, submission);
-            repository.delete(jobId);
+            rollbackSubmission(
+                    state,
+                    submission);
             throw failure;
         }
 
-        return snapshot(state);
+        return lifecycle.snapshot(state);
     }
 
     @Override
@@ -109,393 +130,245 @@ public final class JobApplicationService implements JobApplication {
             JobSubmission submission) {
 
         ensureOpen();
-        String normalizedJobId = requireText(jobId, "jobId");
-        Objects.requireNonNull(submission, "submission must not be null");
 
-        if (activeJobs.containsKey(normalizedJobId)) {
+        String normalizedJobId =
+                requireText(
+                        jobId,
+                        "jobId");
+
+        Objects.requireNonNull(
+                submission,
+                "submission must not be null");
+
+        if (activeJobs.contains(normalizedJobId)) {
             throw new JobRetryNotAllowedException(
                     retryDecision(normalizedJobId));
         }
 
-        JobSnapshot previousSnapshot = repository.get(normalizedJobId);
+        JobSnapshot previousSnapshot =
+                repository.get(normalizedJobId);
+
         if (previousSnapshot == null) {
-            throw new JobNotFoundException(normalizedJobId);
+            throw new JobNotFoundException(
+                    normalizedJobId);
         }
+
         JobExecutionMetadata previousMetadata =
                 repository.getMetadata(normalizedJobId);
 
         JobRetryDecision decision =
-                retryPolicy.evaluate(previousSnapshot, previousMetadata);
+                retryPolicy.evaluate(
+                        previousSnapshot,
+                        previousMetadata);
+
         if (!decision.isEligible()) {
             throw new JobRetryNotAllowedException(decision);
         }
 
-        validateRetrySubmission(previousMetadata, submission);
-
-        List<JobExecutionAttempt> previousAttempts =
-                new ArrayList<JobExecutionAttempt>();
-        for (JobAttemptMetadata attempt : previousMetadata.getAttempts()) {
-            previousAttempts.add(attempt.toDomain());
-        }
+        validateRetrySubmission(
+                previousMetadata,
+                submission);
 
         final JobExecutionState state =
-                JobExecutionState.retryFrom(
+                retryState(
                         normalizedJobId,
                         submission,
-                        previousSnapshot.getCreateTimeMillis(),
-                        previousMetadata.getSubmittedTimeMillis(),
-                        previousMetadata.getStateVersion(),
-                        previousMetadata.getCheckpointVersion(),
-                        previousSnapshot.getStatus(),
-                        previousMetadata.getTransitions(),
-                        previousAttempts);
+                        previousSnapshot,
+                        previousMetadata);
 
-        JobExecutionState active = activeJobs.putIfAbsent(
-                normalizedJobId,
-                state);
+        JobExecutionState active =
+                activeJobs.putIfAbsent(state);
+
         if (active != null) {
             throw new JobRetryNotAllowedException(
                     retryPolicy.evaluate(
-                            snapshot(active),
-                            JobExecutionMetadata.fromState(active)));
+                            lifecycle.snapshot(active),
+                            lifecycle.metadata(active)));
         }
 
-        checkpoint(state);
+        lifecycle.checkpoint(state);
+
         try {
-            runtimeScheduler.schedule(
-                    normalizedJobId,
-                    submission.getDefinition(),
-                    listener(state));
+            schedule(state, submission);
         } catch (RuntimeException failure) {
-            if (activeJobs.get(normalizedJobId) == state) {
-                state.failBeforeExecution(failure);
-                repository.save(
-                        snapshot(state),
-                        JobExecutionMetadata.fromState(state));
-                activeJobs.remove(normalizedJobId, state);
-            }
+            lifecycle.failBeforeExecutionAndArchive(
+                    state,
+                    failure);
             throw failure;
         }
 
-        return snapshot(state);
+        return lifecycle.snapshot(state);
     }
 
     @Override
     public JobRetryDecision retryDecision(String jobId) {
-        String normalizedJobId = requireText(jobId, "jobId");
-        JobExecutionState active = activeJobs.get(normalizedJobId);
+        String normalizedJobId =
+                requireText(
+                        jobId,
+                        "jobId");
+
+        JobExecutionState active =
+                activeJobs.get(normalizedJobId);
+
         if (active != null) {
             return retryPolicy.evaluate(
-                    snapshot(active),
-                    JobExecutionMetadata.fromState(active));
+                    lifecycle.snapshot(active),
+                    lifecycle.metadata(active));
         }
 
-        JobSnapshot snapshot = repository.get(normalizedJobId);
+        JobSnapshot snapshot =
+                repository.get(normalizedJobId);
+
         if (snapshot == null) {
-            throw new JobNotFoundException(normalizedJobId);
+            throw new JobNotFoundException(
+                    normalizedJobId);
         }
+
         return retryPolicy.evaluate(
                 snapshot,
                 repository.getMetadata(normalizedJobId));
     }
 
-    private void validateRetrySubmission(
-            JobExecutionMetadata metadata,
-            JobSubmission submission) {
-
-        if (metadata == null
-                || !submission.getExternalExecutionId()
-                .equals(metadata.getExternalExecutionId())
-                || !submission.getIdempotencyKey()
-                .equals(metadata.getIdempotencyKey())
-                || submission.getDefinitionVersion()
-                != metadata.getDefinitionVersion()
-                || !submission.getConfigDigest()
-                .equals(metadata.getConfigDigest())) {
-            throw new JobSubmissionConflictException(
-                    "Retry request must use the same externalExecutionId, idempotencyKey, definitionVersion and job content");
-        }
-    }
-
-    private JobRuntimeScheduler.Listener listener(final JobExecutionState state) {
-        return new JobRuntimeScheduler.Listener() {
-            @Override
-            public void onQueued() {
-                state.markQueued();
-                checkpoint(state);
-            }
-
-            @Override
-            public boolean onStarting() {
-                boolean started = state.markRunning();
-                if (started) {
-                    checkpoint(state);
-                }
-                return started;
-            }
-
-            @Override
-            public void onJobLogCreated(
-                    String runId,
-                    String jobLogFile) {
-                state.bindLogIdentity(runId, jobLogFile);
-                checkpoint(state);
-            }
-
-            @Override
-            public void onCompleted(
-                    JobResult result,
-                    Throwable failure,
-                    boolean cancellationLike) {
-                completeAndArchive(
-                        state,
-                        terminalStatus(
-                                state,
-                                result,
-                                failure,
-                                cancellationLike),
-                        result,
-                        terminalFailure(
-                                state,
-                                result,
-                                failure,
-                                cancellationLike));
-            }
-
-            @Override
-            public void onLost() {
-                completeAndArchive(
-                        state,
-                        ServerJobStatus.LOST,
-                        null,
-                        null);
-            }
-        };
-    }
-
-    private void recoverPersistedJobs() {
-        List<JobRepositoryEntry> persisted = repository.listEntries();
-        for (JobRepositoryEntry entry : persisted) {
-            JobSnapshot snapshot = entry.getSnapshot();
-            JobExecutionMetadata metadata = entry.getMetadata();
-
-            if (metadata != null) {
-                submissionRegistry.restore(snapshot.getJobId(), metadata);
-            }
-
-            if (!snapshot.getStatus().isTerminal()) {
-                long recoveryTimeMillis = System.currentTimeMillis();
-                JobSnapshot lost =
-                        JobRecoverySnapshotFactory.recoverLost(
-                                snapshot,
-                                recoveryTimeMillis,
-                                RESTART_LOST_REASON);
-                JobExecutionMetadata recoveredMetadata =
-                        metadata == null
-                                ? null
-                                : metadata.recoverLost(
-                                        snapshot.getStatus(),
-                                        recoveryTimeMillis,
-                                        RESTART_LOST_REASON);
-                repository.save(lost, recoveredMetadata);
-            }
-        }
-    }
-
-    private JobSnapshot findExistingSubmission(JobSubmission submission) {
-        String jobId = submissionRegistry.lookup(submission);
-        if (jobId == null) {
-            return null;
-        }
-
-        JobSnapshot snapshot;
-        try {
-            snapshot = getJob(jobId);
-        } catch (JobNotFoundException stale) {
-            submissionRegistry.unregister(jobId, submission);
-            return null;
-        }
-
-        JobExecutionMetadata metadata = getMetadata(jobId);
-        if (metadata == null
-                || !submission.getExternalExecutionId()
-                .equals(metadata.getExternalExecutionId())
-                || !submission.getIdempotencyKey()
-                .equals(metadata.getIdempotencyKey())
-                || submission.getDefinitionVersion()
-                != metadata.getDefinitionVersion()
-                || !submission.getConfigDigest()
-                .equals(metadata.getConfigDigest())) {
-            throw new JobSubmissionConflictException(
-                    "The idempotency key or external execution ID was reused with different content");
-        }
-        return snapshot;
-    }
-
-    private ServerJobStatus terminalStatus(
-            JobExecutionState state,
-            JobResult result,
-            Throwable failure,
-            boolean cancellationLike) {
-        if (state.isCancellationRequested()
-                || cancellationLike
-                || result != null && result.getStatus() == JobStatus.CANCELED) {
-            return ServerJobStatus.CANCELED;
-        }
-        if (result != null
-                && result.getStatus() == JobStatus.SUCCEEDED
-                && failure == null) {
-            return ServerJobStatus.SUCCEEDED;
-        }
-        return ServerJobStatus.FAILED;
-    }
-
-    private Throwable terminalFailure(
-            JobExecutionState state,
-            JobResult result,
-            Throwable failure,
-            boolean cancellationLike) {
-        if (state.isCancellationRequested() || cancellationLike) {
-            return null;
-        }
-        if (failure != null) {
-            return failure;
-        }
-        return result == null ? null : result.getFailure();
-    }
-
-    private void completeAndArchive(
-            JobExecutionState state,
-            ServerJobStatus status,
-            JobResult result,
-            Throwable failure) {
-        if (!state.complete(status, result, failure)) {
-            return;
-        }
-        repository.save(
-                snapshot(state),
-                JobExecutionMetadata.fromState(state));
-        activeJobs.remove(state.getJobId(), state);
-    }
-
-    private void checkpoint(JobExecutionState state) {
-        repository.save(
-                snapshot(state),
-                JobExecutionMetadata.fromState(state));
-    }
-
-    private JobSnapshot snapshot(JobExecutionState state) {
-        return JobSnapshotFactory.create(
-                state,
-                runtimeScheduler.getMetrics(state.getJobId()));
-    }
-
     @Override
     public JobSnapshot getJob(String jobId) {
-        requireText(jobId, "jobId");
-        JobExecutionState active = activeJobs.get(jobId);
+        String normalizedJobId =
+                requireText(
+                        jobId,
+                        "jobId");
+
+        JobExecutionState active =
+                activeJobs.get(normalizedJobId);
+
         if (active != null) {
-            return snapshot(active);
+            return lifecycle.snapshot(active);
         }
-        JobSnapshot finished = repository.get(jobId);
+
+        JobSnapshot finished =
+                repository.get(normalizedJobId);
+
         if (finished == null) {
-            throw new JobNotFoundException(jobId);
+            throw new JobNotFoundException(
+                    normalizedJobId);
         }
+
         return finished;
     }
 
     @Override
-    public JobSnapshot getJobByExternalExecutionId(String externalExecutionId) {
-        String externalId = requireText(
-                externalExecutionId,
-                "externalExecutionId");
-        String jobId = submissionRegistry.findByExternalExecutionId(externalId);
+    public JobSnapshot getJobByExternalExecutionId(
+            String externalExecutionId) {
+
+        String externalId =
+                requireText(
+                        externalExecutionId,
+                        "externalExecutionId");
+
+        String jobId =
+                submissionRegistry.findByExternalExecutionId(
+                        externalId);
+
         if (jobId == null) {
-            throw new JobNotFoundException(externalId);
+            throw new JobNotFoundException(
+                    externalId);
         }
+
         return getJob(jobId);
     }
 
     @Override
     public JobExecutionMetadata getMetadata(String jobId) {
-        requireText(jobId, "jobId");
-        JobExecutionState active = activeJobs.get(jobId);
-        if (active != null) {
-            return JobExecutionMetadata.fromState(active);
-        }
-        return repository.getMetadata(jobId);
+        String normalizedJobId =
+                requireText(
+                        jobId,
+                        "jobId");
+
+        JobExecutionState active =
+                activeJobs.get(normalizedJobId);
+
+        return active != null
+                ? lifecycle.metadata(active)
+                : repository.getMetadata(normalizedJobId);
     }
 
     @Override
     public List<JobSnapshot> listJobs() {
         Map<String, JobSnapshot> snapshots =
                 new LinkedHashMap<String, JobSnapshot>();
+
         for (JobSnapshot snapshot : repository.list()) {
-            snapshots.put(snapshot.getJobId(), snapshot);
+            snapshots.put(
+                    snapshot.getJobId(),
+                    snapshot);
         }
-        for (JobExecutionState state : activeJobs.values()) {
-            JobSnapshot snapshot = snapshot(state);
-            snapshots.put(snapshot.getJobId(), snapshot);
+
+        for (JobExecutionState state : activeJobs.snapshot()) {
+            JobSnapshot snapshot =
+                    lifecycle.snapshot(state);
+            snapshots.put(
+                    snapshot.getJobId(),
+                    snapshot);
         }
+
         List<JobSnapshot> result =
-                new ArrayList<JobSnapshot>(snapshots.values());
+                new ArrayList<JobSnapshot>(
+                        snapshots.values());
+
         Collections.sort(
                 result,
                 new Comparator<JobSnapshot>() {
                     @Override
-                    public int compare(JobSnapshot left, JobSnapshot right) {
+                    public int compare(
+                            JobSnapshot left,
+                            JobSnapshot right) {
+
                         return Long.compare(
                                 right.getCreateTimeMillis(),
                                 left.getCreateTimeMillis());
                     }
                 });
+
         return result;
     }
 
     @Override
     public JobSnapshot cancel(String jobId) {
-        requireText(jobId, "jobId");
-        JobExecutionState state = activeJobs.get(jobId);
+        String normalizedJobId =
+                requireText(
+                        jobId,
+                        "jobId");
+
+        JobExecutionState state =
+                activeJobs.get(normalizedJobId);
+
         if (state == null) {
-            JobSnapshot finished = repository.get(jobId);
+            JobSnapshot finished =
+                    repository.get(normalizedJobId);
+
             if (finished != null) {
-                throw new JobStateConflictException(jobId, finished.getStatus());
+                throw new JobStateConflictException(
+                        normalizedJobId,
+                        finished.getStatus());
             }
-            throw new JobNotFoundException(jobId);
+
+            throw new JobNotFoundException(
+                    normalizedJobId);
         }
+
         state.requestCancellation();
-        checkpoint(state);
-        runtimeScheduler.cancel(jobId);
-        return getJob(jobId);
+        lifecycle.checkpoint(state);
+        runtimeScheduler.cancel(normalizedJobId);
+        return getJob(normalizedJobId);
     }
 
     @Override
     public int getRunningJobCount() {
-        return count(ServerJobStatus.RUNNING);
+        return activeJobs.count(
+                ServerJobStatus.RUNNING);
     }
 
     @Override
     public int getQueuedJobCount() {
-        int count = 0;
-        for (JobExecutionState state : activeJobs.values()) {
-            ServerJobStatus status = state.getStatus();
-            if (status == ServerJobStatus.CREATED
-                    || status == ServerJobStatus.SUBMITTED
-                    || status == ServerJobStatus.QUEUED) {
-                count++;
-            }
-        }
-        return count;
-    }
-
-    private int count(ServerJobStatus status) {
-        int count = 0;
-        for (JobExecutionState state : activeJobs.values()) {
-            if (state.getStatus() == status) {
-                count++;
-            }
-        }
-        return count;
+        return activeJobs.countQueued();
     }
 
     @Override
@@ -513,26 +386,150 @@ public final class JobApplicationService implements JobApplication {
         if (!closed.compareAndSet(false, true)) {
             return;
         }
+
         runtimeScheduler.close();
-        for (JobExecutionState state : activeJobs.values()) {
-            completeAndArchive(
-                    state,
-                    ServerJobStatus.LOST,
-                    null,
-                    null);
+
+        for (JobExecutionState state : activeJobs.snapshot()) {
+            lifecycle.archiveAsLost(state);
         }
+    }
+
+    private void schedule(
+            JobExecutionState state,
+            JobSubmission submission) {
+
+        runtimeScheduler.schedule(
+                state.getJobId(),
+                submission.getDefinition(),
+                lifecycle.listener(state));
+    }
+
+    private void rollbackSubmission(
+            JobExecutionState state,
+            JobSubmission submission) {
+
+        activeJobs.remove(
+                state.getJobId(),
+                state);
+        submissionRegistry.unregister(
+                state.getJobId(),
+                submission);
+        repository.delete(
+                state.getJobId());
+    }
+
+    private JobExecutionState retryState(
+            String jobId,
+            JobSubmission submission,
+            JobSnapshot previousSnapshot,
+            JobExecutionMetadata previousMetadata) {
+
+        List<JobExecutionAttempt> previousAttempts =
+                new ArrayList<JobExecutionAttempt>();
+
+        for (JobAttemptMetadata attempt :
+                previousMetadata.getAttempts()) {
+            previousAttempts.add(
+                    attempt.toDomain());
+        }
+
+        return JobExecutionState.retryFrom(
+                jobId,
+                submission,
+                previousSnapshot.getCreateTimeMillis(),
+                previousMetadata.getSubmittedTimeMillis(),
+                previousMetadata.getStateVersion(),
+                previousMetadata.getCheckpointVersion(),
+                previousSnapshot.getStatus(),
+                previousMetadata.getTransitions(),
+                previousAttempts);
+    }
+
+    private void validateRetrySubmission(
+            JobExecutionMetadata metadata,
+            JobSubmission submission) {
+
+        if (metadata == null
+                || !submission.getExternalExecutionId()
+                .equals(metadata.getExternalExecutionId())
+                || !submission.getIdempotencyKey()
+                .equals(metadata.getIdempotencyKey())
+                || submission.getDefinitionVersion()
+                != metadata.getDefinitionVersion()
+                || !submission.getConfigDigest()
+                .equals(metadata.getConfigDigest())) {
+
+            throw new JobSubmissionConflictException(
+                    "Retry request must use the same externalExecutionId, "
+                            + "idempotencyKey, definitionVersion and job content");
+        }
+    }
+
+    private JobSnapshot findExistingSubmission(
+            JobSubmission submission) {
+
+        String jobId =
+                submissionRegistry.lookup(submission);
+
+        if (jobId == null) {
+            return null;
+        }
+
+        JobSnapshot snapshot;
+
+        try {
+            snapshot = getJob(jobId);
+        } catch (JobNotFoundException stale) {
+            submissionRegistry.unregister(
+                    jobId,
+                    submission);
+            return null;
+        }
+
+        JobExecutionMetadata metadata =
+                getMetadata(jobId);
+
+        if (!sameSubmission(metadata, submission)) {
+            throw new JobSubmissionConflictException(
+                    "The idempotency key or external execution ID was reused with different content");
+        }
+
+        return snapshot;
+    }
+
+    private boolean sameSubmission(
+            JobExecutionMetadata metadata,
+            JobSubmission submission) {
+
+        return metadata != null
+                && submission.getExternalExecutionId()
+                .equals(metadata.getExternalExecutionId())
+                && submission.getIdempotencyKey()
+                .equals(metadata.getIdempotencyKey())
+                && submission.getDefinitionVersion()
+                == metadata.getDefinitionVersion()
+                && submission.getConfigDigest()
+                .equals(metadata.getConfigDigest());
     }
 
     private void ensureOpen() {
-        if (closed.get() || runtimeScheduler.isClosed()) {
-            throw new IllegalStateException("Job application is closed");
+        if (closed.get()
+                || runtimeScheduler.isClosed()) {
+            throw new IllegalStateException(
+                    "Job application is closed");
         }
     }
 
-    private static String requireText(String value, String name) {
-        if (value == null || value.trim().isEmpty()) {
-            throw new IllegalArgumentException(name + " must not be blank");
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null
+                || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
         }
+
         return value.trim();
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/application/JobRecoveryService.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobRecoveryService.java
@@ -1,0 +1,75 @@
+package com.link.up.server.application;
+
+import com.link.up.server.application.port.JobRepository;
+import com.link.up.server.application.port.JobRepositoryEntry;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobRecoverySnapshotFactory;
+import com.link.up.server.runtime.JobSnapshot;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Restores persisted idempotency state and marks unfinished jobs as LOST. */
+final class JobRecoveryService {
+
+    private static final String RESTART_LOST_REASON =
+            "Worker restarted before the job reached a terminal state";
+
+    private final JobRepository repository;
+    private final JobSubmissionRegistry submissionRegistry;
+
+    JobRecoveryService(
+            JobRepository repository,
+            JobSubmissionRegistry submissionRegistry) {
+
+        this.repository = Objects.requireNonNull(
+                repository,
+                "repository must not be null");
+        this.submissionRegistry = Objects.requireNonNull(
+                submissionRegistry,
+                "submissionRegistry must not be null");
+    }
+
+    void recover() {
+        List<JobRepositoryEntry> persisted = repository.listEntries();
+
+        for (JobRepositoryEntry entry : persisted) {
+            recover(entry);
+        }
+    }
+
+    private void recover(JobRepositoryEntry entry) {
+        JobSnapshot snapshot = entry.getSnapshot();
+        JobExecutionMetadata metadata = entry.getMetadata();
+
+        if (metadata != null) {
+            submissionRegistry.restore(
+                    snapshot.getJobId(),
+                    metadata);
+        }
+
+        if (snapshot.getStatus().isTerminal()) {
+            return;
+        }
+
+        long recoveryTimeMillis = System.currentTimeMillis();
+
+        JobSnapshot lost =
+                JobRecoverySnapshotFactory.recoverLost(
+                        snapshot,
+                        recoveryTimeMillis,
+                        RESTART_LOST_REASON);
+
+        JobExecutionMetadata recoveredMetadata =
+                metadata == null
+                        ? null
+                        : metadata.recoverLost(
+                                snapshot.getStatus(),
+                                recoveryTimeMillis,
+                                RESTART_LOST_REASON);
+
+        repository.save(
+                lost,
+                recoveredMetadata);
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/application/JobRuntimeLifecycle.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobRuntimeLifecycle.java
@@ -1,0 +1,202 @@
+package com.link.up.server.application;
+
+import com.link.up.framework.job.JobResult;
+import com.link.up.framework.job.JobStatus;
+import com.link.up.server.application.port.JobRepository;
+import com.link.up.server.application.port.JobRuntimeScheduler;
+import com.link.up.server.domain.JobExecutionState;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobSnapshotFactory;
+import com.link.up.server.runtime.ServerJobStatus;
+
+import java.util.Objects;
+
+/**
+ * Applies runtime callbacks to domain state and persists lifecycle checkpoints.
+ */
+final class JobRuntimeLifecycle {
+
+    private final JobRuntimeScheduler runtimeScheduler;
+    private final JobRepository repository;
+    private final ActiveJobRegistry activeJobs;
+
+    JobRuntimeLifecycle(
+            JobRuntimeScheduler runtimeScheduler,
+            JobRepository repository,
+            ActiveJobRegistry activeJobs) {
+
+        this.runtimeScheduler = Objects.requireNonNull(
+                runtimeScheduler,
+                "runtimeScheduler must not be null");
+        this.repository = Objects.requireNonNull(
+                repository,
+                "repository must not be null");
+        this.activeJobs = Objects.requireNonNull(
+                activeJobs,
+                "activeJobs must not be null");
+    }
+
+    JobSnapshot snapshot(JobExecutionState state) {
+        return JobSnapshotFactory.create(
+                state,
+                runtimeScheduler.getMetrics(state.getJobId()));
+    }
+
+    JobExecutionMetadata metadata(JobExecutionState state) {
+        return JobExecutionMetadata.fromState(state);
+    }
+
+    void checkpoint(JobExecutionState state) {
+        repository.save(
+                snapshot(state),
+                metadata(state));
+    }
+
+    JobRuntimeScheduler.Listener listener(
+            final JobExecutionState state) {
+
+        return new JobRuntimeScheduler.Listener() {
+            @Override
+            public void onQueued() {
+                state.markQueued();
+                checkpoint(state);
+            }
+
+            @Override
+            public boolean onStarting() {
+                boolean started = state.markRunning();
+                if (started) {
+                    checkpoint(state);
+                }
+                return started;
+            }
+
+            @Override
+            public void onJobLogCreated(
+                    String runId,
+                    String jobLogFile) {
+
+                state.bindLogIdentity(
+                        runId,
+                        jobLogFile);
+                checkpoint(state);
+            }
+
+            @Override
+            public void onCompleted(
+                    JobResult result,
+                    Throwable failure,
+                    boolean cancellationLike) {
+
+                completeAndArchive(
+                        state,
+                        terminalStatus(
+                                state,
+                                result,
+                                failure,
+                                cancellationLike),
+                        result,
+                        terminalFailure(
+                                state,
+                                result,
+                                failure,
+                                cancellationLike));
+            }
+
+            @Override
+            public void onLost() {
+                completeAndArchive(
+                        state,
+                        ServerJobStatus.LOST,
+                        null,
+                        null);
+            }
+        };
+    }
+
+    void failBeforeExecutionAndArchive(
+            JobExecutionState state,
+            RuntimeException failure) {
+
+        if (activeJobs.get(state.getJobId()) != state) {
+            return;
+        }
+
+        state.failBeforeExecution(failure);
+        repository.save(
+                snapshot(state),
+                metadata(state));
+        activeJobs.remove(
+                state.getJobId(),
+                state);
+    }
+
+    void archiveAsLost(JobExecutionState state) {
+        completeAndArchive(
+                state,
+                ServerJobStatus.LOST,
+                null,
+                null);
+    }
+
+    private void completeAndArchive(
+            JobExecutionState state,
+            ServerJobStatus status,
+            JobResult result,
+            Throwable failure) {
+
+        if (!state.complete(status, result, failure)) {
+            return;
+        }
+
+        repository.save(
+                snapshot(state),
+                metadata(state));
+        activeJobs.remove(
+                state.getJobId(),
+                state);
+    }
+
+    private ServerJobStatus terminalStatus(
+            JobExecutionState state,
+            JobResult result,
+            Throwable failure,
+            boolean cancellationLike) {
+
+        if (state.isCancellationRequested()
+                || cancellationLike
+                || result != null
+                && result.getStatus() == JobStatus.CANCELED) {
+            return ServerJobStatus.CANCELED;
+        }
+
+        if (result != null
+                && result.getStatus() == JobStatus.SUCCEEDED
+                && failure == null) {
+            return ServerJobStatus.SUCCEEDED;
+        }
+
+        return ServerJobStatus.FAILED;
+    }
+
+    private Throwable terminalFailure(
+            JobExecutionState state,
+            JobResult result,
+            Throwable failure,
+            boolean cancellationLike) {
+
+        if (state.isCancellationRequested()
+                || cancellationLike) {
+            return null;
+        }
+
+        if (failure != null) {
+            return failure;
+        }
+
+        return result == null
+                ? null
+                : result.getFailure();
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/http/FluxServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/FluxServlet.java
@@ -9,10 +9,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
-/**
- * REST Servlet 基类。
- */
+/** Base servlet for Link-Up REST adapters. */
 public abstract class FluxServlet
         extends HttpServlet {
 
@@ -43,7 +42,6 @@ public abstract class FluxServlet
 
         ServletInputStream input =
                 request.getInputStream();
-
         ByteArrayOutputStream output =
                 new ByteArrayOutputStream();
 
@@ -79,8 +77,7 @@ public abstract class FluxServlet
             String name,
             int defaultValue) {
 
-        String value =
-                request.getParameter(name);
+        String value = request.getParameter(name);
 
         if (value == null
                 || value.trim().isEmpty()) {
@@ -89,7 +86,7 @@ public abstract class FluxServlet
 
         try {
             return Integer.parseInt(value);
-        } catch (NumberFormatException exception) {
+        } catch (NumberFormatException failure) {
             throw new IllegalArgumentException(
                     name + " must be an integer");
         }
@@ -100,8 +97,7 @@ public abstract class FluxServlet
             String name,
             long defaultValue) {
 
-        String value =
-                request.getParameter(name);
+        String value = request.getParameter(name);
 
         if (value == null
                 || value.trim().isEmpty()) {
@@ -110,7 +106,7 @@ public abstract class FluxServlet
 
         try {
             return Long.parseLong(value);
-        } catch (NumberFormatException exception) {
+        } catch (NumberFormatException failure) {
             throw new IllegalArgumentException(
                     name + " must be a long integer");
         }
@@ -119,9 +115,7 @@ public abstract class FluxServlet
     protected List<String> pathSegments(
             HttpServletRequest request) {
 
-        String path =
-                request.getPathInfo();
-
+        String path = request.getPathInfo();
         List<String> segments =
                 new ArrayList<String>();
 
@@ -130,15 +124,10 @@ public abstract class FluxServlet
             return segments;
         }
 
-        String[] values =
-                path.split("/");
-
-        for (String value : values) {
+        for (String value : path.split("/")) {
             if (value != null
                     && !value.trim().isEmpty()) {
-
-                segments.add(
-                        value.trim());
+                segments.add(value.trim());
             }
         }
 
@@ -148,25 +137,11 @@ public abstract class FluxServlet
     protected void validateSubmitContentType(
             HttpServletRequest request) {
 
-        String contentType =
-                request.getContentType();
+        String mediaType = mediaType(request);
 
-        if (contentType == null) {
+        if (mediaType == null) {
             return;
         }
-
-        int semicolon =
-                contentType.indexOf(';');
-
-        String mediaType =
-                (semicolon >= 0
-                        ? contentType.substring(
-                        0,
-                        semicolon)
-                        : contentType)
-                        .trim()
-                        .toLowerCase(
-                                java.util.Locale.ROOT);
 
         if (!"application/hocon".equals(mediaType)
                 && !"text/plain".equals(mediaType)
@@ -178,6 +153,26 @@ public abstract class FluxServlet
                     "Unsupported Content-Type: "
                             + mediaType);
         }
+    }
+
+    protected boolean isJsonContentType(
+            HttpServletRequest request) {
+        return "application/json".equals(
+                mediaType(request));
+    }
+
+    protected void requireJsonContentType(
+            HttpServletRequest request,
+            String message) {
+
+        if (isJsonContentType(request)) {
+            return;
+        }
+
+        throw new RestException(
+                415,
+                "FLUX-REST-415",
+                message);
     }
 
     protected final RestException methodNotAllowed(
@@ -194,28 +189,48 @@ public abstract class FluxServlet
     protected void doPut(
             HttpServletRequest request,
             HttpServletResponse response) {
-
         throw methodNotAllowed(request);
     }
 
     protected void doDelete(
             HttpServletRequest request,
-            HttpServletResponse response) throws IOException{
-
+            HttpServletResponse response)
+            throws IOException {
         throw methodNotAllowed(request);
     }
 
     protected void doPost(
             HttpServletRequest request,
-            HttpServletResponse response) throws IOException{
-
+            HttpServletResponse response)
+            throws IOException {
         throw methodNotAllowed(request);
     }
 
     protected void doGet(
             HttpServletRequest request,
-            HttpServletResponse response) throws IOException{
-
+            HttpServletResponse response)
+            throws IOException {
         throw methodNotAllowed(request);
+    }
+
+    private String mediaType(
+            HttpServletRequest request) {
+
+        String contentType = request.getContentType();
+
+        if (contentType == null) {
+            return null;
+        }
+
+        int separator = contentType.indexOf(';');
+        String value =
+                separator >= 0
+                        ? contentType.substring(
+                                0,
+                                separator)
+                        : contentType;
+
+        return value.trim()
+                .toLowerCase(Locale.ROOT);
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/JobResourceServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/JobResourceServlet.java
@@ -1,152 +1,190 @@
 package com.link.up.server.http.servlet;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.link.up.server.application.JobNotFoundException;
 import com.link.up.server.dto.JobSubmitRequest;
 import com.link.up.server.http.FluxServlet;
-import com.link.up.server.http.JsonSupport;
-import com.link.up.server.http.RestException;
 import com.link.up.server.service.JobRestService;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
-import java.util.Locale;
 
 /** Handles one offline Job resource, details, cancellation and explicit retry. */
-public final class JobResourceServlet extends FluxServlet {
+public final class JobResourceServlet
+        extends FluxServlet {
 
-    private static final int DEFAULT_MAX_REQUEST_BYTES = 1024 * 1024;
+    private static final int DEFAULT_MAX_REQUEST_BYTES =
+            1024 * 1024;
 
     private final JobRestService service;
     private final int maxRequestBytes;
 
     public JobResourceServlet(JobRestService service) {
-        this(service, DEFAULT_MAX_REQUEST_BYTES);
+        this(
+                service,
+                DEFAULT_MAX_REQUEST_BYTES);
     }
 
     public JobResourceServlet(
             JobRestService service,
             int maxRequestBytes) {
+
         this.service = service;
         this.maxRequestBytes = maxRequestBytes;
     }
 
+    @Override
     protected void doGet(
             HttpServletRequest request,
             HttpServletResponse response)
             throws IOException {
 
-        List<String> segments = pathSegments(request);
+        List<String> segments =
+                pathSegments(request);
 
         if (segments.size() == 1) {
-            write(response, 200, service.jobResponse(segments.get(0)));
+            write(
+                    response,
+                    200,
+                    service.jobResponse(
+                            segments.get(0)));
             return;
         }
 
         if (segments.size() == 2
                 && "external".equals(segments.get(0))) {
+
             write(
                     response,
                     200,
-                    service.jobByExternalExecutionId(segments.get(1)));
+                    service.jobByExternalExecutionId(
+                            segments.get(1)));
             return;
         }
 
         if (segments.size() == 2) {
-            String jobId = segments.get(0);
-            String resource = segments.get(1);
-
-            if ("pipelines".equals(resource)) {
-                write(response, 200, service.pipelines(jobId));
-                return;
-            }
-            if ("tasks".equals(resource)) {
-                write(response, 200, service.tasks(jobId));
-                return;
-            }
-            if ("metrics".equals(resource)) {
-                write(response, 200, service.metrics(jobId));
-                return;
-            }
-            if ("logs".equals(resource)) {
-                write(
-                        response,
-                        200,
-                        service.logs(
-                                jobId,
-                                longParameter(request, "cursor", 0L),
-                                intParameter(request, "limit", 500)));
-                return;
-            }
+            writeNestedResource(
+                    request,
+                    response,
+                    segments.get(0),
+                    segments.get(1));
+            return;
         }
 
-        throw new JobNotFoundException(request.getRequestURI());
+        throw notFound(request);
     }
 
+    @Override
     protected void doPost(
             HttpServletRequest request,
             HttpServletResponse response)
             throws IOException {
 
-        List<String> segments = pathSegments(request);
+        List<String> segments =
+                pathSegments(request);
+
         if (segments.size() != 2
                 || !"retry".equals(segments.get(1))) {
-            throw new JobNotFoundException(request.getRequestURI());
+            throw notFound(request);
         }
 
-        requireJson(request);
-        String body = requestBody(request, maxRequestBytes);
-        try {
-            JobSubmitRequest retryRequest =
-                    JsonSupport.mapper().readValue(
-                            body,
-                            JobSubmitRequest.class);
-            write(
-                    response,
-                    202,
-                    service.retry(segments.get(0), retryRequest));
-        } catch (JsonProcessingException failure) {
-            throw new IllegalArgumentException(
-                    "Invalid JSON retry request");
-        }
+        requireJsonContentType(
+                request,
+                "Retry requires Content-Type: application/json");
+
+        String body =
+                requestBody(
+                        request,
+                        maxRequestBytes);
+
+        JobSubmitRequest retryRequest =
+                JobSubmitRequestDecoder.decode(
+                        body,
+                        "Invalid JSON retry request");
+
+        write(
+                response,
+                202,
+                service.retry(
+                        segments.get(0),
+                        retryRequest));
     }
 
+    @Override
     protected void doDelete(
             HttpServletRequest request,
             HttpServletResponse response)
             throws IOException {
 
-        List<String> segments = pathSegments(request);
+        List<String> segments =
+                pathSegments(request);
+
         if (segments.size() != 1) {
-            throw new JobNotFoundException(request.getRequestURI());
+            throw notFound(request);
         }
 
         write(
                 response,
                 202,
-                service.cancelResponse(segments.get(0)));
+                service.cancelResponse(
+                        segments.get(0)));
     }
 
-    private void requireJson(HttpServletRequest request) {
-        String contentType = request.getContentType();
-        if (contentType == null) {
-            throw new RestException(
-                    415,
-                    "FLUX-REST-415",
-                    "Retry requires Content-Type: application/json");
+    private void writeNestedResource(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            String jobId,
+            String resource)
+            throws IOException {
+
+        if ("pipelines".equals(resource)) {
+            write(
+                    response,
+                    200,
+                    service.pipelines(jobId));
+            return;
         }
-        int separator = contentType.indexOf(';');
-        String mediaType = separator >= 0
-                ? contentType.substring(0, separator)
-                : contentType;
-        if (!"application/json".equals(
-                mediaType.trim().toLowerCase(Locale.ROOT))) {
-            throw new RestException(
-                    415,
-                    "FLUX-REST-415",
-                    "Retry requires Content-Type: application/json");
+
+        if ("tasks".equals(resource)) {
+            write(
+                    response,
+                    200,
+                    service.tasks(jobId));
+            return;
         }
+
+        if ("metrics".equals(resource)) {
+            write(
+                    response,
+                    200,
+                    service.metrics(jobId));
+            return;
+        }
+
+        if ("logs".equals(resource)) {
+            write(
+                    response,
+                    200,
+                    service.logs(
+                            jobId,
+                            longParameter(
+                                    request,
+                                    "cursor",
+                                    0L),
+                            intParameter(
+                                    request,
+                                    "limit",
+                                    500)));
+            return;
+        }
+
+        throw notFound(request);
+    }
+
+    private JobNotFoundException notFound(
+            HttpServletRequest request) {
+        return new JobNotFoundException(
+                request.getRequestURI());
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/JobSubmitRequestDecoder.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/JobSubmitRequestDecoder.java
@@ -1,0 +1,28 @@
+package com.link.up.server.http.servlet;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.link.up.server.dto.JobSubmitRequest;
+import com.link.up.server.http.JsonSupport;
+
+/** Decodes the JSON transport request used for submit/retry endpoints. */
+final class JobSubmitRequestDecoder {
+
+    private JobSubmitRequestDecoder() {
+    }
+
+    static JobSubmitRequest decode(
+            String body,
+            String invalidMessage) {
+
+        try {
+            return JsonSupport.mapper()
+                    .readValue(
+                            body,
+                            JobSubmitRequest.class);
+        } catch (JsonProcessingException failure) {
+            throw new IllegalArgumentException(
+                    invalidMessage,
+                    failure);
+        }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/JobsServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/JobsServlet.java
@@ -1,10 +1,8 @@
 package com.link.up.server.http.servlet;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.link.up.api.job.JobSpec;
 import com.link.up.server.dto.JobSubmitRequest;
 import com.link.up.server.http.FluxServlet;
-import com.link.up.server.http.JsonSupport;
 import com.link.up.server.service.JobRestService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -13,17 +11,13 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.Locale;
 
-/**
- * /api/v1/jobs 集合资源。
- */
+/** Handles the /api/v1/jobs collection resource. */
 public final class JobsServlet
         extends FluxServlet {
 
     private static final Logger LOG =
-            LogManager.getLogger(
-                    JobsServlet.class);
+            LogManager.getLogger(JobsServlet.class);
 
     private final JobRestService service;
     private final int maxRequestBytes;
@@ -36,6 +30,7 @@ public final class JobsServlet
         this.maxRequestBytes = maxRequestBytes;
     }
 
+    @Override
     protected void doPost(
             HttpServletRequest request,
             HttpServletResponse response)
@@ -48,46 +43,30 @@ public final class JobsServlet
                         request,
                         maxRequestBytes);
 
-        Object result;
+        Object result =
+                isJsonContentType(request)
+                        ? submitJson(
+                                request,
+                                body)
+                        : submitLegacy(
+                                request,
+                                body);
 
-        if (isJson(request)) {
-            try {
-                JobSubmitRequest submitRequest =
-                        JsonSupport.mapper()
-                                .readValue(
-                                        body,
-                                        JobSubmitRequest.class);
-
-                logSubmissionSummary(
-                        request,
-                        submitRequest,
-                        body);
-
-                result = service.submit(submitRequest);
-            } catch (JsonProcessingException exception) {
-                throw new IllegalArgumentException(
-                        "Invalid JSON submit request");
-            }
-        } else {
-            LOG.info(
-                    "Received legacy job submission, contentType={}, bodyBytes={}",
-                    safeLogValue(
-                            request.getContentType()),
-                    utf8Length(body));
-
-            result = service.submitLegacyResponse(body);
-        }
-
-        write(response, 202, result);
+        write(
+                response,
+                202,
+                result);
     }
 
+    @Override
     protected void doGet(
             HttpServletRequest request,
             HttpServletResponse response)
             throws IOException {
 
         String externalExecutionId =
-                request.getParameter("externalExecutionId");
+                request.getParameter(
+                        "externalExecutionId");
 
         if (externalExecutionId != null
                 && !externalExecutionId.trim().isEmpty()) {
@@ -100,8 +79,16 @@ public final class JobsServlet
             return;
         }
 
-        int page = intParameter(request, "page", 1);
-        int pageSize = intParameter(request, "pageSize", 20);
+        int page =
+                intParameter(
+                        request,
+                        "page",
+                        1);
+        int pageSize =
+                intParameter(
+                        request,
+                        "pageSize",
+                        20);
 
         write(
                 response,
@@ -110,6 +97,35 @@ public final class JobsServlet
                         request.getParameter("status"),
                         page,
                         pageSize));
+    }
+
+    private Object submitJson(
+            HttpServletRequest request,
+            String body) {
+
+        JobSubmitRequest submitRequest =
+                JobSubmitRequestDecoder.decode(
+                        body,
+                        "Invalid JSON submit request");
+
+        logSubmissionSummary(
+                request,
+                submitRequest,
+                body);
+
+        return service.submit(submitRequest);
+    }
+
+    private Object submitLegacy(
+            HttpServletRequest request,
+            String body) {
+
+        LOG.info(
+                "Received legacy job submission, contentType={}, bodyBytes={}",
+                safeLogValue(request.getContentType()),
+                utf8Length(body));
+
+        return service.submitLegacyResponse(body);
     }
 
     private void logSubmissionSummary(
@@ -123,9 +139,10 @@ public final class JobsServlet
                         : submitRequest.getJobSpec();
 
         LOG.info(
-                "Received job submission, contentType={}, bodyBytes={}, externalExecutionId={}, definitionVersion={}, jobName={}, sourceConnector={}, sinkConnector={}",
-                safeLogValue(
-                        request.getContentType()),
+                "Received job submission, contentType={}, bodyBytes={}, "
+                        + "externalExecutionId={}, definitionVersion={}, "
+                        + "jobName={}, sourceConnector={}, sinkConnector={}",
+                safeLogValue(request.getContentType()),
                 utf8Length(body),
                 safeLogValue(
                         submitRequest == null
@@ -152,7 +169,6 @@ public final class JobsServlet
 
     private String connectorId(
             JobSpec.Connector connector) {
-
         return connector == null
                 ? null
                 : connector.getConnectorId();
@@ -174,23 +190,5 @@ public final class JobsServlet
                 : value.getBytes(
                         StandardCharsets.UTF_8)
                         .length;
-    }
-
-    private boolean isJson(HttpServletRequest request) {
-        String contentType = request.getContentType();
-
-        if (contentType == null) {
-            return false;
-        }
-
-        int separator = contentType.indexOf(';');
-        String mediaType =
-                separator >= 0
-                        ? contentType.substring(0, separator)
-                        : contentType;
-
-        return "application/json".equals(
-                mediaType.trim()
-                        .toLowerCase(Locale.ROOT));
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/FileJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/FileJobRepository.java
@@ -1,26 +1,13 @@
 package com.link.up.server.infrastructure.persistence;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.link.up.server.application.port.JobRepository;
 import com.link.up.server.application.port.JobRepositoryEntry;
-import com.link.up.server.domain.JobAttemptStatus;
-import com.link.up.server.runtime.JobAttemptMetadata;
 import com.link.up.server.runtime.JobExecutionMetadata;
-import com.link.up.server.runtime.JobRecoverySnapshotFactory;
 import com.link.up.server.runtime.JobSnapshot;
-import com.link.up.server.runtime.JobStateTransition;
-import com.link.up.server.runtime.ServerJobStatus;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -29,16 +16,18 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 
-/** Local durable Worker checkpoint repository using versioned per-job JSON files. */
-public final class FileJobRepository implements JobRepository {
+/**
+ * Durable Worker checkpoint repository backed by versioned per-job JSON files.
+ *
+ * <p>The repository owns the in-memory index, checkpoint revision ordering and
+ * terminal-history retention. File naming, JSON IO and atomic replacement
+ * belong to {@link JobStateFileStore}.</p>
+ */
+public final class FileJobRepository
+        implements JobRepository {
 
-    private static final int CURRENT_FORMAT_VERSION = 2;
-    private static final int MIN_SUPPORTED_FORMAT_VERSION = 1;
-    private static final String FILE_SUFFIX = ".job.json";
-
-    private final Path stateDirectory;
+    private final JobStateFileStore fileStore;
     private final int historyLimit;
-    private final ObjectMapper mapper = new ObjectMapper();
     private final ConcurrentMap<String, JobSnapshot> snapshots =
             new ConcurrentHashMap<String, JobSnapshot>();
     private final ConcurrentMap<String, JobExecutionMetadata> metadata =
@@ -46,27 +35,25 @@ public final class FileJobRepository implements JobRepository {
     private final ConcurrentLinkedDeque<String> orderedJobIds =
             new ConcurrentLinkedDeque<String>();
 
-    public FileJobRepository(Path stateDirectory, int historyLimit) {
+    public FileJobRepository(
+            Path stateDirectory,
+            int historyLimit) {
+
         if (stateDirectory == null) {
-            throw new IllegalArgumentException("stateDirectory must not be null");
-        }
-        if (historyLimit <= 0) {
-            throw new IllegalArgumentException("historyLimit must be greater than 0");
+            throw new IllegalArgumentException(
+                    "stateDirectory must not be null");
         }
 
-        this.stateDirectory = stateDirectory.toAbsolutePath().normalize();
+        if (historyLimit <= 0) {
+            throw new IllegalArgumentException(
+                    "historyLimit must be greater than 0");
+        }
+
+        this.fileStore =
+                new JobStateFileStore(stateDirectory);
         this.historyLimit = historyLimit;
 
-        try {
-            Files.createDirectories(this.stateDirectory);
-            loadExisting();
-            trimTerminalHistory();
-        } catch (IOException failure) {
-            throw persistenceFailure(
-                    "Could not initialize Worker state directory "
-                            + this.stateDirectory,
-                    failure);
-        }
+        initialize();
     }
 
     @Override
@@ -80,26 +67,23 @@ public final class FileJobRepository implements JobRepository {
             JobExecutionMetadata executionMetadata) {
 
         if (snapshot == null) {
-            throw new IllegalArgumentException("snapshot must not be null");
+            throw new IllegalArgumentException(
+                    "snapshot must not be null");
         }
 
-        JobExecutionMetadata current = metadata.get(snapshot.getJobId());
-        if (isStale(current, executionMetadata)) {
+        JobExecutionMetadata current =
+                metadata.get(snapshot.getJobId());
+
+        if (isStale(
+                current,
+                executionMetadata)) {
             return;
         }
 
-        JobSnapshot previous = snapshots.put(snapshot.getJobId(), snapshot);
-        if (executionMetadata != null) {
-            metadata.put(snapshot.getJobId(), executionMetadata);
-        }
-        if (previous == null) {
-            orderedJobIds.addFirst(snapshot.getJobId());
-        }
-
-        writeAtomically(
-                StoredJobRecord.from(
-                        snapshot,
-                        metadata.get(snapshot.getJobId())));
+        remember(
+                snapshot,
+                executionMetadata);
+        persist(snapshot.getJobId());
         trimTerminalHistory();
     }
 
@@ -115,23 +99,18 @@ public final class FileJobRepository implements JobRepository {
 
     @Override
     public List<JobSnapshot> list() {
-        List<JobSnapshot> result = new ArrayList<JobSnapshot>();
+        List<JobSnapshot> result =
+                new ArrayList<JobSnapshot>();
+
         for (String jobId : orderedJobIds) {
             JobSnapshot snapshot = snapshots.get(jobId);
+
             if (snapshot != null) {
                 result.add(snapshot);
             }
         }
-        Collections.sort(
-                result,
-                new Comparator<JobSnapshot>() {
-                    @Override
-                    public int compare(JobSnapshot left, JobSnapshot right) {
-                        return Long.compare(
-                                right.getCreateTimeMillis(),
-                                left.getCreateTimeMillis());
-                    }
-                });
+
+        sortNewestFirst(result);
         return result;
     }
 
@@ -140,54 +119,43 @@ public final class FileJobRepository implements JobRepository {
         if (jobId == null) {
             return;
         }
+
         snapshots.remove(jobId);
         metadata.remove(jobId);
         orderedJobIds.remove(jobId);
+
         try {
-            Files.deleteIfExists(fileFor(jobId));
+            fileStore.delete(jobId);
         } catch (IOException failure) {
             throw persistenceFailure(
-                    "Could not delete Worker checkpoint for " + jobId,
+                    "Could not delete Worker checkpoint for "
+                            + jobId,
                     failure);
         }
     }
 
     public Path getStateDirectory() {
-        return stateDirectory;
+        return fileStore.getStateDirectory();
     }
 
-    private static boolean isStale(
-            JobExecutionMetadata current,
-            JobExecutionMetadata candidate) {
-        return current != null
-                && candidate != null
-                && candidate.getCheckpointVersion()
-                < current.getCheckpointVersion();
-    }
-
-    private void loadExisting() throws IOException {
-        List<JobRepositoryEntry> loaded = new ArrayList<JobRepositoryEntry>();
-
-        try (DirectoryStream<Path> stream =
-                     Files.newDirectoryStream(stateDirectory, "*" + FILE_SUFFIX)) {
-            for (Path file : stream) {
-                StoredJobRecord record;
-                try {
-                    record = mapper.readValue(file.toFile(), StoredJobRecord.class);
-                } catch (Exception failure) {
-                    throw new IOException("Invalid Worker state file: " + file, failure);
-                }
-                if (record.formatVersion < MIN_SUPPORTED_FORMAT_VERSION
-                        || record.formatVersion > CURRENT_FORMAT_VERSION) {
-                    throw new IOException(
-                            "Unsupported Worker state formatVersion="
-                                    + record.formatVersion
-                                    + " in "
-                                    + file);
-                }
-                loaded.add(record.toEntry());
-            }
+    private void initialize() {
+        try {
+            fileStore.initialize();
+            loadExisting();
+            trimTerminalHistory();
+        } catch (IOException failure) {
+            throw persistenceFailure(
+                    "Could not initialize Worker state directory "
+                            + fileStore.getStateDirectory(),
+                    failure);
         }
+    }
+
+    private void loadExisting()
+            throws IOException {
+
+        List<JobRepositoryEntry> loaded =
+                fileStore.loadEntries();
 
         Collections.sort(
                 loaded,
@@ -196,330 +164,146 @@ public final class FileJobRepository implements JobRepository {
                     public int compare(
                             JobRepositoryEntry left,
                             JobRepositoryEntry right) {
+
                         return Long.compare(
-                                right.getSnapshot().getCreateTimeMillis(),
-                                left.getSnapshot().getCreateTimeMillis());
+                                right.getSnapshot()
+                                        .getCreateTimeMillis(),
+                                left.getSnapshot()
+                                        .getCreateTimeMillis());
                     }
                 });
 
         for (JobRepositoryEntry entry : loaded) {
-            String jobId = entry.getSnapshot().getJobId();
-            snapshots.put(jobId, entry.getSnapshot());
+            JobSnapshot snapshot = entry.getSnapshot();
+            String jobId = snapshot.getJobId();
+
+            snapshots.put(
+                    jobId,
+                    snapshot);
+
             if (entry.getMetadata() != null) {
-                metadata.put(jobId, entry.getMetadata());
+                metadata.put(
+                        jobId,
+                        entry.getMetadata());
             }
+
             orderedJobIds.addLast(jobId);
         }
     }
 
-    private void writeAtomically(StoredJobRecord record) {
-        Path target = fileFor(record.jobId);
-        Path temporary = null;
-        try {
-            byte[] bytes = mapper.writerWithDefaultPrettyPrinter()
-                    .writeValueAsBytes(record);
-            temporary = Files.createTempFile(
-                    stateDirectory,
-                    ".job-state-",
-                    ".tmp");
+    private void remember(
+            JobSnapshot snapshot,
+            JobExecutionMetadata executionMetadata) {
 
-            try (FileOutputStream output = new FileOutputStream(temporary.toFile())) {
-                output.write(bytes);
-                output.flush();
-                output.getFD().sync();
-            }
+        JobSnapshot previous =
+                snapshots.put(
+                        snapshot.getJobId(),
+                        snapshot);
 
-            try {
-                Files.move(
-                        temporary,
-                        target,
-                        StandardCopyOption.REPLACE_EXISTING,
-                        StandardCopyOption.ATOMIC_MOVE);
-            } catch (AtomicMoveNotSupportedException unsupported) {
-                Files.move(
-                        temporary,
-                        target,
-                        StandardCopyOption.REPLACE_EXISTING);
-            }
-        } catch (IOException failure) {
-            throw persistenceFailure(
-                    "Could not persist Worker checkpoint for " + record.jobId,
-                    failure);
-        } finally {
-            if (temporary != null) {
-                try {
-                    Files.deleteIfExists(temporary);
-                } catch (IOException ignored) {
-                    // Best-effort cleanup.
-                }
-            }
+        if (executionMetadata != null) {
+            metadata.put(
+                    snapshot.getJobId(),
+                    executionMetadata);
+        }
+
+        if (previous == null) {
+            orderedJobIds.addFirst(
+                    snapshot.getJobId());
         }
     }
 
-    private Path fileFor(String jobId) {
-        String encoded = Base64.getUrlEncoder()
-                .withoutPadding()
-                .encodeToString(jobId.getBytes(StandardCharsets.UTF_8));
-        return stateDirectory.resolve(encoded + FILE_SUFFIX);
+    private void persist(String jobId) {
+        StoredJobRecord record =
+                StoredJobRecord.from(
+                        snapshots.get(jobId),
+                        metadata.get(jobId));
+
+        try {
+            fileStore.write(record);
+        } catch (IOException failure) {
+            throw persistenceFailure(
+                    "Could not persist Worker checkpoint for "
+                            + jobId,
+                    failure);
+        }
     }
 
     private void trimTerminalHistory() {
         while (terminalCount() > historyLimit) {
-            String oldestTerminal = null;
-            Iterator<String> iterator = orderedJobIds.descendingIterator();
-            while (iterator.hasNext()) {
-                String jobId = iterator.next();
-                JobSnapshot snapshot = snapshots.get(jobId);
-                if (snapshot != null && snapshot.getStatus().isTerminal()) {
-                    oldestTerminal = jobId;
-                    break;
-                }
-            }
+            String oldestTerminal =
+                    oldestTerminalJobId();
+
             if (oldestTerminal == null) {
                 return;
             }
+
             delete(oldestTerminal);
         }
     }
 
+    private String oldestTerminalJobId() {
+        Iterator<String> iterator =
+                orderedJobIds.descendingIterator();
+
+        while (iterator.hasNext()) {
+            String jobId = iterator.next();
+            JobSnapshot snapshot = snapshots.get(jobId);
+
+            if (snapshot != null
+                    && snapshot.getStatus().isTerminal()) {
+                return jobId;
+            }
+        }
+
+        return null;
+    }
+
     private int terminalCount() {
         int count = 0;
+
         for (JobSnapshot snapshot : snapshots.values()) {
             if (snapshot.getStatus().isTerminal()) {
                 count++;
             }
         }
+
         return count;
+    }
+
+    private static boolean isStale(
+            JobExecutionMetadata current,
+            JobExecutionMetadata candidate) {
+
+        return current != null
+                && candidate != null
+                && candidate.getCheckpointVersion()
+                < current.getCheckpointVersion();
+    }
+
+    private static void sortNewestFirst(
+            List<JobSnapshot> snapshots) {
+
+        Collections.sort(
+                snapshots,
+                new Comparator<JobSnapshot>() {
+                    @Override
+                    public int compare(
+                            JobSnapshot left,
+                            JobSnapshot right) {
+
+                        return Long.compare(
+                                right.getCreateTimeMillis(),
+                                left.getCreateTimeMillis());
+                    }
+                });
     }
 
     private static IllegalStateException persistenceFailure(
             String message,
             Exception failure) {
-        return new IllegalStateException(message, failure);
-    }
 
-    public static final class StoredJobRecord {
-        public int formatVersion;
-        public String jobId;
-        public String jobName;
-        public String status;
-        public long createTimeMillis;
-        public long startTimeMillis;
-        public long endTimeMillis;
-        public String errorCode;
-        public String errorMessage;
-        public StoredMetadata metadata;
-
-        public StoredJobRecord() {
-        }
-
-        static StoredJobRecord from(
-                JobSnapshot snapshot,
-                JobExecutionMetadata metadata) {
-            StoredJobRecord record = new StoredJobRecord();
-            record.formatVersion = CURRENT_FORMAT_VERSION;
-            record.jobId = snapshot.getJobId();
-            record.jobName = snapshot.getJobName();
-            record.status = snapshot.getStatus().name();
-            record.createTimeMillis = snapshot.getCreateTimeMillis();
-            record.startTimeMillis = snapshot.getStartTimeMillis();
-            record.endTimeMillis = snapshot.getEndTimeMillis();
-            record.errorCode = snapshot.getErrorCode();
-            record.errorMessage = snapshot.getErrorMessage();
-            record.metadata = StoredMetadata.from(metadata);
-            return record;
-        }
-
-        JobRepositoryEntry toEntry() {
-            JobSnapshot restoredSnapshot =
-                    JobRecoverySnapshotFactory.restoreBasic(
-                            jobId,
-                            jobName,
-                            ServerJobStatus.valueOf(status),
-                            createTimeMillis,
-                            startTimeMillis,
-                            endTimeMillis,
-                            errorCode,
-                            errorMessage);
-            return new JobRepositoryEntry(
-                    restoredSnapshot,
-                    metadata == null ? null : metadata.toMetadata());
-        }
-    }
-
-    public static final class StoredMetadata {
-        public String externalExecutionId;
-        public String idempotencyKey;
-        public int definitionVersion;
-        public String configDigest;
-        public long submittedTimeMillis;
-        public long queuedTimeMillis;
-        public long stateVersion;
-        public long checkpointVersion;
-        public boolean cancellationRequested;
-        public String runId;
-        public String jobLogFile;
-        public List<StoredTransition> transitions = new ArrayList<StoredTransition>();
-        public List<StoredAttempt> attempts = new ArrayList<StoredAttempt>();
-
-        public StoredMetadata() {
-        }
-
-        static StoredMetadata from(JobExecutionMetadata metadata) {
-            if (metadata == null) {
-                return null;
-            }
-            StoredMetadata stored = new StoredMetadata();
-            stored.externalExecutionId = metadata.getExternalExecutionId();
-            stored.idempotencyKey = metadata.getIdempotencyKey();
-            stored.definitionVersion = metadata.getDefinitionVersion();
-            stored.configDigest = metadata.getConfigDigest();
-            stored.submittedTimeMillis = metadata.getSubmittedTimeMillis();
-            stored.queuedTimeMillis = metadata.getQueuedTimeMillis();
-            stored.stateVersion = metadata.getStateVersion();
-            stored.checkpointVersion = metadata.getCheckpointVersion();
-            stored.cancellationRequested = metadata.isCancellationRequested();
-            stored.runId = metadata.getRunId();
-            stored.jobLogFile = metadata.getJobLogFile();
-            for (JobStateTransition transition : metadata.getTransitions()) {
-                stored.transitions.add(StoredTransition.from(transition));
-            }
-            for (JobAttemptMetadata attempt : metadata.getAttempts()) {
-                stored.attempts.add(StoredAttempt.from(attempt));
-            }
-            return stored;
-        }
-
-        JobExecutionMetadata toMetadata() {
-            List<JobStateTransition> restoredTransitions =
-                    new ArrayList<JobStateTransition>();
-            for (StoredTransition transition : transitions) {
-                restoredTransitions.add(transition.toTransition());
-            }
-            List<JobAttemptMetadata> restoredAttempts =
-                    new ArrayList<JobAttemptMetadata>();
-            for (StoredAttempt attempt : attempts) {
-                restoredAttempts.add(attempt.toAttempt());
-            }
-            return new JobExecutionMetadata(
-                    externalExecutionId,
-                    idempotencyKey,
-                    definitionVersion,
-                    configDigest,
-                    submittedTimeMillis,
-                    queuedTimeMillis,
-                    stateVersion,
-                    checkpointVersion,
-                    cancellationRequested,
-                    restoredTransitions,
-                    Collections.<String, com.link.up.api.sink.TableDdl>emptyMap(),
-                    runId,
-                    jobLogFile,
-                    restoredAttempts);
-        }
-    }
-
-    public static final class StoredTransition {
-        public long version;
-        public String fromStatus;
-        public String toStatus;
-        public long transitionTimeMillis;
-        public String reason;
-
-        public StoredTransition() {
-        }
-
-        static StoredTransition from(JobStateTransition transition) {
-            StoredTransition stored = new StoredTransition();
-            stored.version = transition.getVersion();
-            stored.fromStatus = transition.getFromStatus() == null
-                    ? null
-                    : transition.getFromStatus().name();
-            stored.toStatus = transition.getToStatus().name();
-            stored.transitionTimeMillis = transition.getTransitionTimeMillis();
-            stored.reason = transition.getReason();
-            return stored;
-        }
-
-        JobStateTransition toTransition() {
-            return new JobStateTransition(
-                    version,
-                    fromStatus == null
-                            ? null
-                            : ServerJobStatus.valueOf(fromStatus),
-                    ServerJobStatus.valueOf(toStatus),
-                    transitionTimeMillis,
-                    reason);
-        }
-    }
-
-    public static final class StoredAttempt {
-        public int attemptNumber;
-        public String attemptId;
-        public String status;
-        public long createTimeMillis;
-        public long queuedTimeMillis;
-        public long startTimeMillis;
-        public long endTimeMillis;
-        public String runId;
-        public String jobLogFile;
-        public String failureType;
-        public String failureMessage;
-        public String retryAdvice;
-        public boolean commitEvidenceAvailable;
-        public int dataCommittedTaskCount;
-        public long successfullyCommittedRecordCount;
-        public long unknownStateRecordCount;
-        public boolean partialDataCommit;
-        public String commitScope;
-
-        public StoredAttempt() {
-        }
-
-        static StoredAttempt from(JobAttemptMetadata attempt) {
-            StoredAttempt stored = new StoredAttempt();
-            stored.attemptNumber = attempt.getAttemptNumber();
-            stored.attemptId = attempt.getAttemptId();
-            stored.status = attempt.getStatus().name();
-            stored.createTimeMillis = attempt.getCreateTimeMillis();
-            stored.queuedTimeMillis = attempt.getQueuedTimeMillis();
-            stored.startTimeMillis = attempt.getStartTimeMillis();
-            stored.endTimeMillis = attempt.getEndTimeMillis();
-            stored.runId = attempt.getRunId();
-            stored.jobLogFile = attempt.getJobLogFile();
-            stored.failureType = attempt.getFailureType();
-            stored.failureMessage = attempt.getFailureMessage();
-            stored.retryAdvice = attempt.getRetryAdvice();
-            stored.commitEvidenceAvailable = attempt.isCommitEvidenceAvailable();
-            stored.dataCommittedTaskCount = attempt.getDataCommittedTaskCount();
-            stored.successfullyCommittedRecordCount =
-                    attempt.getSuccessfullyCommittedRecordCount();
-            stored.unknownStateRecordCount = attempt.getUnknownStateRecordCount();
-            stored.partialDataCommit = attempt.isPartialDataCommit();
-            stored.commitScope = attempt.getCommitScope();
-            return stored;
-        }
-
-        JobAttemptMetadata toAttempt() {
-            return new JobAttemptMetadata(
-                    attemptNumber,
-                    attemptId,
-                    JobAttemptStatus.valueOf(status),
-                    createTimeMillis,
-                    queuedTimeMillis,
-                    startTimeMillis,
-                    endTimeMillis,
-                    runId,
-                    jobLogFile,
-                    failureType,
-                    failureMessage,
-                    retryAdvice,
-                    commitEvidenceAvailable,
-                    dataCommittedTaskCount,
-                    successfullyCommittedRecordCount,
-                    unknownStateRecordCount,
-                    partialDataCommit,
-                    commitScope);
-        }
+        return new IllegalStateException(
+                message,
+                failure);
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/JobStateFileStore.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/JobStateFileStore.java
@@ -1,0 +1,173 @@
+package com.link.up.server.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.server.application.port.JobRepositoryEntry;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+/** Owns Worker checkpoint file naming, JSON IO and atomic replacement. */
+final class JobStateFileStore {
+
+    private static final String FILE_SUFFIX = ".job.json";
+
+    private final Path stateDirectory;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    JobStateFileStore(Path stateDirectory) {
+        if (stateDirectory == null) {
+            throw new IllegalArgumentException(
+                    "stateDirectory must not be null");
+        }
+
+        this.stateDirectory =
+                stateDirectory
+                        .toAbsolutePath()
+                        .normalize();
+    }
+
+    void initialize() throws IOException {
+        Files.createDirectories(stateDirectory);
+    }
+
+    List<JobRepositoryEntry> loadEntries()
+            throws IOException {
+
+        List<JobRepositoryEntry> loaded =
+                new ArrayList<JobRepositoryEntry>();
+
+        try (DirectoryStream<Path> stream =
+                     Files.newDirectoryStream(
+                             stateDirectory,
+                             "*" + FILE_SUFFIX)) {
+
+            for (Path file : stream) {
+                StoredJobRecord record = read(file);
+                record.validateFormat(file.toString());
+                loaded.add(record.toEntry());
+            }
+        }
+
+        return loaded;
+    }
+
+    void write(StoredJobRecord record)
+            throws IOException {
+
+        Path target = fileFor(record.jobId);
+        Path temporary = null;
+
+        try {
+            byte[] bytes =
+                    mapper.writerWithDefaultPrettyPrinter()
+                            .writeValueAsBytes(record);
+
+            temporary =
+                    Files.createTempFile(
+                            stateDirectory,
+                            ".job-state-",
+                            ".tmp");
+
+            syncWrite(
+                    temporary,
+                    bytes);
+            replace(
+                    temporary,
+                    target);
+
+        } finally {
+            deleteTemporary(temporary);
+        }
+    }
+
+    void delete(String jobId)
+            throws IOException {
+        Files.deleteIfExists(fileFor(jobId));
+    }
+
+    Path getStateDirectory() {
+        return stateDirectory;
+    }
+
+    private StoredJobRecord read(Path file)
+            throws IOException {
+
+        try {
+            return mapper.readValue(
+                    file.toFile(),
+                    StoredJobRecord.class);
+        } catch (Exception failure) {
+            throw new IOException(
+                    "Invalid Worker state file: "
+                            + file,
+                    failure);
+        }
+    }
+
+    private void syncWrite(
+            Path target,
+            byte[] bytes)
+            throws IOException {
+
+        try (FileOutputStream output =
+                     new FileOutputStream(
+                             target.toFile())) {
+
+            output.write(bytes);
+            output.flush();
+            output.getFD().sync();
+        }
+    }
+
+    private void replace(
+            Path source,
+            Path target)
+            throws IOException {
+
+        try {
+            Files.move(
+                    source,
+                    target,
+                    StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException unsupported) {
+            Files.move(
+                    source,
+                    target,
+                    StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    private Path fileFor(String jobId) {
+        String encoded =
+                Base64.getUrlEncoder()
+                        .withoutPadding()
+                        .encodeToString(
+                                jobId.getBytes(
+                                        StandardCharsets.UTF_8));
+
+        return stateDirectory.resolve(
+                encoded + FILE_SUFFIX);
+    }
+
+    private void deleteTemporary(Path temporary) {
+        if (temporary == null) {
+            return;
+        }
+
+        try {
+            Files.deleteIfExists(temporary);
+        } catch (IOException ignored) {
+            // Best-effort cleanup after a failed or completed atomic write.
+        }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/StoredJobRecord.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/StoredJobRecord.java
@@ -1,0 +1,301 @@
+package com.link.up.server.infrastructure.persistence;
+
+import com.link.up.api.sink.TableDdl;
+import com.link.up.server.application.port.JobRepositoryEntry;
+import com.link.up.server.domain.JobAttemptStatus;
+import com.link.up.server.runtime.JobAttemptMetadata;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobRecoverySnapshotFactory;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobStateTransition;
+import com.link.up.server.runtime.ServerJobStatus;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Versioned JSON persistence model for one Worker job checkpoint. */
+final class StoredJobRecord {
+
+    static final int CURRENT_FORMAT_VERSION = 2;
+    static final int MIN_SUPPORTED_FORMAT_VERSION = 1;
+
+    public int formatVersion;
+    public String jobId;
+    public String jobName;
+    public String status;
+    public long createTimeMillis;
+    public long startTimeMillis;
+    public long endTimeMillis;
+    public String errorCode;
+    public String errorMessage;
+    public StoredMetadata metadata;
+
+    public StoredJobRecord() {
+    }
+
+    static StoredJobRecord from(
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata) {
+
+        StoredJobRecord record = new StoredJobRecord();
+        record.formatVersion = CURRENT_FORMAT_VERSION;
+        record.jobId = snapshot.getJobId();
+        record.jobName = snapshot.getJobName();
+        record.status = snapshot.getStatus().name();
+        record.createTimeMillis = snapshot.getCreateTimeMillis();
+        record.startTimeMillis = snapshot.getStartTimeMillis();
+        record.endTimeMillis = snapshot.getEndTimeMillis();
+        record.errorCode = snapshot.getErrorCode();
+        record.errorMessage = snapshot.getErrorMessage();
+        record.metadata = StoredMetadata.from(metadata);
+        return record;
+    }
+
+    void validateFormat(String source) throws IOException {
+        if (formatVersion < MIN_SUPPORTED_FORMAT_VERSION
+                || formatVersion > CURRENT_FORMAT_VERSION) {
+            throw new IOException(
+                    "Unsupported Worker state formatVersion="
+                            + formatVersion
+                            + " in "
+                            + source);
+        }
+    }
+
+    JobRepositoryEntry toEntry() {
+        JobSnapshot restoredSnapshot =
+                JobRecoverySnapshotFactory.restoreBasic(
+                        jobId,
+                        jobName,
+                        ServerJobStatus.valueOf(status),
+                        createTimeMillis,
+                        startTimeMillis,
+                        endTimeMillis,
+                        errorCode,
+                        errorMessage);
+
+        return new JobRepositoryEntry(
+                restoredSnapshot,
+                metadata == null
+                        ? null
+                        : metadata.toMetadata());
+    }
+
+    public static final class StoredMetadata {
+        public String externalExecutionId;
+        public String idempotencyKey;
+        public int definitionVersion;
+        public String configDigest;
+        public long submittedTimeMillis;
+        public long queuedTimeMillis;
+        public long stateVersion;
+        public long checkpointVersion;
+        public boolean cancellationRequested;
+        public String runId;
+        public String jobLogFile;
+        public List<StoredTransition> transitions =
+                new ArrayList<StoredTransition>();
+        public List<StoredAttempt> attempts =
+                new ArrayList<StoredAttempt>();
+
+        public StoredMetadata() {
+        }
+
+        static StoredMetadata from(
+                JobExecutionMetadata metadata) {
+
+            if (metadata == null) {
+                return null;
+            }
+
+            StoredMetadata stored = new StoredMetadata();
+            stored.externalExecutionId =
+                    metadata.getExternalExecutionId();
+            stored.idempotencyKey =
+                    metadata.getIdempotencyKey();
+            stored.definitionVersion =
+                    metadata.getDefinitionVersion();
+            stored.configDigest =
+                    metadata.getConfigDigest();
+            stored.submittedTimeMillis =
+                    metadata.getSubmittedTimeMillis();
+            stored.queuedTimeMillis =
+                    metadata.getQueuedTimeMillis();
+            stored.stateVersion =
+                    metadata.getStateVersion();
+            stored.checkpointVersion =
+                    metadata.getCheckpointVersion();
+            stored.cancellationRequested =
+                    metadata.isCancellationRequested();
+            stored.runId = metadata.getRunId();
+            stored.jobLogFile = metadata.getJobLogFile();
+
+            for (JobStateTransition transition :
+                    metadata.getTransitions()) {
+                stored.transitions.add(
+                        StoredTransition.from(transition));
+            }
+
+            for (JobAttemptMetadata attempt :
+                    metadata.getAttempts()) {
+                stored.attempts.add(
+                        StoredAttempt.from(attempt));
+            }
+
+            return stored;
+        }
+
+        JobExecutionMetadata toMetadata() {
+            List<JobStateTransition> restoredTransitions =
+                    new ArrayList<JobStateTransition>();
+
+            for (StoredTransition transition : transitions) {
+                restoredTransitions.add(
+                        transition.toTransition());
+            }
+
+            List<JobAttemptMetadata> restoredAttempts =
+                    new ArrayList<JobAttemptMetadata>();
+
+            for (StoredAttempt attempt : attempts) {
+                restoredAttempts.add(
+                        attempt.toAttempt());
+            }
+
+            return new JobExecutionMetadata(
+                    externalExecutionId,
+                    idempotencyKey,
+                    definitionVersion,
+                    configDigest,
+                    submittedTimeMillis,
+                    queuedTimeMillis,
+                    stateVersion,
+                    checkpointVersion,
+                    cancellationRequested,
+                    restoredTransitions,
+                    Collections.<String, TableDdl>emptyMap(),
+                    runId,
+                    jobLogFile,
+                    restoredAttempts);
+        }
+    }
+
+    public static final class StoredTransition {
+        public long version;
+        public String fromStatus;
+        public String toStatus;
+        public long transitionTimeMillis;
+        public String reason;
+
+        public StoredTransition() {
+        }
+
+        static StoredTransition from(
+                JobStateTransition transition) {
+
+            StoredTransition stored =
+                    new StoredTransition();
+
+            stored.version = transition.getVersion();
+            stored.fromStatus =
+                    transition.getFromStatus() == null
+                            ? null
+                            : transition.getFromStatus().name();
+            stored.toStatus =
+                    transition.getToStatus().name();
+            stored.transitionTimeMillis =
+                    transition.getTransitionTimeMillis();
+            stored.reason = transition.getReason();
+            return stored;
+        }
+
+        JobStateTransition toTransition() {
+            return new JobStateTransition(
+                    version,
+                    fromStatus == null
+                            ? null
+                            : ServerJobStatus.valueOf(fromStatus),
+                    ServerJobStatus.valueOf(toStatus),
+                    transitionTimeMillis,
+                    reason);
+        }
+    }
+
+    public static final class StoredAttempt {
+        public int attemptNumber;
+        public String attemptId;
+        public String status;
+        public long createTimeMillis;
+        public long queuedTimeMillis;
+        public long startTimeMillis;
+        public long endTimeMillis;
+        public String runId;
+        public String jobLogFile;
+        public String failureType;
+        public String failureMessage;
+        public String retryAdvice;
+        public boolean commitEvidenceAvailable;
+        public int dataCommittedTaskCount;
+        public long successfullyCommittedRecordCount;
+        public long unknownStateRecordCount;
+        public boolean partialDataCommit;
+        public String commitScope;
+
+        public StoredAttempt() {
+        }
+
+        static StoredAttempt from(
+                JobAttemptMetadata attempt) {
+
+            StoredAttempt stored = new StoredAttempt();
+            stored.attemptNumber = attempt.getAttemptNumber();
+            stored.attemptId = attempt.getAttemptId();
+            stored.status = attempt.getStatus().name();
+            stored.createTimeMillis = attempt.getCreateTimeMillis();
+            stored.queuedTimeMillis = attempt.getQueuedTimeMillis();
+            stored.startTimeMillis = attempt.getStartTimeMillis();
+            stored.endTimeMillis = attempt.getEndTimeMillis();
+            stored.runId = attempt.getRunId();
+            stored.jobLogFile = attempt.getJobLogFile();
+            stored.failureType = attempt.getFailureType();
+            stored.failureMessage = attempt.getFailureMessage();
+            stored.retryAdvice = attempt.getRetryAdvice();
+            stored.commitEvidenceAvailable =
+                    attempt.isCommitEvidenceAvailable();
+            stored.dataCommittedTaskCount =
+                    attempt.getDataCommittedTaskCount();
+            stored.successfullyCommittedRecordCount =
+                    attempt.getSuccessfullyCommittedRecordCount();
+            stored.unknownStateRecordCount =
+                    attempt.getUnknownStateRecordCount();
+            stored.partialDataCommit =
+                    attempt.isPartialDataCommit();
+            stored.commitScope = attempt.getCommitScope();
+            return stored;
+        }
+
+        JobAttemptMetadata toAttempt() {
+            return new JobAttemptMetadata(
+                    attemptNumber,
+                    attemptId,
+                    JobAttemptStatus.valueOf(status),
+                    createTimeMillis,
+                    queuedTimeMillis,
+                    startTimeMillis,
+                    endTimeMillis,
+                    runId,
+                    jobLogFile,
+                    failureType,
+                    failureMessage,
+                    retryAdvice,
+                    commitEvidenceAvailable,
+                    dataCommittedTaskCount,
+                    successfullyCommittedRecordCount,
+                    unknownStateRecordCount,
+                    partialDataCommit,
+                    commitScope);
+        }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/runtime/ActiveJobExecution.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/runtime/ActiveJobExecution.java
@@ -1,0 +1,105 @@
+package com.link.up.server.infrastructure.runtime;
+
+import com.link.up.framework.execution.JobExecution;
+import com.link.up.framework.metrics.JobMetrics;
+import com.link.up.server.application.port.JobRuntimeScheduler;
+
+import java.util.Objects;
+
+/** Runtime-only binding between one scheduled job, its thread and execution. */
+final class ActiveJobExecution {
+
+    private final String jobId;
+    private final JobRuntimeScheduler.Listener listener;
+
+    private volatile Thread thread;
+    private volatile JobExecution execution;
+    private volatile boolean cancellationRequested;
+
+    ActiveJobExecution(
+            String jobId,
+            JobRuntimeScheduler.Listener listener) {
+
+        this.jobId = requireText(
+                jobId,
+                "jobId");
+        this.listener = Objects.requireNonNull(
+                listener,
+                "listener must not be null");
+    }
+
+    String getJobId() {
+        return jobId;
+    }
+
+    JobRuntimeScheduler.Listener getListener() {
+        return listener;
+    }
+
+    synchronized void bindThread(Thread thread) {
+        this.thread = Objects.requireNonNull(
+                thread,
+                "thread must not be null");
+
+        if (cancellationRequested) {
+            thread.interrupt();
+        }
+    }
+
+    synchronized void bindExecution(JobExecution execution) {
+        this.execution = Objects.requireNonNull(
+                execution,
+                "execution must not be null");
+
+        if (cancellationRequested) {
+            execution.cancel();
+        }
+    }
+
+    synchronized void cancel() {
+        cancellationRequested = true;
+
+        JobExecution currentExecution = execution;
+        if (currentExecution != null) {
+            currentExecution.cancel();
+        }
+
+        Thread currentThread = thread;
+        if (currentThread != null) {
+            currentThread.interrupt();
+        }
+    }
+
+    synchronized void clearExecution() {
+        execution = null;
+    }
+
+    boolean isCancellationRequested() {
+        return cancellationRequested;
+    }
+
+    Thread getThread() {
+        return thread;
+    }
+
+    JobMetrics getMetrics() {
+        JobExecution currentExecution = execution;
+
+        return currentExecution == null
+                ? null
+                : currentExecution.getMetrics();
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null
+                || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+
+        return value.trim();
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/runtime/LocalJobRunner.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/runtime/LocalJobRunner.java
@@ -1,0 +1,98 @@
+package com.link.up.server.infrastructure.runtime;
+
+import com.link.up.framework.execution.JobExecution;
+import com.link.up.framework.execution.JobExecutionListener;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.JobResult;
+import com.link.up.server.application.port.JobExecutor;
+
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+
+/** Executes one accepted local job and bridges Framework callbacks. */
+final class LocalJobRunner {
+
+    private final JobExecutor jobExecutor;
+
+    LocalJobRunner(JobExecutor jobExecutor) {
+        this.jobExecutor = Objects.requireNonNull(
+                jobExecutor,
+                "jobExecutor must not be null");
+    }
+
+    void run(
+            final ActiveJobExecution active,
+            JobDefinition definition) {
+
+        Objects.requireNonNull(
+                active,
+                "active must not be null");
+        Objects.requireNonNull(
+                definition,
+                "definition must not be null");
+
+        try {
+            if (!active.getListener().onStarting()) {
+                active.getListener().onCompleted(
+                        null,
+                        null,
+                        true);
+                return;
+            }
+
+            JobResult result =
+                    jobExecutor.execute(
+                            definition,
+                            executionListener(active));
+
+            active.getListener().onCompleted(
+                    result,
+                    null,
+                    false);
+
+        } catch (Throwable failure) {
+            boolean cancellationLike =
+                    active.isCancellationRequested()
+                            || failure instanceof CancellationException
+                            || failure instanceof InterruptedException;
+
+            if (failure instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+
+            active.getListener().onCompleted(
+                    null,
+                    failure,
+                    cancellationLike);
+
+            if (failure instanceof Error) {
+                throw (Error) failure;
+            }
+        } finally {
+            active.clearExecution();
+        }
+    }
+
+    private JobExecutionListener executionListener(
+            final ActiveJobExecution active) {
+
+        return new JobExecutionListener() {
+            @Override
+            public void onJobLogCreated(
+                    String runId,
+                    String jobLogFile) {
+
+                active.getListener().onJobLogCreated(
+                        runId,
+                        jobLogFile);
+            }
+
+            @Override
+            public void onJobExecutionCreated(
+                    JobExecution execution) {
+
+                active.bindExecution(execution);
+            }
+        };
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/runtime/LocalJobRuntimeScheduler.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/runtime/LocalJobRuntimeScheduler.java
@@ -1,15 +1,11 @@
 package com.link.up.server.infrastructure.runtime;
 
-import com.link.up.framework.execution.JobExecution;
-import com.link.up.framework.execution.JobExecutionListener;
 import com.link.up.framework.job.JobDefinition;
-import com.link.up.framework.job.JobResult;
 import com.link.up.framework.metrics.JobMetrics;
 import com.link.up.server.application.port.JobExecutor;
 import com.link.up.server.application.port.JobRuntimeScheduler;
 
 import java.util.Objects;
-import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.RejectedExecutionException;
@@ -18,11 +14,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Local Worker scheduler that owns admission, job threads and framework
- * execution bindings.
+ * Local Worker scheduler that owns admission, job threads and shutdown.
  *
- * <p>This adapter intentionally preserves the existing single-node admission
- * semantics: one permit is held for each accepted queued/running job.</p>
+ * <p>The accepted job's Thread/Framework execution binding belongs to
+ * {@link ActiveJobExecution}; invoking the Framework belongs to
+ * {@link LocalJobRunner}.</p>
  */
 public final class LocalJobRuntimeScheduler
         implements JobRuntimeScheduler {
@@ -30,7 +26,7 @@ public final class LocalJobRuntimeScheduler
     private final int maxActiveJobs;
     private final Semaphore admissionSemaphore;
     private final long shutdownTimeoutMillis;
-    private final JobExecutor jobExecutor;
+    private final LocalJobRunner jobRunner;
     private final ConcurrentMap<String, ActiveJobExecution> activeJobs =
             new ConcurrentHashMap<String, ActiveJobExecution>();
     private final AtomicInteger threadSequence =
@@ -50,10 +46,14 @@ public final class LocalJobRuntimeScheduler
 
         this.maxActiveJobs = maxActiveJobs;
         this.shutdownTimeoutMillis =
-                Math.max(0L, shutdownTimeoutMillis);
-        this.jobExecutor = Objects.requireNonNull(
-                jobExecutor,
-                "jobExecutor must not be null");
+                Math.max(
+                        0L,
+                        shutdownTimeoutMillis);
+        this.jobRunner =
+                new LocalJobRunner(
+                        Objects.requireNonNull(
+                                jobExecutor,
+                                "jobExecutor must not be null"));
         this.admissionSemaphore =
                 new Semaphore(maxActiveJobs);
     }
@@ -65,7 +65,12 @@ public final class LocalJobRuntimeScheduler
             final Listener listener) {
 
         ensureOpen();
-        requireText(jobId, "jobId");
+
+        String normalizedJobId =
+                requireText(
+                        jobId,
+                        "jobId");
+
         Objects.requireNonNull(
                 definition,
                 "definition must not be null");
@@ -73,122 +78,55 @@ public final class LocalJobRuntimeScheduler
                 listener,
                 "listener must not be null");
 
-        if (!admissionSemaphore.tryAcquire()) {
-            throw new RejectedExecutionException(
-                    "Job queue is full (maxQueuedJobs="
-                            + maxActiveJobs
-                            + ")");
-        }
+        acquireAdmission();
 
         final ActiveJobExecution active =
-                new ActiveJobExecution(jobId, listener);
+                new ActiveJobExecution(
+                        normalizedJobId,
+                        listener);
 
         ActiveJobExecution previous =
-                activeJobs.putIfAbsent(jobId, active);
+                activeJobs.putIfAbsent(
+                        normalizedJobId,
+                        active);
 
         if (previous != null) {
             admissionSemaphore.release();
             throw new IllegalStateException(
-                    "Duplicate active jobId: " + jobId);
+                    "Duplicate active jobId: "
+                            + normalizedJobId);
         }
 
         try {
             listener.onQueued();
 
             Thread thread =
-                    new Thread(
-                            new Runnable() {
-                                @Override
-                                public void run() {
-                                    runJob(
-                                            active,
-                                            definition);
-                                }
-                            },
-                            "link-up-job-"
-                                    + jobId
-                                    + "-"
-                                    + threadSequence.incrementAndGet());
-            thread.setDaemon(false);
+                    createJobThread(
+                            active,
+                            definition);
+
             active.bindThread(thread);
             thread.start();
+
         } catch (RuntimeException failure) {
-            activeJobs.remove(jobId, active);
+            activeJobs.remove(
+                    normalizedJobId,
+                    active);
             admissionSemaphore.release();
             throw failure;
         }
     }
 
-    private void runJob(
-            final ActiveJobExecution active,
-            JobDefinition definition) {
-
-        try {
-            if (!active.listener.onStarting()) {
-                active.listener.onCompleted(
-                        null,
-                        null,
-                        true);
-                return;
-            }
-
-            JobResult result =
-                    jobExecutor.execute(
-                            definition,
-                            new JobExecutionListener() {
-                                @Override
-                                public void onJobLogCreated(
-                                        String runId,
-                                        String jobLogFile) {
-                                    active.listener.onJobLogCreated(
-                                            runId,
-                                            jobLogFile);
-                                }
-
-                                @Override
-                                public void onJobExecutionCreated(
-                                        JobExecution execution) {
-                                    active.bindExecution(execution);
-                                }
-                            });
-
-            active.listener.onCompleted(
-                    result,
-                    null,
-                    false);
-
-        } catch (Throwable failure) {
-            boolean cancellationLike =
-                    active.isCancellationRequested()
-                            || failure instanceof CancellationException
-                            || failure instanceof InterruptedException;
-
-            if (failure instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-
-            active.listener.onCompleted(
-                    null,
-                    failure,
-                    cancellationLike);
-
-            if (failure instanceof Error) {
-                throw (Error) failure;
-            }
-        } finally {
-            active.clearExecution();
-            activeJobs.remove(
-                    active.jobId,
-                    active);
-            admissionSemaphore.release();
-        }
-    }
-
     @Override
     public void cancel(String jobId) {
-        requireText(jobId, "jobId");
+        String normalizedJobId =
+                requireText(
+                        jobId,
+                        "jobId");
+
         ActiveJobExecution active =
-                activeJobs.get(jobId);
+                activeJobs.get(normalizedJobId);
+
         if (active != null) {
             active.cancel();
         }
@@ -198,6 +136,7 @@ public final class LocalJobRuntimeScheduler
     public JobMetrics getMetrics(String jobId) {
         ActiveJobExecution active =
                 activeJobs.get(jobId);
+
         return active == null
                 ? null
                 : active.getMetrics();
@@ -214,36 +153,99 @@ public final class LocalJobRuntimeScheduler
             return;
         }
 
+        cancelActiveJobs();
+        awaitActiveJobs();
+        notifyLostJobs();
+    }
+
+    private void acquireAdmission() {
+        if (admissionSemaphore.tryAcquire()) {
+            return;
+        }
+
+        throw new RejectedExecutionException(
+                "Job queue is full (maxQueuedJobs="
+                        + maxActiveJobs
+                        + ")");
+    }
+
+    private Thread createJobThread(
+            final ActiveJobExecution active,
+            final JobDefinition definition) {
+
+        Thread thread =
+                new Thread(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                runScheduledJob(
+                                        active,
+                                        definition);
+                            }
+                        },
+                        "link-up-job-"
+                                + active.getJobId()
+                                + "-"
+                                + threadSequence.incrementAndGet());
+
+        thread.setDaemon(false);
+        return thread;
+    }
+
+    private void runScheduledJob(
+            ActiveJobExecution active,
+            JobDefinition definition) {
+
+        try {
+            jobRunner.run(
+                    active,
+                    definition);
+        } finally {
+            activeJobs.remove(
+                    active.getJobId(),
+                    active);
+            admissionSemaphore.release();
+        }
+    }
+
+    private void cancelActiveJobs() {
         for (ActiveJobExecution active : activeJobs.values()) {
             active.cancel();
         }
+    }
 
+    private void awaitActiveJobs() {
         long deadline =
                 System.currentTimeMillis()
                         + shutdownTimeoutMillis;
 
         for (ActiveJobExecution active : activeJobs.values()) {
             Thread thread = active.getThread();
+
             if (thread == null) {
                 continue;
             }
 
             long remaining =
-                    deadline - System.currentTimeMillis();
+                    deadline
+                            - System.currentTimeMillis();
+
             if (remaining <= 0L) {
-                break;
+                return;
             }
 
             try {
                 thread.join(remaining);
             } catch (InterruptedException interrupted) {
                 Thread.currentThread().interrupt();
-                break;
+                return;
             }
         }
+    }
 
+    private void notifyLostJobs() {
         for (ActiveJobExecution active : activeJobs.values()) {
-            active.listener.onLost();
+            active.getListener().onLost();
         }
     }
 
@@ -257,79 +259,13 @@ public final class LocalJobRuntimeScheduler
     private static String requireText(
             String value,
             String name) {
-        if (value == null || value.trim().isEmpty()) {
+
+        if (value == null
+                || value.trim().isEmpty()) {
             throw new IllegalArgumentException(
                     name + " must not be blank");
         }
+
         return value.trim();
-    }
-
-    /** Runtime-only binding for a scheduled job. */
-    private static final class ActiveJobExecution {
-        private final String jobId;
-        private final Listener listener;
-        private volatile Thread thread;
-        private volatile JobExecution execution;
-        private volatile boolean cancellationRequested;
-
-        private ActiveJobExecution(
-                String jobId,
-                Listener listener) {
-            this.jobId = jobId;
-            this.listener = listener;
-        }
-
-        private synchronized void bindThread(
-                Thread thread) {
-            this.thread = Objects.requireNonNull(
-                    thread,
-                    "thread must not be null");
-            if (cancellationRequested) {
-                thread.interrupt();
-            }
-        }
-
-        private synchronized void bindExecution(
-                JobExecution execution) {
-            this.execution = Objects.requireNonNull(
-                    execution,
-                    "execution must not be null");
-            if (cancellationRequested) {
-                execution.cancel();
-            }
-        }
-
-        private synchronized void cancel() {
-            cancellationRequested = true;
-
-            JobExecution currentExecution = execution;
-            if (currentExecution != null) {
-                currentExecution.cancel();
-            }
-
-            Thread currentThread = thread;
-            if (currentThread != null) {
-                currentThread.interrupt();
-            }
-        }
-
-        private synchronized void clearExecution() {
-            execution = null;
-        }
-
-        private boolean isCancellationRequested() {
-            return cancellationRequested;
-        }
-
-        private Thread getThread() {
-            return thread;
-        }
-
-        private JobMetrics getMetrics() {
-            JobExecution currentExecution = execution;
-            return currentExecution == null
-                    ? null
-                    : currentExecution.getMetrics();
-        }
     }
 }

--- a/link-up-server/src/test/java/com/link/up/server/application/JobApplicationRoleBoundaryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/application/JobApplicationRoleBoundaryTest.java
@@ -1,0 +1,90 @@
+package com.link.up.server.application;
+
+import com.link.up.server.application.port.JobRepository;
+import com.link.up.server.application.port.JobRuntimeScheduler;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Architecture guards for application-layer role ownership. */
+public class JobApplicationRoleBoundaryTest {
+
+    @Test
+    public void applicationServiceShouldDelegateActiveStateAndLifecycle() {
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        JobApplicationService.class);
+
+        assertTrue(
+                fieldTypes.contains(
+                        ActiveJobRegistry.class));
+        assertTrue(
+                fieldTypes.contains(
+                        JobRuntimeLifecycle.class));
+        assertFalse(
+                fieldTypes.contains(
+                        ConcurrentMap.class));
+    }
+
+    @Test
+    public void runtimeLifecycleShouldDependOnPortsNotInfrastructure() {
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        JobRuntimeLifecycle.class);
+
+        assertTrue(
+                fieldTypes.contains(
+                        JobRuntimeScheduler.class));
+        assertTrue(
+                fieldTypes.contains(
+                        JobRepository.class));
+        assertTrue(
+                fieldTypes.contains(
+                        ActiveJobRegistry.class));
+
+        assertNoInfrastructureField(
+                JobRuntimeLifecycle.class);
+        assertNoInfrastructureField(
+                JobRecoveryService.class);
+    }
+
+    private static Set<Class<?>> instanceFieldTypes(
+            Class<?> type) {
+
+        Set<Class<?>> types =
+                new HashSet<Class<?>>();
+
+        for (Field field : type.getDeclaredFields()) {
+            if (!java.lang.reflect.Modifier.isStatic(
+                    field.getModifiers())) {
+                types.add(field.getType());
+            }
+        }
+
+        return types;
+    }
+
+    private static void assertNoInfrastructureField(
+            Class<?> type) {
+
+        for (Field field : type.getDeclaredFields()) {
+            String fieldType =
+                    field.getGenericType()
+                            .getTypeName();
+
+            assertFalse(
+                    type.getSimpleName()
+                            + "."
+                            + field.getName()
+                            + " must not depend on concrete infrastructure",
+                    fieldType.contains(
+                            "com.link.up.server.infrastructure."));
+        }
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/http/servlet/JobSubmitRequestDecoderTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/http/servlet/JobSubmitRequestDecoderTest.java
@@ -1,0 +1,48 @@
+package com.link.up.server.http.servlet;
+
+import com.link.up.server.dto.JobSubmitRequest;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class JobSubmitRequestDecoderTest {
+
+    @Test
+    public void shouldDecodeStableSubmissionFields() {
+        JobSubmitRequest request =
+                JobSubmitRequestDecoder.decode(
+                        "{\"externalExecutionId\":\"external-1\","
+                                + "\"idempotencyKey\":\"key-1\","
+                                + "\"definitionVersion\":2,"
+                                + "\"hocon\":\"job {}\"}",
+                        "invalid");
+
+        assertEquals(
+                "external-1",
+                request.getExternalExecutionId());
+        assertEquals(
+                "key-1",
+                request.getIdempotencyKey());
+        assertEquals(
+                Integer.valueOf(2),
+                request.getDefinitionVersion());
+        assertEquals(
+                "job {}",
+                request.getHocon());
+    }
+
+    @Test
+    public void shouldMapInvalidJsonToIllegalArgumentException() {
+        try {
+            JobSubmitRequestDecoder.decode(
+                    "{invalid",
+                    "Invalid JSON submit request");
+            fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException failure) {
+            assertEquals(
+                    "Invalid JSON submit request",
+                    failure.getMessage());
+        }
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryBoundaryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryBoundaryTest.java
@@ -1,0 +1,57 @@
+package com.link.up.server.infrastructure.persistence;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+
+import java.io.FileOutputStream;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Architecture guards for durable checkpoint persistence roles. */
+public class FileJobRepositoryBoundaryTest {
+
+    @Test
+    public void repositoryShouldDelegateFileIoToStateFileStore() {
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        FileJobRepository.class);
+
+        assertTrue(
+                fieldTypes.contains(
+                        JobStateFileStore.class));
+        assertFalse(fieldTypes.contains(ObjectMapper.class));
+        assertFalse(fieldTypes.contains(Path.class));
+        assertFalse(fieldTypes.contains(FileOutputStream.class));
+    }
+
+    @Test
+    public void fileStoreShouldOwnJsonAndPathIo() {
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        JobStateFileStore.class);
+
+        assertTrue(fieldTypes.contains(ObjectMapper.class));
+        assertTrue(fieldTypes.contains(Path.class));
+    }
+
+    private static Set<Class<?>> instanceFieldTypes(
+            Class<?> type) {
+
+        Set<Class<?>> types =
+                new HashSet<Class<?>>();
+
+        for (Field field : type.getDeclaredFields()) {
+            if (!java.lang.reflect.Modifier.isStatic(
+                    field.getModifiers())) {
+                types.add(field.getType());
+            }
+        }
+
+        return types;
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/runtime/LocalJobRuntimeSchedulerBoundaryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/runtime/LocalJobRuntimeSchedulerBoundaryTest.java
@@ -1,0 +1,68 @@
+package com.link.up.server.infrastructure.runtime;
+
+import com.link.up.framework.execution.JobExecution;
+import com.link.up.server.application.port.JobExecutor;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Architecture guards for local runtime ownership. */
+public class LocalJobRuntimeSchedulerBoundaryTest {
+
+    @Test
+    public void schedulerShouldDelegateFrameworkExecutionToRunner() {
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        LocalJobRuntimeScheduler.class);
+
+        assertTrue(
+                fieldTypes.contains(
+                        LocalJobRunner.class));
+        assertFalse(
+                fieldTypes.contains(
+                        JobExecution.class));
+        assertFalse(
+                fieldTypes.contains(
+                        Thread.class));
+    }
+
+    @Test
+    public void activeExecutionShouldOwnThreadAndFrameworkHandle() {
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        ActiveJobExecution.class);
+
+        assertTrue(fieldTypes.contains(Thread.class));
+        assertTrue(fieldTypes.contains(JobExecution.class));
+    }
+
+    @Test
+    public void localRunnerShouldDependOnExecutorPort() {
+        Set<Class<?>> fieldTypes =
+                instanceFieldTypes(
+                        LocalJobRunner.class);
+
+        assertTrue(fieldTypes.contains(JobExecutor.class));
+    }
+
+    private static Set<Class<?>> instanceFieldTypes(
+            Class<?> type) {
+
+        Set<Class<?>> types =
+                new HashSet<Class<?>>();
+
+        for (Field field : type.getDeclaredFields()) {
+            if (!java.lang.reflect.Modifier.isStatic(
+                    field.getModifiers())) {
+                types.add(field.getType());
+            }
+        }
+
+        return types;
+    }
+}


### PR DESCRIPTION
## Summary

Applies the canonical `CODE_STYLE.md` to `link-up-server` as the fourth repository-wide Link-Up style refactoring sample.

This is not a mechanical formatting pass. The focus is to keep the Server control plane readable through explicit ownership and straight-line use cases:

```text
HTTP adapter
  -> application use cases
  -> domain state
  -> application ports
  -> infrastructure adapters
```

The refactor preserves the control-plane architecture introduced in Phase 6 and the durable Attempt/checkpoint/retry semantics introduced in Phases 7/8.

## Application use cases

`JobApplicationService` previously combined use-case sequencing with active-job indexing, runtime-listener state transitions, checkpoint persistence and startup recovery.

It now reads as a use-case facade over explicit application roles:

```text
JobApplicationService
  -> ActiveJobRegistry
  -> JobRuntimeLifecycle
  -> JobRecoveryService
  -> JobRetryPolicy
  -> application ports
```

Responsibilities:

- `JobApplicationService`: submit / retry / query / cancel / close sequencing
- `ActiveJobRegistry`: in-process active `JobExecutionState` index and counters
- `JobRuntimeLifecycle`: runtime callback -> domain transition -> checkpoint/archive
- `JobRecoveryService`: startup idempotency restoration and unfinished -> LOST recovery

`JobApplicationService` no longer directly owns a `ConcurrentMap` or concrete infrastructure adapter.

Existing behavior is intentionally preserved:

- idempotent submit lookup
- conflicting content rejection
- same-jobId manual retry with a new Attempt
- retry identity/digest validation
- active/queued/running counters
- cancel checkpoint before runtime cancellation
- shutdown archives remaining active jobs as LOST
- restart recovery restores submission indexes and never auto-retries

## Runtime ownership

`LocalJobRuntimeScheduler` previously contained the runtime-only Thread/Framework `JobExecution` binding as a nested implementation detail while also invoking the Framework directly.

The ownership is now explicit:

```text
LocalJobRuntimeScheduler
  -> admission / job thread lifecycle / shutdown
  -> ActiveJobExecution
     -> Thread
     -> framework JobExecution
     -> cancellation binding
  -> LocalJobRunner
     -> JobExecutor port
     -> Framework listener bridge
```

The scheduler no longer directly owns a `Thread` or Framework `JobExecution` field.

Existing runtime semantics remain unchanged:

- one semaphore permit per accepted queued/running job
- queue-full rejection remains fail-fast
- Sink/Framework execution is still invoked through the `JobExecutor` port
- cancellation before/after Thread or JobExecution binding is propagated
- `InterruptedException` restores the interrupt flag
- permits are released in the scheduled-job finally path
- shutdown cancels active jobs, waits until the configured deadline and marks remaining jobs LOST

## Durable persistence

`FileJobRepository` previously mixed four responsibilities:

```text
repository/index
+ checkpoint JSON model
+ file naming / IO
+ atomic replacement
```

It is now split into:

```text
FileJobRepository
  -> in-memory index
  -> checkpointVersion stale-write protection
  -> terminal history retention

JobStateFileStore
  -> state directory
  -> Base64 file naming
  -> JSON read/write
  -> fsync
  -> atomic move fallback
  -> temporary-file cleanup

StoredJobRecord
  -> versioned checkpoint JSON protocol
  -> metadata / transition / attempt mapping
```

The persisted protocol is intentionally unchanged:

- current format version remains `2`
- minimum supported format remains `1`
- file suffix remains `.job.json`
- job lifecycle fields are unchanged
- externalExecutionId / idempotencyKey / definitionVersion / configDigest are unchanged
- stateVersion / checkpointVersion are unchanged
- runId / jobLogFile are unchanged
- transition history is unchanged
- Attempt lifecycle and commit-evidence fields are unchanged
- v1 checkpoints without evidence continue to deserialize conservatively
- no JobSpec, connector options, passwords or runtime objects are persisted

Existing `FileJobRepositoryTest` and `FileJobRepositoryRetryEvidenceTest` remain the behavior-level reopen/revision/evidence regression coverage.

## HTTP adapter

The REST routes and response status codes are unchanged.

`FluxServlet` now centralizes media-type parsing and provides reusable JSON-content helpers. `JobsServlet` and `JobResourceServlet` use a small `JobSubmitRequestDecoder` rather than each duplicating Jackson error handling.

The route flow now reads as:

```text
validate media type
-> read bounded request body
-> decode transport request
-> call JobRestService
-> write response
```

Preserved endpoints include:

- `POST /api/v1/jobs`
- `GET /api/v1/jobs`
- `GET /api/v1/jobs/{jobId}`
- `GET /api/v1/jobs/external/{externalExecutionId}`
- `GET /api/v1/jobs/{jobId}/pipelines`
- `GET /api/v1/jobs/{jobId}/tasks`
- `GET /api/v1/jobs/{jobId}/metrics`
- `GET /api/v1/jobs/{jobId}/logs`
- `POST /api/v1/jobs/{jobId}/retry`
- `DELETE /api/v1/jobs/{jobId}`

Retry still requires `Content-Type: application/json`; legacy HOCON/text submit support remains unchanged.

## Architecture guards and tests

Added:

- `JobApplicationRoleBoundaryTest`
  - `JobApplicationService` delegates active state/lifecycle
  - application collaborators do not depend on concrete infrastructure
- `LocalJobRuntimeSchedulerBoundaryTest`
  - scheduler delegates Framework invocation to `LocalJobRunner`
  - Thread + Framework JobExecution belong to `ActiveJobExecution`
  - runner depends on the `JobExecutor` port
- `FileJobRepositoryBoundaryTest`
  - repository delegates Path/ObjectMapper/file IO to `JobStateFileStore`
- `JobSubmitRequestDecoderTest`
  - stable JSON field mapping
  - invalid JSON maps to the existing IllegalArgumentException boundary

Existing Server control-plane, retry, recovery and repository tests remain in place.

## Deliberate non-goals

This PR intentionally does **not** rewrite:

```text
JobExecutionState
JobExecutionAttempt
JobStateMachine
JobRetryPolicy
JobRestService
JobLogReader
FluxServerConfig
```

It also does not change:

- REST JSON shape
- Worker protocol
- Job/Attempt state transitions
- safe-retry eligibility rules
- checkpoint version or persisted field names
- scheduler concurrency/admission limits
- repository history-limit semantics
- Framework/Connector execution behavior

## Validation

- based directly on current `main` after PR #77
- `main...refactor/link-up-server-style`: 1 commit ahead, 0 behind
- 18 changed files, all under `link-up-server`
- no `link-up-api`, `link-up-framework` or `link-up-connectors` files changed
- repository code search found no callers of the removed nested `FileJobRepository.StoredJobRecord` implementation detail
- GitHub currently reports no status checks and no Actions workflow runs for the branch head

A full Maven checkout/build is not available from the current execution environment, so this PR intentionally does **not** claim Maven tests have passed.

Recommended locally before marking ready:

```bash
mvn --batch-mode -pl link-up-server -am test
mvn --batch-mode clean verify
```
