### PR TITLE
feat: add runtime event journal foundation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,6 +142,42 @@ HTTP
 
 Domain 不持有 `Thread`、`Future`、`Semaphore`、`ExecutorService` 或 framework `JobExecution`。
 
+## Runtime Event Journal
+
+Runtime Event 不替代现有状态模型，而是观察成功持久化的 checkpoint：
+
+```text
+JobRuntimeLifecycle
+  -> JobRepository.save(snapshot, metadata)
+  -> EventPublishingJobRepository
+       1. durable checkpoint
+       2. derive one lifecycle fact
+       3. JobEventBus.publish
+  -> JsonLineJobEventStore
+       <stateDirectory>/job-events/<jobId>.jsonl
+```
+
+边界约束：
+
+- `JobSnapshot` / `JobExecutionMetadata` 仍是控制面状态真相。
+- Event Journal 只追加，不反向修改 Job 状态，不参与 Retry/Commit 决策。
+- 只有 checkpoint 成功后才派生事件。
+- `JobEventBus` 保持同一 Job 的同步顺序，并隔离 Listener 失败。
+- 每条事件使用 `checkpointVersion` 作为单 Job 序号，Retry 后继续递增。
+- Event JSON 不包含 JobSpec、Connector options、SQL、Secret、异常正文、Prepared Connector 或私有 metadata。
+- 当前只记录 Job/Attempt 生命周期；Pipeline/Task 细粒度事件留给后续阶段。
+
+查询链路：
+
+```text
+GET /api/v1/jobs/{jobId}/events?afterSequence=N&limit=M
+  -> JobEventRestService
+  -> JobEventReader
+  -> sequence-based page
+```
+
+`afterSequence` 是排他游标。读取损坏或不支持版本的事件文件会返回稳定的 Event History 错误，但不会改变已运行任务的结果。
+
 ## Retry
 
 Retry 是新的 Attempt，不是把旧 Attempt 改活：

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -62,6 +62,46 @@ Attempt 记录：
 
 Attempt 不拥有线程和 framework 执行对象。
 
+## Runtime Event
+
+Runtime Event 是一次已经持久化的 Worker 生命周期事实，不是新的状态机：
+
+```text
+JobEventEnvelope
+  ├── schemaVersion
+  ├── eventId
+  ├── jobId
+  ├── attemptId / attemptNumber
+  ├── sequence == checkpointVersion
+  ├── occurredAtMillis
+  └── JobRuntimeEvent
+```
+
+当前稳定事件：
+
+```text
+JOB_SUBMITTED
+JOB_RETRY_CREATED
+JOB_QUEUED
+JOB_STARTED
+JOB_LOG_CREATED
+JOB_CANCEL_REQUESTED
+JOB_SUCCEEDED
+JOB_FAILED
+JOB_CANCELED
+JOB_LOST
+```
+
+语义约束：
+
+- Event 只在对应 checkpoint 保存成功后发布。
+- 同一个 `jobId` 的 `sequence` 单调递增，Retry 不重置序号。
+- Event Journal 允许序号缺口，因为观察器写入失败不能反向让 Job 失败。
+- 重复或晚到的旧序号不会再次追加。
+- Event 不参与状态恢复、RetryPolicy 或 Commit 判定。
+- Event 不保存用户配置、SQL、Secret 或异常正文。
+- `failureType` 只描述故障类型，不替代后续 Structured Error。
+
 ## Retry Decision
 
 RetryPolicy 输出显式决策码：
@@ -83,6 +123,6 @@ RetryPolicy 输出显式决策码：
 
 `stateVersion` 只记录业务状态转换。
 
-`checkpointVersion` 记录所有需要持久化的变化，包括日志绑定、取消意图和 Retry Attempt 创建，用于防止旧 checkpoint 覆盖新状态。
+`checkpointVersion` 记录所有需要持久化的变化，包括日志绑定、取消意图和 Retry Attempt 创建，用于防止旧 checkpoint 覆盖新状态，也作为 Runtime Event 的单 Job 序号。
 
-Worker 重启后，遗留的非终态 Job 统一恢复为 `LOST`；不会自动执行 Retry。
+Worker 重启后，遗留的非终态 Job 统一恢复为 `LOST`；不会自动执行 Retry。恢复生成的新 LOST checkpoint 同样会追加 `JOB_LOST` 事件。

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Link-Up 是一个轻量、可嵌入的离线数据同步引擎。它把数据同
 - Job / Attempt 模型：同一个 Job 可以保留多次执行尝试。
 - 安全手动重试：只有明确证明“没有已提交或未知数据”的 FAILED Attempt 才允许重试。
 - 提交前校验和 Explain：查看规范化逻辑计划、实际 Source Split/Task 拓扑与稳定指纹。
+- 追加式 Runtime Event Journal：按 Job/Attempt 回看提交、排队、运行、取消与终态时间线。
 
 ## 核心模型
 
@@ -37,6 +38,8 @@ HTTP
         -> Attempt #1 / #2 / ...
      -> JobRuntimeScheduler
      -> JobRepository
+        -> JobSnapshot / JobExecutionMetadata
+        -> Runtime Event Journal (observer)
 ```
 
 一次安全重试不会创建新 Job：
@@ -57,7 +60,8 @@ POST /api/v1/jobs/validate
 POST /api/v1/jobs/explain
 ```
 
-两个接口都接收与结构化提交一致的 JSON 外壳，只要求 `jobSpec` 或 `hocon` 二选一；规划时不要求 `externalExecutionId`、`idempotencyKey` 和 `definitionVersion`。
+两个接口都接收与结构化提交一致的 JSON 外壳，只要求 `jobSpec` 或 `hocon` 二选一；
+规划时不要求 `externalExecutionId`、`idempotencyKey` 和 `definitionVersion`。
 
 边界约束：
 
@@ -87,6 +91,41 @@ POST /api/v1/jobs/explain
 }
 ```
 
+## Runtime Event Journal
+
+每次持久化生命周期 checkpoint 后，Worker 会把对应事实追加到：
+
+```text
+<stateDirectory>/job-events/<jobId>.jsonl
+```
+
+当前事件包括：
+
+```text
+JOB_SUBMITTED
+JOB_RETRY_CREATED
+JOB_QUEUED
+JOB_STARTED
+JOB_LOG_CREATED
+JOB_CANCEL_REQUESTED
+JOB_SUCCEEDED
+JOB_FAILED
+JOB_CANCELED
+JOB_LOST
+```
+
+事件使用 `checkpointVersion` 作为单 Job 单调递增序号。查询接口采用排他游标：
+
+```text
+GET /api/v1/jobs/{jobId}/events?afterSequence=0&limit=200
+```
+
+当前阶段仍以 `JobSnapshot` 和 `JobExecutionMetadata` 为控制面状态真相。
+Event Journal 只负责可观察历史，不反向驱动状态机；事件监听器或文件写入失败会被隔离，
+不改变任务执行、Commit 或 Retry 语义。
+
+安全边界：事件不保存 JobSpec、Connector options、SQL、Secret、异常正文或 Connector 私有 metadata，只保存稳定生命周期字段、Attempt 身份、状态、原因代码和故障类型。
+
 ## 模块
 
 | 模块 | 职责 |
@@ -94,7 +133,7 @@ POST /api/v1/jobs/explain
 | `link-up-api` | Connector 扩展契约和公共模型 |
 | `link-up-framework` | Planning、JobGraph、ExecutionGraph、本地执行运行时 |
 | `link-up-connectors` | JDBC / HTTP / Doris 等实现 |
-| `link-up-server` | Worker 控制面、REST、持久化、Attempt/Retry |
+| `link-up-server` | Worker 控制面、REST、持久化、Attempt/Retry、Runtime Event Journal |
 | `link-up-launcher` | 本地命令行组合入口 |
 | `link-up-dist` | 分发包 |
 | `link-up-bom` | 依赖版本管理 |
@@ -132,6 +171,7 @@ POST   /api/v1/jobs/validate
 POST   /api/v1/jobs/explain
 POST   /api/v1/jobs
 GET    /api/v1/jobs/{jobId}
+GET    /api/v1/jobs/{jobId}/events
 GET    /api/v1/jobs/{jobId}/logs
 GET    /api/v1/jobs/{jobId}/metrics
 DELETE /api/v1/jobs/{jobId}
@@ -140,7 +180,7 @@ GET    /api/v1/connectors
 GET    /api/v1/node
 ```
 
-Retry 请求必须重新携带与原 Job 完全一致的结构化提交内容。Worker 不会为了 Retry 把数据库密码、Token 或完整 JobSpec 写进 checkpoint。
+Retry 请求必须重新携带与原 Job 完全一致的结构化提交内容。Worker 不会为了 Retry 把数据库密码、Token 或完整 JobSpec 写进 checkpoint 或 Runtime Event Journal。
 
 ## 文档
 

--- a/link-up-server/src/main/java/com/link/up/server/FluxServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/FluxServer.java
@@ -7,12 +7,15 @@ import com.link.up.framework.planner.JobPlanner;
 import com.link.up.framework.planning.JobPlanExplainer;
 import com.link.up.server.application.JobApplication;
 import com.link.up.server.application.JobApplicationService;
