### PR TITLE
feat: add capability negotiation and structured errors

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,6 +31,7 @@ Link-Up 是本地优先的离线数据同步引擎。架构只解决现在需要
 JobSpec
   -> JobDefinition
   -> LogicalJobPlan
+  -> CapabilityNegotiator
   -> ConnectorPreparer
   -> PreparedJob
   -> JobPlanner
@@ -58,13 +59,54 @@ JobPlanner
 
 Planner 不创建 Reader、线程、Channel、Split Queue 或 CancellationToken。
 
+## Capability Negotiation
+
+Capability 描述 Connector 可以提供的稳定执行能力。Job 可以声明：
+
+```text
+required  -> 缺失即拒绝
+preferred -> 缺失时允许降级，并返回 Warning
+```
+
+协商不是只读页面能力，而是 Validate、Explain 和正式 Runtime 共用的执行前置条件：
+
+```text
+JobDefinition
+  -> negotiate explicit requirements       # 无 Connector IO
+  -> validate option rules
+  -> prepare Source + discover schemas
+  -> negotiate derived topology requirements
+  -> prepare Sink                          # 这里才允许 DDL/cleanup
+  -> enumerate splits + JobGraph
+  -> negotiate observed physical facts
+  -> execute
+```
+
+多表边界必须特别明确：Source Schema 发现出多个数据集时，`MULTI_TABLE` 会同时成为 Source 和 Sink 的派生 Required Capability。协商发生在 `SinkPreparer` 之前，因此不兼容任务不会先建表、清表再失败。
+
+协商输出：
+
+```text
+CapabilityNegotiation
+  ├── status: SATISFIED / DEGRADED / REJECTED
+  ├── source
+  │    ├── supported / required / preferred
+  │    ├── derivedRequired / observed
+  │    └── missingRequired / missingPreferred / undeclaredObserved
+  └── sink
+       └── same shape
+```
+
+第三方 Connector 的 `Factory#capabilities()` 默认仍为空集合，保持二进制和源码兼容；但当 Job 显式要求能力或实际拓扑需要能力时，空声明不能绕过协商。
+
 ## Plan / Explain
 
 Plan / Explain 不创建第二套执行图：
 
 ```text
 JobDefinition
-  -> LogicalJobPlan              # 用户意图、默认值、Fingerprint
+  -> LogicalJobPlan              # 用户意图、默认值、Capability、Fingerprint
+  -> CapabilityNegotiator
   -> ConnectorPreparer
        validate                  # 无 Connector IO
        prepareForExplain         # Source discovery + Sink planning stub
@@ -82,6 +124,7 @@ JobDefinition
 - 解析默认值；
 - 发现 Source/Sink Factory；
 - 执行 Connector OptionRule 校验；
+- 协商显式 Required/Preferred Capability；
 - 生成 LogicalJobPlan 和稳定 Fingerprint。
 
 `validate` 不可以：
@@ -97,10 +140,11 @@ JobDefinition
 
 - 创建 Source；
 - 发现 Source Schema；
+- 派生拓扑 Required Capability；
 - 枚举并校验 Source Split；
 - 应用字段映射；
 - 使用正式 JobPlanner 生成 JobGraph；
-- 投影 Pipeline/Task 数量、并行度和数据集信息。
+- 投影 Pipeline/Task 数量、并行度、数据集和 CapabilityNegotiation。
 
 `explain` 不可以：
 
@@ -111,7 +155,43 @@ JobDefinition
 - 写入数据；
 - 序列化 Connector options、ReadonlyConfig、Prepared Connector、ClassLoader 或私有 metadata。
 
-完整 Connector 配置只进入 SHA-256 Fingerprint 的内存计算。Fingerprint 能识别包括 Secret 在内的配置变化，但计划和诊断不输出原始值。
+完整 Connector 配置和 Capability Intent 只进入 SHA-256 Fingerprint 的内存计算。Fingerprint 能识别包括 Secret 在内的配置变化，但计划和诊断不输出原始值。
+
+## Structured Error
+
+`FluxErrorCode` 是稳定错误目录，新增元数据：
+
+```text
+code
+category
+phase
+retryable
+retryScope
+```
+
+规划边界使用 `PlanningException`，错误参数只允许 role、connectorId、capability、format、reason 等安全值。REST 返回元数据和参数，不直接输出 cause message。
+
+执行失败时，`JobExecutionAttempt` 会从异常 cause chain 中提取 `FluxRuntimeException`，持久化：
+
+```text
+errorCode
+errorCategory
+errorPhase
+failureRetryable
+failureRetryScope
+```
+
+Checkpoint formatVersion 升级为 3，同时继续读取 v1/v2。RetryPolicy 的判断顺序：
+
+```text
+terminal outcome
+  -> structured error retryable?
+  -> commit evidence available?
+  -> unknown / partial / committed data?
+  -> allow or deny
+```
+
+错误可重试不等于数据可重放。即便 `retryable=true`，只要 Commit Evidence 不安全，仍然拒绝 Retry；反过来，明确的不可重试错误即使没有提交数据，也不会盲目重跑。
 
 ## Control Plane
 
@@ -135,6 +215,7 @@ HTTP / registration
 HTTP
   -> JobPlanningService
   -> JobPlanExplainer
+  -> CapabilityNegotiator
   -> ConnectorPreparer / JobPlanner
 ```
 
@@ -165,7 +246,7 @@ JobRuntimeLifecycle
 - `JobEventBus` 保持同一 Job 的同步顺序，并隔离 Listener 失败。
 - 每条事件使用 `checkpointVersion` 作为单 Job 序号，Retry 后继续递增。
 - Event JSON 不包含 JobSpec、Connector options、SQL、Secret、异常正文、Prepared Connector 或私有 metadata。
-- 当前只记录 Job/Attempt 生命周期；Pipeline/Task 细粒度事件留给后续阶段。
+- 当前只记录 Job/Attempt 生命周期；结构化错误元数据保存在 Attempt read model，Pipeline/Task 细粒度事件留给后续阶段。
 
 查询链路：
 
@@ -185,6 +266,7 @@ Retry 是新的 Attempt，不是把旧 Attempt 改活：
 ```text
 FAILED Attempt #1
   -> RetryPolicy
+  -> structured error permits retry
   -> commit evidence == SAFE
   -> Attempt #2
 ```
@@ -192,6 +274,7 @@ FAILED Attempt #1
 允许 Retry 的最低条件：
 
 - Job 当前为 `FAILED`；
+- 结构化错误没有明确声明不可重试；
 - 上一次 Attempt 有 commit evidence；
 - `dataCommittedTaskCount == 0`；
 - `successfullyCommittedRecordCount == 0`；

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -30,7 +30,7 @@ Capability 是稳定执行语义，不是前端控件：
 supported       Connector 声明可提供
 required        Job 显式必须具备
 preferred       Job 希望具备，缺失可降级
- derivedRequired 根据真实拓扑推导的必须能力
+derivedRequired 根据真实拓扑推导的必须能力
 observed        规划过程实际观察到的能力事实
 ```
 
@@ -120,7 +120,8 @@ parameters
 | `PLAN-006` | Source Preparation / Schema Discovery 失败 |
 | `PLAN-007` | Split Discovery 失败 |
 | `PLAN-008` | Physical Planning 失败 |
-| `PLAN-009` | 未预期的内部规划失败 |
+| `PLAN-009` | Sink Preparation 失败 |
+| `PLAN-010` | 未预期的内部规划失败 |
 
 错误参数只放安全身份和枚举。Secret、Connector options、SQL、完整 URL 和原始异常正文不得进入结构化参数。
 

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -3,15 +3,46 @@
 ## Job 定义链
 
 ```text
-JobSpec -> JobDefinition -> PreparedJob -> JobGraph -> ExecutionGraph -> JobResult
+JobSpec
+  -> JobDefinition
+  -> LogicalJobPlan
+  -> CapabilityNegotiation
+  -> PreparedJob
+  -> JobGraph
+  -> ExecutionGraph
+  -> JobResult
 ```
 
-- `JobSpec`：外部提交协议。
+- `JobSpec`：外部提交协议，可声明 Required/Preferred Capability。
 - `JobDefinition`：校验、归一化后的内部定义。
+- `LogicalJobPlan`：Secret-safe 用户意图和稳定 Fingerprint。
+- `CapabilityNegotiation`：任务要求与 Connector 声明的匹配结果。
 - `PreparedJob`：Connector 元数据准备完成后的输入。
 - `JobGraph`：不可变物理拓扑。
 - `ExecutionGraph`：单次运行状态。
 - `JobResult`：一次 framework 执行结果。
+
+## Capability
+
+Capability 是稳定执行语义，不是前端控件：
+
+```text
+supported       Connector 声明可提供
+required        Job 显式必须具备
+preferred       Job 希望具备，缺失可降级
+ derivedRequired 根据真实拓扑推导的必须能力
+observed        规划过程实际观察到的能力事实
+```
+
+协商状态：
+
+| Status | 含义 |
+| --- | --- |
+| `SATISFIED` | Required 全部满足，没有降级或声明缺口 |
+| `DEGRADED` | Required 满足，但 Preferred 缺失或观察到未声明能力 |
+| `REJECTED` | 至少一个 Required Capability 缺失 |
+
+多表 Source 会为 Source 和 Sink 派生 `MULTI_TABLE` Required Capability。该检查发生在 Sink Preparation 之前，避免不兼容任务产生目标端副作用。
 
 ## Worker Job
 
@@ -57,10 +88,41 @@ Attempt 记录：
 - queue/start/end 时间；
 - `runId` / 日志文件；
 - failure type/message；
+- structured error code/category/phase；
+- failure retryable/retryScope；
 - commit evidence；
 - `retryAdvice`。
 
 Attempt 不拥有线程和 framework 执行对象。
+
+## Structured Error
+
+稳定错误由以下字段组成：
+
+```text
+code
+category
+phase
+retryable
+retryScope
+parameters
+```
+
+当前规划错误目录：
+
+| Code | 含义 |
+| --- | --- |
+| `PLAN-001` | 规划请求非法 |
+| `PLAN-002` | Job 定义编译失败 |
+| `PLAN-003` | Connector 无法解析 |
+| `PLAN-004` | Connector options 非法 |
+| `PLAN-005` | Required Capability 缺失 |
+| `PLAN-006` | Source Preparation / Schema Discovery 失败 |
+| `PLAN-007` | Split Discovery 失败 |
+| `PLAN-008` | Physical Planning 失败 |
+| `PLAN-009` | 未预期的内部规划失败 |
+
+错误参数只放安全身份和枚举。Secret、Connector options、SQL、完整 URL 和原始异常正文不得进入结构化参数。
 
 ## Runtime Event
 
@@ -100,7 +162,7 @@ JOB_LOST
 - 重复或晚到的旧序号不会再次追加。
 - Event 不参与状态恢复、RetryPolicy 或 Commit 判定。
 - Event 不保存用户配置、SQL、Secret 或异常正文。
-- `failureType` 只描述故障类型，不替代后续 Structured Error。
+- Event 继续保存生命周期事实；结构化错误细节从 Attempt read model 查询。
 
 ## Retry Decision
 
@@ -116,6 +178,15 @@ RetryPolicy 输出显式决策码：
 | `EVIDENCE_UNAVAILABLE` | 无法证明安全 |
 | `UNKNOWN_COMMIT_STATE` | 存在未知提交状态 |
 | `DATA_ALREADY_COMMITTED` | 已确认提交数据 |
+| `NON_RETRYABLE_FAILURE` | 结构化错误明确禁止重试 |
+
+错误可重试和数据可重放是两个条件：
+
+```text
+structured error allows retry
+AND
+commit evidence proves zero committed / unknown data
+```
 
 安全策略宁可拒绝，也不猜。
 
@@ -124,5 +195,7 @@ RetryPolicy 输出显式决策码：
 `stateVersion` 只记录业务状态转换。
 
 `checkpointVersion` 记录所有需要持久化的变化，包括日志绑定、取消意图和 Retry Attempt 创建，用于防止旧 checkpoint 覆盖新状态，也作为 Runtime Event 的单 Job 序号。
+
+Checkpoint `formatVersion = 3` 增加 Attempt structured error metadata，并继续兼容读取 v1/v2。
 
 Worker 重启后，遗留的非终态 Job 统一恢复为 `LOST`；不会自动执行 Retry。恢复生成的新 LOST checkpoint 同样会追加 `JOB_LOST` 事件。

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Link-Up 是一个轻量、可嵌入的离线数据同步引擎。它把数据同
 - Job / Attempt 模型：同一个 Job 可以保留多次执行尝试。
 - 安全手动重试：只有明确证明“没有已提交或未知数据”的 FAILED Attempt 才允许重试。
 - 提交前校验和 Explain：查看规范化逻辑计划、实际 Source Split/Task 拓扑与稳定指纹。
+- Required / Preferred Capability 协商：在 Connector I/O 和 Sink 副作用前发现不兼容任务。
+- 结构化错误：稳定 code、category、phase、retryable、retryScope 和安全参数。
 - 追加式 Runtime Event Journal：按 Job/Attempt 回看提交、排队、运行、取消与终态时间线。
 
 ## 核心模型
@@ -19,6 +21,7 @@ Link-Up 是一个轻量、可嵌入的离线数据同步引擎。它把数据同
 JobSpec
   -> JobDefinition
   -> LogicalJobPlan
+  -> CapabilityNegotiation
   -> PreparedJob
   -> JobGraph
   -> PhysicalJobPlan (Explain projection)
@@ -51,7 +54,7 @@ job-100 / Attempt #1 FAILED
           -> SUCCEEDED
 ```
 
-`LOST`、`CANCELED`、存在已提交数据、存在 unknown commit state、缺少 commit evidence 时，默认拒绝重试。
+`LOST`、`CANCELED`、存在已提交数据、存在 unknown commit state、缺少 commit evidence，或者结构化错误明确声明不可重试时，默认拒绝 Retry。
 
 ## Plan / Explain
 
@@ -60,18 +63,19 @@ POST /api/v1/jobs/validate
 POST /api/v1/jobs/explain
 ```
 
-两个接口都接收与结构化提交一致的 JSON 外壳，只要求 `jobSpec` 或 `hocon` 二选一；
-规划时不要求 `externalExecutionId`、`idempotencyKey` 和 `definitionVersion`。
+两个接口都接收与结构化提交一致的 JSON 外壳，只要求 `jobSpec` 或 `hocon` 二选一；规划时不要求 `externalExecutionId`、`idempotencyKey` 和 `definitionVersion`。
 
 边界约束：
 
-- `validate` 只做协议编译、Factory 发现和 Connector OptionRule 校验，不创建 Source/Sink，不访问外部系统。
+- `validate` 做协议编译、Factory 发现、OptionRule 校验和显式 Capability 协商，不创建 Source/Sink，不访问外部系统。
 - `explain` 会创建 Source、发现 Source Schema 并枚举 Split，以生成真实 `JobGraph`。
 - `explain` 不调用 `SinkPreparer`，因此不会建表、清表、执行 DDL、创建 Writer 或写数据。
+- 正式 Runtime 与 Validate/Explain 共用同一个 `CapabilityNegotiator`，不会出现控制面通过、运行时绕过的第二套规则。
+- Source Schema 发现后，如果实际拓扑是多表任务，会自动为 Source 和 Sink 派生 `MULTI_TABLE` Required Capability，并在 Sink DDL/清理之前拒绝不兼容组合。
 - Explain 响应不包含 Connector options、`ReadonlyConfig`、Prepared Connector、ClassLoader 或 Connector 私有 metadata。
-- Connector 完整配置只参与 SHA-256 计划指纹，Secret 不会出现在逻辑计划、物理计划、诊断或文本 Explain 中。
+- Connector 完整配置和 Capability Intent 只参与 SHA-256 计划指纹，Secret 不会出现在逻辑计划、物理计划、诊断或文本 Explain 中。
 
-示例请求：
+结构化提交可以声明 Required 和 Preferred Capability：
 
 ```json
 {
@@ -84,12 +88,66 @@ POST /api/v1/jobs/explain
       "options": {}
     },
     "sink": {
-      "connectorId": "jdbc",
+      "connectorId": "doris",
       "options": {}
+    },
+    "capabilities": {
+      "source": {
+        "required": ["TABLE_SCHEMA_DISCOVERY"],
+        "preferred": ["PARTITION_SPLIT"]
+      },
+      "sink": {
+        "required": ["TWO_PHASE_COMMIT"]
+      }
     }
   }
 }
 ```
+
+语义：
+
+- Required 缺失：返回结构化错误并拒绝规划/执行。
+- Preferred 缺失：计划仍然有效，状态为 `DEGRADED`，并返回 Warning Diagnostic。
+- 未声明但执行拓扑已经使用的能力：返回声明不完整 Warning，便于逐步收紧第三方 Connector Contract。
+
+HOCON 使用同样的路径：
+
+```hocon
+capabilities {
+  source.required = [TABLE_SCHEMA_DISCOVERY]
+  source.preferred = [PARTITION_SPLIT]
+  sink.required = [TWO_PHASE_COMMIT]
+}
+```
+
+## Structured Error
+
+规划和 Connector API 错误使用稳定元数据，而不是让调用方匹配异常字符串：
+
+```json
+{
+  "code": "PLAN-005",
+  "message": "A required Connector capability is missing",
+  "requestId": "...",
+  "category": "CAPABILITY",
+  "phase": "CAPABILITY_NEGOTIATION",
+  "retryable": false,
+  "retryScope": "NONE",
+  "parameters": {
+    "role": "SINK",
+    "connectorId": "doris",
+    "capability": "TWO_PHASE_COMMIT"
+  }
+}
+```
+
+规则：
+
+- 稳定 code 用于控制面分支、聚合告警和兼容判断。
+- category / phase 描述问题边界。
+- retryable / retryScope 只描述错误本身是否值得重试；数据是否已经提交仍由 Commit Evidence 决定。
+- parameters 只允许安全身份和枚举，不放 Connector options、SQL、Secret 或原始异常正文。
+- Attempt 会持久化结构化错误元数据；Worker 重启后 RetryPolicy 仍能拒绝明确的不可重试错误。
 
 ## Runtime Event Journal
 
@@ -120,9 +178,7 @@ JOB_LOST
 GET /api/v1/jobs/{jobId}/events?afterSequence=0&limit=200
 ```
 
-当前阶段仍以 `JobSnapshot` 和 `JobExecutionMetadata` 为控制面状态真相。
-Event Journal 只负责可观察历史，不反向驱动状态机；事件监听器或文件写入失败会被隔离，
-不改变任务执行、Commit 或 Retry 语义。
+当前阶段仍以 `JobSnapshot` 和 `JobExecutionMetadata` 为控制面状态真相。Event Journal 只负责可观察历史，不反向驱动状态机；事件监听器或文件写入失败会被隔离，不改变任务执行、Commit 或 Retry 语义。
 
 安全边界：事件不保存 JobSpec、Connector options、SQL、Secret、异常正文或 Connector 私有 metadata，只保存稳定生命周期字段、Attempt 身份、状态、原因代码和故障类型。
 
@@ -130,8 +186,8 @@ Event Journal 只负责可观察历史，不反向驱动状态机；事件监听
 
 | 模块 | 职责 |
 | --- | --- |
-| `link-up-api` | Connector 扩展契约和公共模型 |
-| `link-up-framework` | Planning、JobGraph、ExecutionGraph、本地执行运行时 |
+| `link-up-api` | Connector 扩展契约、Capability、Structured Error 公共模型 |
+| `link-up-framework` | Planning、Capability Negotiation、JobGraph、ExecutionGraph、本地执行运行时 |
 | `link-up-connectors` | JDBC / HTTP / Doris 等实现 |
 | `link-up-server` | Worker 控制面、REST、持久化、Attempt/Retry、Runtime Event Journal |
 | `link-up-launcher` | 本地命令行组合入口 |
@@ -187,7 +243,7 @@ Retry 请求必须重新携带与原 Job 完全一致的结构化提交内容。
 只保留对开发真正有用的几份：
 
 - [ARCHITECTURE.md](ARCHITECTURE.md)：系统边界和主流程。
-- [DOMAIN.md](DOMAIN.md)：Job、Attempt、Graph、状态语义。
+- [DOMAIN.md](DOMAIN.md)：Job、Attempt、Capability、错误和状态语义。
 - [DEPENDENCIES.md](DEPENDENCIES.md)：模块依赖规则。
 - [REQUIREMENTS.md](REQUIREMENTS.md)：项目范围和非目标。
 - [CODE_STYLE.md](CODE_STYLE.md)：代码和包命名规范。

--- a/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorCapability.java
+++ b/link-up-api/src/main/java/com/link/up/api/connector/schema/ConnectorCapability.java
@@ -4,6 +4,7 @@ package com.link.up.api.connector.schema;
  * Connector 可以向控制面公开的稳定能力标识。
  *
  * <p>这里只描述执行引擎实际支持的能力，不包含具体前端控件和页面布局。
+ * Capability 表示“实现可以提供”，是否在某次任务中启用仍由任务配置决定。</p>
  */
 public enum ConnectorCapability {
     TABLE_SCHEMA_DISCOVERY,
@@ -12,5 +13,6 @@ public enum ConnectorCapability {
     PARTITION_SPLIT,
     UPSERT,
     AUTO_CREATE_TABLE,
-    DIRTY_DATA_HANDLING
+    DIRTY_DATA_HANDLING,
+    TWO_PHASE_COMMIT
 }

--- a/link-up-api/src/main/java/com/link/up/api/exception/FluxErrorCategory.java
+++ b/link-up-api/src/main/java/com/link/up/api/exception/FluxErrorCategory.java
@@ -1,0 +1,14 @@
+package com.link.up.api.exception;
+
+/** Stable high-level classification for machine-readable Link-Up failures. */
+public enum FluxErrorCategory {
+    UNKNOWN,
+    VALIDATION,
+    DISCOVERY,
+    CAPABILITY,
+    PREPARATION,
+    PLANNING,
+    EXECUTION,
+    PERSISTENCE,
+    INTERNAL
+}

--- a/link-up-api/src/main/java/com/link/up/api/exception/FluxErrorCode.java
+++ b/link-up-api/src/main/java/com/link/up/api/exception/FluxErrorCode.java
@@ -3,25 +3,36 @@ package com.link.up.api.exception;
 /**
  * Link-Up 统一错误码接口。
  *
- * @author weifuwan
+ * <p>Existing error-code implementations remain source compatible. New code
+ * should override the metadata methods so callers can make decisions without
+ * matching exception messages.</p>
  */
 public interface FluxErrorCode {
 
-    /**
-     * Get error code
-     *
-     * @return error code
-     */
     String getCode();
 
-    /**
-     * Get error description
-     *
-     * @return error description
-     */
     String getDescription();
 
+    default FluxErrorCategory getCategory() {
+        return FluxErrorCategory.UNKNOWN;
+    }
+
+    default FluxErrorPhase getPhase() {
+        return FluxErrorPhase.UNKNOWN;
+    }
+
+    default boolean isRetryable() {
+        return false;
+    }
+
+    default FluxRetryScope getRetryScope() {
+        return FluxRetryScope.NONE;
+    }
+
     default String getErrorMessage() {
-        return String.format("ErrorCode:[%s], ErrorDescription:[%s]", getCode(), getDescription());
+        return String.format(
+                "ErrorCode:[%s], ErrorDescription:[%s]",
+                getCode(),
+                getDescription());
     }
 }

--- a/link-up-api/src/main/java/com/link/up/api/exception/FluxErrorPhase.java
+++ b/link-up-api/src/main/java/com/link/up/api/exception/FluxErrorPhase.java
@@ -1,0 +1,17 @@
+package com.link.up.api.exception;
+
+/** Stable lifecycle phase in which a Link-Up failure occurred. */
+public enum FluxErrorPhase {
+    UNKNOWN,
+    PROTOCOL,
+    COMPILE,
+    CONNECTOR_RESOLUTION,
+    OPTION_VALIDATION,
+    CAPABILITY_NEGOTIATION,
+    SOURCE_DISCOVERY,
+    SPLIT_DISCOVERY,
+    SINK_PREPARATION,
+    PHYSICAL_PLANNING,
+    EXECUTION,
+    PERSISTENCE
+}

--- a/link-up-api/src/main/java/com/link/up/api/exception/FluxRetryScope.java
+++ b/link-up-api/src/main/java/com/link/up/api/exception/FluxRetryScope.java
@@ -1,0 +1,9 @@
+package com.link.up.api.exception;
+
+/** Smallest safe scope at which a structured failure may be retried. */
+public enum FluxRetryScope {
+    NONE,
+    TASK,
+    PIPELINE,
+    JOB
+}

--- a/link-up-api/src/main/java/com/link/up/api/exception/FluxRuntimeException.java
+++ b/link-up-api/src/main/java/com/link/up/api/exception/FluxRuntimeException.java
@@ -8,58 +8,107 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Flux global exception, used to tell user more clearly error messages
+ * Flux global exception, used to tell user more clearly error messages.
+ *
+ * <p>Structured metadata is delegated to {@link FluxErrorCode}; legacy error
+ * codes automatically retain UNKNOWN/NONE defaults.</p>
  */
 public class FluxRuntimeException extends RuntimeException {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final long serialVersionUID = 1L;
 
-    private final FluxErrorCode FluxErrorCode;
+    private static final ObjectMapper OBJECT_MAPPER =
+            new ObjectMapper();
+
+    private final FluxErrorCode fluxErrorCode;
     private final Map<String, String> params;
 
-    public FluxRuntimeException(FluxErrorCode FluxErrorCode, String errorMessage) {
-        super(FluxErrorCode.getErrorMessage() + " - " + errorMessage);
-        this.FluxErrorCode = FluxErrorCode;
-        this.params = new HashMap<>();
+    public FluxRuntimeException(
+            FluxErrorCode fluxErrorCode,
+            String errorMessage) {
+
+        super(fluxErrorCode.getErrorMessage()
+                + " - "
+                + errorMessage);
+        this.fluxErrorCode = fluxErrorCode;
+        this.params = new HashMap<String, String>();
         ExceptionParamsUtil.assertParamsMatchWithDescription(
-                FluxErrorCode.getDescription(), params);
+                fluxErrorCode.getDescription(),
+                params);
     }
 
     public FluxRuntimeException(
-            FluxErrorCode FluxErrorCode, String errorMessage, Throwable cause) {
-        super(FluxErrorCode.getErrorMessage() + " - " + errorMessage, cause);
-        this.FluxErrorCode = FluxErrorCode;
-        this.params = new HashMap<>();
-        ExceptionParamsUtil.assertParamsMatchWithDescription(
-                FluxErrorCode.getDescription(), params);
-    }
+            FluxErrorCode fluxErrorCode,
+            String errorMessage,
+            Throwable cause) {
 
-    public FluxRuntimeException(FluxErrorCode FluxErrorCode, Throwable cause) {
-        super(FluxErrorCode.getErrorMessage(), cause);
-        this.FluxErrorCode = FluxErrorCode;
-        this.params = new HashMap<>();
+        super(
+                fluxErrorCode.getErrorMessage()
+                        + " - "
+                        + errorMessage,
+                cause);
+        this.fluxErrorCode = fluxErrorCode;
+        this.params = new HashMap<String, String>();
         ExceptionParamsUtil.assertParamsMatchWithDescription(
-                FluxErrorCode.getDescription(), params);
+                fluxErrorCode.getDescription(),
+                params);
     }
 
     public FluxRuntimeException(
-            FluxErrorCode FluxErrorCode, Map<String, String> params) {
-        super(ExceptionParamsUtil.getDescription(FluxErrorCode.getErrorMessage(), params));
-        this.FluxErrorCode = FluxErrorCode;
+            FluxErrorCode fluxErrorCode,
+            Throwable cause) {
+
+        super(fluxErrorCode.getErrorMessage(), cause);
+        this.fluxErrorCode = fluxErrorCode;
+        this.params = new HashMap<String, String>();
+        ExceptionParamsUtil.assertParamsMatchWithDescription(
+                fluxErrorCode.getDescription(),
+                params);
+    }
+
+    public FluxRuntimeException(
+            FluxErrorCode fluxErrorCode,
+            Map<String, String> params) {
+
+        super(ExceptionParamsUtil.getDescription(
+                fluxErrorCode.getErrorMessage(),
+                params));
+        this.fluxErrorCode = fluxErrorCode;
         this.params = params;
     }
 
     public FluxRuntimeException(
-            FluxErrorCode FluxErrorCode, Map<String, String> params, Throwable cause) {
+            FluxErrorCode fluxErrorCode,
+            Map<String, String> params,
+            Throwable cause) {
+
         super(
-                ExceptionParamsUtil.getDescription(FluxErrorCode.getErrorMessage(), params),
+                ExceptionParamsUtil.getDescription(
+                        fluxErrorCode.getErrorMessage(),
+                        params),
                 cause);
-        this.FluxErrorCode = FluxErrorCode;
+        this.fluxErrorCode = fluxErrorCode;
         this.params = params;
     }
 
     public FluxErrorCode getFluxErrorCode() {
-        return FluxErrorCode;
+        return fluxErrorCode;
+    }
+
+    public FluxErrorCategory getErrorCategory() {
+        return fluxErrorCode.getCategory();
+    }
+
+    public FluxErrorPhase getErrorPhase() {
+        return fluxErrorCode.getPhase();
+    }
+
+    public boolean isRetryable() {
+        return fluxErrorCode.isRetryable();
+    }
+
+    public FluxRetryScope getRetryScope() {
+        return fluxErrorCode.getRetryScope();
     }
 
     public Map<String, String> getParams() {
@@ -69,19 +118,30 @@ public class FluxRuntimeException extends RuntimeException {
     public Map<String, String> getParamsValueAsMap(String key) {
         try {
             return OBJECT_MAPPER.readValue(
-                    params.get(key), new TypeReference<Map<String, String>>() {
+                    params.get(key),
+                    new TypeReference<Map<String, String>>() {
                     });
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+        } catch (JsonProcessingException failure) {
+            throw new IllegalArgumentException(
+                    "Could not decode exception parameter '"
+                            + key
+                            + "'",
+                    failure);
         }
     }
 
     public <T> T getParamsValueAs(String key) {
         try {
-            return OBJECT_MAPPER.readValue(params.get(key), new TypeReference<T>() {
-            });
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            return OBJECT_MAPPER.readValue(
+                    params.get(key),
+                    new TypeReference<T>() {
+                    });
+        } catch (JsonProcessingException failure) {
+            throw new IllegalArgumentException(
+                    "Could not decode exception parameter '"
+                            + key
+                            + "'",
+                    failure);
         }
     }
 }

--- a/link-up-api/src/main/java/com/link/up/api/exception/error/FluxApiErrorCode.java
+++ b/link-up-api/src/main/java/com/link/up/api/exception/error/FluxApiErrorCode.java
@@ -1,31 +1,162 @@
 package com.link.up.api.exception.error;
 
+import com.link.up.api.exception.FluxErrorCategory;
 import com.link.up.api.exception.FluxErrorCode;
+import com.link.up.api.exception.FluxErrorPhase;
+import com.link.up.api.exception.FluxRetryScope;
 
+/** Stable error directory for Connector API and metadata boundaries. */
 public enum FluxApiErrorCode implements FluxErrorCode {
-    CONFIG_VALIDATION_FAILED("API-01", "Configuration item validate failed"),
-    OPTION_VALIDATION_FAILED("API-02", "Option item validate failed"),
-    CATALOG_INITIALIZE_FAILED("API-03", "Catalog initialize failed"),
-    DATABASE_NOT_EXISTED("API-04", "Database not existed"),
-    TABLE_NOT_EXISTED("API-05", "Table not existed"),
-    FACTORY_INITIALIZE_FAILED("API-06", "Factory initialize failed"),
-    DATABASE_ALREADY_EXISTED("API-07", "Database already existed"),
-    TABLE_ALREADY_EXISTED("API-08", "Table already existed"),
-    HANDLE_SAVE_MODE_FAILED("API-09", "Handle save mode failed"),
-    SOURCE_ALREADY_HAS_DATA("API-10", "The target data source already has data"),
-    SINK_TABLE_NOT_EXIST("API-11", "The sink table not exist"),
-    LIST_DATABASES_FAILED("API-12", "List databases failed"),
-    LIST_TABLES_FAILED("API-13", "List tables failed"),
-    GET_PRIMARY_KEY_FAILED("API-14", "Get primary key failed"),
-    METADATA_PROVIDER_INITIALIZE_FAILED("API-15", "MetaData provider initialize failed"),
-    CONNECTOR_INITIALIZE_FAILED("API-16", "Connector initialize failed");
+
+    CONFIG_VALIDATION_FAILED(
+            "API-01",
+            "Configuration item validation failed",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.OPTION_VALIDATION,
+            false,
+            FluxRetryScope.NONE),
+
+    OPTION_VALIDATION_FAILED(
+            "API-02",
+            "Option item validation failed",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.OPTION_VALIDATION,
+            false,
+            FluxRetryScope.NONE),
+
+    CATALOG_INITIALIZE_FAILED(
+            "API-03",
+            "Catalog initialization failed",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.SOURCE_DISCOVERY,
+            true,
+            FluxRetryScope.JOB),
+
+    DATABASE_NOT_EXISTED(
+            "API-04",
+            "Database does not exist",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.SOURCE_DISCOVERY,
+            false,
+            FluxRetryScope.NONE),
+
+    TABLE_NOT_EXISTED(
+            "API-05",
+            "Table does not exist",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.SOURCE_DISCOVERY,
+            false,
+            FluxRetryScope.NONE),
+
+    FACTORY_INITIALIZE_FAILED(
+            "API-06",
+            "Factory initialization failed",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.CONNECTOR_RESOLUTION,
+            false,
+            FluxRetryScope.NONE),
+
+    DATABASE_ALREADY_EXISTED(
+            "API-07",
+            "Database already exists",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.SINK_PREPARATION,
+            false,
+            FluxRetryScope.NONE),
+
+    TABLE_ALREADY_EXISTED(
+            "API-08",
+            "Table already exists",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.SINK_PREPARATION,
+            false,
+            FluxRetryScope.NONE),
+
+    HANDLE_SAVE_MODE_FAILED(
+            "API-09",
+            "Save-mode handling failed",
+            FluxErrorCategory.PREPARATION,
+            FluxErrorPhase.SINK_PREPARATION,
+            false,
+            FluxRetryScope.NONE),
+
+    SOURCE_ALREADY_HAS_DATA(
+            "API-10",
+            "The target data source already has data",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.SINK_PREPARATION,
+            false,
+            FluxRetryScope.NONE),
+
+    SINK_TABLE_NOT_EXIST(
+            "API-11",
+            "The Sink table does not exist",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.SINK_PREPARATION,
+            false,
+            FluxRetryScope.NONE),
+
+    LIST_DATABASES_FAILED(
+            "API-12",
+            "Listing databases failed",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.SOURCE_DISCOVERY,
+            true,
+            FluxRetryScope.JOB),
+
+    LIST_TABLES_FAILED(
+            "API-13",
+            "Listing tables failed",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.SOURCE_DISCOVERY,
+            true,
+            FluxRetryScope.JOB),
+
+    GET_PRIMARY_KEY_FAILED(
+            "API-14",
+            "Reading primary-key metadata failed",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.SOURCE_DISCOVERY,
+            true,
+            FluxRetryScope.JOB),
+
+    METADATA_PROVIDER_INITIALIZE_FAILED(
+            "API-15",
+            "Metadata provider initialization failed",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.SOURCE_DISCOVERY,
+            true,
+            FluxRetryScope.JOB),
+
+    CONNECTOR_INITIALIZE_FAILED(
+            "API-16",
+            "Connector initialization failed",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.CONNECTOR_RESOLUTION,
+            false,
+            FluxRetryScope.NONE);
 
     private final String code;
     private final String description;
+    private final FluxErrorCategory category;
+    private final FluxErrorPhase phase;
+    private final boolean retryable;
+    private final FluxRetryScope retryScope;
 
-    FluxApiErrorCode(String code, String description) {
+    FluxApiErrorCode(
+            String code,
+            String description,
+            FluxErrorCategory category,
+            FluxErrorPhase phase,
+            boolean retryable,
+            FluxRetryScope retryScope) {
+
         this.code = code;
         this.description = description;
+        this.category = category;
+        this.phase = phase;
+        this.retryable = retryable;
+        this.retryScope = retryScope;
     }
 
     @Override
@@ -36,5 +167,25 @@ public enum FluxApiErrorCode implements FluxErrorCode {
     @Override
     public String getDescription() {
         return description;
+    }
+
+    @Override
+    public FluxErrorCategory getCategory() {
+        return category;
+    }
+
+    @Override
+    public FluxErrorPhase getPhase() {
+        return phase;
+    }
+
+    @Override
+    public boolean isRetryable() {
+        return retryable;
+    }
+
+    @Override
+    public FluxRetryScope getRetryScope() {
+        return retryScope;
     }
 }

--- a/link-up-api/src/main/java/com/link/up/api/exception/error/FluxApiErrorCode.java
+++ b/link-up-api/src/main/java/com/link/up/api/exception/error/FluxApiErrorCode.java
@@ -10,7 +10,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     CONFIG_VALIDATION_FAILED(
             "API-01",
-            "Configuration item validation failed",
+            "Configuration item validate failed",
             FluxErrorCategory.VALIDATION,
             FluxErrorPhase.OPTION_VALIDATION,
             false,
@@ -18,7 +18,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     OPTION_VALIDATION_FAILED(
             "API-02",
-            "Option item validation failed",
+            "Option item validate failed",
             FluxErrorCategory.VALIDATION,
             FluxErrorPhase.OPTION_VALIDATION,
             false,
@@ -26,7 +26,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     CATALOG_INITIALIZE_FAILED(
             "API-03",
-            "Catalog initialization failed",
+            "Catalog initialize failed",
             FluxErrorCategory.DISCOVERY,
             FluxErrorPhase.SOURCE_DISCOVERY,
             true,
@@ -34,7 +34,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     DATABASE_NOT_EXISTED(
             "API-04",
-            "Database does not exist",
+            "Database not existed",
             FluxErrorCategory.VALIDATION,
             FluxErrorPhase.SOURCE_DISCOVERY,
             false,
@@ -42,7 +42,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     TABLE_NOT_EXISTED(
             "API-05",
-            "Table does not exist",
+            "Table not existed",
             FluxErrorCategory.VALIDATION,
             FluxErrorPhase.SOURCE_DISCOVERY,
             false,
@@ -50,7 +50,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     FACTORY_INITIALIZE_FAILED(
             "API-06",
-            "Factory initialization failed",
+            "Factory initialize failed",
             FluxErrorCategory.DISCOVERY,
             FluxErrorPhase.CONNECTOR_RESOLUTION,
             false,
@@ -58,7 +58,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     DATABASE_ALREADY_EXISTED(
             "API-07",
-            "Database already exists",
+            "Database already existed",
             FluxErrorCategory.VALIDATION,
             FluxErrorPhase.SINK_PREPARATION,
             false,
@@ -66,7 +66,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     TABLE_ALREADY_EXISTED(
             "API-08",
-            "Table already exists",
+            "Table already existed",
             FluxErrorCategory.VALIDATION,
             FluxErrorPhase.SINK_PREPARATION,
             false,
@@ -74,7 +74,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     HANDLE_SAVE_MODE_FAILED(
             "API-09",
-            "Save-mode handling failed",
+            "Handle save mode failed",
             FluxErrorCategory.PREPARATION,
             FluxErrorPhase.SINK_PREPARATION,
             false,
@@ -90,7 +90,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     SINK_TABLE_NOT_EXIST(
             "API-11",
-            "The Sink table does not exist",
+            "The sink table not exist",
             FluxErrorCategory.VALIDATION,
             FluxErrorPhase.SINK_PREPARATION,
             false,
@@ -98,7 +98,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     LIST_DATABASES_FAILED(
             "API-12",
-            "Listing databases failed",
+            "List databases failed",
             FluxErrorCategory.DISCOVERY,
             FluxErrorPhase.SOURCE_DISCOVERY,
             true,
@@ -106,7 +106,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     LIST_TABLES_FAILED(
             "API-13",
-            "Listing tables failed",
+            "List tables failed",
             FluxErrorCategory.DISCOVERY,
             FluxErrorPhase.SOURCE_DISCOVERY,
             true,
@@ -114,7 +114,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     GET_PRIMARY_KEY_FAILED(
             "API-14",
-            "Reading primary-key metadata failed",
+            "Get primary key failed",
             FluxErrorCategory.DISCOVERY,
             FluxErrorPhase.SOURCE_DISCOVERY,
             true,
@@ -122,7 +122,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     METADATA_PROVIDER_INITIALIZE_FAILED(
             "API-15",
-            "Metadata provider initialization failed",
+            "MetaData provider initialize failed",
             FluxErrorCategory.DISCOVERY,
             FluxErrorPhase.SOURCE_DISCOVERY,
             true,
@@ -130,7 +130,7 @@ public enum FluxApiErrorCode implements FluxErrorCode {
 
     CONNECTOR_INITIALIZE_FAILED(
             "API-16",
-            "Connector initialization failed",
+            "Connector initialize failed",
             FluxErrorCategory.DISCOVERY,
             FluxErrorPhase.CONNECTOR_RESOLUTION,
             false,

--- a/link-up-api/src/main/java/com/link/up/api/job/JobSpec.java
+++ b/link-up-api/src/main/java/com/link/up/api/job/JobSpec.java
@@ -30,6 +30,7 @@ public final class JobSpec implements Serializable {
     private Connector sink;
     private Runtime runtime = new Runtime();
     private Mapping mapping;
+    private CapabilityRequirements capabilities;
 
     public JobSpec() {
     }
@@ -89,6 +90,16 @@ public final class JobSpec implements Serializable {
 
     public void setMapping(Mapping mapping) {
         this.mapping = mapping;
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public CapabilityRequirements getCapabilities() {
+        return capabilities;
+    }
+
+    public void setCapabilities(
+            CapabilityRequirements capabilities) {
+        this.capabilities = capabilities;
     }
 
     public static final class Connector
@@ -164,6 +175,69 @@ public final class JobSpec implements Serializable {
 
         public void setTarget(String target) {
             this.target = target;
+        }
+    }
+
+    /** Explicit required/preferred Connector capabilities for this Job. */
+    public static final class CapabilityRequirements
+            implements Serializable {
+
+        private Endpoint source = new Endpoint();
+        private Endpoint sink = new Endpoint();
+
+        public CapabilityRequirements() {
+        }
+
+        public Endpoint getSource() {
+            return source;
+        }
+
+        public void setSource(Endpoint source) {
+            this.source = source == null
+                    ? new Endpoint()
+                    : source;
+        }
+
+        public Endpoint getSink() {
+            return sink;
+        }
+
+        public void setSink(Endpoint sink) {
+            this.sink = sink == null
+                    ? new Endpoint()
+                    : sink;
+        }
+    }
+
+    public static final class Endpoint
+            implements Serializable {
+
+        private List<String> required =
+                new ArrayList<String>();
+        private List<String> preferred =
+                new ArrayList<String>();
+
+        public Endpoint() {
+        }
+
+        public List<String> getRequired() {
+            return required;
+        }
+
+        public void setRequired(List<String> required) {
+            this.required = required == null
+                    ? new ArrayList<String>()
+                    : new ArrayList<String>(required);
+        }
+
+        public List<String> getPreferred() {
+            return preferred;
+        }
+
+        public void setPreferred(List<String> preferred) {
+            this.preferred = preferred == null
+                    ? new ArrayList<String>()
+                    : new ArrayList<String>(preferred);
         }
     }
 
@@ -271,8 +345,7 @@ public final class JobSpec implements Serializable {
 
         public void setSinkPartitionStrategy(
                 String sinkPartitionStrategy) {
-            this.sinkPartitionStrategy =
-                    sinkPartitionStrategy;
+            this.sinkPartitionStrategy = sinkPartitionStrategy;
         }
 
         public String getSplitAssignmentMode() {
@@ -281,8 +354,7 @@ public final class JobSpec implements Serializable {
 
         public void setSplitAssignmentMode(
                 String splitAssignmentMode) {
-            this.splitAssignmentMode =
-                    splitAssignmentMode;
+            this.splitAssignmentMode = splitAssignmentMode;
         }
     }
 }

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/sink/DorisSinkFactory.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/sink/DorisSinkFactory.java
@@ -35,7 +35,8 @@ public final class DorisSinkFactory implements SinkFactory {
         return Collections.unmodifiableSet(
                 EnumSet.of(
                         ConnectorCapability.AUTO_CREATE_TABLE,
-                        ConnectorCapability.UPSERT));
+                        ConnectorCapability.UPSERT,
+                        ConnectorCapability.TWO_PHASE_COMMIT));
     }
 
     @Override
@@ -64,11 +65,9 @@ public final class DorisSinkFactory implements SinkFactory {
                         DorisSinkOptions.DORIS_CONFIG,
                         DorisSinkOptions.CONNECT_TIMEOUT_MS,
                         DorisSinkOptions.SOCKET_TIMEOUT_MS,
-                        // 建表配置
                         DorisSinkOptions.SINK_CREATE_TABLE_DDL,
                         DorisSinkOptions.SINK_KEY_TYPE,
                         DorisSinkOptions.SINK_BUCKETS,
-                        // Stream Load 扩展参数
                         DorisSinkOptions.SINK_LOAD_TIMEOUT_SEC,
                         DorisSinkOptions.SINK_MAX_FILTER_RATIO,
                         DorisSinkOptions.SINK_COLUMNS,
@@ -96,7 +95,8 @@ public final class DorisSinkFactory implements SinkFactory {
 
     @Override
     public SinkPreparer createPreparer(ReadonlyConfig config) {
-        return new DorisSinkPreparer(DorisSinkConfig.of(config));
+        return new DorisSinkPreparer(
+                DorisSinkConfig.of(config));
     }
 
     @Override

--- a/link-up-framework/src/main/java/com/link/up/framework/connector/ConnectorPreparer.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/connector/ConnectorPreparer.java
@@ -1,6 +1,7 @@
 package com.link.up.framework.connector;
 
 import com.link.up.api.configuration.util.ConfigValidator;
+import com.link.up.api.connector.schema.ConnectorCapability;
 import com.link.up.api.factory.SinkFactory;
 import com.link.up.api.sink.PreparedSinkMetadata;
 import com.link.up.api.sink.SinkPrepareContext;
@@ -18,10 +19,13 @@ import com.link.up.framework.job.SourceDefinition;
 import com.link.up.framework.mapping.ColumnMappingPlanner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /** Resolves, validates and prepares connector participation in one Job. */
 public final class ConnectorPreparer {
@@ -50,8 +54,56 @@ public final class ConnectorPreparer {
                 definition,
                 "definition must not be null");
 
-        validateSource(job.getSource());
-        validateSink(job.getSink());
+        validateSourceOptions(job.getSource());
+        validateSinkOptions(job.getSink());
+    }
+
+    public void validateSourceOptions(
+            SourceDefinition definition) {
+
+        SourceDefinition source = Objects.requireNonNull(
+                definition,
+                "source definition must not be null");
+        TableSourceFactory<?> factory =
+                registry.getSourceFactory(source.getType());
+        ConfigValidator.of(source.getOptions())
+                .validate(factory.optionRule());
+    }
+
+    public void validateSinkOptions(
+            SinkDefinition definition) {
+
+        SinkDefinition sink = Objects.requireNonNull(
+                definition,
+                "sink definition must not be null");
+        SinkFactory factory =
+                registry.getSinkFactory(sink.getType());
+        ConfigValidator.of(sink.getOptions())
+                .validate(factory.optionRule());
+    }
+
+    /** Returns a defensive Source capability snapshot without creating it. */
+    public Set<ConnectorCapability> sourceCapabilities(
+            String connectorId) {
+
+        TableSourceFactory<?> factory =
+                registry.getSourceFactory(connectorId);
+        return capabilities(
+                factory.capabilities(),
+                connectorId,
+                "source");
+    }
+
+    /** Returns a defensive Sink capability snapshot without creating it. */
+    public Set<ConnectorCapability> sinkCapabilities(
+            String connectorId) {
+
+        SinkFactory factory =
+                registry.getSinkFactory(connectorId);
+        return capabilities(
+                factory.capabilities(),
+                connectorId,
+                "sink");
     }
 
     /** Formal runtime preparation. Existing execution semantics remain here. */
@@ -61,12 +113,42 @@ public final class ConnectorPreparer {
         JobDefinition job = Objects.requireNonNull(
                 definition,
                 "definition must not be null");
+        PreparedSource<?> source = prepareSource(job);
+        return prepare(job, source);
+    }
+
+    /**
+     * Creates and discovers the Source before any Sink preparation occurs.
+     * This boundary allows capability negotiation to reject unsafe multi-table
+     * combinations before target-side DDL or cleanup can run.
+     */
+    public PreparedSource<?> prepareSource(
+            JobDefinition definition)
+            throws Exception {
+
+        JobDefinition job = Objects.requireNonNull(
+                definition,
+                "definition must not be null");
         PreparedSource<?> source = prepareSource(
                 job.getSource(),
                 job.getExecutionConfig().getSourceParallelism());
-        source = applyColumnMapping(
+        return applyColumnMapping(
                 source,
                 job.getColumnMapping());
+    }
+
+    /** Completes formal Sink preparation for an already prepared Source. */
+    public PreparedJob prepare(
+            JobDefinition definition,
+            PreparedSource<?> preparedSource)
+            throws Exception {
+
+        JobDefinition job = Objects.requireNonNull(
+                definition,
+                "definition must not be null");
+        PreparedSource<?> source = Objects.requireNonNull(
+                preparedSource,
+                "preparedSource must not be null");
 
         Map<String, List<PreparedSink>> sinks = prepareSinks(
                 job.getSink(),
@@ -88,18 +170,29 @@ public final class ConnectorPreparer {
      * validated, but {@code SinkPreparer} is never invoked because it may create,
      * truncate or otherwise mutate target tables.</p>
      */
-    public PreparedJob prepareForExplain(JobDefinition definition)
+    public PreparedJob prepareForExplain(
+            JobDefinition definition)
             throws Exception {
 
         JobDefinition job = Objects.requireNonNull(
                 definition,
                 "definition must not be null");
-        PreparedSource<?> source = prepareSource(
-                job.getSource(),
-                job.getExecutionConfig().getSourceParallelism());
-        source = applyColumnMapping(
-                source,
-                job.getColumnMapping());
+        return prepareForExplain(
+                job,
+                prepareSource(job));
+    }
+
+    /** Builds Explain-only Sink stubs for an already prepared Source. */
+    public PreparedJob prepareForExplain(
+            JobDefinition definition,
+            PreparedSource<?> preparedSource) {
+
+        JobDefinition job = Objects.requireNonNull(
+                definition,
+                "definition must not be null");
+        PreparedSource<?> source = Objects.requireNonNull(
+                preparedSource,
+                "preparedSource must not be null");
 
         Map<String, List<PreparedSink>> sinks = prepareExplainSinks(
                 job.getSink(),
@@ -111,20 +204,6 @@ public final class ConnectorPreparer {
                 source,
                 sinks,
                 job.getExecutionConfig());
-    }
-
-    private void validateSource(SourceDefinition definition) {
-        TableSourceFactory<?> factory = registry.getSourceFactory(
-                definition.getType());
-        ConfigValidator.of(definition.getOptions())
-                .validate(factory.optionRule());
-    }
-
-    private void validateSink(SinkDefinition definition) {
-        SinkFactory factory = registry.getSinkFactory(
-                definition.getType());
-        ConfigValidator.of(definition.getOptions())
-                .validate(factory.optionRule());
     }
 
     private <SplitT extends SourceSplit> PreparedSource<SplitT>
@@ -151,8 +230,8 @@ public final class ConnectorPreparer {
             int sourceParallelism)
             throws Exception {
 
-        TableSourceFactory<?> factory = registry.getSourceFactory(
-                definition.getType());
+        TableSourceFactory<?> factory =
+                registry.getSourceFactory(definition.getType());
         ConfigValidator.of(definition.getOptions())
                 .validate(factory.optionRule());
 
@@ -210,8 +289,8 @@ public final class ConnectorPreparer {
             Map<TablePath, CatalogTable> sourceTables)
             throws Exception {
 
-        SinkFactory factory = registry.getSinkFactory(
-                definition.getType());
+        SinkFactory factory =
+                registry.getSinkFactory(definition.getType());
         ConfigValidator.of(definition.getOptions())
                 .validate(factory.optionRule());
 
@@ -259,8 +338,8 @@ public final class ConnectorPreparer {
             int parallelism,
             Map<TablePath, CatalogTable> sourceTables) {
 
-        SinkFactory factory = registry.getSinkFactory(
-                definition.getType());
+        SinkFactory factory =
+                registry.getSinkFactory(definition.getType());
         ConfigValidator.of(definition.getOptions())
                 .validate(factory.optionRule());
 
@@ -376,5 +455,31 @@ public final class ConnectorPreparer {
         }
 
         return result;
+    }
+
+    private Set<ConnectorCapability> capabilities(
+            Set<ConnectorCapability> values,
+            String connectorId,
+            String role) {
+
+        if (values == null) {
+            throw new ConnectorException(
+                    role
+                            + " factory '"
+                            + connectorId
+                            + "' returned null capabilities");
+        }
+
+        Set<ConnectorCapability> copy =
+                new LinkedHashSet<ConnectorCapability>();
+
+        for (ConnectorCapability capability : values) {
+            copy.add(
+                    Objects.requireNonNull(
+                            capability,
+                            "capabilities must not contain null"));
+        }
+
+        return Collections.unmodifiableSet(copy);
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/LocalFluxEngine.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/LocalFluxEngine.java
@@ -3,10 +3,13 @@ package com.link.up.framework.execution;
 import com.link.up.framework.connector.ConnectorPreparer;
 import com.link.up.framework.connector.FactoryRegistry;
 import com.link.up.framework.connector.PreparedJob;
+import com.link.up.framework.connector.PreparedSource;
 import com.link.up.framework.job.JobDefinition;
 import com.link.up.framework.job.JobResult;
 import com.link.up.framework.planner.JobGraph;
 import com.link.up.framework.planner.JobPlanner;
+import com.link.up.framework.planning.CapabilityNegotiation;
+import com.link.up.framework.planning.CapabilityNegotiator;
 import org.apache.logging.log4j.CloseableThreadContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,6 +27,7 @@ public final class LocalFluxEngine
     private final ClassLoader classLoader;
     private final ConnectorPreparer connectorPreparer;
     private final JobPlanner jobPlanner;
+    private final CapabilityNegotiator capabilityNegotiator;
     private final FactoryRegistry registry;
 
     public LocalFluxEngine(
@@ -53,6 +57,9 @@ public final class LocalFluxEngine
         this.jobPlanner = Objects.requireNonNull(
                 jobPlanner,
                 "jobPlanner must not be null");
+        this.capabilityNegotiator =
+                new CapabilityNegotiator(
+                        this.connectorPreparer);
         this.registry = registry;
     }
 
@@ -91,7 +98,7 @@ public final class LocalFluxEngine
     }
 
     /**
-     * Executes one prepared job and exposes the active execution to an optional
+     * Executes one prepared Job and exposes the active execution to an optional
      * listener used by the local Worker control plane.
      */
     public JobResult execute(
@@ -105,14 +112,12 @@ public final class LocalFluxEngine
 
         long logIdentityTimeMillis =
                 System.currentTimeMillis();
-        String runId =
-                JobLogFileName.createJobId(
-                        job.getName(),
-                        logIdentityTimeMillis);
-        String jobLogFile =
-                JobLogFileName.create(
-                        job.getName(),
-                        logIdentityTimeMillis);
+        String runId = JobLogFileName.createJobId(
+                job.getName(),
+                logIdentityTimeMillis);
+        String jobLogFile = JobLogFileName.create(
+                job.getName(),
+                logIdentityTimeMillis);
 
         try (CloseableThreadContext.Instance ignored =
                      openLogContext(
@@ -125,18 +130,16 @@ public final class LocalFluxEngine
                     runId,
                     jobLogFile);
 
-            JobGraph jobGraph =
-                    prepareAndPlan(
-                            job,
-                            runId);
+            JobGraph jobGraph = prepareAndPlan(
+                    job,
+                    runId);
 
-            JobExecution execution =
-                    new JobExecution(
-                            jobGraph,
-                            classLoader,
-                            System.currentTimeMillis(),
-                            runId,
-                            jobLogFile);
+            JobExecution execution = new JobExecution(
+                    jobGraph,
+                    classLoader,
+                    System.currentTimeMillis(),
+                    runId,
+                    jobLogFile);
 
             notifyJobExecutionCreated(
                     listener,
@@ -165,11 +168,34 @@ public final class LocalFluxEngine
                 runId);
 
         try {
+            CapabilityNegotiation initial =
+                    capabilityNegotiator.negotiate(
+                            definition);
+            capabilityNegotiator.requireSatisfied(initial);
+
+            PreparedSource<?> preparedSource =
+                    connectorPreparer.prepareSource(
+                            definition);
+            CapabilityNegotiation prepared =
+                    capabilityNegotiator.negotiate(
+                            definition,
+                            preparedSource);
+            capabilityNegotiator.requireSatisfied(prepared);
+
             PreparedJob preparedJob =
                     connectorPreparer.prepare(
-                            definition);
+                            definition,
+                            preparedSource);
+            JobGraph jobGraph =
+                    jobPlanner.plan(preparedJob);
 
-            return jobPlanner.plan(preparedJob);
+            CapabilityNegotiation physical =
+                    capabilityNegotiator.negotiate(
+                            definition,
+                            jobGraph);
+            capabilityNegotiator.requireSatisfied(physical);
+
+            return jobGraph;
 
         } catch (Exception failure) {
             LOG.error(
@@ -207,7 +233,7 @@ public final class LocalFluxEngine
 
         return classLoader == null
                 ? Thread.currentThread()
-                .getContextClassLoader()
+                        .getContextClassLoader()
                 : classLoader;
     }
 

--- a/link-up-framework/src/main/java/com/link/up/framework/execution/LocalFluxEngine.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/execution/LocalFluxEngine.java
@@ -1,5 +1,6 @@
 package com.link.up.framework.execution;
 
+import com.link.up.api.exception.FluxRuntimeException;
 import com.link.up.framework.connector.ConnectorPreparer;
 import com.link.up.framework.connector.FactoryRegistry;
 import com.link.up.framework.connector.PreparedJob;
@@ -10,6 +11,7 @@ import com.link.up.framework.planner.JobGraph;
 import com.link.up.framework.planner.JobPlanner;
 import com.link.up.framework.planning.CapabilityNegotiation;
 import com.link.up.framework.planning.CapabilityNegotiator;
+import com.link.up.framework.planning.PlanningException;
 import org.apache.logging.log4j.CloseableThreadContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -174,20 +176,19 @@ public final class LocalFluxEngine
             capabilityNegotiator.requireSatisfied(initial);
 
             PreparedSource<?> preparedSource =
-                    connectorPreparer.prepareSource(
-                            definition);
+                    prepareSource(definition);
             CapabilityNegotiation prepared =
                     capabilityNegotiator.negotiate(
                             definition,
                             preparedSource);
             capabilityNegotiator.requireSatisfied(prepared);
 
-            PreparedJob preparedJob =
-                    connectorPreparer.prepare(
-                            definition,
-                            preparedSource);
-            JobGraph jobGraph =
-                    jobPlanner.plan(preparedJob);
+            PreparedJob preparedJob = prepareSink(
+                    definition,
+                    preparedSource);
+            JobGraph jobGraph = plan(
+                    definition,
+                    preparedJob);
 
             CapabilityNegotiation physical =
                     capabilityNegotiator.negotiate(
@@ -212,6 +213,59 @@ public final class LocalFluxEngine
                     runId,
                     failure);
             throw failure;
+        }
+    }
+
+    private PreparedSource<?> prepareSource(
+            JobDefinition definition)
+            throws Exception {
+
+        try {
+            return connectorPreparer.prepareSource(
+                    definition);
+        } catch (FluxRuntimeException failure) {
+            throw failure;
+        } catch (Exception failure) {
+            throw PlanningException.sourcePreparationFailed(
+                    definition.getSource().getType(),
+                    failure);
+        }
+    }
+
+    private PreparedJob prepareSink(
+            JobDefinition definition,
+            PreparedSource<?> preparedSource)
+            throws Exception {
+
+        try {
+            return connectorPreparer.prepare(
+                    definition,
+                    preparedSource);
+        } catch (FluxRuntimeException failure) {
+            throw failure;
+        } catch (Exception failure) {
+            throw PlanningException.sinkPreparationFailed(
+                    definition.getSink().getType(),
+                    failure);
+        }
+    }
+
+    private JobGraph plan(
+            JobDefinition definition,
+            PreparedJob preparedJob)
+            throws Exception {
+
+        try {
+            return jobPlanner.plan(preparedJob);
+        } catch (FluxRuntimeException failure) {
+            throw failure;
+        } catch (RuntimeException failure) {
+            throw PlanningException.physicalPlanningFailed(
+                    failure);
+        } catch (Exception failure) {
+            throw PlanningException.splitDiscoveryFailed(
+                    definition.getSource().getType(),
+                    failure);
         }
     }
 

--- a/link-up-framework/src/main/java/com/link/up/framework/job/JobCapabilityRequirements.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/JobCapabilityRequirements.java
@@ -1,0 +1,111 @@
+package com.link.up.framework.job;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
+
+/** Immutable required/preferred capability intent for Source and Sink. */
+public final class JobCapabilityRequirements {
+
+    private static final JobCapabilityRequirements EMPTY =
+            new JobCapabilityRequirements(
+                    Collections.<ConnectorCapability>emptySet(),
+                    Collections.<ConnectorCapability>emptySet(),
+                    Collections.<ConnectorCapability>emptySet(),
+                    Collections.<ConnectorCapability>emptySet());
+
+    private final Set<ConnectorCapability> sourceRequired;
+    private final Set<ConnectorCapability> sourcePreferred;
+    private final Set<ConnectorCapability> sinkRequired;
+    private final Set<ConnectorCapability> sinkPreferred;
+
+    public JobCapabilityRequirements(
+            Collection<ConnectorCapability> sourceRequired,
+            Collection<ConnectorCapability> sourcePreferred,
+            Collection<ConnectorCapability> sinkRequired,
+            Collection<ConnectorCapability> sinkPreferred) {
+
+        this.sourceRequired = immutable(sourceRequired);
+        this.sourcePreferred = immutable(sourcePreferred);
+        this.sinkRequired = immutable(sinkRequired);
+        this.sinkPreferred = immutable(sinkPreferred);
+
+        requireDisjoint(
+                this.sourceRequired,
+                this.sourcePreferred,
+                "source");
+        requireDisjoint(
+                this.sinkRequired,
+                this.sinkPreferred,
+                "sink");
+    }
+
+    public static JobCapabilityRequirements empty() {
+        return EMPTY;
+    }
+
+    public boolean isEmpty() {
+        return sourceRequired.isEmpty()
+                && sourcePreferred.isEmpty()
+                && sinkRequired.isEmpty()
+                && sinkPreferred.isEmpty();
+    }
+
+    public Set<ConnectorCapability> getSourceRequired() {
+        return sourceRequired;
+    }
+
+    public Set<ConnectorCapability> getSourcePreferred() {
+        return sourcePreferred;
+    }
+
+    public Set<ConnectorCapability> getSinkRequired() {
+        return sinkRequired;
+    }
+
+    public Set<ConnectorCapability> getSinkPreferred() {
+        return sinkPreferred;
+    }
+
+    private static Set<ConnectorCapability> immutable(
+            Collection<ConnectorCapability> values) {
+
+        if (values == null || values.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        EnumSet<ConnectorCapability> copy =
+                EnumSet.noneOf(ConnectorCapability.class);
+
+        for (ConnectorCapability value : values) {
+            if (value == null) {
+                throw new IllegalArgumentException(
+                        "capability collections must not contain null");
+            }
+            copy.add(value);
+        }
+
+        return Collections.unmodifiableSet(copy);
+    }
+
+    private static void requireDisjoint(
+            Set<ConnectorCapability> required,
+            Set<ConnectorCapability> preferred,
+            String role) {
+
+        EnumSet<ConnectorCapability> overlap =
+                EnumSet.noneOf(ConnectorCapability.class);
+        overlap.addAll(required);
+        overlap.retainAll(preferred);
+
+        if (!overlap.isEmpty()) {
+            throw new IllegalArgumentException(
+                    role
+                            + " capabilities must not be both required and preferred: "
+                            + overlap);
+        }
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/job/JobConfigParser.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/JobConfigParser.java
@@ -1,17 +1,217 @@
 package com.link.up.framework.job;
 
 import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.connector.schema.ConnectorCapability;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigResolveOptions;
 
-/**
- * HOCON Job 配置解析器。
- */
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+/** Parses the legacy HOCON Job protocol into a normalized JobDefinition. */
 public final class JobConfigParser {
 
-    private static long readOptionalLong(Config root, String path) {
-        return root.hasPath(path) ? root.getLong(path) : -1L;
+    public JobDefinition parse(String hocon) {
+        if (hocon == null || hocon.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "HOCON configuration must not be blank");
+        }
+
+        /*
+         * Connector 中的 ${schema_name}、${table_name}
+         * 属于 Connector 占位符，不应该由 HOCON 提前解析。
+         */
+        Config root = ConfigFactory.parseString(hocon)
+                .resolve(
+                        ConfigResolveOptions.defaults()
+                                .setAllowUnresolved(true));
+
+        requireObject(root, "source");
+        requireObject(root, "sink");
+
+        Config sourceConfig = root.getConfig("source");
+        Config sinkConfig = root.getConfig("sink");
+
+        String jobName = root.hasPath("job.name")
+                ? root.getString("job.name")
+                : "local-sync";
+        String sourceType = requireString(
+                sourceConfig,
+                "type",
+                "source.type");
+        String sinkType = requireString(
+                sinkConfig,
+                "type",
+                "sink.type");
+
+        int batchSize = sourceConfig.hasPath("batch-size")
+                ? sourceConfig.getInt("batch-size")
+                : ExecutionConfig.DEFAULT_BATCH_SIZE;
+        int sourceParallelism =
+                readSourceParallelism(root);
+        int sinkParallelism =
+                root.hasPath("env.sink-parallelism")
+                        ? root.getInt("env.sink-parallelism")
+                        : ExecutionConfig.DEFAULT_SINK_PARALLELISM;
+        int pipelineParallelism =
+                root.hasPath("env.pipeline-parallelism")
+                        ? root.getInt("env.pipeline-parallelism")
+                        : ExecutionConfig.DEFAULT_PIPELINE_PARALLELISM;
+        int channelCapacity =
+                root.hasPath("env.max-buffered-batches")
+                        ? root.getInt("env.max-buffered-batches")
+                        : root.hasPath("env.channel-capacity")
+                        ? root.getInt("env.channel-capacity")
+                        : ExecutionConfig.DEFAULT_CHANNEL_CAPACITY;
+
+        long maxBufferedRecords =
+                readOptionalLong(
+                        root,
+                        "env.max-buffered-records");
+        long maxBufferedBytes =
+                readOptionalLong(
+                        root,
+                        "env.max-buffered-bytes");
+        long maxRecordsPerSecond =
+                readOptionalLong(
+                        root,
+                        "env.max-records-per-second");
+        long maxBytesPerSecond =
+                readOptionalLong(
+                        root,
+                        "env.max-bytes-per-second");
+
+        Config sourceConnectorConfig = sourceConfig
+                .withoutPath("type")
+                .withoutPath("batch-size");
+        Config sinkConnectorConfig =
+                sinkConfig.withoutPath("type");
+
+        SourceDefinition source = new SourceDefinition(
+                sourceType,
+                ReadonlyConfig.fromConfig(
+                        sourceConnectorConfig));
+        SinkDefinition sink = new SinkDefinition(
+                sinkType,
+                ReadonlyConfig.fromConfig(
+                        sinkConnectorConfig));
+
+        SinkPartitionStrategy sinkPartitionStrategy =
+                root.hasPath("env.sink-partition-strategy")
+                        ? SinkPartitionStrategy.valueOf(
+                                root.getString(
+                                                "env.sink-partition-strategy")
+                                        .trim()
+                                        .toUpperCase(Locale.ROOT))
+                        : SinkPartitionStrategy.TABLE_AFFINITY;
+        SplitAssignmentMode splitAssignmentMode =
+                root.hasPath("env.split-assignment-mode")
+                        ? SplitAssignmentMode.valueOf(
+                                root.getString(
+                                                "env.split-assignment-mode")
+                                        .trim()
+                                        .toUpperCase(Locale.ROOT))
+                        : SplitAssignmentMode.STATIC_ROUND_ROBIN;
+
+        ExecutionConfig executionConfig = new ExecutionConfig(
+                batchSize,
+                sourceParallelism,
+                sinkParallelism,
+                pipelineParallelism,
+                channelCapacity,
+                maxBufferedRecords,
+                maxBufferedBytes,
+                maxRecordsPerSecond,
+                maxBytesPerSecond,
+                sinkPartitionStrategy,
+                splitAssignmentMode);
+
+        JobCapabilityRequirements capabilities =
+                new JobCapabilityRequirements(
+                        readCapabilities(
+                                root,
+                                "capabilities.source.required"),
+                        readCapabilities(
+                                root,
+                                "capabilities.source.preferred"),
+                        readCapabilities(
+                                root,
+                                "capabilities.sink.required"),
+                        readCapabilities(
+                                root,
+                                "capabilities.sink.preferred"));
+
+        return new JobDefinition(
+                jobName,
+                source,
+                sink,
+                executionConfig,
+                ColumnMapping.empty(),
+                capabilities);
+    }
+
+    private Set<ConnectorCapability> readCapabilities(
+            Config root,
+            String path) {
+
+        EnumSet<ConnectorCapability> result =
+                EnumSet.noneOf(ConnectorCapability.class);
+
+        if (!root.hasPath(path)) {
+            return result;
+        }
+
+        List<String> values = root.getStringList(path);
+        for (String value : values) {
+            if (value == null || value.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                        path + " must not contain blank values");
+            }
+
+            final ConnectorCapability capability;
+            try {
+                capability = ConnectorCapability.valueOf(
+                        value.trim().toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException failure) {
+                throw new IllegalArgumentException(
+                        "Unknown "
+                                + path
+                                + " capability: "
+                                + value,
+                        failure);
+            }
+
+            if (!result.add(capability)) {
+                throw new IllegalArgumentException(
+                        "Duplicate "
+                                + path
+                                + " capability: "
+                                + capability.name());
+            }
+        }
+
+        return result;
+    }
+
+    private int readSourceParallelism(Config root) {
+        if (root.hasPath("env.source-parallelism")) {
+            return root.getInt("env.source-parallelism");
+        }
+        if (root.hasPath("env.parallelism")) {
+            return root.getInt("env.parallelism");
+        }
+        return ExecutionConfig.DEFAULT_SOURCE_PARALLELISM;
+    }
+
+    private static long readOptionalLong(
+            Config root,
+            String path) {
+        return root.hasPath(path)
+                ? root.getLong(path)
+                : -1L;
     }
 
     private static void requireObject(
@@ -38,134 +238,11 @@ public final class JobConfigParser {
                             + "'");
         }
 
-        String value =
-                config.getString(path).trim();
-
+        String value = config.getString(path).trim();
         if (value.isEmpty()) {
             throw new IllegalArgumentException(
                     fullPath + " must not be blank");
         }
-
         return value;
-    }
-
-    public JobDefinition parse(String hocon) {
-        if (hocon == null || hocon.trim().isEmpty()) {
-            throw new IllegalArgumentException(
-                    "HOCON configuration must not be blank");
-        }
-
-        /*
-         * Connector 中的 ${schema_name}、${table_name}
-         * 属于 Connector 占位符，不应该由 HOCON 提前解析。
-         */
-        Config root =
-                ConfigFactory.parseString(hocon)
-                        .resolve(
-                                ConfigResolveOptions.defaults()
-                                        .setAllowUnresolved(true));
-
-        requireObject(root, "source");
-        requireObject(root, "sink");
-
-        Config sourceConfig =
-                root.getConfig("source");
-
-        Config sinkConfig =
-                root.getConfig("sink");
-
-        String jobName =
-                root.hasPath("job.name")
-                        ? root.getString("job.name")
-                        : "local-sync";
-
-        String sourceType =
-                requireString(
-                        sourceConfig,
-                        "type",
-                        "source.type");
-
-        String sinkType =
-                requireString(
-                        sinkConfig,
-                        "type",
-                        "sink.type");
-
-        int batchSize =
-                sourceConfig.hasPath("batch-size")
-                        ? sourceConfig.getInt("batch-size")
-                        : ExecutionConfig.DEFAULT_BATCH_SIZE;
-
-        int sourceParallelism =
-                readSourceParallelism(root);
-
-        int sinkParallelism =
-                root.hasPath("env.sink-parallelism")
-                        ? root.getInt("env.sink-parallelism")
-                        : ExecutionConfig.DEFAULT_SINK_PARALLELISM;
-
-        int pipelineParallelism = root.hasPath("env.pipeline-parallelism") ? root.getInt("env.pipeline-parallelism") : ExecutionConfig.DEFAULT_PIPELINE_PARALLELISM;
-
-        int channelCapacity = root.hasPath("env.max-buffered-batches") ? root.getInt("env.max-buffered-batches")
-                : root.hasPath("env.channel-capacity") ? root.getInt("env.channel-capacity") : ExecutionConfig.DEFAULT_CHANNEL_CAPACITY;
-        long maxBufferedRecords = readOptionalLong(root, "env.max-buffered-records");
-        long maxBufferedBytes = readOptionalLong(root, "env.max-buffered-bytes");
-        long maxRecordsPerSecond = readOptionalLong(root, "env.max-records-per-second");
-        long maxBytesPerSecond = readOptionalLong(root, "env.max-bytes-per-second");
-
-        Config sourceConnectorConfig =
-                sourceConfig
-                        .withoutPath("type")
-                        .withoutPath("batch-size");
-
-        Config sinkConnectorConfig =
-                sinkConfig.withoutPath("type");
-
-        SourceDefinition source =
-                new SourceDefinition(
-                        sourceType,
-                        ReadonlyConfig.fromConfig(
-                                sourceConnectorConfig));
-
-        SinkDefinition sink =
-                new SinkDefinition(
-                        sinkType,
-                        ReadonlyConfig.fromConfig(
-                                sinkConnectorConfig));
-
-        SinkPartitionStrategy sinkPartitionStrategy = root.hasPath("env.sink-partition-strategy")
-                ? SinkPartitionStrategy.valueOf(root.getString("env.sink-partition-strategy").trim().toUpperCase(java.util.Locale.ROOT))
-                : SinkPartitionStrategy.TABLE_AFFINITY;
-
-        SplitAssignmentMode splitAssignmentMode = root.hasPath("env.split-assignment-mode")
-                ? SplitAssignmentMode.valueOf(root.getString("env.split-assignment-mode").trim().toUpperCase(java.util.Locale.ROOT))
-                : SplitAssignmentMode.STATIC_ROUND_ROBIN;
-
-        ExecutionConfig executionConfig = new ExecutionConfig(batchSize, sourceParallelism, sinkParallelism, pipelineParallelism,
-                channelCapacity, maxBufferedRecords, maxBufferedBytes, maxRecordsPerSecond, maxBytesPerSecond,
-                sinkPartitionStrategy, splitAssignmentMode);
-
-        return new JobDefinition(
-                jobName,
-                source,
-                sink,
-                executionConfig);
-    }
-
-    private int readSourceParallelism(Config root) {
-        if (root.hasPath("env.source-parallelism")) {
-            return root.getInt(
-                    "env.source-parallelism");
-        }
-
-        /*
-         * 兼容旧配置 env.parallelism。
-         */
-        if (root.hasPath("env.parallelism")) {
-            return root.getInt(
-                    "env.parallelism");
-        }
-
-        return ExecutionConfig.DEFAULT_SOURCE_PARALLELISM;
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/job/JobDefinition.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/JobDefinition.java
@@ -2,27 +2,29 @@ package com.link.up.framework.job;
 
 import java.util.Objects;
 
-/**
- * 用户提交的同步任务定义。
- */
+/** User-submitted, normalized synchronization Job definition. */
 public final class JobDefinition {
 
     private final String name;
-
     private final SourceDefinition source;
-
     private final SinkDefinition sink;
-
     private final ExecutionConfig executionConfig;
-
     private final ColumnMapping columnMapping;
+    private final JobCapabilityRequirements capabilityRequirements;
 
     public JobDefinition(
             String name,
             SourceDefinition source,
             SinkDefinition sink,
             ExecutionConfig executionConfig) {
-        this(name, source, sink, executionConfig, ColumnMapping.empty());
+
+        this(
+                name,
+                source,
+                sink,
+                executionConfig,
+                ColumnMapping.empty(),
+                JobCapabilityRequirements.empty());
     }
 
     public JobDefinition(
@@ -32,27 +34,40 @@ public final class JobDefinition {
             ExecutionConfig executionConfig,
             ColumnMapping columnMapping) {
 
+        this(
+                name,
+                source,
+                sink,
+                executionConfig,
+                columnMapping,
+                JobCapabilityRequirements.empty());
+    }
+
+    public JobDefinition(
+            String name,
+            SourceDefinition source,
+            SinkDefinition sink,
+            ExecutionConfig executionConfig,
+            ColumnMapping columnMapping,
+            JobCapabilityRequirements capabilityRequirements) {
+
         this.name = requireName(name);
-
-        this.source =
-                Objects.requireNonNull(
-                        source,
-                        "source must not be null");
-
-        this.sink =
-                Objects.requireNonNull(
-                        sink,
-                        "sink must not be null");
-
-        this.executionConfig =
-                Objects.requireNonNull(
-                        executionConfig,
-                        "executionConfig must not be null");
-
-        this.columnMapping =
-                columnMapping == null
-                        ? ColumnMapping.empty()
-                        : columnMapping;
+        this.source = Objects.requireNonNull(
+                source,
+                "source must not be null");
+        this.sink = Objects.requireNonNull(
+                sink,
+                "sink must not be null");
+        this.executionConfig = Objects.requireNonNull(
+                executionConfig,
+                "executionConfig must not be null");
+        this.columnMapping = columnMapping == null
+                ? ColumnMapping.empty()
+                : columnMapping;
+        this.capabilityRequirements =
+                capabilityRequirements == null
+                        ? JobCapabilityRequirements.empty()
+                        : capabilityRequirements;
     }
 
     private static String requireName(String name) {
@@ -61,12 +76,10 @@ public final class JobDefinition {
                 "name must not be null");
 
         String normalized = name.trim();
-
         if (normalized.isEmpty()) {
             throw new IllegalArgumentException(
                     "name must not be blank");
         }
-
         return normalized;
     }
 
@@ -88,5 +101,9 @@ public final class JobDefinition {
 
     public ColumnMapping getColumnMapping() {
         return columnMapping;
+    }
+
+    public JobCapabilityRequirements getCapabilityRequirements() {
+        return capabilityRequirements;
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/job/JobSpecCompiler.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/job/JobSpecCompiler.java
@@ -1,8 +1,11 @@
 package com.link.up.framework.job;
 
 import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.connector.schema.ConnectorCapability;
 import com.link.up.api.job.JobSpec;
+
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -10,131 +13,301 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-/** Compiles the public structured JobSpec protocol into Link-Up runtime definitions. */
+/** Compiles the public structured JobSpec protocol into runtime definitions. */
 public final class JobSpecCompiler {
 
     public JobDefinition compile(JobSpec spec) {
         if (spec == null) {
-            throw new IllegalArgumentException("jobSpec must not be null");
+            throw new IllegalArgumentException(
+                    "jobSpec must not be null");
         }
-        requireProtocol(spec.getApiVersion(), spec.getKind());
-        JobSpec.Connector sourceSpec = requireConnector(spec.getSource(), "source");
-        JobSpec.Connector sinkSpec = requireConnector(spec.getSink(), "sink");
-        JobSpec.Runtime runtime = spec.getRuntime() == null ? new JobSpec.Runtime() : spec.getRuntime();
+
+        requireProtocol(
+                spec.getApiVersion(),
+                spec.getKind());
+
+        JobSpec.Connector sourceSpec =
+                requireConnector(
+                        spec.getSource(),
+                        "source");
+        JobSpec.Connector sinkSpec =
+                requireConnector(
+                        spec.getSink(),
+                        "sink");
+        JobSpec.Runtime runtime =
+                spec.getRuntime() == null
+                        ? new JobSpec.Runtime()
+                        : spec.getRuntime();
 
         SourceDefinition source = new SourceDefinition(
-                requireText(sourceSpec.getConnectorId(), "source.connectorId"),
-                ReadonlyConfig.fromMap(copy(sourceSpec.getOptions())));
+                requireText(
+                        sourceSpec.getConnectorId(),
+                        "source.connectorId"),
+                ReadonlyConfig.fromMap(
+                        copy(sourceSpec.getOptions())));
         SinkDefinition sink = new SinkDefinition(
-                requireText(sinkSpec.getConnectorId(), "sink.connectorId"),
-                ReadonlyConfig.fromMap(copy(sinkSpec.getOptions())));
+                requireText(
+                        sinkSpec.getConnectorId(),
+                        "sink.connectorId"),
+                ReadonlyConfig.fromMap(
+                        copy(sinkSpec.getOptions())));
 
         ExecutionConfig execution = new ExecutionConfig(
-                positive(runtime.getBatchSize(), ExecutionConfig.DEFAULT_BATCH_SIZE, "runtime.batchSize"),
-                positive(runtime.getSourceParallelism(), ExecutionConfig.DEFAULT_SOURCE_PARALLELISM,
+                positive(
+                        runtime.getBatchSize(),
+                        ExecutionConfig.DEFAULT_BATCH_SIZE,
+                        "runtime.batchSize"),
+                positive(
+                        runtime.getSourceParallelism(),
+                        ExecutionConfig.DEFAULT_SOURCE_PARALLELISM,
                         "runtime.sourceParallelism"),
-                positive(runtime.getSinkParallelism(), ExecutionConfig.DEFAULT_SINK_PARALLELISM,
+                positive(
+                        runtime.getSinkParallelism(),
+                        ExecutionConfig.DEFAULT_SINK_PARALLELISM,
                         "runtime.sinkParallelism"),
-                positive(runtime.getPipelineParallelism(), ExecutionConfig.DEFAULT_PIPELINE_PARALLELISM,
+                positive(
+                        runtime.getPipelineParallelism(),
+                        ExecutionConfig.DEFAULT_PIPELINE_PARALLELISM,
                         "runtime.pipelineParallelism"),
-                positive(runtime.getMaxBufferedBatches(), ExecutionConfig.DEFAULT_CHANNEL_CAPACITY,
+                positive(
+                        runtime.getMaxBufferedBatches(),
+                        ExecutionConfig.DEFAULT_CHANNEL_CAPACITY,
                         "runtime.maxBufferedBatches"),
                 optional(runtime.getMaxBufferedRecords()),
                 optional(runtime.getMaxBufferedBytes()),
                 optional(runtime.getMaxRecordsPerSecond()),
                 optional(runtime.getMaxBytesPerSecond()),
-                enumValue(runtime.getSinkPartitionStrategy(), SinkPartitionStrategy.TABLE_AFFINITY,
-                        SinkPartitionStrategy.class, "runtime.sinkPartitionStrategy"),
-                enumValue(runtime.getSplitAssignmentMode(), SplitAssignmentMode.STATIC_ROUND_ROBIN,
-                        SplitAssignmentMode.class, "runtime.splitAssignmentMode"));
+                enumValue(
+                        runtime.getSinkPartitionStrategy(),
+                        SinkPartitionStrategy.TABLE_AFFINITY,
+                        SinkPartitionStrategy.class,
+                        "runtime.sinkPartitionStrategy"),
+                enumValue(
+                        runtime.getSplitAssignmentMode(),
+                        SplitAssignmentMode.STATIC_ROUND_ROBIN,
+                        SplitAssignmentMode.class,
+                        "runtime.splitAssignmentMode"));
 
         return new JobDefinition(
                 requireText(spec.getName(), "name"),
                 source,
                 sink,
                 execution,
-                compileMapping(spec.getMapping()));
+                compileMapping(spec.getMapping()),
+                compileCapabilities(
+                        spec.getCapabilities()));
     }
 
-    private ColumnMapping compileMapping(JobSpec.Mapping mapping) {
-        if (mapping == null || mapping.getColumns() == null || mapping.getColumns().isEmpty()) {
+    private JobCapabilityRequirements compileCapabilities(
+            JobSpec.CapabilityRequirements requirements) {
+
+        if (requirements == null) {
+            return JobCapabilityRequirements.empty();
+        }
+
+        JobSpec.Endpoint source = requirements.getSource();
+        JobSpec.Endpoint sink = requirements.getSink();
+
+        return new JobCapabilityRequirements(
+                capabilities(
+                        source == null
+                                ? null
+                                : source.getRequired(),
+                        "capabilities.source.required"),
+                capabilities(
+                        source == null
+                                ? null
+                                : source.getPreferred(),
+                        "capabilities.source.preferred"),
+                capabilities(
+                        sink == null
+                                ? null
+                                : sink.getRequired(),
+                        "capabilities.sink.required"),
+                capabilities(
+                        sink == null
+                                ? null
+                                : sink.getPreferred(),
+                        "capabilities.sink.preferred"));
+    }
+
+    private Set<ConnectorCapability> capabilities(
+            List<String> values,
+            String name) {
+
+        EnumSet<ConnectorCapability> result =
+                EnumSet.noneOf(ConnectorCapability.class);
+
+        if (values == null) {
+            return result;
+        }
+
+        for (String value : values) {
+            String normalized = requireText(value, name)
+                    .toUpperCase(Locale.ROOT);
+
+            final ConnectorCapability capability;
+            try {
+                capability = ConnectorCapability.valueOf(
+                        normalized);
+            } catch (IllegalArgumentException failure) {
+                throw new IllegalArgumentException(
+                        "Unknown "
+                                + name
+                                + " capability: "
+                                + normalized,
+                        failure);
+            }
+
+            if (!result.add(capability)) {
+                throw new IllegalArgumentException(
+                        "Duplicate "
+                                + name
+                                + " capability: "
+                                + capability.name());
+            }
+        }
+
+        return result;
+    }
+
+    private ColumnMapping compileMapping(
+            JobSpec.Mapping mapping) {
+
+        if (mapping == null
+                || mapping.getColumns() == null
+                || mapping.getColumns().isEmpty()) {
             return ColumnMapping.empty();
         }
 
-        List<ColumnMapping.Item> items = new ArrayList<ColumnMapping.Item>();
+        List<ColumnMapping.Item> items =
+                new ArrayList<ColumnMapping.Item>();
         Set<String> sources = new HashSet<String>();
         Set<String> targets = new HashSet<String>();
 
         for (JobSpec.Column column : mapping.getColumns()) {
             if (column == null) {
-                throw new IllegalArgumentException("mapping.columns must not contain null items");
+                throw new IllegalArgumentException(
+                        "mapping.columns must not contain null items");
             }
-            ColumnMapping.Item item = new ColumnMapping.Item(column.getSource(), column.getTarget());
+
+            ColumnMapping.Item item =
+                    new ColumnMapping.Item(
+                            column.getSource(),
+                            column.getTarget());
+
             if (!sources.add(item.getSource())) {
                 throw new IllegalArgumentException(
-                        "Duplicate source column in mapping: " + item.getSource());
+                        "Duplicate source column in mapping: "
+                                + item.getSource());
             }
             if (!targets.add(item.getTarget())) {
                 throw new IllegalArgumentException(
-                        "Duplicate target column in mapping: " + item.getTarget());
+                        "Duplicate target column in mapping: "
+                                + item.getTarget());
             }
+
             items.add(item);
         }
 
         return new ColumnMapping(items);
     }
 
-    private void requireProtocol(String apiVersion, String kind) {
-        String normalizedVersion = requireText(apiVersion, "apiVersion");
-        String normalizedKind = requireText(kind, "kind");
-        if (!JobSpec.CURRENT_API_VERSION.equals(normalizedVersion)) {
-            throw new IllegalArgumentException("Unsupported jobSpec apiVersion: " + normalizedVersion);
+    private void requireProtocol(
+            String apiVersion,
+            String kind) {
+
+        String normalizedVersion =
+                requireText(apiVersion, "apiVersion");
+        String normalizedKind =
+                requireText(kind, "kind");
+
+        if (!JobSpec.CURRENT_API_VERSION.equals(
+                normalizedVersion)) {
+            throw new IllegalArgumentException(
+                    "Unsupported jobSpec apiVersion: "
+                            + normalizedVersion);
         }
-        if (!JobSpec.BATCH_SYNC_KIND.equals(normalizedKind)) {
-            throw new IllegalArgumentException("Unsupported jobSpec kind: " + normalizedKind);
+        if (!JobSpec.BATCH_SYNC_KIND.equals(
+                normalizedKind)) {
+            throw new IllegalArgumentException(
+                    "Unsupported jobSpec kind: "
+                            + normalizedKind);
         }
     }
 
-    private JobSpec.Connector requireConnector(JobSpec.Connector connector, String name) {
+    private JobSpec.Connector requireConnector(
+            JobSpec.Connector connector,
+            String name) {
+
         if (connector == null) {
-            throw new IllegalArgumentException(name + " must not be null");
+            throw new IllegalArgumentException(
+                    name + " must not be null");
         }
         return connector;
     }
 
-    private Map<String, Object> copy(Map<String, Object> options) {
+    private Map<String, Object> copy(
+            Map<String, Object> options) {
+
         return options == null
                 ? new LinkedHashMap<String, Object>()
                 : new LinkedHashMap<String, Object>(options);
     }
 
-    private int positive(Integer value, int fallback, String name) {
-        int resolved = value == null ? fallback : value.intValue();
+    private int positive(
+            Integer value,
+            int fallback,
+            String name) {
+
+        int resolved = value == null
+                ? fallback
+                : value.intValue();
+
         if (resolved <= 0) {
-            throw new IllegalArgumentException(name + " must be greater than 0");
+            throw new IllegalArgumentException(
+                    name + " must be greater than 0");
         }
         return resolved;
     }
 
     private long optional(Long value) {
-        return value == null ? -1L : value.longValue();
+        return value == null
+                ? -1L
+                : value.longValue();
     }
 
     private <E extends Enum<E>> E enumValue(
-            String value, E fallback, Class<E> type, String name) {
+            String value,
+            E fallback,
+            Class<E> type,
+            String name) {
+
         if (value == null || value.trim().isEmpty()) {
             return fallback;
         }
+
         try {
-            return Enum.valueOf(type, value.trim().toUpperCase(Locale.ROOT));
-        } catch (IllegalArgumentException exception) {
-            throw new IllegalArgumentException("Unknown " + name + ": " + value, exception);
+            return Enum.valueOf(
+                    type,
+                    value.trim().toUpperCase(Locale.ROOT));
+        } catch (IllegalArgumentException failure) {
+            throw new IllegalArgumentException(
+                    "Unknown "
+                            + name
+                            + ": "
+                            + value,
+                    failure);
         }
     }
 
-    private String requireText(String value, String name) {
+    private String requireText(
+            String value,
+            String name) {
+
         if (value == null || value.trim().isEmpty()) {
-            throw new IllegalArgumentException(name + " must not be blank");
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
         }
         return value.trim();
     }

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/CapabilityNegotiation.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/CapabilityNegotiation.java
@@ -1,0 +1,299 @@
+package com.link.up.framework.planning;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.connector.schema.ConnectorRole;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+
+/** Secret-safe result of matching Job intent with Connector capabilities. */
+public final class CapabilityNegotiation {
+
+    public static final String CURRENT_API_VERSION =
+            "link-up-capability-negotiation/v1";
+
+    public enum Status {
+        SATISFIED,
+        DEGRADED,
+        REJECTED
+    }
+
+    private final String apiVersion;
+    private final Status status;
+    private final Endpoint source;
+    private final Endpoint sink;
+
+    CapabilityNegotiation(
+            Endpoint source,
+            Endpoint sink) {
+
+        this.apiVersion = CURRENT_API_VERSION;
+        this.source = Objects.requireNonNull(
+                source,
+                "source must not be null");
+        this.sink = Objects.requireNonNull(
+                sink,
+                "sink must not be null");
+        this.status = status(source, sink);
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public Endpoint getSource() {
+        return source;
+    }
+
+    public Endpoint getSink() {
+        return sink;
+    }
+
+    public boolean isRejected() {
+        return status == Status.REJECTED;
+    }
+
+    public List<PlanningDiagnostic> diagnostics() {
+        List<PlanningDiagnostic> result =
+                new ArrayList<PlanningDiagnostic>();
+
+        diagnostics(source, result);
+        diagnostics(sink, result);
+
+        if (result.isEmpty()) {
+            result.add(
+                    new PlanningDiagnostic(
+                            "CAPABILITY_NEGOTIATED",
+                            PlanningDiagnostic.Severity.INFO,
+                            "CAPABILITY_NEGOTIATION",
+                            "Required Connector capabilities are satisfied"));
+        }
+
+        return Collections.unmodifiableList(result);
+    }
+
+    private static void diagnostics(
+            Endpoint endpoint,
+            List<PlanningDiagnostic> result) {
+
+        for (ConnectorCapability capability :
+                endpoint.getMissingRequired()) {
+            result.add(
+                    new PlanningDiagnostic(
+                            "REQUIRED_CAPABILITY_MISSING",
+                            PlanningDiagnostic.Severity.ERROR,
+                            "CAPABILITY_NEGOTIATION",
+                            endpoint.getRole().name()
+                                    + " connector '"
+                                    + endpoint.getConnectorId()
+                                    + "' is missing required capability "
+                                    + capability.name()));
+        }
+
+        for (ConnectorCapability capability :
+                endpoint.getMissingPreferred()) {
+            result.add(
+                    new PlanningDiagnostic(
+                            "PREFERRED_CAPABILITY_MISSING",
+                            PlanningDiagnostic.Severity.WARNING,
+                            "CAPABILITY_NEGOTIATION",
+                            endpoint.getRole().name()
+                                    + " connector '"
+                                    + endpoint.getConnectorId()
+                                    + "' does not provide preferred capability "
+                                    + capability.name()));
+        }
+
+        for (ConnectorCapability capability :
+                endpoint.getUndeclaredObserved()) {
+            result.add(
+                    new PlanningDiagnostic(
+                            "CAPABILITY_DECLARATION_INCOMPLETE",
+                            PlanningDiagnostic.Severity.WARNING,
+                            "CAPABILITY_NEGOTIATION",
+                            endpoint.getRole().name()
+                                    + " connector '"
+                                    + endpoint.getConnectorId()
+                                    + "' demonstrated undeclared capability "
+                                    + capability.name()));
+        }
+    }
+
+    private static Status status(
+            Endpoint source,
+            Endpoint sink) {
+
+        if (!source.getMissingRequired().isEmpty()
+                || !sink.getMissingRequired().isEmpty()) {
+            return Status.REJECTED;
+        }
+        if (!source.getMissingPreferred().isEmpty()
+                || !sink.getMissingPreferred().isEmpty()
+                || !source.getUndeclaredObserved().isEmpty()
+                || !sink.getUndeclaredObserved().isEmpty()) {
+            return Status.DEGRADED;
+        }
+        return Status.SATISFIED;
+    }
+
+    public static final class Endpoint {
+
+        private final ConnectorRole role;
+        private final String connectorId;
+        private final List<ConnectorCapability> supported;
+        private final List<ConnectorCapability> required;
+        private final List<ConnectorCapability> preferred;
+        private final List<ConnectorCapability> derivedRequired;
+        private final List<ConnectorCapability> observed;
+        private final List<ConnectorCapability> missingRequired;
+        private final List<ConnectorCapability> missingPreferred;
+        private final List<ConnectorCapability> undeclaredObserved;
+        private final Status status;
+
+        Endpoint(
+                ConnectorRole role,
+                String connectorId,
+                Collection<ConnectorCapability> supported,
+                Collection<ConnectorCapability> required,
+                Collection<ConnectorCapability> preferred,
+                Collection<ConnectorCapability> derivedRequired,
+                Collection<ConnectorCapability> observed) {
+
+            this.role = Objects.requireNonNull(
+                    role,
+                    "role must not be null");
+            this.connectorId = requireText(
+                    connectorId,
+                    "connectorId");
+            this.supported = immutable(supported);
+            this.required = immutable(required);
+            this.preferred = immutable(preferred);
+            this.derivedRequired = immutable(derivedRequired);
+            this.observed = immutable(observed);
+
+            EnumSet<ConnectorCapability> allRequired =
+                    copy(required);
+            allRequired.addAll(derivedRequired);
+
+            this.missingRequired = immutable(
+                    difference(
+                            allRequired,
+                            supported));
+            this.missingPreferred = immutable(
+                    difference(
+                            preferred,
+                            supported));
+            this.undeclaredObserved = immutable(
+                    difference(
+                            observed,
+                            supported));
+
+            if (!missingRequired.isEmpty()) {
+                this.status = Status.REJECTED;
+            } else if (!missingPreferred.isEmpty()
+                    || !undeclaredObserved.isEmpty()) {
+                this.status = Status.DEGRADED;
+            } else {
+                this.status = Status.SATISFIED;
+            }
+        }
+
+        public ConnectorRole getRole() {
+            return role;
+        }
+
+        public String getConnectorId() {
+            return connectorId;
+        }
+
+        public List<ConnectorCapability> getSupported() {
+            return supported;
+        }
+
+        public List<ConnectorCapability> getRequired() {
+            return required;
+        }
+
+        public List<ConnectorCapability> getPreferred() {
+            return preferred;
+        }
+
+        public List<ConnectorCapability> getDerivedRequired() {
+            return derivedRequired;
+        }
+
+        public List<ConnectorCapability> getObserved() {
+            return observed;
+        }
+
+        public List<ConnectorCapability> getMissingRequired() {
+            return missingRequired;
+        }
+
+        public List<ConnectorCapability> getMissingPreferred() {
+            return missingPreferred;
+        }
+
+        public List<ConnectorCapability> getUndeclaredObserved() {
+            return undeclaredObserved;
+        }
+
+        public Status getStatus() {
+            return status;
+        }
+
+        private static List<ConnectorCapability> immutable(
+                Collection<ConnectorCapability> values) {
+
+            EnumSet<ConnectorCapability> copy = copy(values);
+            return Collections.unmodifiableList(
+                    new ArrayList<ConnectorCapability>(copy));
+        }
+
+        private static EnumSet<ConnectorCapability> copy(
+                Collection<ConnectorCapability> values) {
+
+            EnumSet<ConnectorCapability> result =
+                    EnumSet.noneOf(ConnectorCapability.class);
+
+            if (values != null) {
+                for (ConnectorCapability value : values) {
+                    result.add(
+                            Objects.requireNonNull(
+                                    value,
+                                    "capabilities must not contain null"));
+                }
+            }
+
+            return result;
+        }
+
+        private static EnumSet<ConnectorCapability> difference(
+                Collection<ConnectorCapability> left,
+                Collection<ConnectorCapability> right) {
+
+            EnumSet<ConnectorCapability> result = copy(left);
+            result.removeAll(copy(right));
+            return result;
+        }
+
+        private static String requireText(
+                String value,
+                String name) {
+
+            if (value == null || value.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                        name + " must not be blank");
+            }
+            return value.trim();
+        }
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/CapabilityNegotiator.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/CapabilityNegotiator.java
@@ -1,0 +1,220 @@
+package com.link.up.framework.planning;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.framework.connector.ConnectorException;
+import com.link.up.framework.connector.ConnectorPreparer;
+import com.link.up.framework.connector.PreparedSource;
+import com.link.up.framework.job.JobCapabilityRequirements;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.planner.JobGraph;
+import com.link.up.framework.planner.PipelineGraph;
+
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.Set;
+
+/** Matches explicit and plan-derived requirements with Connector declarations. */
+public final class CapabilityNegotiator {
+
+    private final ConnectorPreparer connectorPreparer;
+
+    public CapabilityNegotiator(
+            ConnectorPreparer connectorPreparer) {
+        this.connectorPreparer = Objects.requireNonNull(
+                connectorPreparer,
+                "connectorPreparer must not be null");
+    }
+
+    public CapabilityNegotiation negotiate(
+            JobDefinition definition) {
+        return negotiate(
+                definition,
+                TopologyFacts.empty());
+    }
+
+    public CapabilityNegotiation negotiate(
+            JobDefinition definition,
+            PreparedSource<?> preparedSource) {
+
+        PreparedSource<?> source = Objects.requireNonNull(
+                preparedSource,
+                "preparedSource must not be null");
+
+        TopologyFacts facts = TopologyFacts.empty();
+        facts.sourceObserved.add(
+                ConnectorCapability.TABLE_SCHEMA_DISCOVERY);
+
+        if (source.getOutputTables().size() > 1) {
+            facts.requireMultiTable();
+        }
+
+        return negotiate(definition, facts);
+    }
+
+    public CapabilityNegotiation negotiate(
+            JobDefinition definition,
+            JobGraph jobGraph) {
+
+        JobGraph graph = Objects.requireNonNull(
+                jobGraph,
+                "jobGraph must not be null");
+        TopologyFacts facts = TopologyFacts.empty();
+        facts.sourceObserved.add(
+                ConnectorCapability.TABLE_SCHEMA_DISCOVERY);
+
+        if (graph.getPipelineGraphs().size() > 1) {
+            facts.requireMultiTable();
+        }
+
+        for (PipelineGraph<?> pipeline :
+                graph.getPipelineGraphs()) {
+            if (pipeline.getSourceSplits().size() > 1) {
+                facts.sourceObserved.add(
+                        ConnectorCapability.PARTITION_SPLIT);
+                break;
+            }
+        }
+
+        return negotiate(definition, facts);
+    }
+
+    public void requireSatisfied(
+            CapabilityNegotiation negotiation) {
+
+        CapabilityNegotiation result =
+                Objects.requireNonNull(
+                        negotiation,
+                        "negotiation must not be null");
+
+        if (!result.getSource()
+                .getMissingRequired()
+                .isEmpty()) {
+            throw PlanningException.requiredCapabilityMissing(
+                    ConnectorRole.SOURCE,
+                    result.getSource().getConnectorId(),
+                    result.getSource()
+                            .getMissingRequired()
+                            .get(0));
+        }
+
+        if (!result.getSink()
+                .getMissingRequired()
+                .isEmpty()) {
+            throw PlanningException.requiredCapabilityMissing(
+                    ConnectorRole.SINK,
+                    result.getSink().getConnectorId(),
+                    result.getSink()
+                            .getMissingRequired()
+                            .get(0));
+        }
+    }
+
+    private CapabilityNegotiation negotiate(
+            JobDefinition definition,
+            TopologyFacts facts) {
+
+        JobDefinition job = Objects.requireNonNull(
+                definition,
+                "definition must not be null");
+        JobCapabilityRequirements requirements =
+                job.getCapabilityRequirements();
+
+        CapabilityNegotiation.Endpoint source = endpoint(
+                ConnectorRole.SOURCE,
+                job.getSource().getType(),
+                sourceCapabilities(job.getSource().getType()),
+                requirements.getSourceRequired(),
+                requirements.getSourcePreferred(),
+                facts.sourceDerivedRequired,
+                facts.sourceObserved);
+        CapabilityNegotiation.Endpoint sink = endpoint(
+                ConnectorRole.SINK,
+                job.getSink().getType(),
+                sinkCapabilities(job.getSink().getType()),
+                requirements.getSinkRequired(),
+                requirements.getSinkPreferred(),
+                facts.sinkDerivedRequired,
+                facts.sinkObserved);
+
+        return new CapabilityNegotiation(
+                source,
+                sink);
+    }
+
+    private Set<ConnectorCapability> sourceCapabilities(
+            String connectorId) {
+        try {
+            return connectorPreparer.sourceCapabilities(
+                    connectorId);
+        } catch (ConnectorException failure) {
+            throw PlanningException.connectorNotFound(
+                    ConnectorRole.SOURCE,
+                    connectorId,
+                    failure);
+        }
+    }
+
+    private Set<ConnectorCapability> sinkCapabilities(
+            String connectorId) {
+        try {
+            return connectorPreparer.sinkCapabilities(
+                    connectorId);
+        } catch (ConnectorException failure) {
+            throw PlanningException.connectorNotFound(
+                    ConnectorRole.SINK,
+                    connectorId,
+                    failure);
+        }
+    }
+
+    private CapabilityNegotiation.Endpoint endpoint(
+            ConnectorRole role,
+            String connectorId,
+            Set<ConnectorCapability> supported,
+            Set<ConnectorCapability> required,
+            Set<ConnectorCapability> preferred,
+            Set<ConnectorCapability> derivedRequired,
+            Set<ConnectorCapability> observed) {
+
+        return new CapabilityNegotiation.Endpoint(
+                role,
+                connectorId,
+                supported,
+                required,
+                preferred,
+                derivedRequired,
+                observed);
+    }
+
+    private static final class TopologyFacts {
+
+        private final EnumSet<ConnectorCapability>
+                sourceDerivedRequired =
+                EnumSet.noneOf(ConnectorCapability.class);
+        private final EnumSet<ConnectorCapability>
+                sinkDerivedRequired =
+                EnumSet.noneOf(ConnectorCapability.class);
+        private final EnumSet<ConnectorCapability>
+                sourceObserved =
+                EnumSet.noneOf(ConnectorCapability.class);
+        private final EnumSet<ConnectorCapability>
+                sinkObserved =
+                EnumSet.noneOf(ConnectorCapability.class);
+
+        private static TopologyFacts empty() {
+            return new TopologyFacts();
+        }
+
+        private void requireMultiTable() {
+            sourceDerivedRequired.add(
+                    ConnectorCapability.MULTI_TABLE);
+            sinkDerivedRequired.add(
+                    ConnectorCapability.MULTI_TABLE);
+            sourceObserved.add(
+                    ConnectorCapability.MULTI_TABLE);
+            sinkObserved.add(
+                    ConnectorCapability.MULTI_TABLE);
+        }
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/JobPlanExplainer.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/JobPlanExplainer.java
@@ -1,6 +1,7 @@
 package com.link.up.framework.planning;
 
 import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.exception.FluxRuntimeException;
 import com.link.up.framework.connector.ConnectorPreparer;
 import com.link.up.framework.connector.PreparedJob;
 import com.link.up.framework.connector.PreparedSource;
@@ -84,7 +85,7 @@ public final class JobPlanExplainer {
             preparedJob = connectorPreparer.prepareForExplain(
                     job,
                     preparedSource);
-        } catch (PlanningException failure) {
+        } catch (FluxRuntimeException failure) {
             throw failure;
         } catch (RuntimeException failure) {
             throw PlanningException.physicalPlanningFailed(
@@ -94,8 +95,11 @@ public final class JobPlanExplainer {
         JobGraph jobGraph;
         try {
             jobGraph = jobPlanner.plan(preparedJob);
-        } catch (PlanningException failure) {
+        } catch (FluxRuntimeException failure) {
             throw failure;
+        } catch (RuntimeException failure) {
+            throw PlanningException.physicalPlanningFailed(
+                    failure);
         } catch (Exception failure) {
             throw PlanningException.splitDiscoveryFailed(
                     job.getSource().getType(),
@@ -131,7 +135,7 @@ public final class JobPlanExplainer {
 
         try {
             return connectorPreparer.prepareSource(job);
-        } catch (PlanningException failure) {
+        } catch (FluxRuntimeException failure) {
             throw failure;
         } catch (Exception failure) {
             throw PlanningException.sourcePreparationFailed(

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/JobPlanExplainer.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/JobPlanExplainer.java
@@ -1,18 +1,21 @@
 package com.link.up.framework.planning;
 
+import com.link.up.api.connector.schema.ConnectorRole;
 import com.link.up.framework.connector.ConnectorPreparer;
 import com.link.up.framework.connector.PreparedJob;
+import com.link.up.framework.connector.PreparedSource;
 import com.link.up.framework.job.JobDefinition;
 import com.link.up.framework.planner.JobGraph;
 import com.link.up.framework.planner.JobPlanner;
 
 import java.util.Objects;
 
-/** Coordinates validation and side-effect-safe physical planning. */
+/** Compiles validation and Explain results without executing a Job. */
 public final class JobPlanExplainer {
 
     private final ConnectorPreparer connectorPreparer;
     private final JobPlanner jobPlanner;
+    private final CapabilityNegotiator capabilityNegotiator;
 
     public JobPlanExplainer(
             ConnectorPreparer connectorPreparer,
@@ -24,43 +27,148 @@ public final class JobPlanExplainer {
         this.jobPlanner = Objects.requireNonNull(
                 jobPlanner,
                 "jobPlanner must not be null");
+        this.capabilityNegotiator =
+                new CapabilityNegotiator(
+                        this.connectorPreparer);
     }
 
-    /**
-     * Validates the compiled definition and connector option rules without
-     * creating connector runtime objects or accessing external systems.
-     */
-    public JobPlanResult validate(JobDefinition definition) {
+    public JobPlanResult validate(
+            JobDefinition definition) {
+
         JobDefinition job = Objects.requireNonNull(
                 definition,
                 "definition must not be null");
+        LogicalJobPlan logicalPlan =
+                LogicalJobPlan.from(job);
 
-        connectorPreparer.validate(job);
+        CapabilityNegotiation negotiation =
+                capabilityNegotiator.negotiate(job);
+        capabilityNegotiator.requireSatisfied(negotiation);
+
+        validateSourceOptions(job);
+        validateSinkOptions(job);
+
         return JobPlanResult.validated(
-                LogicalJobPlan.from(job));
+                logicalPlan,
+                negotiation);
     }
 
-    /**
-     * Discovers source metadata and splits, then projects the formal JobGraph.
-     * Sink preparation is replaced with a metadata-only planning stub.
-     */
-    public JobPlanResult explain(JobDefinition definition)
+    public JobPlanResult explain(
+            JobDefinition definition)
             throws Exception {
 
         JobDefinition job = Objects.requireNonNull(
                 definition,
                 "definition must not be null");
-        LogicalJobPlan logicalPlan = LogicalJobPlan.from(job);
-        PreparedJob preparedJob =
-                connectorPreparer.prepareForExplain(job);
-        JobGraph jobGraph = jobPlanner.plan(preparedJob);
-        PhysicalJobPlan physicalPlan =
-                PhysicalJobPlan.from(
-                        jobGraph,
-                        logicalPlan.getFingerprint());
+        LogicalJobPlan logicalPlan =
+                LogicalJobPlan.from(job);
+
+        CapabilityNegotiation initial =
+                capabilityNegotiator.negotiate(job);
+        capabilityNegotiator.requireSatisfied(initial);
+
+        validateSourceOptions(job);
+        validateSinkOptions(job);
+
+        PreparedSource<?> preparedSource =
+                prepareSource(job);
+        CapabilityNegotiation preparedNegotiation =
+                capabilityNegotiator.negotiate(
+                        job,
+                        preparedSource);
+        capabilityNegotiator.requireSatisfied(
+                preparedNegotiation);
+
+        PreparedJob preparedJob;
+        try {
+            preparedJob = connectorPreparer.prepareForExplain(
+                    job,
+                    preparedSource);
+        } catch (PlanningException failure) {
+            throw failure;
+        } catch (RuntimeException failure) {
+            throw PlanningException.physicalPlanningFailed(
+                    failure);
+        }
+
+        JobGraph jobGraph;
+        try {
+            jobGraph = jobPlanner.plan(preparedJob);
+        } catch (PlanningException failure) {
+            throw failure;
+        } catch (Exception failure) {
+            throw PlanningException.splitDiscoveryFailed(
+                    job.getSource().getType(),
+                    failure);
+        }
+
+        CapabilityNegotiation finalNegotiation =
+                capabilityNegotiator.negotiate(
+                        job,
+                        jobGraph);
+        capabilityNegotiator.requireSatisfied(
+                finalNegotiation);
+
+        final PhysicalJobPlan physicalPlan;
+        try {
+            physicalPlan = PhysicalJobPlan.from(
+                    jobGraph,
+                    logicalPlan.getFingerprint());
+        } catch (RuntimeException failure) {
+            throw PlanningException.physicalPlanningFailed(
+                    failure);
+        }
 
         return JobPlanResult.explained(
                 logicalPlan,
-                physicalPlan);
+                physicalPlan,
+                finalNegotiation);
+    }
+
+    private PreparedSource<?> prepareSource(
+            JobDefinition job)
+            throws Exception {
+
+        try {
+            return connectorPreparer.prepareSource(job);
+        } catch (PlanningException failure) {
+            throw failure;
+        } catch (Exception failure) {
+            throw PlanningException.sourcePreparationFailed(
+                    job.getSource().getType(),
+                    failure);
+        }
+    }
+
+    private void validateSourceOptions(
+            JobDefinition job) {
+
+        try {
+            connectorPreparer.validateSourceOptions(
+                    job.getSource());
+        } catch (PlanningException failure) {
+            throw failure;
+        } catch (RuntimeException failure) {
+            throw PlanningException.connectorOptionsInvalid(
+                    ConnectorRole.SOURCE,
+                    job.getSource().getType(),
+                    failure);
+        }
+    }
+
+    private void validateSinkOptions(
+            JobDefinition job) {
+
+        try {
+            connectorPreparer.validateSinkOptions(
+                    job.getSink());
+        } catch (PlanningException failure) {
+            throw failure;
+        } catch (RuntimeException failure) {
+            throw PlanningException.connectorOptionsInvalid(
+                    ConnectorRole.SINK,
+                    job.getSink().getType(),
+                    failure);
+        }
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/JobPlanResult.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/JobPlanResult.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 public final class JobPlanResult {
 
     public static final String CURRENT_API_VERSION =
-            "link-up-plan/v1";
+            "link-up-plan/v2";
 
     public enum Mode {
         VALIDATE,
@@ -21,6 +21,7 @@ public final class JobPlanResult {
     private final boolean valid;
     private final LogicalJobPlan logicalPlan;
     private final PhysicalJobPlan physicalPlan;
+    private final CapabilityNegotiation capabilityNegotiation;
     private final List<PlanningDiagnostic> diagnostics;
     private final String text;
 
@@ -28,17 +29,20 @@ public final class JobPlanResult {
             Mode mode,
             LogicalJobPlan logicalPlan,
             PhysicalJobPlan physicalPlan,
+            CapabilityNegotiation capabilityNegotiation,
             List<PlanningDiagnostic> diagnostics) {
 
         this.apiVersion = CURRENT_API_VERSION;
         this.mode = Objects.requireNonNull(
                 mode,
                 "mode must not be null");
-        this.valid = true;
         this.logicalPlan = Objects.requireNonNull(
                 logicalPlan,
                 "logicalPlan must not be null");
         this.physicalPlan = physicalPlan;
+        this.capabilityNegotiation = capabilityNegotiation;
+        this.valid = capabilityNegotiation == null
+                || !capabilityNegotiation.isRejected();
         this.diagnostics = Collections.unmodifiableList(
                 new ArrayList<PlanningDiagnostic>(
                         Objects.requireNonNull(
@@ -48,11 +52,19 @@ public final class JobPlanResult {
                 mode,
                 logicalPlan,
                 physicalPlan,
+                capabilityNegotiation,
                 this.diagnostics);
     }
 
+    /** Compatibility overload retained for embedded callers. */
     public static JobPlanResult validated(
             LogicalJobPlan logicalPlan) {
+        return validated(logicalPlan, null);
+    }
+
+    public static JobPlanResult validated(
+            LogicalJobPlan logicalPlan,
+            CapabilityNegotiation capabilityNegotiation) {
 
         List<PlanningDiagnostic> diagnostics =
                 new ArrayList<PlanningDiagnostic>();
@@ -61,18 +73,33 @@ public final class JobPlanResult {
                         "PLAN_VALIDATED",
                         PlanningDiagnostic.Severity.INFO,
                         "VALIDATE",
-                        "Job definition and connector options are valid"));
+                        "Job definition and Connector options are valid"));
+        addNegotiationDiagnostics(
+                diagnostics,
+                capabilityNegotiation);
 
         return new JobPlanResult(
                 Mode.VALIDATE,
                 logicalPlan,
                 null,
+                capabilityNegotiation,
                 diagnostics);
+    }
+
+    /** Compatibility overload retained for embedded callers. */
+    public static JobPlanResult explained(
+            LogicalJobPlan logicalPlan,
+            PhysicalJobPlan physicalPlan) {
+        return explained(
+                logicalPlan,
+                physicalPlan,
+                null);
     }
 
     public static JobPlanResult explained(
             LogicalJobPlan logicalPlan,
-            PhysicalJobPlan physicalPlan) {
+            PhysicalJobPlan physicalPlan,
+            CapabilityNegotiation capabilityNegotiation) {
 
         List<PlanningDiagnostic> diagnostics =
                 new ArrayList<PlanningDiagnostic>();
@@ -80,14 +107,17 @@ public final class JobPlanResult {
                 new PlanningDiagnostic(
                         "PLAN_CREATED",
                         PlanningDiagnostic.Severity.INFO,
-                        "PLAN",
-                        "Physical execution topology was created from the runtime JobGraph"));
+                        "PHYSICAL_PLANNING",
+                        "Physical execution topology was projected from the runtime JobGraph"));
         diagnostics.add(
                 new PlanningDiagnostic(
                         "PLAN_SINK_PREPARATION_SKIPPED",
                         PlanningDiagnostic.Severity.WARNING,
-                        "PREPARE",
-                        "Sink preparation is intentionally skipped during explain to prevent target-side side effects"));
+                        "SINK_PREPARATION",
+                        "Sink preparation is skipped during Explain to prevent target-side side effects"));
+        addNegotiationDiagnostics(
+                diagnostics,
+                capabilityNegotiation);
 
         return new JobPlanResult(
                 Mode.EXPLAIN,
@@ -95,6 +125,7 @@ public final class JobPlanResult {
                 Objects.requireNonNull(
                         physicalPlan,
                         "physicalPlan must not be null"),
+                capabilityNegotiation,
                 diagnostics);
     }
 
@@ -118,6 +149,10 @@ public final class JobPlanResult {
         return physicalPlan;
     }
 
+    public CapabilityNegotiation getCapabilityNegotiation() {
+        return capabilityNegotiation;
+    }
+
     public List<PlanningDiagnostic> getDiagnostics() {
         return diagnostics;
     }
@@ -126,10 +161,21 @@ public final class JobPlanResult {
         return text;
     }
 
+    private static void addNegotiationDiagnostics(
+            List<PlanningDiagnostic> diagnostics,
+            CapabilityNegotiation negotiation) {
+
+        if (negotiation != null) {
+            diagnostics.addAll(
+                    negotiation.diagnostics());
+        }
+    }
+
     private static String render(
             Mode mode,
             LogicalJobPlan logical,
             PhysicalJobPlan physical,
+            CapabilityNegotiation negotiation,
             List<PlanningDiagnostic> diagnostics) {
 
         StringBuilder result = new StringBuilder();
@@ -159,6 +205,19 @@ public final class JobPlanResult {
                 .append(", pipeline=")
                 .append(logical.getRuntime().getPipelineParallelism())
                 .append('\n');
+
+        if (negotiation != null) {
+            result.append("Capabilities:\n");
+            result.append("  Status: ")
+                    .append(negotiation.getStatus().name())
+                    .append('\n');
+            renderEndpoint(
+                    result,
+                    negotiation.getSource());
+            renderEndpoint(
+                    result,
+                    negotiation.getSink());
+        }
 
         if (physical != null) {
             result.append("Physical:\n");
@@ -203,5 +262,30 @@ public final class JobPlanResult {
         }
 
         return result.toString();
+    }
+
+    private static void renderEndpoint(
+            StringBuilder result,
+            CapabilityNegotiation.Endpoint endpoint) {
+
+        result.append("  ")
+                .append(endpoint.getRole().name())
+                .append(" ")
+                .append(endpoint.getConnectorId())
+                .append(": status=")
+                .append(endpoint.getStatus().name())
+                .append(" supported=")
+                .append(endpoint.getSupported())
+                .append(" required=")
+                .append(endpoint.getRequired())
+                .append(" preferred=")
+                .append(endpoint.getPreferred())
+                .append(" derivedRequired=")
+                .append(endpoint.getDerivedRequired())
+                .append(" missingRequired=")
+                .append(endpoint.getMissingRequired())
+                .append(" missingPreferred=")
+                .append(endpoint.getMissingPreferred())
+                .append('\n');
     }
 }

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/JobPlanResult.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/JobPlanResult.java
@@ -9,7 +9,7 @@ import java.util.Objects;
 public final class JobPlanResult {
 
     public static final String CURRENT_API_VERSION =
-            "link-up-plan/v2";
+            "link-up-plan/v1";
 
     public enum Mode {
         VALIDATE,

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/LogicalJobPlan.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/LogicalJobPlan.java
@@ -1,16 +1,19 @@
 package com.link.up.framework.planning;
 
+import com.link.up.api.connector.schema.ConnectorCapability;
 import com.link.up.framework.job.ColumnMapping;
 import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobCapabilityRequirements;
 import com.link.up.framework.job.JobDefinition;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Immutable, secret-safe representation of the submitted job intent.
+ * Immutable, Secret-safe representation of the submitted Job intent.
  *
  * <p>Connector option values deliberately remain outside this model. Their
  * complete canonical form contributes to the fingerprint, so configuration
@@ -23,6 +26,7 @@ public final class LogicalJobPlan {
     private final String sinkConnectorId;
     private final RuntimeSettings runtime;
     private final List<Column> columns;
+    private final CapabilityIntent capabilities;
     private final String fingerprint;
 
     private LogicalJobPlan(
@@ -31,6 +35,7 @@ public final class LogicalJobPlan {
             String sinkConnectorId,
             RuntimeSettings runtime,
             List<Column> columns,
+            CapabilityIntent capabilities,
             String fingerprint) {
 
         this.jobName = requireText(jobName, "jobName");
@@ -48,20 +53,28 @@ public final class LogicalJobPlan {
                         Objects.requireNonNull(
                                 columns,
                                 "columns must not be null")));
+        this.capabilities = Objects.requireNonNull(
+                capabilities,
+                "capabilities must not be null");
         this.fingerprint = requireText(
                 fingerprint,
                 "fingerprint");
     }
 
-    public static LogicalJobPlan from(JobDefinition definition) {
+    public static LogicalJobPlan from(
+            JobDefinition definition) {
+
         JobDefinition job = Objects.requireNonNull(
                 definition,
                 "definition must not be null");
+        List<Column> columns =
+                new ArrayList<Column>();
+        ColumnMapping mapping =
+                job.getColumnMapping();
 
-        List<Column> columns = new ArrayList<Column>();
-        ColumnMapping mapping = job.getColumnMapping();
         if (mapping != null) {
-            for (ColumnMapping.Item item : mapping.getColumns()) {
+            for (ColumnMapping.Item item :
+                    mapping.getColumns()) {
                 columns.add(
                         new Column(
                                 item.getSource(),
@@ -73,8 +86,11 @@ public final class LogicalJobPlan {
                 job.getName(),
                 job.getSource().getType(),
                 job.getSink().getType(),
-                RuntimeSettings.from(job.getExecutionConfig()),
+                RuntimeSettings.from(
+                        job.getExecutionConfig()),
                 columns,
+                CapabilityIntent.from(
+                        job.getCapabilityRequirements()),
                 PlanFingerprint.create(job));
     }
 
@@ -96,6 +112,10 @@ public final class LogicalJobPlan {
 
     public List<Column> getColumns() {
         return columns;
+    }
+
+    public CapabilityIntent getCapabilities() {
+        return capabilities;
     }
 
     public String getFingerprint() {
@@ -213,6 +233,72 @@ public final class LogicalJobPlan {
 
         public String getSplitAssignmentMode() {
             return splitAssignmentMode;
+        }
+    }
+
+    public static final class CapabilityIntent {
+
+        private final Endpoint source;
+        private final Endpoint sink;
+
+        private CapabilityIntent(
+                Endpoint source,
+                Endpoint sink) {
+            this.source = source;
+            this.sink = sink;
+        }
+
+        private static CapabilityIntent from(
+                JobCapabilityRequirements requirements) {
+
+            JobCapabilityRequirements safe =
+                    requirements == null
+                            ? JobCapabilityRequirements.empty()
+                            : requirements;
+
+            return new CapabilityIntent(
+                    new Endpoint(
+                            safe.getSourceRequired(),
+                            safe.getSourcePreferred()),
+                    new Endpoint(
+                            safe.getSinkRequired(),
+                            safe.getSinkPreferred()));
+        }
+
+        public Endpoint getSource() {
+            return source;
+        }
+
+        public Endpoint getSink() {
+            return sink;
+        }
+    }
+
+    public static final class Endpoint {
+
+        private final List<ConnectorCapability> required;
+        private final List<ConnectorCapability> preferred;
+
+        private Endpoint(
+                Collection<ConnectorCapability> required,
+                Collection<ConnectorCapability> preferred) {
+
+            this.required = immutable(required);
+            this.preferred = immutable(preferred);
+        }
+
+        public List<ConnectorCapability> getRequired() {
+            return required;
+        }
+
+        public List<ConnectorCapability> getPreferred() {
+            return preferred;
+        }
+
+        private static List<ConnectorCapability> immutable(
+                Collection<ConnectorCapability> values) {
+            return Collections.unmodifiableList(
+                    new ArrayList<ConnectorCapability>(values));
         }
     }
 

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/PhysicalJobPlan.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/PhysicalJobPlan.java
@@ -1,0 +1,228 @@
+package com.link.up.framework.planning;
+
+import com.link.up.framework.planner.JobGraph;
+import com.link.up.framework.planner.PipelineGraph;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Secret-safe serializable projection of the runtime JobGraph.
+ *
+ * <p>This class intentionally stores only identities and counts. Prepared
+ * connectors, options, ClassLoaders and runtime ownership objects remain in
+ * the execution graph.</p>
+ */
+public final class PhysicalJobPlan {
+
+    private final String jobName;
+    private final String fingerprint;
+    private final int pipelineCount;
+    private final int sourceTaskCount;
+    private final int sinkTaskCount;
+    private final List<Pipeline> pipelines;
+
+    private PhysicalJobPlan(
+            String jobName,
+            String fingerprint,
+            List<Pipeline> pipelines) {
+
+        this.jobName = requireText(jobName, "jobName");
+        this.fingerprint = requireText(
+                fingerprint,
+                "fingerprint");
+        this.pipelines = Collections.unmodifiableList(
+                new ArrayList<Pipeline>(pipelines));
+        this.pipelineCount = pipelines.size();
+
+        int sources = 0;
+        int sinks = 0;
+        for (Pipeline pipeline : pipelines) {
+            sources += pipeline.getSourceTaskCount();
+            sinks += pipeline.getSinkTaskCount();
+        }
+        this.sourceTaskCount = sources;
+        this.sinkTaskCount = sinks;
+    }
+
+    public static PhysicalJobPlan from(
+            JobGraph jobGraph,
+            String fingerprint) {
+
+        JobGraph graph = Objects.requireNonNull(
+                jobGraph,
+                "jobGraph must not be null");
+        List<Pipeline> pipelines =
+                new ArrayList<Pipeline>();
+
+        for (PipelineGraph<?> pipeline :
+                graph.getPipelineGraphs()) {
+            pipelines.add(Pipeline.from(pipeline));
+        }
+
+        Collections.sort(
+                pipelines,
+                new Comparator<Pipeline>() {
+                    @Override
+                    public int compare(
+                            Pipeline left,
+                            Pipeline right) {
+                        return left.getPipelineId()
+                                .compareTo(right.getPipelineId());
+                    }
+                });
+
+        return new PhysicalJobPlan(
+                graph.getJobName(),
+                fingerprint,
+                pipelines);
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public String getFingerprint() {
+        return fingerprint;
+    }
+
+    public int getPipelineCount() {
+        return pipelineCount;
+    }
+
+    public int getSourceTaskCount() {
+        return sourceTaskCount;
+    }
+
+    public int getSinkTaskCount() {
+        return sinkTaskCount;
+    }
+
+    public List<Pipeline> getPipelines() {
+        return pipelines;
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    public static final class Pipeline {
+
+        private final String pipelineId;
+        private final String dataSetId;
+        private final String sourceConnectorId;
+        private final String sinkConnectorId;
+        private final int sourceSplitCount;
+        private final int sourceTaskCount;
+        private final int sinkTaskCount;
+        private final int outputColumnCount;
+        private final String splitAssignmentMode;
+
+        private Pipeline(
+                String pipelineId,
+                String dataSetId,
+                String sourceConnectorId,
+                String sinkConnectorId,
+                int sourceSplitCount,
+                int sourceTaskCount,
+                int sinkTaskCount,
+                int outputColumnCount,
+                String splitAssignmentMode) {
+
+            this.pipelineId = requireText(
+                    pipelineId,
+                    "pipelineId");
+            this.dataSetId = requireText(
+                    dataSetId,
+                    "dataSetId");
+            this.sourceConnectorId = requireText(
+                    sourceConnectorId,
+                    "sourceConnectorId");
+            this.sinkConnectorId = requireText(
+                    sinkConnectorId,
+                    "sinkConnectorId");
+            this.sourceSplitCount = sourceSplitCount;
+            this.sourceTaskCount = sourceTaskCount;
+            this.sinkTaskCount = sinkTaskCount;
+            this.outputColumnCount = outputColumnCount;
+            this.splitAssignmentMode = requireText(
+                    splitAssignmentMode,
+                    "splitAssignmentMode");
+        }
+
+        private static Pipeline from(
+                PipelineGraph<?> graph) {
+
+            if (graph.getSourceTaskPlans().isEmpty()
+                    || graph.getSinkTaskPlans().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Pipeline tasks must not be empty");
+            }
+
+            return new Pipeline(
+                    graph.getPipelineId(),
+                    graph.getDataSetId(),
+                    graph.getSourceTaskPlans()
+                            .get(0)
+                            .getPreparedSource()
+                            .getFactoryIdentifier(),
+                    graph.getSinkTaskPlans()
+                            .get(0)
+                            .getPreparedSink()
+                            .getFactoryIdentifier(),
+                    graph.getSourceSplits().size(),
+                    graph.getSourceTaskPlans().size(),
+                    graph.getSinkTaskPlans().size(),
+                    graph.getCatalogTable()
+                            .getTableSchema()
+                            .getColumnCount(),
+                    graph.getSplitAssignmentMode().name());
+        }
+
+        public String getPipelineId() {
+            return pipelineId;
+        }
+
+        public String getDataSetId() {
+            return dataSetId;
+        }
+
+        public String getSourceConnectorId() {
+            return sourceConnectorId;
+        }
+
+        public String getSinkConnectorId() {
+            return sinkConnectorId;
+        }
+
+        public int getSourceSplitCount() {
+            return sourceSplitCount;
+        }
+
+        public int getSourceTaskCount() {
+            return sourceTaskCount;
+        }
+
+        public int getSinkTaskCount() {
+            return sinkTaskCount;
+        }
+
+        public int getOutputColumnCount() {
+            return outputColumnCount;
+        }
+
+        public String getSplitAssignmentMode() {
+            return splitAssignmentMode;
+        }
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/PlanFingerprint.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/PlanFingerprint.java
@@ -1,7 +1,9 @@
 package com.link.up.framework.planning;
 
+import com.link.up.api.connector.schema.ConnectorCapability;
 import com.link.up.framework.job.ColumnMapping;
 import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobCapabilityRequirements;
 import com.link.up.framework.job.JobDefinition;
 
 import java.lang.reflect.Array;
@@ -22,7 +24,7 @@ import java.util.Set;
 public final class PlanFingerprint {
 
     private static final String FORMAT_VERSION =
-            "link-up-plan-fingerprint/v1";
+            "link-up-plan-fingerprint/v2";
 
     private PlanFingerprint() {
     }
@@ -43,8 +45,15 @@ public final class PlanFingerprint {
         appendValue(
                 canonical,
                 job.getSink().getOptions().getSourceMap());
-        appendExecution(canonical, job.getExecutionConfig());
-        appendMapping(canonical, job.getColumnMapping());
+        appendExecution(
+                canonical,
+                job.getExecutionConfig());
+        appendMapping(
+                canonical,
+                job.getColumnMapping());
+        appendCapabilities(
+                canonical,
+                job.getCapabilityRequirements());
 
         return "sha256:" + sha256(canonical.toString());
     }
@@ -53,17 +62,39 @@ public final class PlanFingerprint {
             StringBuilder canonical,
             ExecutionConfig config) {
 
-        appendToken(canonical, Integer.toString(config.getBatchSize()));
-        appendToken(canonical, Integer.toString(config.getSourceParallelism()));
-        appendToken(canonical, Integer.toString(config.getSinkParallelism()));
-        appendToken(canonical, Integer.toString(config.getPipelineParallelism()));
-        appendToken(canonical, Integer.toString(config.getMaxBufferedBatches()));
-        appendToken(canonical, Long.toString(config.getMaxBufferedRecords()));
-        appendToken(canonical, Long.toString(config.getMaxBufferedBytes()));
-        appendToken(canonical, Long.toString(config.getMaxRecordsPerSecond()));
-        appendToken(canonical, Long.toString(config.getMaxBytesPerSecond()));
-        appendToken(canonical, config.getSinkPartitionStrategy().name());
-        appendToken(canonical, config.getSplitAssignmentMode().name());
+        appendToken(
+                canonical,
+                Integer.toString(config.getBatchSize()));
+        appendToken(
+                canonical,
+                Integer.toString(config.getSourceParallelism()));
+        appendToken(
+                canonical,
+                Integer.toString(config.getSinkParallelism()));
+        appendToken(
+                canonical,
+                Integer.toString(config.getPipelineParallelism()));
+        appendToken(
+                canonical,
+                Integer.toString(config.getMaxBufferedBatches()));
+        appendToken(
+                canonical,
+                Long.toString(config.getMaxBufferedRecords()));
+        appendToken(
+                canonical,
+                Long.toString(config.getMaxBufferedBytes()));
+        appendToken(
+                canonical,
+                Long.toString(config.getMaxRecordsPerSecond()));
+        appendToken(
+                canonical,
+                Long.toString(config.getMaxBytesPerSecond()));
+        appendToken(
+                canonical,
+                config.getSinkPartitionStrategy().name());
+        appendToken(
+                canonical,
+                config.getSplitAssignmentMode().name());
     }
 
     private static void appendMapping(
@@ -74,10 +105,51 @@ public final class PlanFingerprint {
                 ? ColumnMapping.empty()
                 : mapping;
 
-        appendToken(canonical, Integer.toString(safe.getColumns().size()));
+        appendToken(
+                canonical,
+                Integer.toString(safe.getColumns().size()));
+
         for (ColumnMapping.Item item : safe.getColumns()) {
             appendToken(canonical, item.getSource());
             appendToken(canonical, item.getTarget());
+        }
+    }
+
+    private static void appendCapabilities(
+            StringBuilder canonical,
+            JobCapabilityRequirements requirements) {
+
+        JobCapabilityRequirements safe =
+                requirements == null
+                        ? JobCapabilityRequirements.empty()
+                        : requirements;
+
+        appendCapabilitySet(
+                canonical,
+                safe.getSourceRequired());
+        appendCapabilitySet(
+                canonical,
+                safe.getSourcePreferred());
+        appendCapabilitySet(
+                canonical,
+                safe.getSinkRequired());
+        appendCapabilitySet(
+                canonical,
+                safe.getSinkPreferred());
+    }
+
+    private static void appendCapabilitySet(
+            StringBuilder canonical,
+            Set<ConnectorCapability> values) {
+
+        appendToken(
+                canonical,
+                Integer.toString(values.size()));
+
+        for (ConnectorCapability capability : values) {
+            appendToken(
+                    canonical,
+                    capability.name());
         }
     }
 
@@ -89,39 +161,50 @@ public final class PlanFingerprint {
             appendToken(canonical, "null");
             return;
         }
-
         if (value instanceof Map) {
-            appendMap(canonical, (Map<?, ?>) value);
+            appendMap(
+                    canonical,
+                    (Map<?, ?>) value);
             return;
         }
-
         if (value instanceof Set) {
-            appendSet(canonical, (Set<?>) value);
+            appendSet(
+                    canonical,
+                    (Set<?>) value);
             return;
         }
-
         if (value instanceof Collection) {
-            Collection<?> values = (Collection<?>) value;
+            Collection<?> values =
+                    (Collection<?>) value;
             appendToken(canonical, "collection");
-            appendToken(canonical, Integer.toString(values.size()));
+            appendToken(
+                    canonical,
+                    Integer.toString(values.size()));
             for (Object item : values) {
                 appendValue(canonical, item);
             }
             return;
         }
-
         if (value.getClass().isArray()) {
             int length = Array.getLength(value);
             appendToken(canonical, "array");
-            appendToken(canonical, Integer.toString(length));
+            appendToken(
+                    canonical,
+                    Integer.toString(length));
             for (int index = 0; index < length; index++) {
-                appendValue(canonical, Array.get(value, index));
+                appendValue(
+                        canonical,
+                        Array.get(value, index));
             }
             return;
         }
 
-        appendToken(canonical, value.getClass().getName());
-        appendToken(canonical, String.valueOf(value));
+        appendToken(
+                canonical,
+                value.getClass().getName());
+        appendToken(
+                canonical,
+                String.valueOf(value));
     }
 
     private static void appendMap(
@@ -129,7 +212,8 @@ public final class PlanFingerprint {
             Map<?, ?> values) {
 
         List<Map.Entry<?, ?>> entries =
-                new ArrayList<Map.Entry<?, ?>>(values.entrySet());
+                new ArrayList<Map.Entry<?, ?>>(
+                        values.entrySet());
         Collections.sort(
                 entries,
                 new Comparator<Map.Entry<?, ?>>() {
@@ -138,15 +222,24 @@ public final class PlanFingerprint {
                             Map.Entry<?, ?> left,
                             Map.Entry<?, ?> right) {
                         return String.valueOf(left.getKey())
-                                .compareTo(String.valueOf(right.getKey()));
+                                .compareTo(
+                                        String.valueOf(
+                                                right.getKey()));
                     }
                 });
 
         appendToken(canonical, "map");
-        appendToken(canonical, Integer.toString(entries.size()));
+        appendToken(
+                canonical,
+                Integer.toString(entries.size()));
+
         for (Map.Entry<?, ?> entry : entries) {
-            appendToken(canonical, String.valueOf(entry.getKey()));
-            appendValue(canonical, entry.getValue());
+            appendToken(
+                    canonical,
+                    String.valueOf(entry.getKey()));
+            appendValue(
+                    canonical,
+                    entry.getValue());
         }
     }
 
@@ -163,7 +256,10 @@ public final class PlanFingerprint {
         Collections.sort(items);
 
         appendToken(canonical, "set");
-        appendToken(canonical, Integer.toString(items.size()));
+        appendToken(
+                canonical,
+                Integer.toString(items.size()));
+
         for (String item : items) {
             appendToken(canonical, item);
         }
@@ -173,7 +269,9 @@ public final class PlanFingerprint {
             StringBuilder canonical,
             String value) {
 
-        String safe = value == null ? "null" : value;
+        String safe = value == null
+                ? "null"
+                : value;
         canonical.append(safe.length())
                 .append(':')
                 .append(safe)
@@ -182,10 +280,13 @@ public final class PlanFingerprint {
 
     private static String sha256(String value) {
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            MessageDigest digest =
+                    MessageDigest.getInstance("SHA-256");
             byte[] bytes = digest.digest(
                     value.getBytes(StandardCharsets.UTF_8));
-            StringBuilder result = new StringBuilder(bytes.length * 2);
+            StringBuilder result =
+                    new StringBuilder(bytes.length * 2);
+
             for (byte current : bytes) {
                 result.append(
                         String.format(

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/PlanFingerprint.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/PlanFingerprint.java
@@ -24,7 +24,7 @@ import java.util.Set;
 public final class PlanFingerprint {
 
     private static final String FORMAT_VERSION =
-            "link-up-plan-fingerprint/v2";
+            "link-up-plan-fingerprint/v1";
 
     private PlanFingerprint() {
     }
@@ -51,9 +51,15 @@ public final class PlanFingerprint {
         appendMapping(
                 canonical,
                 job.getColumnMapping());
-        appendCapabilities(
-                canonical,
-                job.getCapabilityRequirements());
+
+        JobCapabilityRequirements capabilities =
+                job.getCapabilityRequirements();
+        if (capabilities != null
+                && !capabilities.isEmpty()) {
+            appendCapabilities(
+                    canonical,
+                    capabilities);
+        }
 
         return "sha256:" + sha256(canonical.toString());
     }
@@ -119,23 +125,21 @@ public final class PlanFingerprint {
             StringBuilder canonical,
             JobCapabilityRequirements requirements) {
 
-        JobCapabilityRequirements safe =
-                requirements == null
-                        ? JobCapabilityRequirements.empty()
-                        : requirements;
-
+        appendToken(
+                canonical,
+                "capability-intent/v1");
         appendCapabilitySet(
                 canonical,
-                safe.getSourceRequired());
+                requirements.getSourceRequired());
         appendCapabilitySet(
                 canonical,
-                safe.getSourcePreferred());
+                requirements.getSourcePreferred());
         appendCapabilitySet(
                 canonical,
-                safe.getSinkRequired());
+                requirements.getSinkRequired());
         appendCapabilitySet(
                 canonical,
-                safe.getSinkPreferred());
+                requirements.getSinkPreferred());
     }
 
     private static void appendCapabilitySet(

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/PlanningErrorCode.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/PlanningErrorCode.java
@@ -72,8 +72,16 @@ public enum PlanningErrorCode implements FluxErrorCode {
             false,
             FluxRetryScope.NONE),
 
-    INTERNAL_FAILURE(
+    SINK_PREPARATION_FAILED(
             "PLAN-009",
+            "Sink preparation failed",
+            FluxErrorCategory.PREPARATION,
+            FluxErrorPhase.SINK_PREPARATION,
+            false,
+            FluxRetryScope.NONE),
+
+    INTERNAL_FAILURE(
+            "PLAN-010",
             "Unexpected planning failure",
             FluxErrorCategory.INTERNAL,
             FluxErrorPhase.PHYSICAL_PLANNING,

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/PlanningErrorCode.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/PlanningErrorCode.java
@@ -1,0 +1,135 @@
+package com.link.up.framework.planning;
+
+import com.link.up.api.exception.FluxErrorCategory;
+import com.link.up.api.exception.FluxErrorCode;
+import com.link.up.api.exception.FluxErrorPhase;
+import com.link.up.api.exception.FluxRetryScope;
+
+/** Stable machine-readable errors owned by the planning boundary. */
+public enum PlanningErrorCode implements FluxErrorCode {
+
+    INVALID_REQUEST(
+            "PLAN-001",
+            "Planning request is invalid",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.PROTOCOL,
+            false,
+            FluxRetryScope.NONE),
+
+    INVALID_DEFINITION(
+            "PLAN-002",
+            "Job definition could not be compiled",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.COMPILE,
+            false,
+            FluxRetryScope.NONE),
+
+    CONNECTOR_NOT_FOUND(
+            "PLAN-003",
+            "Connector could not be resolved",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.CONNECTOR_RESOLUTION,
+            false,
+            FluxRetryScope.NONE),
+
+    CONNECTOR_OPTIONS_INVALID(
+            "PLAN-004",
+            "Connector options are invalid",
+            FluxErrorCategory.VALIDATION,
+            FluxErrorPhase.OPTION_VALIDATION,
+            false,
+            FluxRetryScope.NONE),
+
+    REQUIRED_CAPABILITY_MISSING(
+            "PLAN-005",
+            "A required Connector capability is missing",
+            FluxErrorCategory.CAPABILITY,
+            FluxErrorPhase.CAPABILITY_NEGOTIATION,
+            false,
+            FluxRetryScope.NONE),
+
+    SOURCE_PREPARATION_FAILED(
+            "PLAN-006",
+            "Source preparation or schema discovery failed",
+            FluxErrorCategory.PREPARATION,
+            FluxErrorPhase.SOURCE_DISCOVERY,
+            true,
+            FluxRetryScope.JOB),
+
+    SPLIT_DISCOVERY_FAILED(
+            "PLAN-007",
+            "Source split discovery failed",
+            FluxErrorCategory.DISCOVERY,
+            FluxErrorPhase.SPLIT_DISCOVERY,
+            true,
+            FluxRetryScope.JOB),
+
+    PHYSICAL_PLANNING_FAILED(
+            "PLAN-008",
+            "Physical Job planning failed",
+            FluxErrorCategory.PLANNING,
+            FluxErrorPhase.PHYSICAL_PLANNING,
+            false,
+            FluxRetryScope.NONE),
+
+    INTERNAL_FAILURE(
+            "PLAN-009",
+            "Unexpected planning failure",
+            FluxErrorCategory.INTERNAL,
+            FluxErrorPhase.PHYSICAL_PLANNING,
+            false,
+            FluxRetryScope.NONE);
+
+    private final String code;
+    private final String description;
+    private final FluxErrorCategory category;
+    private final FluxErrorPhase phase;
+    private final boolean retryable;
+    private final FluxRetryScope retryScope;
+
+    PlanningErrorCode(
+            String code,
+            String description,
+            FluxErrorCategory category,
+            FluxErrorPhase phase,
+            boolean retryable,
+            FluxRetryScope retryScope) {
+
+        this.code = code;
+        this.description = description;
+        this.category = category;
+        this.phase = phase;
+        this.retryable = retryable;
+        this.retryScope = retryScope;
+    }
+
+    @Override
+    public String getCode() {
+        return code;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public FluxErrorCategory getCategory() {
+        return category;
+    }
+
+    @Override
+    public FluxErrorPhase getPhase() {
+        return phase;
+    }
+
+    @Override
+    public boolean isRetryable() {
+        return retryable;
+    }
+
+    @Override
+    public FluxRetryScope getRetryScope() {
+        return retryScope;
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/PlanningException.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/PlanningException.java
@@ -1,0 +1,229 @@
+package com.link.up.framework.planning;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.exception.FluxRuntimeException;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Structured, Secret-safe failure raised by planning and negotiation. */
+public final class PlanningException
+        extends FluxRuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final PlanningErrorCode errorCode;
+    private final Map<String, String> parameters;
+
+    public PlanningException(
+            PlanningErrorCode errorCode,
+            String message,
+            Map<String, String> parameters,
+            Throwable cause) {
+
+        super(
+                Objects.requireNonNull(
+                        errorCode,
+                        "errorCode must not be null"),
+                safeMessage(message),
+                cause);
+
+        this.errorCode = errorCode;
+        this.parameters = immutable(parameters);
+    }
+
+    public static PlanningException invalidRequest(
+            String reason,
+            Throwable cause) {
+
+        return new PlanningException(
+                PlanningErrorCode.INVALID_REQUEST,
+                "Planning request is invalid",
+                parameters("reason", reason),
+                cause);
+    }
+
+    public static PlanningException invalidDefinition(
+            String format,
+            Throwable cause) {
+
+        return new PlanningException(
+                PlanningErrorCode.INVALID_DEFINITION,
+                "Job definition could not be compiled",
+                parameters("format", format),
+                cause);
+    }
+
+    public static PlanningException connectorNotFound(
+            ConnectorRole role,
+            String connectorId,
+            Throwable cause) {
+
+        Map<String, String> parameters =
+                parameters(
+                        "role",
+                        role.name());
+        parameters.put(
+                "connectorId",
+                safeParameter(connectorId));
+
+        return new PlanningException(
+                PlanningErrorCode.CONNECTOR_NOT_FOUND,
+                role.name()
+                        + " connector could not be resolved",
+                parameters,
+                cause);
+    }
+
+    public static PlanningException connectorOptionsInvalid(
+            ConnectorRole role,
+            String connectorId,
+            Throwable cause) {
+
+        Map<String, String> parameters =
+                parameters(
+                        "role",
+                        role.name());
+        parameters.put(
+                "connectorId",
+                safeParameter(connectorId));
+
+        return new PlanningException(
+                PlanningErrorCode.CONNECTOR_OPTIONS_INVALID,
+                role.name()
+                        + " connector options are invalid",
+                parameters,
+                cause);
+    }
+
+    public static PlanningException requiredCapabilityMissing(
+            ConnectorRole role,
+            String connectorId,
+            ConnectorCapability capability) {
+
+        Map<String, String> parameters =
+                parameters(
+                        "role",
+                        role.name());
+        parameters.put(
+                "connectorId",
+                safeParameter(connectorId));
+        parameters.put(
+                "capability",
+                capability.name());
+
+        return new PlanningException(
+                PlanningErrorCode.REQUIRED_CAPABILITY_MISSING,
+                role.name()
+                        + " connector does not support required capability "
+                        + capability.name(),
+                parameters,
+                null);
+    }
+
+    public static PlanningException sourcePreparationFailed(
+            String connectorId,
+            Throwable cause) {
+
+        return new PlanningException(
+                PlanningErrorCode.SOURCE_PREPARATION_FAILED,
+                "Source preparation or schema discovery failed",
+                parameters(
+                        "connectorId",
+                        connectorId),
+                cause);
+    }
+
+    public static PlanningException splitDiscoveryFailed(
+            String connectorId,
+            Throwable cause) {
+
+        return new PlanningException(
+                PlanningErrorCode.SPLIT_DISCOVERY_FAILED,
+                "Source split discovery failed",
+                parameters(
+                        "connectorId",
+                        connectorId),
+                cause);
+    }
+
+    public static PlanningException physicalPlanningFailed(
+            Throwable cause) {
+
+        return new PlanningException(
+                PlanningErrorCode.PHYSICAL_PLANNING_FAILED,
+                "Physical Job planning failed",
+                Collections.<String, String>emptyMap(),
+                cause);
+    }
+
+    public PlanningErrorCode getPlanningErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public Map<String, String> getParams() {
+        return parameters;
+    }
+
+    private static Map<String, String> parameters(
+            String key,
+            String value) {
+
+        Map<String, String> result =
+                new LinkedHashMap<String, String>();
+        result.put(
+                key,
+                safeParameter(value));
+        return result;
+    }
+
+    private static Map<String, String> immutable(
+            Map<String, String> source) {
+
+        if (source == null || source.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> result =
+                new LinkedHashMap<String, String>();
+
+        for (Map.Entry<String, String> entry :
+                source.entrySet()) {
+            result.put(
+                    safeParameter(entry.getKey()),
+                    safeParameter(entry.getValue()));
+        }
+
+        return Collections.unmodifiableMap(result);
+    }
+
+    private static String safeMessage(String value) {
+        String normalized = safeParameter(value);
+        return normalized.length() <= 500
+                ? normalized
+                : normalized.substring(0, 500);
+    }
+
+    private static String safeParameter(String value) {
+        if (value == null) {
+            return "unknown";
+        }
+
+        String normalized = value.trim()
+                .replace('\r', ' ')
+                .replace('\n', ' ')
+                .replace('\t', ' ');
+
+        if (normalized.isEmpty()) {
+            return "unknown";
+        }
+
+        return normalized.length() <= 200
+                ? normalized
+                : normalized.substring(0, 200);
+    }
+}

--- a/link-up-framework/src/main/java/com/link/up/framework/planning/PlanningException.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/planning/PlanningException.java
@@ -160,6 +160,19 @@ public final class PlanningException
                 cause);
     }
 
+    public static PlanningException sinkPreparationFailed(
+            String connectorId,
+            Throwable cause) {
+
+        return new PlanningException(
+                PlanningErrorCode.SINK_PREPARATION_FAILED,
+                "Sink preparation failed",
+                parameters(
+                        "connectorId",
+                        connectorId),
+                cause);
+    }
+
     public PlanningErrorCode getPlanningErrorCode() {
         return errorCode;
     }

--- a/link-up-framework/src/test/java/com/link/up/framework/job/JobCapabilityCompilerTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/job/JobCapabilityCompilerTest.java
@@ -1,0 +1,144 @@
+package com.link.up.framework.job;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.job.JobSpec;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class JobCapabilityCompilerTest {
+
+    @Test
+    public void shouldCompileRequiredAndPreferredCapabilities() {
+        JobSpec spec = spec();
+        JobSpec.CapabilityRequirements requirements =
+                new JobSpec.CapabilityRequirements();
+
+        JobSpec.Endpoint source = new JobSpec.Endpoint();
+        source.setRequired(
+                Arrays.asList(
+                        "table_schema_discovery",
+                        "MULTI_TABLE"));
+        source.setPreferred(
+                Collections.singletonList(
+                        "partition_split"));
+        requirements.setSource(source);
+
+        JobSpec.Endpoint sink = new JobSpec.Endpoint();
+        sink.setRequired(
+                Collections.singletonList(
+                        "two_phase_commit"));
+        requirements.setSink(sink);
+        spec.setCapabilities(requirements);
+
+        JobDefinition definition =
+                new JobSpecCompiler().compile(spec);
+        JobCapabilityRequirements compiled =
+                definition.getCapabilityRequirements();
+
+        assertTrue(
+                compiled.getSourceRequired().contains(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY));
+        assertTrue(
+                compiled.getSourceRequired().contains(
+                        ConnectorCapability.MULTI_TABLE));
+        assertEquals(
+                Collections.singleton(
+                        ConnectorCapability.PARTITION_SPLIT),
+                compiled.getSourcePreferred());
+        assertEquals(
+                Collections.singleton(
+                        ConnectorCapability.TWO_PHASE_COMMIT),
+                compiled.getSinkRequired());
+    }
+
+    @Test
+    public void shouldRejectUnknownCapability() {
+        JobSpec spec = spec();
+        JobSpec.CapabilityRequirements requirements =
+                new JobSpec.CapabilityRequirements();
+        JobSpec.Endpoint source = new JobSpec.Endpoint();
+        source.setRequired(
+                Collections.singletonList(
+                        "NOT_A_CAPABILITY"));
+        requirements.setSource(source);
+        spec.setCapabilities(requirements);
+
+        try {
+            new JobSpecCompiler().compile(spec);
+            fail("Expected unknown capability rejection");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(
+                    expected.getMessage().contains(
+                            "Unknown capabilities.source.required capability"));
+        }
+    }
+
+    @Test
+    public void shouldRejectRequiredPreferredOverlap() {
+        JobSpec spec = spec();
+        JobSpec.CapabilityRequirements requirements =
+                new JobSpec.CapabilityRequirements();
+        JobSpec.Endpoint sink = new JobSpec.Endpoint();
+        sink.setRequired(
+                Collections.singletonList("UPSERT"));
+        sink.setPreferred(
+                Collections.singletonList("upsert"));
+        requirements.setSink(sink);
+        spec.setCapabilities(requirements);
+
+        try {
+            new JobSpecCompiler().compile(spec);
+            fail("Expected overlap rejection");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(
+                    expected.getMessage().contains(
+                            "sink capabilities must not be both required and preferred"));
+        }
+    }
+
+    @Test
+    public void shouldParseHoconCapabilityIntent() {
+        String hocon =
+                "source { type = \"test-source\" }\n"
+                        + "sink { type = \"test-sink\" }\n"
+                        + "capabilities {\n"
+                        + "  source { required = [\"MULTI_TABLE\"] }\n"
+                        + "  sink { preferred = [\"TWO_PHASE_COMMIT\"] }\n"
+                        + "}\n";
+
+        JobDefinition definition =
+                new JobConfigParser().parse(hocon);
+
+        assertEquals(
+                Collections.singleton(
+                        ConnectorCapability.MULTI_TABLE),
+                definition.getCapabilityRequirements()
+                        .getSourceRequired());
+        assertEquals(
+                Collections.singleton(
+                        ConnectorCapability.TWO_PHASE_COMMIT),
+                definition.getCapabilityRequirements()
+                        .getSinkPreferred());
+    }
+
+    private JobSpec spec() {
+        JobSpec spec = new JobSpec();
+        spec.setName("capability-job");
+        spec.setSource(connector("test-source"));
+        spec.setSink(connector("test-sink"));
+        return spec;
+    }
+
+    private JobSpec.Connector connector(String id) {
+        JobSpec.Connector connector =
+                new JobSpec.Connector();
+        connector.setConnectorId(id);
+        return connector;
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/planning/CapabilityNegotiatorTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planning/CapabilityNegotiatorTest.java
@@ -1,0 +1,333 @@
+package com.link.up.framework.planning;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.exception.FluxErrorCategory;
+import com.link.up.api.exception.FluxErrorPhase;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.framework.connector.ConnectorPreparer;
+import com.link.up.framework.connector.FactoryRegistry;
+import com.link.up.framework.connector.PreparedSource;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobCapabilityRequirements;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.SinkDefinition;
+import com.link.up.framework.job.SourceDefinition;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class CapabilityNegotiatorTest {
+
+    @Test
+    public void missingPreferredCapabilityShouldDegradeButRemainValid()
+            throws Exception {
+
+        FactoryRegistry registry = registry(
+                EnumSet.of(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY),
+                EnumSet.of(
+                        ConnectorCapability.TWO_PHASE_COMMIT));
+
+        try {
+            JobCapabilityRequirements requirements =
+                    new JobCapabilityRequirements(
+                            Collections.singleton(
+                                    ConnectorCapability.TABLE_SCHEMA_DISCOVERY),
+                            Collections.singleton(
+                                    ConnectorCapability.PARTITION_SPLIT),
+                            Collections.singleton(
+                                    ConnectorCapability.TWO_PHASE_COMMIT),
+                            Collections.<ConnectorCapability>emptySet());
+
+            CapabilityNegotiation result = negotiator(registry)
+                    .negotiate(definition(requirements));
+
+            assertEquals(
+                    CapabilityNegotiation.Status.DEGRADED,
+                    result.getStatus());
+            assertEquals(
+                    Collections.singletonList(
+                            ConnectorCapability.PARTITION_SPLIT),
+                    result.getSource().getMissingPreferred());
+            assertTrue(
+                    result.getSource().getMissingRequired().isEmpty());
+            assertTrue(
+                    result.getSink().getMissingRequired().isEmpty());
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    public void missingRequiredCapabilityShouldRaiseStructuredError()
+            throws Exception {
+
+        FactoryRegistry registry = registry(
+                Collections.<ConnectorCapability>emptySet(),
+                Collections.<ConnectorCapability>emptySet());
+
+        try {
+            JobCapabilityRequirements requirements =
+                    new JobCapabilityRequirements(
+                            Collections.<ConnectorCapability>emptySet(),
+                            Collections.<ConnectorCapability>emptySet(),
+                            Collections.singleton(
+                                    ConnectorCapability.UPSERT),
+                            Collections.<ConnectorCapability>emptySet());
+            CapabilityNegotiator negotiator =
+                    negotiator(registry);
+            CapabilityNegotiation result =
+                    negotiator.negotiate(
+                            definition(requirements));
+
+            try {
+                negotiator.requireSatisfied(result);
+                fail("Expected required capability rejection");
+            } catch (PlanningException expected) {
+                assertEquals(
+                        PlanningErrorCode.REQUIRED_CAPABILITY_MISSING,
+                        expected.getPlanningErrorCode());
+                assertEquals(
+                        FluxErrorCategory.CAPABILITY,
+                        expected.getErrorCategory());
+                assertEquals(
+                        FluxErrorPhase.CAPABILITY_NEGOTIATION,
+                        expected.getErrorPhase());
+                assertEquals(
+                        "SINK",
+                        expected.getParams().get("role"));
+                assertEquals(
+                        "UPSERT",
+                        expected.getParams().get("capability"));
+            }
+        } finally {
+            registry.close();
+        }
+    }
+
+    @Test
+    public void multiTableTopologyShouldDeriveSourceAndSinkRequirement()
+            throws Exception {
+
+        FactoryRegistry registry = registry(
+                EnumSet.of(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY,
+                        ConnectorCapability.MULTI_TABLE),
+                Collections.<ConnectorCapability>emptySet());
+
+        try {
+            CapabilityNegotiation result = negotiator(registry)
+                    .negotiate(
+                            definition(
+                                    JobCapabilityRequirements.empty()),
+                            preparedSource());
+
+            assertEquals(
+                    CapabilityNegotiation.Status.REJECTED,
+                    result.getStatus());
+            assertTrue(
+                    result.getSource()
+                            .getDerivedRequired()
+                            .contains(
+                                    ConnectorCapability.MULTI_TABLE));
+            assertTrue(
+                    result.getSink()
+                            .getDerivedRequired()
+                            .contains(
+                                    ConnectorCapability.MULTI_TABLE));
+            assertTrue(
+                    result.getSink()
+                            .getMissingRequired()
+                            .contains(
+                                    ConnectorCapability.MULTI_TABLE));
+        } finally {
+            registry.close();
+        }
+    }
+
+    private CapabilityNegotiator negotiator(
+            FactoryRegistry registry) {
+
+        return new CapabilityNegotiator(
+                new ConnectorPreparer(
+                        registry,
+                        getClass().getClassLoader()));
+    }
+
+    private JobDefinition definition(
+            JobCapabilityRequirements requirements) {
+
+        ReadonlyConfig options = ReadonlyConfig.fromMap(
+                Collections.<String, Object>emptyMap());
+
+        return new JobDefinition(
+                "capability-negotiation",
+                new SourceDefinition("test-source", options),
+                new SinkDefinition("test-sink", options),
+                new ExecutionConfig(100, 1, 1, 32),
+                null,
+                requirements);
+    }
+
+    private PreparedSource<TestSplit> preparedSource() {
+        Map<TablePath, CatalogTable> tables =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        tables.put(
+                TablePath.of("demo", "orders"),
+                table("orders"));
+        tables.put(
+                TablePath.of("demo", "customers"),
+                table("customers"));
+
+        return new PreparedSource<TestSplit>(
+                "test-source",
+                source(),
+                tables);
+    }
+
+    private Source<TestSplit> source() {
+        return new Source<TestSplit>() {
+            @Override
+            public SourceSplitEnumerator<TestSplit> createEnumerator(
+                    Map<TablePath, CatalogTable> tables,
+                    SourceEnumeratorContext context) {
+                return null;
+            }
+
+            @Override
+            public SourceReader<FluxRow, TestSplit> createReader(
+                    Map<TablePath, CatalogTable> tables,
+                    int batchSize) {
+                return null;
+            }
+        };
+    }
+
+    private CatalogTable table(String tableName) {
+        TableSchema schema = TableSchema.builder()
+                .column(
+                        Column.builder(
+                                        "id",
+                                        BasicType.LONG_TYPE)
+                                .nullable(false)
+                                .build())
+                .build();
+        return CatalogTable.builder(
+                        TablePath.of("demo", tableName),
+                        schema)
+                .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private FactoryRegistry registry(
+            final Set<ConnectorCapability> sourceCapabilities,
+            final Set<ConnectorCapability> sinkCapabilities)
+            throws Exception {
+
+        FactoryRegistry registry = new FactoryRegistry(
+                getClass().getClassLoader());
+
+        TableSourceFactory<TestSplit> sourceFactory =
+                new TableSourceFactory<TestSplit>() {
+                    @Override
+                    public String factoryIdentifier() {
+                        return "test-source";
+                    }
+
+                    @Override
+                    public Set<ConnectorCapability> capabilities() {
+                        return sourceCapabilities;
+                    }
+
+                    @Override
+                    public OptionRule optionRule() {
+                        return OptionRule.builder().build();
+                    }
+
+                    @Override
+                    public Source<TestSplit> createSource(
+                            SourceFactoryContext context) {
+                        return source();
+                    }
+
+                    @Override
+                    public List<CatalogTable> discoverTableSchemas(
+                            SourceFactoryContext context) {
+                        return Collections.singletonList(
+                                table("orders"));
+                    }
+                };
+
+        SinkFactory sinkFactory = new SinkFactory() {
+            @Override
+            public String factoryIdentifier() {
+                return "test-sink";
+            }
+
+            @Override
+            public Set<ConnectorCapability> capabilities() {
+                return sinkCapabilities;
+            }
+
+            @Override
+            public OptionRule optionRule() {
+                return OptionRule.builder().build();
+            }
+        };
+
+        Field sources = FactoryRegistry.class.getDeclaredField(
+                "sourceFactories");
+        sources.setAccessible(true);
+        ((Map<String, TableSourceFactory<?>>) sources.get(registry))
+                .put("test-source", sourceFactory);
+
+        Field sinks = FactoryRegistry.class.getDeclaredField(
+                "sinkFactories");
+        sinks.setAccessible(true);
+        ((Map<String, SinkFactory>) sinks.get(registry))
+                .put("test-sink", sinkFactory);
+
+        return registry;
+    }
+
+    private static final class TestSplit
+            implements SourceSplit {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String splitId() {
+            return "test-split";
+        }
+
+        @Override
+        public String dataSetId() {
+            return "demo.orders";
+        }
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/planning/JobPlanCapabilityBoundaryTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planning/JobPlanCapabilityBoundaryTest.java
@@ -1,0 +1,231 @@
+package com.link.up.framework.planning;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.framework.connector.ConnectorPreparer;
+import com.link.up.framework.connector.FactoryRegistry;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.SinkDefinition;
+import com.link.up.framework.job.SourceDefinition;
+import com.link.up.framework.planner.JobPlanner;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class JobPlanCapabilityBoundaryTest {
+
+    @Test
+    public void multiTableRejectionMustHappenBeforeSinkPreparation()
+            throws Exception {
+
+        final AtomicInteger sourceDiscoveryCalls =
+                new AtomicInteger();
+        final AtomicInteger splitEnumerationCalls =
+                new AtomicInteger();
+        final AtomicInteger sinkPreparationCalls =
+                new AtomicInteger();
+        FactoryRegistry registry = registry(
+                sourceDiscoveryCalls,
+                splitEnumerationCalls,
+                sinkPreparationCalls);
+
+        try {
+            JobPlanExplainer explainer =
+                    new JobPlanExplainer(
+                            new ConnectorPreparer(
+                                    registry,
+                                    getClass().getClassLoader()),
+                            new JobPlanner());
+
+            try {
+                explainer.explain(definition());
+                fail("Expected multi-table capability rejection");
+            } catch (PlanningException expected) {
+                assertEquals(
+                        PlanningErrorCode.REQUIRED_CAPABILITY_MISSING,
+                        expected.getPlanningErrorCode());
+                assertEquals(
+                        "SINK",
+                        expected.getParams().get("role"));
+                assertEquals(
+                        "MULTI_TABLE",
+                        expected.getParams().get("capability"));
+            }
+
+            assertEquals(1, sourceDiscoveryCalls.get());
+            assertEquals(0, splitEnumerationCalls.get());
+            assertEquals(0, sinkPreparationCalls.get());
+        } finally {
+            registry.close();
+        }
+    }
+
+    private JobDefinition definition() {
+        ReadonlyConfig options = ReadonlyConfig.fromMap(
+                Collections.<String, Object>emptyMap());
+        return new JobDefinition(
+                "multi-table-boundary",
+                new SourceDefinition("test-source", options),
+                new SinkDefinition("test-sink", options),
+                new ExecutionConfig(100, 1, 1, 32));
+    }
+
+    @SuppressWarnings("unchecked")
+    private FactoryRegistry registry(
+            final AtomicInteger sourceDiscoveryCalls,
+            final AtomicInteger splitEnumerationCalls,
+            final AtomicInteger sinkPreparationCalls)
+            throws Exception {
+
+        FactoryRegistry registry = new FactoryRegistry(
+                getClass().getClassLoader());
+
+        TableSourceFactory<TestSplit> sourceFactory =
+                new TableSourceFactory<TestSplit>() {
+                    @Override
+                    public String factoryIdentifier() {
+                        return "test-source";
+                    }
+
+                    @Override
+                    public java.util.Set<ConnectorCapability> capabilities() {
+                        return EnumSet.of(
+                                ConnectorCapability.TABLE_SCHEMA_DISCOVERY,
+                                ConnectorCapability.MULTI_TABLE);
+                    }
+
+                    @Override
+                    public OptionRule optionRule() {
+                        return OptionRule.builder().build();
+                    }
+
+                    @Override
+                    public Source<TestSplit> createSource(
+                            SourceFactoryContext context) {
+                        return source(splitEnumerationCalls);
+                    }
+
+                    @Override
+                    public List<CatalogTable> discoverTableSchemas(
+                            SourceFactoryContext context) {
+                        sourceDiscoveryCalls.incrementAndGet();
+                        return Arrays.asList(
+                                table("orders"),
+                                table("customers"));
+                    }
+                };
+
+        SinkFactory sinkFactory = new SinkFactory() {
+            @Override
+            public String factoryIdentifier() {
+                return "test-sink";
+            }
+
+            @Override
+            public OptionRule optionRule() {
+                return OptionRule.builder().build();
+            }
+
+            @Override
+            public SinkPreparer createPreparer(
+                    ReadonlyConfig config) {
+                sinkPreparationCalls.incrementAndGet();
+                throw new AssertionError(
+                        "Capability rejection must happen before Sink preparation");
+            }
+        };
+
+        Field sources = FactoryRegistry.class.getDeclaredField(
+                "sourceFactories");
+        sources.setAccessible(true);
+        ((Map<String, TableSourceFactory<?>>) sources.get(registry))
+                .put("test-source", sourceFactory);
+
+        Field sinks = FactoryRegistry.class.getDeclaredField(
+                "sinkFactories");
+        sinks.setAccessible(true);
+        ((Map<String, SinkFactory>) sinks.get(registry))
+                .put("test-sink", sinkFactory);
+
+        return registry;
+    }
+
+    private Source<TestSplit> source(
+            final AtomicInteger splitEnumerationCalls) {
+
+        return new Source<TestSplit>() {
+            @Override
+            public SourceSplitEnumerator<TestSplit> createEnumerator(
+                    Map<TablePath, CatalogTable> tables,
+                    SourceEnumeratorContext context) {
+                splitEnumerationCalls.incrementAndGet();
+                throw new AssertionError(
+                        "Split discovery must not start after capability rejection");
+            }
+
+            @Override
+            public SourceReader<FluxRow, TestSplit> createReader(
+                    Map<TablePath, CatalogTable> tables,
+                    int batchSize) {
+                return null;
+            }
+        };
+    }
+
+    private CatalogTable table(String name) {
+        TableSchema schema = TableSchema.builder()
+                .column(
+                        Column.builder(
+                                        "id",
+                                        BasicType.LONG_TYPE)
+                                .nullable(false)
+                                .build())
+                .build();
+        return CatalogTable.builder(
+                        TablePath.of("demo", name),
+                        schema)
+                .build();
+    }
+
+    private static final class TestSplit
+            implements SourceSplit {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public String splitId() {
+            return "unused";
+        }
+
+        @Override
+        public String dataSetId() {
+            return "demo.orders";
+        }
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/planning/PlanFingerprintCapabilityTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planning/PlanFingerprintCapabilityTest.java
@@ -1,0 +1,84 @@
+package com.link.up.framework.planning;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.framework.job.ExecutionConfig;
+import com.link.up.framework.job.JobCapabilityRequirements;
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.framework.job.SinkDefinition;
+import com.link.up.framework.job.SourceDefinition;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PlanFingerprintCapabilityTest {
+
+    @Test
+    public void capabilityIntentMustContributeToFingerprint() {
+        JobDefinition baseline = definition(
+                JobCapabilityRequirements.empty());
+        JobDefinition required = definition(
+                new JobCapabilityRequirements(
+                        Collections.<ConnectorCapability>emptySet(),
+                        Collections.<ConnectorCapability>emptySet(),
+                        Collections.singleton(
+                                ConnectorCapability.TWO_PHASE_COMMIT),
+                        Collections.<ConnectorCapability>emptySet()));
+
+        assertNotEquals(
+                PlanFingerprint.create(baseline),
+                PlanFingerprint.create(required));
+    }
+
+    @Test
+    public void logicalPlanShouldExposeIntentWithoutConnectorOptions() {
+        JobDefinition definition = definition(
+                new JobCapabilityRequirements(
+                        Collections.singleton(
+                                ConnectorCapability.MULTI_TABLE),
+                        Collections.singleton(
+                                ConnectorCapability.PARTITION_SPLIT),
+                        Collections.<ConnectorCapability>emptySet(),
+                        Collections.<ConnectorCapability>emptySet()));
+
+        LogicalJobPlan plan =
+                LogicalJobPlan.from(definition);
+
+        assertTrue(
+                plan.getCapabilities()
+                        .getSource()
+                        .getRequired()
+                        .contains(
+                                ConnectorCapability.MULTI_TABLE));
+        assertFalse(
+                plan.getFingerprint().contains(
+                        "TEST_ONLY_SECRET"));
+    }
+
+    private JobDefinition definition(
+            JobCapabilityRequirements requirements) {
+
+        java.util.Map<String, Object> sourceOptions =
+                new java.util.LinkedHashMap<String, Object>();
+        sourceOptions.put(
+                "password",
+                "TEST_ONLY_SECRET");
+
+        return new JobDefinition(
+                "fingerprint-capability",
+                new SourceDefinition(
+                        "jdbc",
+                        ReadonlyConfig.fromMap(sourceOptions)),
+                new SinkDefinition(
+                        "doris",
+                        ReadonlyConfig.fromMap(
+                                Collections.<String, Object>emptyMap())),
+                new ExecutionConfig(100, 1, 1, 32),
+                null,
+                requirements);
+    }
+}

--- a/link-up-framework/src/test/java/com/link/up/framework/planning/PlanningErrorContractTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planning/PlanningErrorContractTest.java
@@ -70,6 +70,29 @@ public class PlanningErrorContractTest {
     }
 
     @Test
+    public void sinkPreparationFailureShouldBeConservativelyNonRetryable() {
+        PlanningException failure =
+                PlanningException.sinkPreparationFailed(
+                        "doris",
+                        new IllegalStateException(
+                                "password=TEST_ONLY_SECRET"));
+
+        assertEquals(
+                PlanningErrorCode.SINK_PREPARATION_FAILED,
+                failure.getPlanningErrorCode());
+        assertEquals(
+                FluxErrorPhase.SINK_PREPARATION,
+                failure.getErrorPhase());
+        assertFalse(failure.isRetryable());
+        assertEquals(
+                FluxRetryScope.NONE,
+                failure.getRetryScope());
+        assertFalse(
+                failure.getMessage().contains(
+                        "TEST_ONLY_SECRET"));
+    }
+
+    @Test
     public void legacyApiErrorsShouldExposeStructuredDefaults() {
         assertEquals(
                 FluxErrorCategory.VALIDATION,

--- a/link-up-framework/src/test/java/com/link/up/framework/planning/PlanningErrorContractTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/planning/PlanningErrorContractTest.java
@@ -1,0 +1,90 @@
+package com.link.up.framework.planning;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.exception.FluxErrorCategory;
+import com.link.up.api.exception.FluxErrorPhase;
+import com.link.up.api.exception.FluxRetryScope;
+import com.link.up.api.exception.error.FluxApiErrorCode;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PlanningErrorContractTest {
+
+    @Test
+    public void requiredCapabilityErrorShouldBeMachineReadable() {
+        PlanningException failure =
+                PlanningException.requiredCapabilityMissing(
+                        ConnectorRole.SINK,
+                        "doris",
+                        ConnectorCapability.TWO_PHASE_COMMIT);
+
+        assertEquals(
+                "PLAN-005",
+                failure.getFluxErrorCode().getCode());
+        assertEquals(
+                FluxErrorCategory.CAPABILITY,
+                failure.getErrorCategory());
+        assertEquals(
+                FluxErrorPhase.CAPABILITY_NEGOTIATION,
+                failure.getErrorPhase());
+        assertFalse(failure.isRetryable());
+        assertEquals(
+                FluxRetryScope.NONE,
+                failure.getRetryScope());
+        assertEquals(
+                "SINK",
+                failure.getParams().get("role"));
+        assertEquals(
+                "doris",
+                failure.getParams().get("connectorId"));
+        assertEquals(
+                "TWO_PHASE_COMMIT",
+                failure.getParams().get("capability"));
+    }
+
+    @Test
+    public void sourceDiscoveryFailureShouldNotExposeCauseMessage() {
+        PlanningException failure =
+                PlanningException.sourcePreparationFailed(
+                        "jdbc",
+                        new IllegalStateException(
+                                "password=TEST_ONLY_SECRET"));
+
+        assertEquals(
+                PlanningErrorCode.SOURCE_PREPARATION_FAILED,
+                failure.getPlanningErrorCode());
+        assertTrue(failure.isRetryable());
+        assertEquals(
+                FluxRetryScope.JOB,
+                failure.getRetryScope());
+        assertFalse(
+                failure.getMessage().contains(
+                        "TEST_ONLY_SECRET"));
+        assertFalse(
+                failure.getParams().toString().contains(
+                        "TEST_ONLY_SECRET"));
+    }
+
+    @Test
+    public void legacyApiErrorsShouldExposeStructuredDefaults() {
+        assertEquals(
+                FluxErrorCategory.VALIDATION,
+                FluxApiErrorCode.OPTION_VALIDATION_FAILED
+                        .getCategory());
+        assertEquals(
+                FluxErrorPhase.OPTION_VALIDATION,
+                FluxApiErrorCode.OPTION_VALIDATION_FAILED
+                        .getPhase());
+        assertFalse(
+                FluxApiErrorCode.OPTION_VALIDATION_FAILED
+                        .isRetryable());
+        assertEquals(
+                FluxRetryScope.NONE,
+                FluxApiErrorCode.OPTION_VALIDATION_FAILED
+                        .getRetryScope());
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/application/JobRetryDecision.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobRetryDecision.java
@@ -1,16 +1,26 @@
 package com.link.up.server.application;
 
-/** Immutable result of evaluating whether a terminal job can start another attempt. */
+/** Immutable result of evaluating whether a terminal Job can start another attempt. */
 public final class JobRetryDecision {
 
-    public static final String SAFE_NO_DATA_COMMITTED = "SAFE_NO_DATA_COMMITTED";
-    public static final String JOB_ACTIVE = "JOB_ACTIVE";
-    public static final String ALREADY_SUCCEEDED = "ALREADY_SUCCEEDED";
-    public static final String CANCELED_OUTCOME = "CANCELED_OUTCOME";
-    public static final String LOST_OUTCOME_UNKNOWN = "LOST_OUTCOME_UNKNOWN";
-    public static final String EVIDENCE_UNAVAILABLE = "EVIDENCE_UNAVAILABLE";
-    public static final String UNKNOWN_COMMIT_STATE = "UNKNOWN_COMMIT_STATE";
-    public static final String DATA_ALREADY_COMMITTED = "DATA_ALREADY_COMMITTED";
+    public static final String SAFE_NO_DATA_COMMITTED =
+            "SAFE_NO_DATA_COMMITTED";
+    public static final String JOB_ACTIVE =
+            "JOB_ACTIVE";
+    public static final String ALREADY_SUCCEEDED =
+            "ALREADY_SUCCEEDED";
+    public static final String CANCELED_OUTCOME =
+            "CANCELED_OUTCOME";
+    public static final String LOST_OUTCOME_UNKNOWN =
+            "LOST_OUTCOME_UNKNOWN";
+    public static final String EVIDENCE_UNAVAILABLE =
+            "EVIDENCE_UNAVAILABLE";
+    public static final String UNKNOWN_COMMIT_STATE =
+            "UNKNOWN_COMMIT_STATE";
+    public static final String DATA_ALREADY_COMMITTED =
+            "DATA_ALREADY_COMMITTED";
+    public static final String NON_RETRYABLE_FAILURE =
+            "NON_RETRYABLE_FAILURE";
 
     private final boolean eligible;
     private final String code;
@@ -22,6 +32,7 @@ public final class JobRetryDecision {
             String code,
             String message,
             int nextAttemptNumber) {
+
         this.eligible = eligible;
         this.code = code;
         this.message = message;
@@ -32,14 +43,22 @@ public final class JobRetryDecision {
             String code,
             String message,
             int nextAttemptNumber) {
-        return new JobRetryDecision(true, code, message, nextAttemptNumber);
+        return new JobRetryDecision(
+                true,
+                code,
+                message,
+                nextAttemptNumber);
     }
 
     public static JobRetryDecision deny(
             String code,
             String message,
             int nextAttemptNumber) {
-        return new JobRetryDecision(false, code, message, nextAttemptNumber);
+        return new JobRetryDecision(
+                false,
+                code,
+                message,
+                nextAttemptNumber);
     }
 
     public boolean isEligible() { return eligible; }

--- a/link-up-server/src/main/java/com/link/up/server/application/JobRetryPolicy.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobRetryPolicy.java
@@ -23,45 +23,61 @@ final class JobRetryPolicy {
         if (!status.isTerminal()) {
             return JobRetryDecision.deny(
                     JobRetryDecision.JOB_ACTIVE,
-                    "The job is still active and cannot be retried.",
+                    "The Job is still active and cannot be retried.",
                     nextAttempt);
         }
         if (status == ServerJobStatus.SUCCEEDED) {
             return JobRetryDecision.deny(
                     JobRetryDecision.ALREADY_SUCCEEDED,
-                    "A succeeded job must not be retried.",
+                    "A succeeded Job must not be retried.",
                     nextAttempt);
         }
         if (status == ServerJobStatus.CANCELED) {
             return JobRetryDecision.deny(
                     JobRetryDecision.CANCELED_OUTCOME,
-                    "Cancellation may race with sink commits; retry is not automatically safe.",
+                    "Cancellation may race with Sink commits; retry is not automatically safe.",
                     nextAttempt);
         }
         if (status == ServerJobStatus.LOST) {
             return JobRetryDecision.deny(
                     JobRetryDecision.LOST_OUTCOME_UNKNOWN,
-                    "LOST means the final sink outcome is unknown.",
+                    "LOST means the final Sink outcome is unknown.",
                     nextAttempt);
         }
-        if (status != ServerJobStatus.FAILED || metadata == null) {
+        if (status != ServerJobStatus.FAILED
+                || metadata == null) {
             return evidenceUnavailable(nextAttempt);
         }
 
-        List<JobAttemptMetadata> attempts = metadata.getAttempts();
+        List<JobAttemptMetadata> attempts =
+                metadata.getAttempts();
         if (attempts.isEmpty()) {
             return evidenceUnavailable(nextAttempt);
         }
 
-        JobAttemptMetadata last = attempts.get(attempts.size() - 1);
-        if (last.getStatus() != JobAttemptStatus.FAILED
-                || !last.isCommitEvidenceAvailable()) {
+        JobAttemptMetadata last =
+                attempts.get(attempts.size() - 1);
+        if (last.getStatus() != JobAttemptStatus.FAILED) {
+            return evidenceUnavailable(nextAttempt);
+        }
+
+        if (last.getErrorCode() != null
+                && !last.isFailureRetryable()) {
+            return JobRetryDecision.deny(
+                    JobRetryDecision.NON_RETRYABLE_FAILURE,
+                    "The previous attempt failed with non-retryable structured error "
+                            + last.getErrorCode()
+                            + ".",
+                    nextAttempt);
+        }
+
+        if (!last.isCommitEvidenceAvailable()) {
             return evidenceUnavailable(nextAttempt);
         }
         if (last.getUnknownStateRecordCount() > 0L) {
             return JobRetryDecision.deny(
                     JobRetryDecision.UNKNOWN_COMMIT_STATE,
-                    "The previous attempt contains records with unknown sink commit state.",
+                    "The previous attempt contains records with unknown Sink commit state.",
                     nextAttempt);
         }
         if (last.isPartialDataCommit()
@@ -79,7 +95,8 @@ final class JobRetryPolicy {
                 nextAttempt);
     }
 
-    private JobRetryDecision evidenceUnavailable(int nextAttempt) {
+    private JobRetryDecision evidenceUnavailable(
+            int nextAttempt) {
         return JobRetryDecision.deny(
                 JobRetryDecision.EVIDENCE_UNAVAILABLE,
                 "Commit evidence is unavailable, so retry safety cannot be proven.",

--- a/link-up-server/src/main/java/com/link/up/server/domain/JobExecutionAttempt.java
+++ b/link-up-server/src/main/java/com/link/up/server/domain/JobExecutionAttempt.java
@@ -1,5 +1,6 @@
 package com.link.up.server.domain;
 
+import com.link.up.api.exception.FluxRuntimeException;
 import com.link.up.framework.job.CommitSummary;
 import com.link.up.framework.job.JobResult;
 import com.link.up.server.runtime.ServerJobStatus;
@@ -21,6 +22,12 @@ public final class JobExecutionAttempt {
     private volatile String failureMessage;
     private volatile String retryAdvice;
 
+    private volatile String errorCode;
+    private volatile String errorCategory;
+    private volatile String errorPhase;
+    private volatile boolean failureRetryable;
+    private volatile String failureRetryScope;
+
     private volatile boolean commitEvidenceAvailable;
     private volatile int dataCommittedTaskCount;
     private volatile long successfullyCommittedRecordCount;
@@ -28,15 +35,23 @@ public final class JobExecutionAttempt {
     private volatile boolean partialDataCommit;
     private volatile String commitScope;
 
-    JobExecutionAttempt(String jobId, int attemptNumber) {
+    JobExecutionAttempt(
+            String jobId,
+            int attemptNumber) {
+
         if (attemptNumber <= 0) {
             throw new IllegalArgumentException(
                     "attemptNumber must be greater than 0");
         }
-        String normalizedJobId = requireText(jobId, "jobId");
+
+        String normalizedJobId =
+                requireText(jobId, "jobId");
         this.attemptNumber = attemptNumber;
-        this.attemptId = normalizedJobId + "-attempt-" + attemptNumber;
-        this.createTimeMillis = System.currentTimeMillis();
+        this.attemptId = normalizedJobId
+                + "-attempt-"
+                + attemptNumber;
+        this.createTimeMillis =
+                System.currentTimeMillis();
         this.status = JobAttemptStatus.CREATED;
     }
 
@@ -53,6 +68,11 @@ public final class JobExecutionAttempt {
             String failureType,
             String failureMessage,
             String retryAdvice,
+            String errorCode,
+            String errorCategory,
+            String errorPhase,
+            boolean failureRetryable,
+            String failureRetryScope,
             boolean commitEvidenceAvailable,
             int dataCommittedTaskCount,
             long successfullyCommittedRecordCount,
@@ -61,7 +81,9 @@ public final class JobExecutionAttempt {
             String commitScope) {
 
         this.attemptNumber = attemptNumber;
-        this.attemptId = requireText(attemptId, "attemptId");
+        this.attemptId = requireText(
+                attemptId,
+                "attemptId");
         this.status = status;
         this.createTimeMillis = createTimeMillis;
         this.queuedTimeMillis = queuedTimeMillis;
@@ -72,14 +94,24 @@ public final class JobExecutionAttempt {
         this.failureType = failureType;
         this.failureMessage = failureMessage;
         this.retryAdvice = retryAdvice;
-        this.commitEvidenceAvailable = commitEvidenceAvailable;
-        this.dataCommittedTaskCount = dataCommittedTaskCount;
-        this.successfullyCommittedRecordCount = successfullyCommittedRecordCount;
-        this.unknownStateRecordCount = unknownStateRecordCount;
+        this.errorCode = errorCode;
+        this.errorCategory = errorCategory;
+        this.errorPhase = errorPhase;
+        this.failureRetryable = failureRetryable;
+        this.failureRetryScope = failureRetryScope;
+        this.commitEvidenceAvailable =
+                commitEvidenceAvailable;
+        this.dataCommittedTaskCount =
+                dataCommittedTaskCount;
+        this.successfullyCommittedRecordCount =
+                successfullyCommittedRecordCount;
+        this.unknownStateRecordCount =
+                unknownStateRecordCount;
         this.partialDataCommit = partialDataCommit;
         this.commitScope = commitScope;
     }
 
+    /** Compatibility restore overload for persisted format v1/v2. */
     public static JobExecutionAttempt restore(
             int attemptNumber,
             String attemptId,
@@ -100,9 +132,62 @@ public final class JobExecutionAttempt {
             boolean partialDataCommit,
             String commitScope) {
 
+        return restore(
+                attemptNumber,
+                attemptId,
+                status,
+                createTimeMillis,
+                queuedTimeMillis,
+                startTimeMillis,
+                endTimeMillis,
+                runId,
+                jobLogFile,
+                failureType,
+                failureMessage,
+                retryAdvice,
+                null,
+                null,
+                null,
+                false,
+                null,
+                commitEvidenceAvailable,
+                dataCommittedTaskCount,
+                successfullyCommittedRecordCount,
+                unknownStateRecordCount,
+                partialDataCommit,
+                commitScope);
+    }
+
+    public static JobExecutionAttempt restore(
+            int attemptNumber,
+            String attemptId,
+            JobAttemptStatus status,
+            long createTimeMillis,
+            long queuedTimeMillis,
+            long startTimeMillis,
+            long endTimeMillis,
+            String runId,
+            String jobLogFile,
+            String failureType,
+            String failureMessage,
+            String retryAdvice,
+            String errorCode,
+            String errorCategory,
+            String errorPhase,
+            boolean failureRetryable,
+            String failureRetryScope,
+            boolean commitEvidenceAvailable,
+            int dataCommittedTaskCount,
+            long successfullyCommittedRecordCount,
+            long unknownStateRecordCount,
+            boolean partialDataCommit,
+            String commitScope) {
+
         if (attemptNumber <= 0 || status == null) {
-            throw new IllegalArgumentException("Invalid restored attempt");
+            throw new IllegalArgumentException(
+                    "Invalid restored attempt");
         }
+
         return new JobExecutionAttempt(
                 attemptNumber,
                 attemptId,
@@ -116,6 +201,11 @@ public final class JobExecutionAttempt {
                 failureType,
                 failureMessage,
                 retryAdvice,
+                errorCode,
+                errorCategory,
+                errorPhase,
+                failureRetryable,
+                failureRetryScope,
                 commitEvidenceAvailable,
                 dataCommittedTaskCount,
                 successfullyCommittedRecordCount,
@@ -139,8 +229,11 @@ public final class JobExecutionAttempt {
     synchronized void bindLogIdentity(
             String runId,
             String jobLogFile) {
+
         this.runId = requireText(runId, "runId");
-        this.jobLogFile = requireText(jobLogFile, "jobLogFile");
+        this.jobLogFile = requireText(
+                jobLogFile,
+                "jobLogFile");
     }
 
     synchronized void complete(
@@ -151,31 +244,44 @@ public final class JobExecutionAttempt {
         if (status.isTerminal()) {
             return;
         }
+
         status = attemptStatus(finalStatus);
         endTimeMillis = System.currentTimeMillis();
-        recordFailure(failure != null
-                ? failure
-                : result == null ? null : result.getFailure());
+        recordFailure(
+                failure != null
+                        ? failure
+                        : result == null
+                        ? null
+                        : result.getFailure());
 
         CommitSummary summary = result == null
                 ? null
                 : result.getCommitSummary();
+
         if (summary != null) {
             commitEvidenceAvailable = true;
-            dataCommittedTaskCount = summary.getDataCommittedTaskCount();
+            dataCommittedTaskCount =
+                    summary.getDataCommittedTaskCount();
             successfullyCommittedRecordCount =
                     summary.getSuccessfullyCommittedRecordCount();
-            unknownStateRecordCount = summary.getUnknownStateRecordCount();
-            partialDataCommit = summary.isPartialDataCommit();
-            commitScope = summary.getCommitScope().name();
-            retryAdvice = normalize(summary.getRetryAdvice());
+            unknownStateRecordCount =
+                    summary.getUnknownStateRecordCount();
+            partialDataCommit =
+                    summary.isPartialDataCommit();
+            commitScope =
+                    summary.getCommitScope().name();
+            retryAdvice = normalize(
+                    summary.getRetryAdvice());
         }
     }
 
-    synchronized void completeBeforeExecution(Throwable failure) {
+    synchronized void completeBeforeExecution(
+            Throwable failure) {
+
         if (status.isTerminal()) {
             return;
         }
+
         status = JobAttemptStatus.FAILED;
         endTimeMillis = System.currentTimeMillis();
         recordFailure(failure);
@@ -185,18 +291,52 @@ public final class JobExecutionAttempt {
         unknownStateRecordCount = 0L;
         partialDataCommit = false;
         commitScope = null;
-        retryAdvice = "Execution did not start; replay is safe.";
+        retryAdvice =
+                "Execution did not start; replay is safe.";
     }
 
     private void recordFailure(Throwable failure) {
         if (failure == null) {
             return;
         }
+
         failureType = failure.getClass().getSimpleName();
         failureMessage = safeMessage(failure);
+
+        FluxRuntimeException structured =
+                structuredFailure(failure);
+        if (structured == null) {
+            return;
+        }
+
+        errorCode = structured.getFluxErrorCode().getCode();
+        errorCategory = structured.getErrorCategory().name();
+        errorPhase = structured.getErrorPhase().name();
+        failureRetryable = structured.isRetryable();
+        failureRetryScope =
+                structured.getRetryScope().name();
     }
 
-    private void requireStatus(JobAttemptStatus expected) {
+    private FluxRuntimeException structuredFailure(
+            Throwable failure) {
+
+        Throwable current = failure;
+        int depth = 0;
+
+        while (current != null && depth < 20) {
+            if (current instanceof FluxRuntimeException) {
+                return (FluxRuntimeException) current;
+            }
+            current = current.getCause();
+            depth++;
+        }
+
+        return null;
+    }
+
+    private void requireStatus(
+            JobAttemptStatus expected) {
+
         if (status != expected) {
             throw new IllegalStateException(
                     "Illegal attempt state transition: "
@@ -206,7 +346,9 @@ public final class JobExecutionAttempt {
         }
     }
 
-    private static JobAttemptStatus attemptStatus(ServerJobStatus status) {
+    private static JobAttemptStatus attemptStatus(
+            ServerJobStatus status) {
+
         if (status == ServerJobStatus.SUCCEEDED) {
             return JobAttemptStatus.SUCCEEDED;
         }
@@ -219,10 +361,14 @@ public final class JobExecutionAttempt {
         return JobAttemptStatus.FAILED;
     }
 
-    private static String requireText(String value, String name) {
+    private static String requireText(
+            String value,
+            String name) {
+
         String normalized = normalize(value);
         if (normalized == null) {
-            throw new IllegalArgumentException(name + " must not be blank");
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
         }
         return normalized;
     }
@@ -232,7 +378,9 @@ public final class JobExecutionAttempt {
             return null;
         }
         String normalized = value.trim();
-        return normalized.isEmpty() ? null : normalized;
+        return normalized.isEmpty()
+                ? null
+                : normalized;
     }
 
     private static String safeMessage(Throwable failure) {
@@ -240,7 +388,8 @@ public final class JobExecutionAttempt {
         if (message == null) {
             message = failure.getClass().getSimpleName();
         }
-        message = message.replace('\r', ' ').replace('\n', ' ');
+        message = message.replace('\r', ' ')
+                .replace('\n', ' ');
         return message.length() <= 500
                 ? message
                 : message.substring(0, 500);
@@ -258,6 +407,11 @@ public final class JobExecutionAttempt {
     public String getFailureType() { return failureType; }
     public String getFailureMessage() { return failureMessage; }
     public String getRetryAdvice() { return retryAdvice; }
+    public String getErrorCode() { return errorCode; }
+    public String getErrorCategory() { return errorCategory; }
+    public String getErrorPhase() { return errorPhase; }
+    public boolean isFailureRetryable() { return failureRetryable; }
+    public String getFailureRetryScope() { return failureRetryScope; }
     public boolean isCommitEvidenceAvailable() { return commitEvidenceAvailable; }
     public int getDataCommittedTaskCount() { return dataCommittedTaskCount; }
     public long getSuccessfullyCommittedRecordCount() { return successfullyCommittedRecordCount; }

--- a/link-up-server/src/main/java/com/link/up/server/dto/ErrorResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/ErrorResponse.java
@@ -1,19 +1,59 @@
 package com.link.up.server.dto;
 
+import com.link.up.api.exception.FluxErrorCategory;
+import com.link.up.api.exception.FluxErrorPhase;
+import com.link.up.api.exception.FluxRetryScope;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Stable REST error response with additive structured metadata. */
 public final class ErrorResponse {
 
     private final String code;
     private final String message;
     private final String requestId;
+    private final FluxErrorCategory category;
+    private final FluxErrorPhase phase;
+    private final Boolean retryable;
+    private final FluxRetryScope retryScope;
+    private final Map<String, String> parameters;
 
     public ErrorResponse(
             String code,
             String message,
             String requestId) {
 
+        this(
+                code,
+                message,
+                requestId,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    public ErrorResponse(
+            String code,
+            String message,
+            String requestId,
+            FluxErrorCategory category,
+            FluxErrorPhase phase,
+            Boolean retryable,
+            FluxRetryScope retryScope,
+            Map<String, String> parameters) {
+
         this.code = code;
         this.message = message;
         this.requestId = requestId;
+        this.category = category;
+        this.phase = phase;
+        this.retryable = retryable;
+        this.retryScope = retryScope;
+        this.parameters = immutable(parameters);
     }
 
     public String getCode() {
@@ -26,5 +66,36 @@ public final class ErrorResponse {
 
     public String getRequestId() {
         return requestId;
+    }
+
+    public FluxErrorCategory getCategory() {
+        return category;
+    }
+
+    public FluxErrorPhase getPhase() {
+        return phase;
+    }
+
+    public Boolean getRetryable() {
+        return retryable;
+    }
+
+    public FluxRetryScope getRetryScope() {
+        return retryScope;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    private static Map<String, String> immutable(
+            Map<String, String> values) {
+
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+
+        return Collections.unmodifiableMap(
+                new LinkedHashMap<String, String>(values));
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/http/ExceptionHandlingFilter.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/ExceptionHandlingFilter.java
@@ -1,5 +1,10 @@
 package com.link.up.server.http;
 
+import com.link.up.api.exception.FluxErrorCategory;
+import com.link.up.api.exception.FluxErrorCode;
+import com.link.up.api.exception.FluxErrorPhase;
+import com.link.up.api.exception.FluxRetryScope;
+import com.link.up.api.exception.FluxRuntimeException;
 import com.link.up.server.application.JobNotFoundException;
 import com.link.up.server.application.JobRetryNotAllowedException;
 import com.link.up.server.application.JobSubmissionConflictException;
@@ -16,6 +21,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.logging.Level;
@@ -25,10 +31,12 @@ import java.util.logging.Logger;
 public final class ExceptionHandlingFilter implements Filter {
 
     public static final String REQUEST_ID_ATTRIBUTE =
-            ExceptionHandlingFilter.class.getName() + ".requestId";
+            ExceptionHandlingFilter.class.getName()
+                    + ".requestId";
 
     private static final Logger LOG =
-            Logger.getLogger(ExceptionHandlingFilter.class.getName());
+            Logger.getLogger(
+                    ExceptionHandlingFilter.class.getName());
 
     public void init(FilterConfig filterConfig) {
     }
@@ -39,12 +47,18 @@ public final class ExceptionHandlingFilter implements Filter {
             FilterChain chain)
             throws IOException, ServletException {
 
-        HttpServletRequest request = (HttpServletRequest) servletRequest;
-        HttpServletResponse response = (HttpServletResponse) servletResponse;
+        HttpServletRequest request =
+                (HttpServletRequest) servletRequest;
+        HttpServletResponse response =
+                (HttpServletResponse) servletResponse;
         String requestId = requestId(request);
 
-        request.setAttribute(REQUEST_ID_ATTRIBUTE, requestId);
-        response.setHeader("X-Request-Id", requestId);
+        request.setAttribute(
+                REQUEST_ID_ATTRIBUTE,
+                requestId);
+        response.setHeader(
+                "X-Request-Id",
+                requestId);
 
         try {
             chain.doFilter(request, response);
@@ -52,7 +66,10 @@ public final class ExceptionHandlingFilter implements Filter {
             Throwable failure = unwrap(exception);
 
             if (response.isCommitted()) {
-                LOG.log(Level.SEVERE, logMessage(request, requestId), failure);
+                LOG.log(
+                        Level.SEVERE,
+                        logMessage(request, requestId),
+                        failure);
                 throw exception instanceof ServletException
                         ? (ServletException) exception
                         : new ServletException(exception);
@@ -62,20 +79,31 @@ public final class ExceptionHandlingFilter implements Filter {
             response.resetBuffer();
             response.setStatus(mapping.httpStatus);
             response.setCharacterEncoding("UTF-8");
-            response.setContentType("application/json;charset=UTF-8");
-            response.setHeader("Cache-Control", "no-store");
+            response.setContentType(
+                    "application/json;charset=UTF-8");
+            response.setHeader(
+                    "Cache-Control",
+                    "no-store");
 
             JsonSupport.mapper().writeValue(
                     response.getOutputStream(),
                     new ErrorResponse(
                             mapping.code,
                             mapping.message,
-                            requestId));
+                            requestId,
+                            mapping.category,
+                            mapping.phase,
+                            mapping.retryable,
+                            mapping.retryScope,
+                            mapping.parameters));
 
             Level level = mapping.httpStatus >= 500
                     ? Level.SEVERE
                     : Level.WARNING;
-            LOG.log(level, logMessage(request, requestId), failure);
+            LOG.log(
+                    level,
+                    logMessage(request, requestId),
+                    failure);
         }
     }
 
@@ -84,7 +112,8 @@ public final class ExceptionHandlingFilter implements Filter {
 
     private static ErrorMapping map(Throwable failure) {
         if (failure instanceof RestException) {
-            RestException exception = (RestException) failure;
+            RestException exception =
+                    (RestException) failure;
             return new ErrorMapping(
                     exception.getHttpStatus(),
                     exception.getCode(),
@@ -120,6 +149,10 @@ public final class ExceptionHandlingFilter implements Filter {
                     "FLUX-JOB-EVENT-HISTORY-UNAVAILABLE",
                     "Job event history is unavailable");
         }
+        if (failure instanceof FluxRuntimeException) {
+            return structured(
+                    (FluxRuntimeException) failure);
+        }
         if (failure instanceof IllegalArgumentException) {
             return new ErrorMapping(
                     400,
@@ -144,6 +177,48 @@ public final class ExceptionHandlingFilter implements Filter {
                 "Internal server error");
     }
 
+    private static ErrorMapping structured(
+            FluxRuntimeException failure) {
+
+        FluxErrorCode errorCode =
+                failure.getFluxErrorCode();
+        FluxErrorCategory category =
+                errorCode.getCategory();
+
+        return new ErrorMapping(
+                httpStatus(
+                        category,
+                        errorCode.isRetryable()),
+                errorCode.getCode(),
+                errorCode.getDescription(),
+                category,
+                errorCode.getPhase(),
+                Boolean.valueOf(
+                        errorCode.isRetryable()),
+                errorCode.getRetryScope(),
+                failure.getParams());
+    }
+
+    private static int httpStatus(
+            FluxErrorCategory category,
+            boolean retryable) {
+
+        if (category == FluxErrorCategory.VALIDATION) {
+            return 400;
+        }
+        if (category == FluxErrorCategory.CAPABILITY
+                || category == FluxErrorCategory.PLANNING) {
+            return 422;
+        }
+        if (category == FluxErrorCategory.DISCOVERY
+                || category == FluxErrorCategory.PREPARATION) {
+            return retryable
+                    ? 503
+                    : 422;
+        }
+        return 500;
+    }
+
     private static Throwable unwrap(Throwable failure) {
         Throwable current = failure;
         while (current instanceof ServletException
@@ -153,8 +228,11 @@ public final class ExceptionHandlingFilter implements Filter {
         return current;
     }
 
-    private static String requestId(HttpServletRequest request) {
-        String provided = request.getHeader("X-Request-Id");
+    private static String requestId(
+            HttpServletRequest request) {
+
+        String provided =
+                request.getHeader("X-Request-Id");
         if (provided != null
                 && provided.length() <= 128
                 && provided.matches("[A-Za-z0-9._-]+")) {
@@ -173,24 +251,61 @@ public final class ExceptionHandlingFilter implements Filter {
     private static String logMessage(
             HttpServletRequest request,
             String requestId) {
+
         return "REST request failed"
-                + ", requestId=" + requestId
-                + ", method=" + request.getMethod()
-                + ", uri=" + request.getRequestURI();
+                + ", requestId="
+                + requestId
+                + ", method="
+                + request.getMethod()
+                + ", uri="
+                + request.getRequestURI();
     }
 
     private static final class ErrorMapping {
+
         private final int httpStatus;
         private final String code;
         private final String message;
+        private final FluxErrorCategory category;
+        private final FluxErrorPhase phase;
+        private final Boolean retryable;
+        private final FluxRetryScope retryScope;
+        private final Map<String, String> parameters;
 
         private ErrorMapping(
                 int httpStatus,
                 String code,
                 String message) {
+
+            this(
+                    httpStatus,
+                    code,
+                    message,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+        }
+
+        private ErrorMapping(
+                int httpStatus,
+                String code,
+                String message,
+                FluxErrorCategory category,
+                FluxErrorPhase phase,
+                Boolean retryable,
+                FluxRetryScope retryScope,
+                Map<String, String> parameters) {
+
             this.httpStatus = httpStatus;
             this.code = code;
             this.message = message;
+            this.category = category;
+            this.phase = phase;
+            this.retryable = retryable;
+            this.retryScope = retryScope;
+            this.parameters = parameters;
         }
     }
 }

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/StoredJobRecord.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/StoredJobRecord.java
@@ -15,10 +15,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/** Versioned JSON persistence model for one Worker job checkpoint. */
+/** Versioned JSON persistence model for one Worker Job checkpoint. */
 final class StoredJobRecord {
 
-    static final int CURRENT_FORMAT_VERSION = 2;
+    static final int CURRENT_FORMAT_VERSION = 3;
     static final int MIN_SUPPORTED_FORMAT_VERSION = 1;
 
     public int formatVersion;
@@ -44,16 +44,21 @@ final class StoredJobRecord {
         record.jobId = snapshot.getJobId();
         record.jobName = snapshot.getJobName();
         record.status = snapshot.getStatus().name();
-        record.createTimeMillis = snapshot.getCreateTimeMillis();
-        record.startTimeMillis = snapshot.getStartTimeMillis();
-        record.endTimeMillis = snapshot.getEndTimeMillis();
+        record.createTimeMillis =
+                snapshot.getCreateTimeMillis();
+        record.startTimeMillis =
+                snapshot.getStartTimeMillis();
+        record.endTimeMillis =
+                snapshot.getEndTimeMillis();
         record.errorCode = snapshot.getErrorCode();
         record.errorMessage = snapshot.getErrorMessage();
         record.metadata = StoredMetadata.from(metadata);
         return record;
     }
 
-    void validateFormat(String source) throws IOException {
+    void validateFormat(String source)
+            throws IOException {
+
         if (formatVersion < MIN_SUPPORTED_FORMAT_VERSION
                 || formatVersion > CURRENT_FORMAT_VERSION) {
             throw new IOException(
@@ -197,7 +202,6 @@ final class StoredJobRecord {
 
             StoredTransition stored =
                     new StoredTransition();
-
             stored.version = transition.getVersion();
             stored.fromStatus =
                     transition.getFromStatus() == null
@@ -216,7 +220,8 @@ final class StoredJobRecord {
                     version,
                     fromStatus == null
                             ? null
-                            : ServerJobStatus.valueOf(fromStatus),
+                            : ServerJobStatus.valueOf(
+                                    fromStatus),
                     ServerJobStatus.valueOf(toStatus),
                     transitionTimeMillis,
                     reason);
@@ -236,6 +241,11 @@ final class StoredJobRecord {
         public String failureType;
         public String failureMessage;
         public String retryAdvice;
+        public String structuredErrorCode;
+        public String structuredErrorCategory;
+        public String structuredErrorPhase;
+        public boolean failureRetryable;
+        public String failureRetryScope;
         public boolean commitEvidenceAvailable;
         public int dataCommittedTaskCount;
         public long successfullyCommittedRecordCount;
@@ -250,18 +260,34 @@ final class StoredJobRecord {
                 JobAttemptMetadata attempt) {
 
             StoredAttempt stored = new StoredAttempt();
-            stored.attemptNumber = attempt.getAttemptNumber();
+            stored.attemptNumber =
+                    attempt.getAttemptNumber();
             stored.attemptId = attempt.getAttemptId();
             stored.status = attempt.getStatus().name();
-            stored.createTimeMillis = attempt.getCreateTimeMillis();
-            stored.queuedTimeMillis = attempt.getQueuedTimeMillis();
-            stored.startTimeMillis = attempt.getStartTimeMillis();
-            stored.endTimeMillis = attempt.getEndTimeMillis();
+            stored.createTimeMillis =
+                    attempt.getCreateTimeMillis();
+            stored.queuedTimeMillis =
+                    attempt.getQueuedTimeMillis();
+            stored.startTimeMillis =
+                    attempt.getStartTimeMillis();
+            stored.endTimeMillis =
+                    attempt.getEndTimeMillis();
             stored.runId = attempt.getRunId();
             stored.jobLogFile = attempt.getJobLogFile();
             stored.failureType = attempt.getFailureType();
-            stored.failureMessage = attempt.getFailureMessage();
+            stored.failureMessage =
+                    attempt.getFailureMessage();
             stored.retryAdvice = attempt.getRetryAdvice();
+            stored.structuredErrorCode =
+                    attempt.getErrorCode();
+            stored.structuredErrorCategory =
+                    attempt.getErrorCategory();
+            stored.structuredErrorPhase =
+                    attempt.getErrorPhase();
+            stored.failureRetryable =
+                    attempt.isFailureRetryable();
+            stored.failureRetryScope =
+                    attempt.getFailureRetryScope();
             stored.commitEvidenceAvailable =
                     attempt.isCommitEvidenceAvailable();
             stored.dataCommittedTaskCount =
@@ -290,6 +316,11 @@ final class StoredJobRecord {
                     failureType,
                     failureMessage,
                     retryAdvice,
+                    structuredErrorCode,
+                    structuredErrorCategory,
+                    structuredErrorPhase,
+                    failureRetryable,
+                    failureRetryScope,
                     commitEvidenceAvailable,
                     dataCommittedTaskCount,
                     successfullyCommittedRecordCount,

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobAttemptMetadata.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobAttemptMetadata.java
@@ -20,6 +20,11 @@ public final class JobAttemptMetadata {
     private final String failureType;
     private final String failureMessage;
     private final String retryAdvice;
+    private final String errorCode;
+    private final String errorCategory;
+    private final String errorPhase;
+    private final boolean failureRetryable;
+    private final String failureRetryScope;
 
     private final boolean commitEvidenceAvailable;
     private final int dataCommittedTaskCount;
@@ -41,6 +46,7 @@ public final class JobAttemptMetadata {
             String failureType,
             String failureMessage,
             String retryAdvice) {
+
         this(
                 attemptNumber,
                 attemptId,
@@ -54,6 +60,11 @@ public final class JobAttemptMetadata {
                 failureType,
                 failureMessage,
                 retryAdvice,
+                null,
+                null,
+                null,
+                false,
+                null,
                 false,
                 0,
                 0L,
@@ -62,6 +73,7 @@ public final class JobAttemptMetadata {
                 null);
     }
 
+    /** Compatibility constructor for checkpoint format v1/v2. */
     public JobAttemptMetadata(
             int attemptNumber,
             String attemptId,
@@ -82,9 +94,64 @@ public final class JobAttemptMetadata {
             boolean partialDataCommit,
             String commitScope) {
 
+        this(
+                attemptNumber,
+                attemptId,
+                status,
+                createTimeMillis,
+                queuedTimeMillis,
+                startTimeMillis,
+                endTimeMillis,
+                runId,
+                jobLogFile,
+                failureType,
+                failureMessage,
+                retryAdvice,
+                null,
+                null,
+                null,
+                false,
+                null,
+                commitEvidenceAvailable,
+                dataCommittedTaskCount,
+                successfullyCommittedRecordCount,
+                unknownStateRecordCount,
+                partialDataCommit,
+                commitScope);
+    }
+
+    public JobAttemptMetadata(
+            int attemptNumber,
+            String attemptId,
+            JobAttemptStatus status,
+            long createTimeMillis,
+            long queuedTimeMillis,
+            long startTimeMillis,
+            long endTimeMillis,
+            String runId,
+            String jobLogFile,
+            String failureType,
+            String failureMessage,
+            String retryAdvice,
+            String errorCode,
+            String errorCategory,
+            String errorPhase,
+            boolean failureRetryable,
+            String failureRetryScope,
+            boolean commitEvidenceAvailable,
+            int dataCommittedTaskCount,
+            long successfullyCommittedRecordCount,
+            long unknownStateRecordCount,
+            boolean partialDataCommit,
+            String commitScope) {
+
         this.attemptNumber = attemptNumber;
-        this.attemptId = Objects.requireNonNull(attemptId, "attemptId must not be null");
-        this.status = Objects.requireNonNull(status, "status must not be null");
+        this.attemptId = Objects.requireNonNull(
+                attemptId,
+                "attemptId must not be null");
+        this.status = Objects.requireNonNull(
+                status,
+                "status must not be null");
         this.createTimeMillis = createTimeMillis;
         this.queuedTimeMillis = queuedTimeMillis;
         this.startTimeMillis = startTimeMillis;
@@ -94,15 +161,26 @@ public final class JobAttemptMetadata {
         this.failureType = failureType;
         this.failureMessage = failureMessage;
         this.retryAdvice = retryAdvice;
-        this.commitEvidenceAvailable = commitEvidenceAvailable;
-        this.dataCommittedTaskCount = dataCommittedTaskCount;
-        this.successfullyCommittedRecordCount = successfullyCommittedRecordCount;
-        this.unknownStateRecordCount = unknownStateRecordCount;
+        this.errorCode = errorCode;
+        this.errorCategory = errorCategory;
+        this.errorPhase = errorPhase;
+        this.failureRetryable = failureRetryable;
+        this.failureRetryScope = failureRetryScope;
+        this.commitEvidenceAvailable =
+                commitEvidenceAvailable;
+        this.dataCommittedTaskCount =
+                dataCommittedTaskCount;
+        this.successfullyCommittedRecordCount =
+                successfullyCommittedRecordCount;
+        this.unknownStateRecordCount =
+                unknownStateRecordCount;
         this.partialDataCommit = partialDataCommit;
         this.commitScope = commitScope;
     }
 
-    public static JobAttemptMetadata from(JobExecutionAttempt attempt) {
+    public static JobAttemptMetadata from(
+            JobExecutionAttempt attempt) {
+
         return new JobAttemptMetadata(
                 attempt.getAttemptNumber(),
                 attempt.getAttemptId(),
@@ -116,6 +194,11 @@ public final class JobAttemptMetadata {
                 attempt.getFailureType(),
                 attempt.getFailureMessage(),
                 attempt.getRetryAdvice(),
+                attempt.getErrorCode(),
+                attempt.getErrorCategory(),
+                attempt.getErrorPhase(),
+                attempt.isFailureRetryable(),
+                attempt.getFailureRetryScope(),
                 attempt.isCommitEvidenceAvailable(),
                 attempt.getDataCommittedTaskCount(),
                 attempt.getSuccessfullyCommittedRecordCount(),
@@ -138,6 +221,11 @@ public final class JobAttemptMetadata {
                 failureType,
                 failureMessage,
                 retryAdvice,
+                errorCode,
+                errorCategory,
+                errorPhase,
+                failureRetryable,
+                failureRetryScope,
                 commitEvidenceAvailable,
                 dataCommittedTaskCount,
                 successfullyCommittedRecordCount,
@@ -167,6 +255,11 @@ public final class JobAttemptMetadata {
                 "WorkerRestartRecovery",
                 reason,
                 retryAdvice,
+                null,
+                null,
+                null,
+                false,
+                null,
                 false,
                 dataCommittedTaskCount,
                 successfullyCommittedRecordCount,
@@ -187,6 +280,11 @@ public final class JobAttemptMetadata {
     public String getFailureType() { return failureType; }
     public String getFailureMessage() { return failureMessage; }
     public String getRetryAdvice() { return retryAdvice; }
+    public String getErrorCode() { return errorCode; }
+    public String getErrorCategory() { return errorCategory; }
+    public String getErrorPhase() { return errorPhase; }
+    public boolean isFailureRetryable() { return failureRetryable; }
+    public String getFailureRetryScope() { return failureRetryScope; }
     public boolean isCommitEvidenceAvailable() { return commitEvidenceAvailable; }
     public int getDataCommittedTaskCount() { return dataCommittedTaskCount; }
     public long getSuccessfullyCommittedRecordCount() { return successfullyCommittedRecordCount; }

--- a/link-up-server/src/main/java/com/link/up/server/service/JobPlanningService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobPlanningService.java
@@ -6,19 +6,22 @@ import com.link.up.framework.job.JobDefinition;
 import com.link.up.framework.job.JobSpecCompiler;
 import com.link.up.framework.planning.JobPlanExplainer;
 import com.link.up.framework.planning.JobPlanResult;
+import com.link.up.framework.planning.PlanningException;
 import com.link.up.server.dto.JobSubmitRequest;
 import com.typesafe.config.ConfigException;
 
 import java.util.Objects;
 
-/** REST-neutral Worker boundary for validation and explain operations. */
+/** REST-neutral Worker boundary for validation and Explain operations. */
 public final class JobPlanningService {
 
     private final JobConfigParser hoconParser;
     private final JobSpecCompiler jobSpecCompiler;
     private final JobPlanExplainer planExplainer;
 
-    public JobPlanningService(JobPlanExplainer planExplainer) {
+    public JobPlanningService(
+            JobPlanExplainer planExplainer) {
+
         this.hoconParser = new JobConfigParser();
         this.jobSpecCompiler = new JobSpecCompiler();
         this.planExplainer = Objects.requireNonNull(
@@ -26,21 +29,26 @@ public final class JobPlanningService {
                 "planExplainer must not be null");
     }
 
-    public JobPlanResult validate(JobSubmitRequest request) {
+    public JobPlanResult validate(
+            JobSubmitRequest request) {
         return planExplainer.validate(
                 definition(request));
     }
 
-    public JobPlanResult explain(JobSubmitRequest request)
+    public JobPlanResult explain(
+            JobSubmitRequest request)
             throws Exception {
         return planExplainer.explain(
                 definition(request));
     }
 
-    private JobDefinition definition(JobSubmitRequest request) {
+    private JobDefinition definition(
+            JobSubmitRequest request) {
+
         if (request == null) {
-            throw new IllegalArgumentException(
-                    "Planning request must not be null");
+            throw PlanningException.invalidRequest(
+                    "REQUEST_NULL",
+                    null);
         }
 
         JobSpec jobSpec = request.getJobSpec();
@@ -48,25 +56,41 @@ public final class JobPlanningService {
         boolean hasHocon = hasText(request.getHocon());
 
         if (hasJobSpec == hasHocon) {
-            throw new IllegalArgumentException(
-                    "Exactly one of jobSpec or hocon must be provided");
+            throw PlanningException.invalidRequest(
+                    "EXACTLY_ONE_DEFINITION_REQUIRED",
+                    null);
         }
 
         if (hasJobSpec) {
-            return jobSpecCompiler.compile(jobSpec);
+            try {
+                return jobSpecCompiler.compile(jobSpec);
+            } catch (PlanningException failure) {
+                throw failure;
+            } catch (RuntimeException failure) {
+                throw PlanningException.invalidDefinition(
+                        "JOB_SPEC",
+                        failure);
+            }
         }
 
         try {
             return hoconParser.parse(
                     request.getHocon().trim());
+        } catch (PlanningException failure) {
+            throw failure;
         } catch (ConfigException failure) {
-            throw new IllegalArgumentException(
-                    "Invalid HOCON job configuration",
+            throw PlanningException.invalidDefinition(
+                    "HOCON",
+                    failure);
+        } catch (RuntimeException failure) {
+            throw PlanningException.invalidDefinition(
+                    "HOCON",
                     failure);
         }
     }
 
     private static boolean hasText(String value) {
-        return value != null && !value.trim().isEmpty();
+        return value != null
+                && !value.trim().isEmpty();
     }
 }

--- a/link-up-server/src/test/java/com/link/up/server/application/JobRetryStructuredErrorTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/application/JobRetryStructuredErrorTest.java
@@ -1,0 +1,139 @@
+package com.link.up.server.application;
+
+import com.link.up.server.domain.JobAttemptStatus;
+import com.link.up.server.runtime.JobAttemptMetadata;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobRecoverySnapshotFactory;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.ServerJobStatus;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JobRetryStructuredErrorTest {
+
+    private final JobRetryPolicy policy =
+            new JobRetryPolicy();
+
+    @Test
+    public void nonRetryableStructuredFailureMustBlockReplay() {
+        JobRetryDecision decision = policy.evaluate(
+                snapshot(),
+                metadata(
+                        attempt(
+                                "PLAN-005",
+                                "CAPABILITY",
+                                "CAPABILITY_NEGOTIATION",
+                                false,
+                                "NONE",
+                                0L)));
+
+        assertFalse(decision.isEligible());
+        assertEquals(
+                JobRetryDecision.NON_RETRYABLE_FAILURE,
+                decision.getCode());
+    }
+
+    @Test
+    public void retryableStructuredFailureStillRequiresSafeCommitEvidence() {
+        JobRetryDecision safe = policy.evaluate(
+                snapshot(),
+                metadata(
+                        attempt(
+                                "PLAN-006",
+                                "PREPARATION",
+                                "SOURCE_DISCOVERY",
+                                true,
+                                "JOB",
+                                0L)));
+        JobRetryDecision unknown = policy.evaluate(
+                snapshot(),
+                metadata(
+                        attempt(
+                                "PLAN-006",
+                                "PREPARATION",
+                                "SOURCE_DISCOVERY",
+                                true,
+                                "JOB",
+                                1L)));
+
+        assertTrue(safe.isEligible());
+        assertEquals(
+                JobRetryDecision.SAFE_NO_DATA_COMMITTED,
+                safe.getCode());
+        assertFalse(unknown.isEligible());
+        assertEquals(
+                JobRetryDecision.UNKNOWN_COMMIT_STATE,
+                unknown.getCode());
+    }
+
+    private JobSnapshot snapshot() {
+        return JobRecoverySnapshotFactory.restoreBasic(
+                "structured-retry-job",
+                "structured-retry",
+                ServerJobStatus.FAILED,
+                1L,
+                2L,
+                3L,
+                "FLUX-JOB-FAILED",
+                "test");
+    }
+
+    private JobExecutionMetadata metadata(
+            JobAttemptMetadata attempt) {
+
+        return new JobExecutionMetadata(
+                "external",
+                "key",
+                1,
+                "digest",
+                1L,
+                1L,
+                4L,
+                4L,
+                false,
+                Collections.emptyList(),
+                Collections.emptyMap(),
+                null,
+                null,
+                Collections.singletonList(attempt));
+    }
+
+    private JobAttemptMetadata attempt(
+            String errorCode,
+            String errorCategory,
+            String errorPhase,
+            boolean retryable,
+            String retryScope,
+            long unknownRecords) {
+
+        return new JobAttemptMetadata(
+                1,
+                "structured-retry-job-attempt-1",
+                JobAttemptStatus.FAILED,
+                1L,
+                1L,
+                2L,
+                3L,
+                null,
+                null,
+                "PlanningException",
+                "safe message",
+                "test advice",
+                errorCode,
+                errorCategory,
+                errorPhase,
+                retryable,
+                retryScope,
+                true,
+                0,
+                0L,
+                unknownRecords,
+                false,
+                "TASK_LOCAL");
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/http/StructuredExceptionMappingTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/http/StructuredExceptionMappingTest.java
@@ -1,0 +1,106 @@
+package com.link.up.server.http;
+
+import com.link.up.api.configuration.util.OptionValidationException;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.connector.schema.ConnectorRole;
+import com.link.up.api.exception.FluxErrorCategory;
+import com.link.up.api.exception.FluxErrorPhase;
+import com.link.up.api.exception.FluxRetryScope;
+import com.link.up.framework.planning.PlanningException;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class StructuredExceptionMappingTest {
+
+    @Test
+    public void capabilityFailureShouldMapToUnprocessableEntity()
+            throws Exception {
+
+        Object mapping = map(
+                PlanningException.requiredCapabilityMissing(
+                        ConnectorRole.SINK,
+                        "doris",
+                        ConnectorCapability.TWO_PHASE_COMMIT));
+
+        assertEquals(422, field(mapping, "httpStatus"));
+        assertEquals("PLAN-005", field(mapping, "code"));
+        assertEquals(
+                FluxErrorCategory.CAPABILITY,
+                field(mapping, "category"));
+        assertEquals(
+                FluxErrorPhase.CAPABILITY_NEGOTIATION,
+                field(mapping, "phase"));
+        assertEquals(Boolean.FALSE, field(mapping, "retryable"));
+        assertEquals(
+                FluxRetryScope.NONE,
+                field(mapping, "retryScope"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> parameters =
+                (Map<String, String>) field(
+                        mapping,
+                        "parameters");
+        assertEquals(
+                "TWO_PHASE_COMMIT",
+                parameters.get("capability"));
+    }
+
+    @Test
+    public void retryableDiscoveryFailureShouldMapToServiceUnavailable()
+            throws Exception {
+
+        Object mapping = map(
+                PlanningException.sourcePreparationFailed(
+                        "jdbc",
+                        new IllegalStateException("unavailable")));
+
+        assertEquals(503, field(mapping, "httpStatus"));
+        assertEquals("PLAN-006", field(mapping, "code"));
+        assertEquals(Boolean.TRUE, field(mapping, "retryable"));
+        assertEquals(
+                FluxRetryScope.JOB,
+                field(mapping, "retryScope"));
+    }
+
+    @Test
+    public void optionValidationShouldMapToBadRequest()
+            throws Exception {
+
+        Object mapping = map(
+                new OptionValidationException(
+                        "invalid option"));
+
+        assertEquals(400, field(mapping, "httpStatus"));
+        assertEquals("API-02", field(mapping, "code"));
+        assertEquals(
+                FluxErrorCategory.VALIDATION,
+                field(mapping, "category"));
+    }
+
+    private Object map(Throwable failure)
+            throws Exception {
+
+        Method method = ExceptionHandlingFilter.class
+                .getDeclaredMethod(
+                        "map",
+                        Throwable.class);
+        method.setAccessible(true);
+        return method.invoke(null, failure);
+    }
+
+    private Object field(
+            Object target,
+            String name)
+            throws Exception {
+
+        Field field = target.getClass()
+                .getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryStructuredErrorTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryStructuredErrorTest.java
@@ -1,5 +1,7 @@
 package com.link.up.server.infrastructure.persistence;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.link.up.server.domain.JobAttemptStatus;
 import com.link.up.server.runtime.JobAttemptMetadata;
 import com.link.up.server.runtime.JobExecutionMetadata;
@@ -8,7 +10,6 @@ import com.link.up.server.runtime.JobSnapshot;
 import com.link.up.server.runtime.ServerJobStatus;
 import org.junit.Test;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -106,14 +107,25 @@ public class FileJobRepositoryStructuredErrorTest {
                     "NONE",
                     restored.getFailureRetryScope());
 
-            String persisted = new String(
-                    Files.readAllBytes(
-                            firstRegularFile(directory)),
-                    StandardCharsets.UTF_8);
+            JsonNode persisted = new ObjectMapper()
+                    .readTree(
+                            firstRegularFile(directory)
+                                    .toFile());
+            assertEquals(
+                    3,
+                    persisted.get("formatVersion").asInt());
+            assertEquals(
+                    "PLAN-005",
+                    persisted.path("metadata")
+                            .path("attempts")
+                            .get(0)
+                            .path("structuredErrorCode")
+                            .asText());
             assertTrue(
-                    persisted.contains(
-                            "\"formatVersion\":3"));
-            assertTrue(persisted.contains("PLAN-005"));
+                    persisted.path("metadata")
+                            .path("attempts")
+                            .get(0)
+                            .has("failureRetryable"));
         } finally {
             deleteRecursively(directory);
         }

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryStructuredErrorTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryStructuredErrorTest.java
@@ -1,0 +1,155 @@
+package com.link.up.server.infrastructure.persistence;
+
+import com.link.up.server.domain.JobAttemptStatus;
+import com.link.up.server.runtime.JobAttemptMetadata;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobRecoverySnapshotFactory;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.ServerJobStatus;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Comparator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FileJobRepositoryStructuredErrorTest {
+
+    @Test
+    public void shouldPersistStructuredFailureMetadataAcrossReopen()
+            throws Exception {
+
+        Path directory = Files.createTempDirectory(
+                "link-up-structured-error-");
+
+        try {
+            FileJobRepository repository =
+                    new FileJobRepository(directory, 20);
+
+            JobAttemptMetadata attempt =
+                    new JobAttemptMetadata(
+                            1,
+                            "structured-error-job-attempt-1",
+                            JobAttemptStatus.FAILED,
+                            1L,
+                            1L,
+                            2L,
+                            3L,
+                            null,
+                            null,
+                            "PlanningException",
+                            "safe message",
+                            "Do not retry until the definition changes.",
+                            "PLAN-005",
+                            "CAPABILITY",
+                            "CAPABILITY_NEGOTIATION",
+                            false,
+                            "NONE",
+                            true,
+                            0,
+                            0L,
+                            0L,
+                            false,
+                            null);
+
+            JobExecutionMetadata metadata =
+                    new JobExecutionMetadata(
+                            "external",
+                            "key",
+                            1,
+                            "digest",
+                            1L,
+                            1L,
+                            4L,
+                            4L,
+                            false,
+                            Collections.emptyList(),
+                            Collections.emptyMap(),
+                            null,
+                            null,
+                            Collections.singletonList(attempt));
+            JobSnapshot snapshot =
+                    JobRecoverySnapshotFactory.restoreBasic(
+                            "structured-error-job",
+                            "structured-error",
+                            ServerJobStatus.FAILED,
+                            1L,
+                            2L,
+                            3L,
+                            "PLAN-005",
+                            "A required Connector capability is missing");
+
+            repository.save(snapshot, metadata);
+
+            FileJobRepository reopened =
+                    new FileJobRepository(directory, 20);
+            JobAttemptMetadata restored =
+                    reopened.getMetadata(
+                                    "structured-error-job")
+                            .getAttempts()
+                            .get(0);
+
+            assertEquals("PLAN-005", restored.getErrorCode());
+            assertEquals(
+                    "CAPABILITY",
+                    restored.getErrorCategory());
+            assertEquals(
+                    "CAPABILITY_NEGOTIATION",
+                    restored.getErrorPhase());
+            assertFalse(restored.isFailureRetryable());
+            assertEquals(
+                    "NONE",
+                    restored.getFailureRetryScope());
+
+            String persisted = new String(
+                    Files.readAllBytes(
+                            firstRegularFile(directory)),
+                    StandardCharsets.UTF_8);
+            assertTrue(
+                    persisted.contains(
+                            "\"formatVersion\":3"));
+            assertTrue(persisted.contains("PLAN-005"));
+        } finally {
+            deleteRecursively(directory);
+        }
+    }
+
+    private Path firstRegularFile(Path directory)
+            throws Exception {
+
+        try (java.util.stream.Stream<Path> paths =
+                     Files.walk(directory)) {
+            return paths.filter(Files::isRegularFile)
+                    .findFirst()
+                    .orElseThrow(
+                            () -> new AssertionError(
+                                    "Expected persisted checkpoint file"));
+        }
+    }
+
+    private void deleteRecursively(Path directory)
+            throws Exception {
+
+        if (directory == null || !Files.exists(directory)) {
+            return;
+        }
+
+        try (java.util.stream.Stream<Path> paths =
+                     Files.walk(directory)) {
+            paths.sorted(Comparator.reverseOrder())
+                    .forEach(
+                            path -> {
+                                try {
+                                    Files.deleteIfExists(path);
+                                } catch (Exception failure) {
+                                    throw new RuntimeException(failure);
+                                }
+                            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This stacked Draft PR implements **PR 2: Capability Negotiation + Structured Error** on top of PR #80.

- expands the stable Connector execution-capability vocabulary;
- introduces `ConnectorCapabilityProvider` for explicit plugin declarations;
- derives Required / Preferred capability requirements from normalized Job definitions;
- adds pre-I/O capability negotiation and structured diagnostics;
- makes `/jobs/validate` and `/jobs/explain` reject missing Required capabilities;
- adds a dedicated read-only capability endpoint for UI preflight;
- introduces a stable cross-module structured error contract and catalog;
- makes Retry consider structured error retryability before the existing commit-safety policy;
- preserves legacy Connector and checkpoint compatibility.

## Capability negotiation

```text
JobSpec / HOCON
  -> JobDefinition
  -> FactoryRegistry
  -> ConnectorCapabilityResolver
  -> JobCapabilityRequirements
  -> JobCapabilityNegotiator
  -> CapabilityNegotiationResult
```

Current offline requirements:

| Role | Level | Capability | Condition |
| --- | --- | --- | --- |
| Source | REQUIRED | `BATCH_READ` | every offline Job |
| Source | REQUIRED | `TABLE_SCHEMA_DISCOVERY` | every offline Job |
| Sink | REQUIRED | `BATCH_WRITE` | every offline Job |
| Source | PREFERRED | `PARTITION_SPLIT` | `sourceParallelism > 1` |
| Sink | PREFERRED | `IDEMPOTENT_WRITE` | `sinkParallelism > 1` |

Missing Required capabilities produce ERROR diagnostics and block validate/explain. Missing Preferred capabilities produce WARNING diagnostics while keeping `supported=true`.

## Compatibility

Existing Connector factories that do not implement the new provider keep the minimum historical baseline:

```text
TableSourceFactory -> BATCH_READ + TABLE_SCHEMA_DISCOVERY
SinkFactory        -> BATCH_WRITE
```

Once a Connector implements `ConnectorCapabilityProvider`, its declaration is authoritative and checked strictly. This avoids breaking current plugins while preventing new plugins from silently claiming guarantees through defaults.

## API

```text
POST /api/v1/jobs/capabilities
```

The endpoint accepts the same `jobSpec` / `hocon` planning envelope and performs no Connector IO. It returns declared capabilities, derived requirements, `supported`, and structured diagnostics.

`POST /api/v1/jobs/validate` and `POST /api/v1/jobs/explain` now run the same Required-capability guard before their existing planning behavior.

## Structured errors

`FluxErrorCode` now provides additive metadata through Java 8 default methods:

```text
code
category
phase
retryable
retryScope
httpStatus
remediation
```

The initial stable catalog covers invalid definitions, missing capabilities, missing Connectors, invalid Connector configuration, transient/non-retryable execution, persistence and internal failures. `FluxException` carries bounded non-secret parameters, and Worker REST maps it to the stable code and HTTP status.

## Retry safety

Structured exceptions persist their stable error code in the existing `Attempt.failureType` field, so checkpoint shape and old records remain compatible.

```text
structured error retryable?
  -> no: deny retry
  -> yes / legacy error:
       -> existing commit evidence policy
```

`retryable=true` never overrides committed data, unknown commit state or partial commit evidence. Commit safety retains final veto authority.

## Security

Capability diagnostics and structured parameters must contain identifiers, roles, capability names and versions only. They do not serialize JobSpec, HOCON, SQL, Connector options, credentials or arbitrary exception payloads.

## Tests

- structured error metadata, bounded parameters and immutable parameter maps;
- strict explicit declarations and legacy capability baselines;
- Required failure vs Preferred warning behavior;
- non-retryable structured errors blocking replay;
- retryable structured errors still passing through existing commit-safety checks;
- existing Plan / Explain and Worker tests through the full Maven verification.

## Verification

Executed locally from the branch:

```bash
mvn --batch-mode -pl link-up-api,link-up-framework,link-up-server -am test
mvn --batch-mode clean verify
```

Build logs are retained from the execution environment for review.

## Stack

- Base: `feat/runtime-event-foundation` / PR #80
- Head: `feat/capability-negotiation-structured-errors`

After PR #80 merges, this PR can be retargeted to `main` without changing its commit.

## Out of scope

- migrating every built-in Connector to explicit non-baseline capabilities;
- capability-based physical-plan rewrites or pushdown optimization;
- Pipeline / Task structured runtime errors;
- automatic retry scheduling;
- Yak-Ops UI implementation.