+import com.link.up.server.application.JobEventBus;
 import com.link.up.server.application.port.JobExecutor;
 import com.link.up.server.application.port.JobIdGenerator;
 import com.link.up.server.application.port.JobRepository;
 import com.link.up.server.application.port.JobRuntimeScheduler;
 import com.link.up.server.config.FluxServerConfig;
 import com.link.up.server.http.JettyServer;
+import com.link.up.server.infrastructure.event.EventPublishingJobRepository;
+import com.link.up.server.infrastructure.event.JsonLineJobEventStore;
 import com.link.up.server.infrastructure.execution.LocalJobExecutor;
 import com.link.up.server.infrastructure.identity.LocalJobIdGenerator;
 import com.link.up.server.infrastructure.persistence.FileJobRepository;
@@ -21,6 +24,7 @@ import com.link.up.server.registration.ControlPlaneRegistrationAgent;
 import com.link.up.server.registration.ControlPlaneRegistrationConfig;
 import com.link.up.server.runtime.WorkerIdentity;
 import com.link.up.server.service.ConnectorRestService;
+import com.link.up.server.service.JobEventRestService;
 import com.link.up.server.service.JobPlanningService;
 import com.link.up.server.service.JobRestService;
 import org.apache.logging.log4j.LogManager;
@@ -28,6 +32,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -78,10 +83,20 @@ public final class FluxServer {
                 new LocalJobExecutor(
                         classLoader,
                         pluginPaths);
+        JsonLineJobEventStore jobEventStore =
+                new JsonLineJobEventStore(
+                        config.getStateDirectory());
+        JobEventBus jobEventBus =
+                new JobEventBus(
+                        Collections.singletonList(
+                                jobEventStore));
         JobRepository repository =
-                new FileJobRepository(
-                        config.getStateDirectory(),
-                        config.getHistoryLimit());
+                new EventPublishingJobRepository(
+                        new FileJobRepository(
+                                config.getStateDirectory(),
+                                config.getHistoryLimit()),
+                        jobEventBus,
+                        jobEventStore);
         JobIdGenerator jobIdGenerator =
                 new LocalJobIdGenerator();
         JobRuntimeScheduler runtimeScheduler =
@@ -108,6 +123,10 @@ public final class FluxServer {
                         workerIdentity,
                         config.getJobThreads(),
                         config.getMaxQueuedJobs());
+        JobEventRestService eventService =
+                new JobEventRestService(
+                        jobApplication,
+                        jobEventStore);
         JobPlanningService planningService =
                 new JobPlanningService(
                         new JobPlanExplainer(
@@ -121,7 +140,8 @@ public final class FluxServer {
                         config,
                         jobService,
                         connectorService,
-                        planningService);
+                        planningService,
+                        eventService);
 
         final ControlPlaneRegistrationConfig registrationConfig =
                 ControlPlaneRegistrationConfig.load();
@@ -183,13 +203,17 @@ public final class FluxServer {
             registrationAgent.start();
 
             LOG.info(
-                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, host={}, port={}, jobThreads={}, stateDirectory={}, connectorSchemas={}, pluginDirectories={}, dynamicRegistration={}",
+                    "Link-Up Offline Worker started, nodeId={}, instanceId={}, "
+                            + "host={}, port={}, jobThreads={}, stateDirectory={}, "
+                            + "eventDirectory={}, connectorSchemas={}, "
+                            + "pluginDirectories={}, dynamicRegistration={}",
                     workerIdentity.getNodeId(),
                     workerIdentity.getInstanceId(),
                     config.getHost(),
                     server.getLocalPort(),
                     config.getJobThreads(),
                     config.getStateDirectory(),
+                    jobEventStore.getEventDirectory(),
                     connectorCatalog.list().size(),
                     config.getPluginDirectories(),
                     registrationConfig.isEnabled());

--- a/link-up-server/src/main/java/com/link/up/server/application/JobEventBus.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobEventBus.java
@@ -1,0 +1,83 @@
+package com.link.up.server.application;
+
+import com.link.up.server.application.port.JobEventListener;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Synchronous ordered event dispatcher with listener-failure isolation.
+ *
+ * <p>JobSnapshot remains the control-plane source of truth in this phase. A
+ * failing observer is logged and isolated so observability storage cannot
+ * change Job execution semantics.</p>
+ */
+public final class JobEventBus
+        implements JobEventListener {
+
+    private static final Logger LOG =
+            LogManager.getLogger(JobEventBus.class);
+
+    private static final JobEventBus NOOP =
+            new JobEventBus(
+                    Collections.<JobEventListener>emptyList());
+
+    private final List<JobEventListener> listeners;
+
+    public JobEventBus(
+            Iterable<? extends JobEventListener> listeners) {
+
+        Objects.requireNonNull(
+                listeners,
+                "listeners must not be null");
+
+        List<JobEventListener> copy =
+                new ArrayList<JobEventListener>();
+
+        for (JobEventListener listener : listeners) {
+            copy.add(
+                    Objects.requireNonNull(
+                            listener,
+                            "listeners must not contain null"));
+        }
+
+        this.listeners =
+                Collections.unmodifiableList(copy);
+    }
+
+    public static JobEventBus noop() {
+        return NOOP;
+    }
+
+    @Override
+    public void onEvent(JobEventEnvelope event) {
+        publish(event);
+    }
+
+    public void publish(JobEventEnvelope event) {
+        JobEventEnvelope safeEvent =
+                Objects.requireNonNull(
+                        event,
+                        "event must not be null");
+
+        for (JobEventListener listener : listeners) {
+            try {
+                listener.onEvent(safeEvent);
+            } catch (RuntimeException failure) {
+                LOG.error(
+                        "Job event listener failed, jobId={}, attemptId={}, sequence={}, eventType={}, listener={}",
+                        safeEvent.getJobId(),
+                        safeEvent.getAttemptId(),
+                        safeEvent.getSequence(),
+                        safeEvent.getEvent().getType(),
+                        listener.getClass().getName(),
+                        failure);
+            }
+        }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/application/port/JobEventHistoryException.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/port/JobEventHistoryException.java
@@ -1,0 +1,14 @@
+package com.link.up.server.application.port;
+
+/** Raised when persisted Job event history cannot be read or appended. */
+public final class JobEventHistoryException
+        extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public JobEventHistoryException(
+            String message,
+            Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/application/port/JobEventListener.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/port/JobEventListener.java
@@ -1,0 +1,9 @@
+package com.link.up.server.application.port;
+
+import com.link.up.server.runtime.event.JobEventEnvelope;
+
+/** Observer port for one ordered Job lifecycle event. */
+public interface JobEventListener {
+
+    void onEvent(JobEventEnvelope event);
+}

--- a/link-up-server/src/main/java/com/link/up/server/application/port/JobEventReader.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/port/JobEventReader.java
@@ -1,0 +1,25 @@
+package com.link.up.server.application.port;
+
+import com.link.up.server.runtime.event.JobEventPage;
+
+/** Query port for one Job's append-only event journal. */
+public interface JobEventReader {
+
+    JobEventReader EMPTY =
+            new JobEventReader() {
+                @Override
+                public JobEventPage read(
+                        String jobId,
+                        long afterSequence,
+                        int limit) {
+                    return JobEventPage.empty(
+                            jobId,
+                            afterSequence);
+                }
+            };
+
+    JobEventPage read(
+            String jobId,
+            long afterSequence,
+            int limit);
+}

--- a/link-up-server/src/main/java/com/link/up/server/application/port/JobEventRetention.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/port/JobEventRetention.java
@@ -1,0 +1,20 @@
+package com.link.up.server.application.port;
+
+/** Lifecycle port for removing event journals outside retained Job history. */
+public interface JobEventRetention {
+
+    JobEventRetention EMPTY =
+            new JobEventRetention() {
+                @Override
+                public void delete(String jobId) {
+                }
+
+                @Override
+                public void retain(Iterable<String> jobIds) {
+                }
+            };
+
+    void delete(String jobId);
+
+    void retain(Iterable<String> jobIds);
+}

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobEventPageResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobEventPageResponse.java
@@ -1,0 +1,51 @@
+package com.link.up.server.dto;
+
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobEventPage;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Sequence-based REST page for one Job's runtime lifecycle events. */
+public final class JobEventPageResponse {
+
+    private final String jobId;
+    private final List<JobEventEnvelope> items;
+    private final long nextSequence;
+    private final boolean hasMore;
+    private final boolean completed;
+
+    public JobEventPageResponse(
+            JobEventPage page,
+            boolean completed) {
+
+        this.jobId = page.getJobId();
+        this.items = Collections.unmodifiableList(
+                new ArrayList<JobEventEnvelope>(
+                        page.getItems()));
+        this.nextSequence = page.getNextSequence();
+        this.hasMore = page.isHasMore();
+        this.completed = completed;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public List<JobEventEnvelope> getItems() {
+        return items;
+    }
+
+    public long getNextSequence() {
+        return nextSequence;
+    }
+
+    public boolean isHasMore() {
+        return hasMore;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/http/ExceptionHandlingFilter.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/ExceptionHandlingFilter.java
@@ -3,6 +3,7 @@ package com.link.up.server.http;
 import com.link.up.server.application.JobNotFoundException;
 import com.link.up.server.application.JobRetryNotAllowedException;
 import com.link.up.server.application.JobSubmissionConflictException;
+import com.link.up.server.application.port.JobEventHistoryException;
 import com.link.up.server.dto.ErrorResponse;
 import com.link.up.server.runtime.JobStateConflictException;
 
@@ -112,6 +113,12 @@ public final class ExceptionHandlingFilter implements Filter {
                     409,
                     "FLUX-JOB-IDEMPOTENCY-CONFLICT",
                     failure.getMessage());
+        }
+        if (failure instanceof JobEventHistoryException) {
+            return new ErrorMapping(
+                    500,
+                    "FLUX-JOB-EVENT-HISTORY-UNAVAILABLE",
+                    "Job event history is unavailable");
         }
         if (failure instanceof IllegalArgumentException) {
             return new ErrorMapping(

--- a/link-up-server/src/main/java/com/link/up/server/http/JettyServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/JettyServer.java
@@ -10,6 +10,7 @@ import com.link.up.server.http.servlet.JobsServlet;
 import com.link.up.server.http.servlet.NodeServlet;
 import com.link.up.server.http.servlet.NotFoundServlet;
 import com.link.up.server.service.ConnectorRestService;
+import com.link.up.server.service.JobEventRestService;
 import com.link.up.server.service.JobPlanningService;
 import com.link.up.server.service.JobRestService;
 import org.eclipse.jetty.server.Server;
@@ -40,6 +41,7 @@ public final class JettyServer implements AutoCloseable {
                 new ConnectorRestService(
                         new ConnectorSchemaCatalog(
                                 Collections.emptyList())),
+                null,
                 null);
     }
 
@@ -51,6 +53,7 @@ public final class JettyServer implements AutoCloseable {
                 config,
                 jobService,
                 connectorService,
+                null,
                 null);
     }
 
@@ -59,6 +62,20 @@ public final class JettyServer implements AutoCloseable {
             JobRestService jobService,
             ConnectorRestService connectorService,
             JobPlanningService planningService) {
+        this(
+                config,
+                jobService,
+                connectorService,
+                planningService,
+                null);
+    }
+
+    public JettyServer(
+            FluxServerConfig config,
+            JobRestService jobService,
+            ConnectorRestService connectorService,
+            JobPlanningService planningService,
+            JobEventRestService eventService) {
 
         int minimumThreads = Math.min(
                 4,
@@ -130,6 +147,7 @@ public final class JettyServer implements AutoCloseable {
                 new ServletHolder(
                         new JobResourceServlet(
                                 jobService,
+                                eventService,
                                 config.getMaxRequestBytes())),
                 RestConstants.JOBS + "/*");
         context.addServlet(

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/JobResourceServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/JobResourceServlet.java
@@ -3,6 +3,8 @@ package com.link.up.server.http.servlet;
 import com.link.up.server.application.JobNotFoundException;
 import com.link.up.server.dto.JobSubmitRequest;
 import com.link.up.server.http.FluxServlet;
+import com.link.up.server.http.RestException;
+import com.link.up.server.service.JobEventRestService;
 import com.link.up.server.service.JobRestService;
 
 import javax.servlet.http.HttpServletRequest;
@@ -18,19 +20,32 @@ public final class JobResourceServlet
             1024 * 1024;
 
     private final JobRestService service;
+    private final JobEventRestService eventService;
     private final int maxRequestBytes;
 
     public JobResourceServlet(JobRestService service) {
         this(
                 service,
+                null,
                 DEFAULT_MAX_REQUEST_BYTES);
     }
 
     public JobResourceServlet(
             JobRestService service,
             int maxRequestBytes) {
+        this(
+                service,
+                null,
+                maxRequestBytes);
+    }
+
+    public JobResourceServlet(
+            JobRestService service,
+            JobEventRestService eventService,
+            int maxRequestBytes) {
 
         this.service = service;
+        this.eventService = eventService;
         this.maxRequestBytes = maxRequestBytes;
     }
 
@@ -176,6 +191,30 @@ public final class JobResourceServlet
                                     request,
                                     "limit",
                                     500)));
+            return;
+        }
+
+        if ("events".equals(resource)) {
+            if (eventService == null) {
+                throw new RestException(
+                        501,
+                        "FLUX-JOB-EVENT-HISTORY-DISABLED",
+                        "Job event history is not configured");
+            }
+
+            write(
+                    response,
+                    200,
+                    eventService.events(
+                            jobId,
+                            longParameter(
+                                    request,
+                                    "afterSequence",
+                                    0L),
+                            intParameter(
+                                    request,
+                                    "limit",
+                                    200)));
             return;
         }
 

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/event/EventPublishingJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/event/EventPublishingJobRepository.java
@@ -1,0 +1,442 @@
+package com.link.up.server.infrastructure.event;
+
+import com.link.up.server.application.port.JobEventListener;
+import com.link.up.server.application.port.JobEventRetention;
+import com.link.up.server.application.port.JobRepository;
+import com.link.up.server.application.port.JobRepositoryEntry;
+import com.link.up.server.runtime.JobAttemptMetadata;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobStateTransition;
+import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobRuntimeEvent;
+import com.link.up.server.runtime.event.JobRuntimeEventType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Repository decorator that publishes one lifecycle fact after a durable
+ * checkpoint succeeds.
+ *
+ * <p>The wrapped repository remains the state source of truth. Event delivery
+ * is best-effort and listener failures are isolated at this boundary.</p>
+ */
+public final class EventPublishingJobRepository
+        implements JobRepository {
+
+    private static final Logger LOG =
+            LogManager.getLogger(
+                    EventPublishingJobRepository.class);
+
+    private final JobRepository delegate;
+    private final JobEventListener eventListener;
+    private final JobEventRetention retention;
+    private final Object[] jobLocks = createLocks();
+
+    public EventPublishingJobRepository(
+            JobRepository delegate,
+            JobEventListener eventListener) {
+        this(
+                delegate,
+                eventListener,
+                JobEventRetention.EMPTY);
+    }
+
+    public EventPublishingJobRepository(
+            JobRepository delegate,
+            JobEventListener eventListener,
+            JobEventRetention retention) {
+
+        this.delegate = Objects.requireNonNull(
+                delegate,
+                "delegate must not be null");
+        this.eventListener = Objects.requireNonNull(
+                eventListener,
+                "eventListener must not be null");
+        this.retention = Objects.requireNonNull(
+                retention,
+                "retention must not be null");
+
+        retainCurrentJobs();
+    }
+
+    @Override
+    public void save(JobSnapshot snapshot) {
+        delegate.save(snapshot);
+    }
+
+    @Override
+    public void save(
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata) {
+
+        JobSnapshot safeSnapshot = Objects.requireNonNull(
+                snapshot,
+                "snapshot must not be null");
+        String jobId = safeSnapshot.getJobId();
+
+        synchronized (lockFor(jobId)) {
+            JobSnapshot previousSnapshot =
+                    delegate.get(jobId);
+            JobExecutionMetadata previousMetadata =
+                    delegate.getMetadata(jobId);
+
+            delegate.save(
+                    safeSnapshot,
+                    metadata);
+
+            JobEventEnvelope event = event(
+                    previousSnapshot,
+                    previousMetadata,
+                    safeSnapshot,
+                    metadata);
+
+            if (event != null) {
+                publish(event);
+            }
+
+            if (safeSnapshot.getStatus().isTerminal()) {
+                retainCurrentJobs();
+            }
+        }
+    }
+
+    @Override
+    public JobSnapshot get(String jobId) {
+        return delegate.get(jobId);
+    }
+
+    @Override
+    public JobExecutionMetadata getMetadata(String jobId) {
+        return delegate.getMetadata(jobId);
+    }
+
+    @Override
+    public List<JobSnapshot> list() {
+        return delegate.list();
+    }
+
+    @Override
+    public List<JobRepositoryEntry> listEntries() {
+        return delegate.listEntries();
+    }
+
+    @Override
+    public void delete(String jobId) {
+        delegate.delete(jobId);
+
+        try {
+            retention.delete(jobId);
+        } catch (RuntimeException failure) {
+            LOG.warn(
+                    "Could not delete Job event history, jobId={}",
+                    jobId,
+                    failure);
+        }
+    }
+
+    private void publish(JobEventEnvelope event) {
+        try {
+            eventListener.onEvent(event);
+        } catch (RuntimeException failure) {
+            LOG.error(
+                    "Could not publish Job event, jobId={}, sequence={}, eventType={}",
+                    event.getJobId(),
+                    event.getSequence(),
+                    event.getEvent().getType(),
+                    failure);
+        }
+    }
+
+    private void retainCurrentJobs() {
+        try {
+            List<String> jobIds =
+                    new ArrayList<String>();
+
+            for (JobSnapshot snapshot : delegate.list()) {
+                jobIds.add(snapshot.getJobId());
+            }
+
+            retention.retain(jobIds);
+        } catch (RuntimeException failure) {
+            LOG.warn(
+                    "Could not apply Job event history retention",
+                    failure);
+        }
+    }
+
+    private JobEventEnvelope event(
+            JobSnapshot previousSnapshot,
+            JobExecutionMetadata previousMetadata,
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata) {
+
+        if (metadata == null
+                || metadata.getCheckpointVersion() <= 0L
+                || !hasAttempt(metadata)) {
+            return null;
+        }
+
+        if (previousMetadata != null
+                && metadata.getCheckpointVersion()
+                <= previousMetadata.getCheckpointVersion()) {
+            return null;
+        }
+
+        JobAttemptMetadata attempt = currentAttempt(metadata);
+        JobRuntimeEvent runtimeEvent = runtimeEvent(
+                previousSnapshot,
+                previousMetadata,
+                snapshot,
+                metadata,
+                attempt);
+
+        if (runtimeEvent == null) {
+            return null;
+        }
+
+        return JobEventEnvelope.create(
+                snapshot.getJobId(),
+                attempt.getAttemptId(),
+                attempt.getAttemptNumber(),
+                metadata.getCheckpointVersion(),
+                occurredAtMillis(
+                        runtimeEvent,
+                        metadata),
+                runtimeEvent);
+    }
+
+    private JobRuntimeEvent runtimeEvent(
+            JobSnapshot previousSnapshot,
+            JobExecutionMetadata previousMetadata,
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata,
+            JobAttemptMetadata attempt) {
+
+        if (previousSnapshot == null) {
+            if (snapshot.getStatus() == ServerJobStatus.SUBMITTED) {
+                return transitionEvent(
+                        JobRuntimeEventType.JOB_SUBMITTED,
+                        metadata,
+                        snapshot.getStatus());
+            }
+
+            return statusEvent(
+                    snapshot.getStatus(),
+                    metadata,
+                    attempt);
+        }
+
+        if (attemptCount(metadata)
+                > attemptCount(previousMetadata)) {
+            return transitionEvent(
+                    JobRuntimeEventType.JOB_RETRY_CREATED,
+                    metadata,
+                    snapshot.getStatus());
+        }
+
+        if (previousSnapshot.getStatus()
+                != snapshot.getStatus()) {
+            return statusEvent(
+                    snapshot.getStatus(),
+                    metadata,
+                    attempt);
+        }
+
+        if (!same(
+                runId(previousMetadata),
+                metadata.getRunId())) {
+            return JobRuntimeEvent.logCreated(
+                    snapshot.getStatus(),
+                    metadata.getRunId());
+        }
+
+        if (!cancellationRequested(previousMetadata)
+                && metadata.isCancellationRequested()) {
+            return JobRuntimeEvent.cancellationRequested(
+                    snapshot.getStatus());
+        }
+
+        return null;
+    }
+
+    private JobRuntimeEvent statusEvent(
+            ServerJobStatus status,
+            JobExecutionMetadata metadata,
+            JobAttemptMetadata attempt) {
+
+        if (status == ServerJobStatus.QUEUED) {
+            return transitionEvent(
+                    JobRuntimeEventType.JOB_QUEUED,
+                    metadata,
+                    status);
+        }
+        if (status == ServerJobStatus.RUNNING) {
+            return transitionEvent(
+                    JobRuntimeEventType.JOB_STARTED,
+                    metadata,
+                    status);
+        }
+        if (status == ServerJobStatus.SUCCEEDED) {
+            return terminalEvent(
+                    JobRuntimeEventType.JOB_SUCCEEDED,
+                    metadata,
+                    status,
+                    null);
+        }
+        if (status == ServerJobStatus.CANCELED) {
+            return terminalEvent(
+                    JobRuntimeEventType.JOB_CANCELED,
+                    metadata,
+                    status,
+                    null);
+        }
+        if (status == ServerJobStatus.LOST) {
+            return terminalEvent(
+                    JobRuntimeEventType.JOB_LOST,
+                    metadata,
+                    status,
+                    attempt.getFailureType());
+        }
+        if (status == ServerJobStatus.FAILED) {
+            return terminalEvent(
+                    JobRuntimeEventType.JOB_FAILED,
+                    metadata,
+                    status,
+                    attempt.getFailureType());
+        }
+
+        return null;
+    }
+
+    private JobRuntimeEvent transitionEvent(
+            JobRuntimeEventType type,
+            JobExecutionMetadata metadata,
+            ServerJobStatus fallbackStatus) {
+
+        JobStateTransition transition =
+                latestTransition(metadata);
+
+        return JobRuntimeEvent.transition(
+                type,
+                transition == null
+                        ? null
+                        : transition.getFromStatus(),
+                transition == null
+                        ? fallbackStatus
+                        : transition.getToStatus(),
+                transition == null
+                        ? null
+                        : transition.getReason());
+    }
+
+    private JobRuntimeEvent terminalEvent(
+            JobRuntimeEventType type,
+            JobExecutionMetadata metadata,
+            ServerJobStatus fallbackStatus,
+            String failureType) {
+
+        JobStateTransition transition =
+                latestTransition(metadata);
+
+        return JobRuntimeEvent.terminal(
+                type,
+                transition == null
+                        ? null
+                        : transition.getFromStatus(),
+                transition == null
+                        ? fallbackStatus
+                        : transition.getToStatus(),
+                transition == null
+                        ? null
+                        : transition.getReason(),
+                failureType);
+    }
+
+    private long occurredAtMillis(
+            JobRuntimeEvent event,
+            JobExecutionMetadata metadata) {
+
+        JobRuntimeEventType type = event.getType();
+        if (type == JobRuntimeEventType.JOB_LOG_CREATED
+                || type == JobRuntimeEventType.JOB_CANCEL_REQUESTED) {
+            return System.currentTimeMillis();
+        }
+
+        JobStateTransition transition =
+                latestTransition(metadata);
+
+        return transition == null
+                ? System.currentTimeMillis()
+                : transition.getTransitionTimeMillis();
+    }
+
+    private Object lockFor(String jobId) {
+        int index = (jobId.hashCode() & Integer.MAX_VALUE)
+                % jobLocks.length;
+        return jobLocks[index];
+    }
+
+    private static Object[] createLocks() {
+        Object[] locks = new Object[64];
+        for (int index = 0; index < locks.length; index++) {
+            locks[index] = new Object();
+        }
+        return locks;
+    }
+
+    private static JobStateTransition latestTransition(
+            JobExecutionMetadata metadata) {
+
+        List<JobStateTransition> transitions =
+                metadata.getTransitions();
+
+        return transitions.isEmpty()
+                ? null
+                : transitions.get(transitions.size() - 1);
+    }
+
+    private static JobAttemptMetadata currentAttempt(
+            JobExecutionMetadata metadata) {
+
+        List<JobAttemptMetadata> attempts =
+                metadata.getAttempts();
+        return attempts.get(attempts.size() - 1);
+    }
+
+    private static boolean hasAttempt(
+            JobExecutionMetadata metadata) {
+        return !metadata.getAttempts().isEmpty();
+    }
+
+    private static int attemptCount(
+            JobExecutionMetadata metadata) {
+        return metadata == null
+                ? 0
+                : metadata.getAttemptCount();
+    }
+
+    private static String runId(
+            JobExecutionMetadata metadata) {
+        return metadata == null
+                ? null
+                : metadata.getRunId();
+    }
+
+    private static boolean cancellationRequested(
+            JobExecutionMetadata metadata) {
+        return metadata != null
+                && metadata.isCancellationRequested();
+    }
+
+    private static boolean same(
+            Object left,
+            Object right) {
+        return Objects.equals(left, right);
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/event/JsonLineJobEventStore.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/event/JsonLineJobEventStore.java
@@ -1,0 +1,446 @@
+package com.link.up.server.infrastructure.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.server.application.port.JobEventHistoryException;
+import com.link.up.server.application.port.JobEventListener;
+import com.link.up.server.application.port.JobEventReader;
+import com.link.up.server.application.port.JobEventRetention;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobEventPage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Per-Job append-only JSONL event journal.
+ *
+ * <p>One event occupies one UTF-8 line. A sequence cursor is exclusive: reading
+ * after sequence 4 starts from event 5. The store is intentionally local and
+ * synchronous for the first phase; dispatch failure isolation belongs to
+ * {@code JobEventBus}.</p>
+ */
+public final class JsonLineJobEventStore
+        implements JobEventListener, JobEventReader, JobEventRetention {
+
+    private static final Logger LOG =
+            LogManager.getLogger(JsonLineJobEventStore.class);
+
+    private static final int MAX_PAGE_SIZE = 1_000;
+    private static final String EVENT_DIRECTORY = "job-events";
+    private static final String EVENT_FILE_SUFFIX = ".jsonl";
+    private static final String SAFE_JOB_ID = "[A-Za-z0-9._-]{1,200}";
+
+    private final Path eventDirectory;
+    private final ObjectMapper mapper;
+    private final Object[] jobLocks = createLocks();
+    private final ConcurrentMap<String, Long> lastSequences =
+            new ConcurrentHashMap<String, Long>();
+
+    public JsonLineJobEventStore(Path stateDirectory) {
+        Objects.requireNonNull(
+                stateDirectory,
+                "stateDirectory must not be null");
+
+        this.eventDirectory =
+                stateDirectory.resolve(EVENT_DIRECTORY);
+        this.mapper = new ObjectMapper();
+
+        try {
+            Files.createDirectories(eventDirectory);
+        } catch (IOException failure) {
+            throw historyFailure(
+                    "Could not initialize Job event directory "
+                            + eventDirectory,
+                    failure);
+        }
+    }
+
+    @Override
+    public void onEvent(JobEventEnvelope event) {
+        append(
+                Objects.requireNonNull(
+                        event,
+                        "event must not be null"));
+    }
+
+    @Override
+    public void delete(String jobId) {
+        String normalizedJobId = requireJobId(jobId);
+
+        synchronized (lockFor(normalizedJobId)) {
+            try {
+                Files.deleteIfExists(
+                        eventFile(normalizedJobId));
+                lastSequences.remove(normalizedJobId);
+            } catch (IOException failure) {
+                throw historyFailure(
+                        "Could not delete Job event history for "
+                                + normalizedJobId,
+                        failure);
+            }
+        }
+    }
+
+    @Override
+    public void retain(Iterable<String> jobIds) {
+        Objects.requireNonNull(
+                jobIds,
+                "jobIds must not be null");
+
+        Set<String> retained = new HashSet<String>();
+        for (String jobId : jobIds) {
+            retained.add(requireJobId(jobId));
+        }
+
+        try (java.nio.file.DirectoryStream<Path> files =
+                     Files.newDirectoryStream(
+                             eventDirectory,
+                             "*" + EVENT_FILE_SUFFIX)) {
+
+            for (Path file : files) {
+                String fileName =
+                        file.getFileName().toString();
+                String jobId = fileName.substring(
+                        0,
+                        fileName.length()
+                                - EVENT_FILE_SUFFIX.length());
+
+                if (!retained.contains(jobId)) {
+                    delete(jobId);
+                }
+            }
+        } catch (IOException failure) {
+            throw historyFailure(
+                    "Could not apply Job event history retention",
+                    failure);
+        }
+    }
+
+    @Override
+    public JobEventPage read(
+            String jobId,
+            long afterSequence,
+            int limit) {
+
+        String normalizedJobId =
+                requireJobId(jobId);
+        validatePage(afterSequence, limit);
+
+        synchronized (lockFor(normalizedJobId)) {
+            return readLocked(
+                    normalizedJobId,
+                    afterSequence,
+                    limit);
+        }
+    }
+
+    public Path getEventDirectory() {
+        return eventDirectory;
+    }
+
+    private void append(JobEventEnvelope event) {
+        String jobId = requireJobId(event.getJobId());
+
+        synchronized (lockFor(jobId)) {
+            long previous = resolveLastSequence(jobId);
+
+            if (event.getSequence() <= previous) {
+                LOG.debug(
+                        "Ignoring duplicate or stale Job event, jobId={}, sequence={}, lastSequence={}",
+                        jobId,
+                        event.getSequence(),
+                        previous);
+                return;
+            }
+
+            if (event.getSequence() > previous + 1L) {
+                LOG.warn(
+                        "Job event sequence gap detected, jobId={}, expectedSequence={}, actualSequence={}",
+                        jobId,
+                        previous + 1L,
+                        event.getSequence());
+            }
+
+            Path file = eventFile(jobId);
+            byte[] line = serialize(event);
+
+            try {
+                Files.write(
+                        file,
+                        line,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.WRITE,
+                        StandardOpenOption.APPEND);
+                lastSequences.put(
+                        jobId,
+                        event.getSequence());
+            } catch (IOException failure) {
+                throw historyFailure(
+                        "Could not append Job event for "
+                                + jobId,
+                        failure);
+            }
+        }
+    }
+
+    private JobEventPage readLocked(
+            String jobId,
+            long afterSequence,
+            int limit) {
+
+        Path file = eventFile(jobId);
+        if (!Files.exists(file)) {
+            return JobEventPage.empty(
+                    jobId,
+                    afterSequence);
+        }
+
+        List<JobEventEnvelope> items =
+                new ArrayList<JobEventEnvelope>(limit);
+        boolean hasMore = false;
+        long previousSequence = 0L;
+        long nextSequence = afterSequence;
+
+        try (BufferedReader reader =
+                     Files.newBufferedReader(
+                             file,
+                             StandardCharsets.UTF_8)) {
+
+            String line;
+            int lineNumber = 0;
+
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                if (line.trim().isEmpty()) {
+                    continue;
+                }
+
+                JobEventEnvelope event =
+                        parse(
+                                jobId,
+                                line,
+                                lineNumber);
+
+                if (event.getSequence() <= previousSequence) {
+                    throw historyFailure(
+                            "Job event sequence is not strictly increasing for "
+                                    + jobId
+                                    + " at line "
+                                    + lineNumber,
+                            null);
+                }
+
+                previousSequence = event.getSequence();
+
+                if (event.getSequence() <= afterSequence) {
+                    continue;
+                }
+
+                if (items.size() == limit) {
+                    hasMore = true;
+                    break;
+                }
+
+                items.add(event);
+                nextSequence = event.getSequence();
+            }
+        } catch (IOException failure) {
+            throw historyFailure(
+                    "Could not read Job event history for "
+                            + jobId,
+                    failure);
+        }
+
+        return new JobEventPage(
+                jobId,
+                items,
+                nextSequence,
+                hasMore);
+    }
+
+    private long resolveLastSequence(String jobId) {
+        Long cached = lastSequences.get(jobId);
+        if (cached != null) {
+            return cached.longValue();
+        }
+
+        Path file = eventFile(jobId);
+        if (!Files.exists(file)) {
+            lastSequences.putIfAbsent(jobId, 0L);
+            return 0L;
+        }
+
+        long last = 0L;
+
+        try (BufferedReader reader =
+                     Files.newBufferedReader(
+                             file,
+                             StandardCharsets.UTF_8)) {
+
+            String line;
+            int lineNumber = 0;
+
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                if (line.trim().isEmpty()) {
+                    continue;
+                }
+
+                JobEventEnvelope event =
+                        parse(
+                                jobId,
+                                line,
+                                lineNumber);
+
+                if (event.getSequence() <= last) {
+                    throw historyFailure(
+                            "Job event sequence is not strictly increasing for "
+                                    + jobId
+                                    + " at line "
+                                    + lineNumber,
+                            null);
+                }
+
+                last = event.getSequence();
+            }
+        } catch (IOException failure) {
+            throw historyFailure(
+                    "Could not scan Job event history for "
+                            + jobId,
+                    failure);
+        }
+
+        Long previous = lastSequences.putIfAbsent(jobId, last);
+        return previous == null
+                ? last
+                : previous.longValue();
+    }
+
+    private JobEventEnvelope parse(
+            String jobId,
+            String line,
+            int lineNumber) {
+
+        try {
+            JobEventEnvelope event =
+                    mapper.readValue(
+                            line,
+                            JobEventEnvelope.class);
+
+            if (event.getSchemaVersion()
+                    > JobEventEnvelope.CURRENT_SCHEMA_VERSION) {
+                throw historyFailure(
+                        "Unsupported Job event schema version "
+                                + event.getSchemaVersion()
+                                + " for "
+                                + jobId
+                                + " at line "
+                                + lineNumber,
+                        null);
+            }
+
+            if (!jobId.equals(event.getJobId())) {
+                throw historyFailure(
+                        "Job event identity mismatch for "
+                                + jobId
+                                + " at line "
+                                + lineNumber,
+                        null);
+            }
+
+            return event;
+        } catch (JsonProcessingException failure) {
+            throw historyFailure(
+                    "Invalid Job event JSON for "
+                            + jobId
+                            + " at line "
+                            + lineNumber,
+                    failure);
+        }
+    }
+
+    private byte[] serialize(JobEventEnvelope event) {
+        try {
+            byte[] json = mapper.writeValueAsBytes(event);
+            byte[] line = new byte[json.length + 1];
+            System.arraycopy(
+                    json,
+                    0,
+                    line,
+                    0,
+                    json.length);
+            line[line.length - 1] = (byte) '\n';
+            return line;
+        } catch (JsonProcessingException failure) {
+            throw historyFailure(
+                    "Could not serialize Job event for "
+                            + event.getJobId(),
+                    failure);
+        }
+    }
+
+    private Object lockFor(String jobId) {
+        int index = (jobId.hashCode() & Integer.MAX_VALUE)
+                % jobLocks.length;
+        return jobLocks[index];
+    }
+
+    private static Object[] createLocks() {
+        Object[] locks = new Object[64];
+        for (int index = 0; index < locks.length; index++) {
+            locks[index] = new Object();
+        }
+        return locks;
+    }
+
+    private Path eventFile(String jobId) {
+        return eventDirectory.resolve(
+                jobId + EVENT_FILE_SUFFIX);
+    }
+
+    private static void validatePage(
+            long afterSequence,
+            int limit) {
+
+        if (afterSequence < 0L) {
+            throw new IllegalArgumentException(
+                    "afterSequence must not be negative");
+        }
+        if (limit <= 0 || limit > MAX_PAGE_SIZE) {
+            throw new IllegalArgumentException(
+                    "limit must be between 1 and "
+                            + MAX_PAGE_SIZE);
+        }
+    }
+
+    private static String requireJobId(String jobId) {
+        if (jobId == null
+                || !jobId.matches(SAFE_JOB_ID)) {
+            throw new IllegalArgumentException(
+                    "jobId contains unsupported characters");
+        }
+        return jobId;
+    }
+
+    private static JobEventHistoryException historyFailure(
+            String message,
+            Throwable cause) {
+        return new JobEventHistoryException(
+                message,
+                cause);
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/event/JobEventEnvelope.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/event/JobEventEnvelope.java
@@ -1,0 +1,130 @@
+package com.link.up.server.runtime.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/** Versioned, job-scoped envelope persisted as one JSON line. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class JobEventEnvelope {
+
+    public static final int CURRENT_SCHEMA_VERSION = 1;
+
+    private final int schemaVersion;
+    private final String eventId;
+    private final String jobId;
+    private final String attemptId;
+    private final int attemptNumber;
+    private final long sequence;
+    private final long occurredAtMillis;
+    private final JobRuntimeEvent event;
+
+    @JsonCreator
+    public JobEventEnvelope(
+            @JsonProperty("schemaVersion") int schemaVersion,
+            @JsonProperty("eventId") String eventId,
+            @JsonProperty("jobId") String jobId,
+            @JsonProperty("attemptId") String attemptId,
+            @JsonProperty("attemptNumber") int attemptNumber,
+            @JsonProperty("sequence") long sequence,
+            @JsonProperty("occurredAtMillis") long occurredAtMillis,
+            @JsonProperty("event") JobRuntimeEvent event) {
+
+        if (schemaVersion <= 0) {
+            throw new IllegalArgumentException(
+                    "schemaVersion must be greater than 0");
+        }
+        if (attemptNumber <= 0) {
+            throw new IllegalArgumentException(
+                    "attemptNumber must be greater than 0");
+        }
+        if (sequence <= 0L) {
+            throw new IllegalArgumentException(
+                    "sequence must be greater than 0");
+        }
+        if (occurredAtMillis <= 0L) {
+            throw new IllegalArgumentException(
+                    "occurredAtMillis must be greater than 0");
+        }
+
+        this.schemaVersion = schemaVersion;
+        this.eventId = requireText(eventId, "eventId");
+        this.jobId = requireText(jobId, "jobId");
+        this.attemptId = requireText(attemptId, "attemptId");
+        this.attemptNumber = attemptNumber;
+        this.sequence = sequence;
+        this.occurredAtMillis = occurredAtMillis;
+        this.event = Objects.requireNonNull(
+                event,
+                "event must not be null");
+    }
+
+    public static JobEventEnvelope create(
+            String jobId,
+            String attemptId,
+            int attemptNumber,
+            long sequence,
+            long occurredAtMillis,
+            JobRuntimeEvent event) {
+
+        String normalizedJobId = requireText(
+                jobId,
+                "jobId");
+
+        return new JobEventEnvelope(
+                CURRENT_SCHEMA_VERSION,
+                normalizedJobId + ":" + sequence,
+                normalizedJobId,
+                attemptId,
+                attemptNumber,
+                sequence,
+                occurredAtMillis,
+                event);
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null
+                || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    public int getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public String getAttemptId() {
+        return attemptId;
+    }
+
+    public int getAttemptNumber() {
+        return attemptNumber;
+    }
+
+    public long getSequence() {
+        return sequence;
+    }
+
+    public long getOccurredAtMillis() {
+        return occurredAtMillis;
+    }
+
+    public JobRuntimeEvent getEvent() {
+        return event;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/event/JobEventPage.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/event/JobEventPage.java
@@ -1,0 +1,64 @@
+package com.link.up.server.runtime.event;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable sequence-based page from one Job event journal. */
+public final class JobEventPage {
+
+    private final String jobId;
+    private final List<JobEventEnvelope> items;
+    private final long nextSequence;
+    private final boolean hasMore;
+
+    public JobEventPage(
+            String jobId,
+            List<JobEventEnvelope> items,
+            long nextSequence,
+            boolean hasMore) {
+
+        if (nextSequence < 0L) {
+            throw new IllegalArgumentException(
+                    "nextSequence must not be negative");
+        }
+
+        this.jobId = Objects.requireNonNull(
+                jobId,
+                "jobId must not be null");
+        this.items = Collections.unmodifiableList(
+                new ArrayList<JobEventEnvelope>(
+                        Objects.requireNonNull(
+                                items,
+                                "items must not be null")));
+        this.nextSequence = nextSequence;
+        this.hasMore = hasMore;
+    }
+
+    public static JobEventPage empty(
+            String jobId,
+            long afterSequence) {
+        return new JobEventPage(
+                jobId,
+                Collections.<JobEventEnvelope>emptyList(),
+                afterSequence,
+                false);
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public List<JobEventEnvelope> getItems() {
+        return items;
+    }
+
+    public long getNextSequence() {
+        return nextSequence;
+    }
+
+    public boolean isHasMore() {
+        return hasMore;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/event/JobRuntimeEvent.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/event/JobRuntimeEvent.java
@@ -1,0 +1,180 @@
+package com.link.up.server.runtime.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.link.up.server.runtime.ServerJobStatus;
+
+import java.util.Objects;
+
+/**
+ * Secret-safe lifecycle fact stored inside a {@link JobEventEnvelope}.
+ *
+ * <p>The event intentionally carries no Connector options, arbitrary payload
+ * map or Throwable message. Failures are represented only by their Java type
+ * until structured runtime errors are introduced.</p>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class JobRuntimeEvent {
+
+    private final JobRuntimeEventType type;
+    private final ServerJobStatus previousStatus;
+    private final ServerJobStatus status;
+    private final String reason;
+    private final String runId;
+    private final String failureType;
+
+    @JsonCreator
+    public JobRuntimeEvent(
+            @JsonProperty("type") JobRuntimeEventType type,
+            @JsonProperty("previousStatus") ServerJobStatus previousStatus,
+            @JsonProperty("status") ServerJobStatus status,
+            @JsonProperty("reason") String reason,
+            @JsonProperty("runId") String runId,
+            @JsonProperty("failureType") String failureType) {
+
+        this.type = Objects.requireNonNull(
+                type,
+                "type must not be null");
+        this.previousStatus = previousStatus;
+        this.status = status;
+        this.reason = safeOptionalText(reason, 200);
+        this.runId = safeOptionalText(runId, 200);
+        this.failureType = safeOptionalText(failureType, 300);
+    }
+
+    public static JobRuntimeEvent transition(
+            JobRuntimeEventType type,
+            ServerJobStatus previousStatus,
+            ServerJobStatus status,
+            String reason) {
+
+        if (isTerminalType(type)) {
+            throw new IllegalArgumentException(
+                    "Use terminal(...) for terminal Job events");
+        }
+
+        return new JobRuntimeEvent(
+                type,
+                previousStatus,
+                status,
+                reason,
+                null,
+                null);
+    }
+
+    public static JobRuntimeEvent logCreated(
+            ServerJobStatus status,
+            String runId) {
+
+        return new JobRuntimeEvent(
+                JobRuntimeEventType.JOB_LOG_CREATED,
+                status,
+                status,
+                "job-log-created",
+                requireText(runId, "runId"),
+                null);
+    }
+
+    public static JobRuntimeEvent cancellationRequested(
+            ServerJobStatus status) {
+
+        return new JobRuntimeEvent(
+                JobRuntimeEventType.JOB_CANCEL_REQUESTED,
+                status,
+                status,
+                "cancellation-requested",
+                null,
+                null);
+    }
+
+    public static JobRuntimeEvent terminal(
+            JobRuntimeEventType type,
+            ServerJobStatus previousStatus,
+            ServerJobStatus status,
+            String reason,
+            String failureType) {
+
+        if (!isTerminalType(type)) {
+            throw new IllegalArgumentException(
+                    "type must describe a terminal Job event");
+        }
+
+        return new JobRuntimeEvent(
+                type,
+                previousStatus,
+                status,
+                reason,
+                null,
+                failureType);
+    }
+
+    private static boolean isTerminalType(
+            JobRuntimeEventType type) {
+
+        return type == JobRuntimeEventType.JOB_SUCCEEDED
+                || type == JobRuntimeEventType.JOB_FAILED
+                || type == JobRuntimeEventType.JOB_CANCELED
+                || type == JobRuntimeEventType.JOB_LOST;
+    }
+
+    private static String safeOptionalText(
+            String value,
+            int maxLength) {
+
+        if (value == null) {
+            return null;
+        }
+
+        String normalized = value.trim()
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replace('\t', ' ');
+
+        if (normalized.isEmpty()) {
+            return null;
+        }
+
+        return normalized.length() <= maxLength
+                ? normalized
+                : normalized.substring(0, maxLength);
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        String normalized = safeOptionalText(value, 500);
+        if (normalized == null) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+        return normalized;
+    }
+
+    public JobRuntimeEventType getType() {
+        return type;
+    }
+
+    public ServerJobStatus getPreviousStatus() {
+        return previousStatus;
+    }
+
+    public ServerJobStatus getStatus() {
+        return status;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+
+    public String getRunId() {
+        return runId;
+    }
+
+    public String getFailureType() {
+        return failureType;
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/event/JobRuntimeEventType.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/event/JobRuntimeEventType.java
@@ -1,0 +1,15 @@
+package com.link.up.server.runtime.event;
+
+/** Stable control-plane event names emitted for one Job lifecycle. */
+public enum JobRuntimeEventType {
+    JOB_SUBMITTED,
+    JOB_QUEUED,
+    JOB_STARTED,
+    JOB_LOG_CREATED,
+    JOB_CANCEL_REQUESTED,
+    JOB_RETRY_CREATED,
+    JOB_SUCCEEDED,
+    JOB_FAILED,
+    JOB_CANCELED,
+    JOB_LOST
+}

--- a/link-up-server/src/main/java/com/link/up/server/service/JobEventRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobEventRestService.java
@@ -1,0 +1,82 @@
+package com.link.up.server.service;
+
+import com.link.up.server.application.JobApplication;
+import com.link.up.server.application.port.JobEventReader;
+import com.link.up.server.dto.JobEventPageResponse;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.event.JobEventPage;
+
+import java.util.Objects;
+
+/** REST query boundary for sequence-based Job lifecycle history. */
+public final class JobEventRestService {
+
+    private static final int MAX_PAGE_SIZE = 1_000;
+
+    private final JobApplication jobApplication;
+    private final JobEventReader eventReader;
+
+    public JobEventRestService(
+            JobApplication jobApplication,
+            JobEventReader eventReader) {
+
+        this.jobApplication = Objects.requireNonNull(
+                jobApplication,
+                "jobApplication must not be null");
+        this.eventReader = Objects.requireNonNull(
+                eventReader,
+                "eventReader must not be null");
+    }
+
+    public JobEventPageResponse events(
+            String jobId,
+            long afterSequence,
+            int limit) {
+
+        String normalizedJobId = requireText(
+                jobId,
+                "jobId");
+        validatePage(
+                afterSequence,
+                limit);
+
+        JobSnapshot snapshot =
+                jobApplication.getJob(normalizedJobId);
+        JobEventPage page =
+                eventReader.read(
+                        normalizedJobId,
+                        afterSequence,
+                        limit);
+
+        return new JobEventPageResponse(
+                page,
+                snapshot.getStatus().isTerminal());
+    }
+
+    private static void validatePage(
+            long afterSequence,
+            int limit) {
+
+        if (afterSequence < 0L) {
+            throw new IllegalArgumentException(
+                    "afterSequence must not be negative");
+        }
+        if (limit <= 0 || limit > MAX_PAGE_SIZE) {
+            throw new IllegalArgumentException(
+                    "limit must be between 1 and "
+                            + MAX_PAGE_SIZE);
+        }
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null
+                || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/application/JobEventBusTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/application/JobEventBusTest.java
@@ -1,0 +1,55 @@
+package com.link.up.server.application;
+
+import com.link.up.server.application.port.JobEventListener;
+import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobRuntimeEvent;
+import com.link.up.server.runtime.event.JobRuntimeEventType;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertSame;
+
+public class JobEventBusTest {
+
+    @Test
+    public void listenerFailureMustNotBlockLaterListeners() {
+        final JobEventEnvelope[] received =
+                new JobEventEnvelope[1];
+
+        JobEventListener failing =
+                new JobEventListener() {
+                    @Override
+                    public void onEvent(JobEventEnvelope event) {
+                        throw new IllegalStateException("observer failed");
+                    }
+                };
+
+        JobEventListener succeeding =
+                new JobEventListener() {
+                    @Override
+                    public void onEvent(JobEventEnvelope event) {
+                        received[0] = event;
+                    }
+                };
+
+        JobEventEnvelope event = JobEventEnvelope.create(
+                "job-1",
+                "job-1-attempt-1",
+                1,
+                1L,
+                System.currentTimeMillis(),
+                JobRuntimeEvent.transition(
+                        JobRuntimeEventType.JOB_SUBMITTED,
+                        ServerJobStatus.CREATED,
+                        ServerJobStatus.SUBMITTED,
+                        "submission-accepted"));
+
+        new JobEventBus(
+                Arrays.asList(failing, succeeding))
+                .publish(event);
+
+        assertSame(event, received[0]);
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/event/EventPublishingJobRepositoryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/event/EventPublishingJobRepositoryTest.java
@@ -1,0 +1,216 @@
+package com.link.up.server.infrastructure.event;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.SinkDefinition;
+import com.link.up.framework.job.SourceDefinition;
+import com.link.up.server.application.JobEventBus;
+import com.link.up.server.application.port.JobEventListener;
+import com.link.up.server.application.port.JobRepository;
+import com.link.up.server.domain.JobExecutionAttempt;
+import com.link.up.server.domain.JobExecutionState;
+import com.link.up.server.domain.JobSubmission;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobSnapshotFactory;
+import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobRuntimeEventType;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class EventPublishingJobRepositoryTest {
+
+    @Test
+    public void shouldPublishCheckpointLifecycleInSequence()
+            throws Exception {
+
+        RecordingListener listener = new RecordingListener();
+        EventPublishingJobRepository repository = repository(listener);
+        JobExecutionState state = state("job-1");
+
+        state.markSubmitted();
+        save(repository, state);
+        state.markQueued();
+        save(repository, state);
+        state.markRunning();
+        save(repository, state);
+        state.bindLogIdentity("run-1", "logs/job-1.log");
+        save(repository, state);
+        state.requestCancellation();
+        save(repository, state);
+        state.complete(ServerJobStatus.CANCELED, null, null);
+        save(repository, state);
+
+        assertEquals(6, listener.events.size());
+        assertTypes(
+                listener.events,
+                JobRuntimeEventType.JOB_SUBMITTED,
+                JobRuntimeEventType.JOB_QUEUED,
+                JobRuntimeEventType.JOB_STARTED,
+                JobRuntimeEventType.JOB_LOG_CREATED,
+                JobRuntimeEventType.JOB_CANCEL_REQUESTED,
+                JobRuntimeEventType.JOB_CANCELED);
+
+        for (int index = 0; index < listener.events.size(); index++) {
+            assertEquals(
+                    index + 1L,
+                    listener.events.get(index).getSequence());
+        }
+
+        String json = new ObjectMapper().writeValueAsString(
+                listener.events);
+        assertFalse(json.contains("TEST_ONLY_PASSWORD"));
+        assertFalse(json.contains("password"));
+    }
+
+    @Test
+    public void shouldPublishRetryAttemptWithoutResettingSequence() {
+        RecordingListener listener = new RecordingListener();
+        EventPublishingJobRepository repository = repository(listener);
+        JobExecutionState failed = state("job-retry");
+
+        failed.markSubmitted();
+        save(repository, failed);
+        failed.failBeforeExecution(
+                new IllegalStateException("TEST_ONLY_PASSWORD"));
+        save(repository, failed);
+
+        JobExecutionMetadata previous =
+                JobExecutionMetadata.fromState(failed);
+        List<JobExecutionAttempt> previousAttempts =
+                new ArrayList<JobExecutionAttempt>(
+                        failed.getAttempts());
+
+        JobExecutionState retry = JobExecutionState.retryFrom(
+                failed.getJobId(),
+                failed.getSubmission(),
+                failed.getCreateTimeMillis(),
+                failed.getSubmittedTimeMillis(),
+                previous.getStateVersion(),
+                previous.getCheckpointVersion(),
+                failed.getStatus(),
+                previous.getTransitions(),
+                previousAttempts);
+
+        save(repository, retry);
+
+        JobEventEnvelope last =
+                listener.events.get(
+                        listener.events.size() - 1);
+        assertEquals(
+                JobRuntimeEventType.JOB_RETRY_CREATED,
+                last.getEvent().getType());
+        assertEquals(2, last.getAttemptNumber());
+        assertEquals(3L, last.getSequence());
+    }
+
+    private EventPublishingJobRepository repository(
+            JobEventListener listener) {
+        return new EventPublishingJobRepository(
+                new MemoryRepository(),
+                new JobEventBus(
+                        Collections.singletonList(listener)));
+    }
+
+    private JobExecutionState state(String jobId) {
+        Map<String, Object> sourceOptions =
+                new LinkedHashMap<String, Object>();
+        sourceOptions.put("password", "TEST_ONLY_PASSWORD");
+
+        JobDefinition definition = new JobDefinition(
+                "event-test",
+                new SourceDefinition(
+                        "test-source",
+                        ReadonlyConfig.fromMap(sourceOptions)),
+                new SinkDefinition(
+                        "test-sink",
+                        ReadonlyConfig.fromMap(
+                                Collections.<String, Object>emptyMap())),
+                new ExecutionConfig(100, 1, 1, 32));
+
+        return new JobExecutionState(
+                jobId,
+                JobSubmission.legacy(definition));
+    }
+
+    private void save(
+            EventPublishingJobRepository repository,
+            JobExecutionState state) {
+        repository.save(
+                JobSnapshotFactory.create(state, null),
+                JobExecutionMetadata.fromState(state));
+    }
+
+    private void assertTypes(
+            List<JobEventEnvelope> events,
+            JobRuntimeEventType... types) {
+
+        assertEquals(types.length, events.size());
+        for (int index = 0; index < types.length; index++) {
+            assertEquals(
+                    types[index],
+                    events.get(index).getEvent().getType());
+        }
+    }
+
+    private static final class RecordingListener
+            implements JobEventListener {
+
+        private final List<JobEventEnvelope> events =
+                new ArrayList<JobEventEnvelope>();
+
+        @Override
+        public void onEvent(JobEventEnvelope event) {
+            events.add(event);
+        }
+    }
+
+    private static final class MemoryRepository
+            implements JobRepository {
+
+        private final Map<String, JobSnapshot> snapshots =
+                new LinkedHashMap<String, JobSnapshot>();
+        private final Map<String, JobExecutionMetadata> metadata =
+                new LinkedHashMap<String, JobExecutionMetadata>();
+
+        @Override
+        public void save(JobSnapshot snapshot) {
+            snapshots.put(snapshot.getJobId(), snapshot);
+        }
+
+        @Override
+        public void save(
+                JobSnapshot snapshot,
+                JobExecutionMetadata executionMetadata) {
+            snapshots.put(snapshot.getJobId(), snapshot);
+            metadata.put(snapshot.getJobId(), executionMetadata);
+        }
+
+        @Override
+        public JobSnapshot get(String jobId) {
+            return snapshots.get(jobId);
+        }
+
+        @Override
+        public JobExecutionMetadata getMetadata(String jobId) {
+            return metadata.get(jobId);
+        }
+
+        @Override
+        public List<JobSnapshot> list() {
+            return new ArrayList<JobSnapshot>(
+                    snapshots.values());
+        }
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/event/JsonLineJobEventStoreTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/event/JsonLineJobEventStoreTest.java
@@ -1,0 +1,148 @@
+package com.link.up.server.infrastructure.event;
+
+import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobEventPage;
+import com.link.up.server.runtime.event.JobRuntimeEvent;
+import com.link.up.server.runtime.event.JobRuntimeEventType;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JsonLineJobEventStoreTest {
+
+    @Rule
+    public TemporaryFolder temporaryFolder =
+            new TemporaryFolder();
+
+    @Test
+    public void shouldAppendPageAndResumeAfterRestart()
+            throws Exception {
+
+        Path stateDirectory =
+                temporaryFolder.newFolder("state")
+                        .toPath();
+        JsonLineJobEventStore store =
+                new JsonLineJobEventStore(stateDirectory);
+
+        store.onEvent(event(1L, JobRuntimeEventType.JOB_SUBMITTED));
+        store.onEvent(event(2L, JobRuntimeEventType.JOB_QUEUED));
+        store.onEvent(event(2L, JobRuntimeEventType.JOB_QUEUED));
+
+        JobEventPage first = store.read("job-1", 0L, 1);
+        assertEquals(1, first.getItems().size());
+        assertEquals(1L, first.getNextSequence());
+        assertTrue(first.isHasMore());
+
+        JobEventPage second = store.read("job-1", 1L, 10);
+        assertEquals(1, second.getItems().size());
+        assertEquals(2L, second.getNextSequence());
+        assertFalse(second.isHasMore());
+
+        JsonLineJobEventStore restarted =
+                new JsonLineJobEventStore(stateDirectory);
+        restarted.onEvent(event(3L, JobRuntimeEventType.JOB_STARTED));
+
+        JobEventPage all = restarted.read("job-1", 0L, 10);
+        assertEquals(3, all.getItems().size());
+        assertEquals(3L, all.getNextSequence());
+
+        List<String> lines = Files.readAllLines(
+                stateDirectory.resolve("job-events/job-1.jsonl"));
+        assertEquals(3, lines.size());
+    }
+
+    @Test
+    public void shouldDeleteJournalsOutsideRetainedHistory()
+            throws Exception {
+
+        Path stateDirectory =
+                temporaryFolder.newFolder("retention")
+                        .toPath();
+        JsonLineJobEventStore store =
+                new JsonLineJobEventStore(stateDirectory);
+
+        store.onEvent(event(
+                "job-1",
+                1L,
+                JobRuntimeEventType.JOB_SUBMITTED));
+        store.onEvent(event(
+                "job-2",
+                1L,
+                JobRuntimeEventType.JOB_SUBMITTED));
+
+        store.retain(Collections.singletonList("job-1"));
+
+        assertTrue(Files.exists(
+                stateDirectory.resolve("job-events/job-1.jsonl")));
+        assertFalse(Files.exists(
+                stateDirectory.resolve("job-events/job-2.jsonl")));
+    }
+
+    private JobEventEnvelope event(
+            long sequence,
+            JobRuntimeEventType type) {
+
+        ServerJobStatus previous =
+                sequence == 1L
+                        ? ServerJobStatus.CREATED
+                        : sequence == 2L
+                        ? ServerJobStatus.SUBMITTED
+                        : ServerJobStatus.QUEUED;
+        ServerJobStatus status =
+                sequence == 1L
+                        ? ServerJobStatus.SUBMITTED
+                        : sequence == 2L
+                        ? ServerJobStatus.QUEUED
+                        : ServerJobStatus.RUNNING;
+
+        return event(
+                "job-1",
+                sequence,
+                type,
+                previous,
+                status);
+    }
+
+    private JobEventEnvelope event(
+            String jobId,
+            long sequence,
+            JobRuntimeEventType type) {
+
+        return event(
+                jobId,
+                sequence,
+                type,
+                ServerJobStatus.CREATED,
+                ServerJobStatus.SUBMITTED);
+    }
+
+    private JobEventEnvelope event(
+            String jobId,
+            long sequence,
+            JobRuntimeEventType type,
+            ServerJobStatus previous,
+            ServerJobStatus status) {
+
+        return JobEventEnvelope.create(
+                jobId,
+                jobId + "-attempt-1",
+                1,
+                sequence,
+                1_000L + sequence,
+                JobRuntimeEvent.transition(
+                        type,
+                        previous,
+                        status,
+                        type.name().toLowerCase()));
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements **PR 1: Runtime Event foundation** on top of the merged Plan / Explain work.

- adds a versioned, Secret-safe `JobEventEnvelope` / `JobRuntimeEvent` protocol;
- derives lifecycle events only after the corresponding durable Job checkpoint succeeds;
- appends one JSON event per line under `<stateDirectory>/job-events/<jobId>.jsonl`;
- exposes sequence-based history through `GET /api/v1/jobs/{jobId}/events`;
- keeps event retention aligned with the existing Worker `historyLimit`;
- preserves the current Job / Attempt / Retry / Commit execution semantics.

## Runtime events

```text
JOB_SUBMITTED
JOB_RETRY_CREATED
JOB_QUEUED
JOB_STARTED
JOB_LOG_CREATED
JOB_CANCEL_REQUESTED
JOB_SUCCEEDED
JOB_FAILED
JOB_CANCELED
JOB_LOST
```

Each event contains a stable schema version, deterministic event ID, Job/Attempt identity, `checkpointVersion` sequence, timestamp and a small typed lifecycle fact.

## State and failure boundary

`JobSnapshot` and `JobExecutionMetadata` remain the control-plane source of truth.

```text
JobRuntimeLifecycle
  -> JobRepository.save(snapshot, metadata)
  -> EventPublishingJobRepository
       1. persist checkpoint
       2. derive lifecycle fact
       3. publish event
  -> JobEventBus
  -> JsonLineJobEventStore
```

Important guarantees:

- events are published only after checkpoint persistence succeeds;
- event listener / JSONL write failure is logged and isolated, and cannot fail the running Job;
- Retry continues the same per-Job sequence instead of resetting it;
- stale or duplicate event sequences are ignored;
- sequence gaps are tolerated because observability must not overwrite execution semantics;
- restart recovery to `LOST` produces a normal `JOB_LOST` event;
- historical terminal Jobs created before this feature are not backfilled and return an empty completed timeline.

## Security boundary

Event JSON does **not** contain:

- JobSpec or HOCON;
- Connector options;
- SQL;
- passwords, tokens or other Secrets;
- exception messages;
- Prepared Connector / ClassLoader / private Connector metadata;
- arbitrary payload maps.

Failures currently expose only the Java failure type. Structured runtime errors remain a later phase.

## API

```text
GET /api/v1/jobs/{jobId}/events?afterSequence=0&limit=200
```

`afterSequence` is an exclusive cursor. The response includes `items`, `nextSequence`, `hasMore` and whether the Job has reached a terminal state.

## Tests added

- listener failure isolation in `JobEventBus`;
- JSONL append, duplicate suppression, cursor pagination and restart resume;
- event history retention cleanup;
- checkpoint-to-event lifecycle ordering;
- Retry Attempt identity and non-resetting sequence;
- explicit Secret leakage assertions.

## Verification performed

- Java 8 source compilation passed for the actual event protocol, store, repository decorator and tests using dependency stubs;
- Java 8 source compilation passed for the modified Worker/Jetty/Servlet wiring using dependency stubs;
- Java 8 source compilation passed for the event REST service and response model.

A complete `mvn --batch-mode clean verify` was not executed in the current environment because external Maven/GitHub dependency resolution is unavailable. It remains a required local pre-merge check.

## Out of scope

- Pipeline / Task progress events;
- event replay as the state source of truth;
- Kafka or remote event transport;
- Capability Negotiation and Structured Error work;
- Yak-Ops UI integration.
