### PR TITLE
feat: add execution history projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Link-Up 是一个轻量、可嵌入的离线数据同步引擎。它把数据同
 - Required / Preferred Capability 协商：在 Connector I/O 和 Sink 副作用前发现不兼容任务。
 - 结构化错误：稳定 code、category、phase、retryable、retryScope 和安全参数。
 - 追加式 Runtime Event Journal：按 Job/Attempt 回看提交、排队、运行、取消与终态时间线。
+- Execution History：把 Event、Attempt、Pipeline、Task 和执行指标投影成 Yak-Ops 可直接消费的历史视图。
 
 ## 核心模型
 
@@ -180,7 +181,32 @@ GET /api/v1/jobs/{jobId}/events?afterSequence=0&limit=200
 
 当前阶段仍以 `JobSnapshot` 和 `JobExecutionMetadata` 为控制面状态真相。Event Journal 只负责可观察历史，不反向驱动状态机；事件监听器或文件写入失败会被隔离，不改变任务执行、Commit 或 Retry 语义。
 
-安全边界：事件不保存 JobSpec、Connector options、SQL、Secret、异常正文或 Connector 私有 metadata，只保存稳定生命周期字段、Attempt 身份、状态、原因代码和故障类型。
+终态事件会附带一份 `JobExecutionFacts`：只保存 Pipeline/Task 身份、状态和数值指标，不新增事件序号。这样仍保持“一次 durable checkpoint = 一个 sequence”，同时正常结束的任务在 Worker 重启后仍能恢复最终执行事实。
+
+安全边界：事件不保存 JobSpec、Connector options、SQL、Secret、异常正文、日志路径、当前表/分片或 Connector 私有 metadata。
+
+## Execution History
+
+History API 把事件时间线、Attempt 历史、结构化错误和最终/当前执行事实组合成一个稳定只读视图：
+
+```text
+GET /api/v1/jobs/{jobId}/history?afterSequence=0&limit=200
+```
+
+返回的 `apiVersion` 为 `link-up-job-history/v1`，核心内容包括：
+
+```text
+events          # sequence 游标分页的 durable lifecycle facts
+attempts        # Attempt 状态、结构化错误和 Commit Evidence
+execution       # Metrics + Pipeline + Task 安全投影
+nextSequence
+hasMore
+completed
+```
+
+运行中的 Job 优先使用当前 `JobSnapshot` 生成 execution；Worker 重启后如果基础快照没有 Pipeline/Task 细节，则从终态 Event Journal 中恢复最近一次 `JobExecutionFacts`。History 是观察投影，不参与状态恢复、调度、Retry 或 Commit 决策。
+
+为了保持协议可安全暴露给 Yak-Ops，History 不返回 failure message、retryAdvice、jobLogFile、Connector 物理表地址、currentTable/currentSplit、SQL 或任意 Connector options。
 
 ## 模块
 
@@ -189,7 +215,7 @@ GET /api/v1/jobs/{jobId}/events?afterSequence=0&limit=200
 | `link-up-api` | Connector 扩展契约、Capability、Structured Error 公共模型 |
 | `link-up-framework` | Planning、Capability Negotiation、JobGraph、ExecutionGraph、本地执行运行时 |
 | `link-up-connectors` | JDBC / HTTP / Doris 等实现 |
-| `link-up-server` | Worker 控制面、REST、持久化、Attempt/Retry、Runtime Event Journal |
+| `link-up-server` | Worker 控制面、REST、持久化、Attempt/Retry、Runtime Event Journal、Execution History |
 | `link-up-launcher` | 本地命令行组合入口 |
 | `link-up-dist` | 分发包 |
 | `link-up-bom` | 依赖版本管理 |
@@ -228,6 +254,7 @@ POST   /api/v1/jobs/explain
 POST   /api/v1/jobs
 GET    /api/v1/jobs/{jobId}
 GET    /api/v1/jobs/{jobId}/events
+GET    /api/v1/jobs/{jobId}/history
 GET    /api/v1/jobs/{jobId}/logs
 GET    /api/v1/jobs/{jobId}/metrics
 DELETE /api/v1/jobs/{jobId}
@@ -236,7 +263,7 @@ GET    /api/v1/connectors
 GET    /api/v1/node
 ```
 
-Retry 请求必须重新携带与原 Job 完全一致的结构化提交内容。Worker 不会为了 Retry 把数据库密码、Token 或完整 JobSpec 写进 checkpoint 或 Runtime Event Journal。
+Retry 请求必须重新携带与原 Job 完全一致的结构化提交内容。Worker 不会为了 Retry 或 History 把数据库密码、Token 或完整 JobSpec 写进 checkpoint 或 Runtime Event Journal。
 
 ## 文档
 

--- a/link-up-server/src/main/java/com/link/up/server/FluxServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/FluxServer.java
@@ -25,6 +25,7 @@ import com.link.up.server.registration.ControlPlaneRegistrationConfig;
 import com.link.up.server.runtime.WorkerIdentity;
 import com.link.up.server.service.ConnectorRestService;
 import com.link.up.server.service.JobEventRestService;
+import com.link.up.server.service.JobHistoryRestService;
 import com.link.up.server.service.JobPlanningService;
 import com.link.up.server.service.JobRestService;
 import org.apache.logging.log4j.LogManager;
@@ -127,6 +128,10 @@ public final class FluxServer {
                 new JobEventRestService(
                         jobApplication,
                         jobEventStore);
+        JobHistoryRestService historyService =
+                new JobHistoryRestService(
+                        jobApplication,
+                        jobEventStore);
         JobPlanningService planningService =
                 new JobPlanningService(
                         new JobPlanExplainer(
@@ -141,7 +146,8 @@ public final class FluxServer {
                         jobService,
                         connectorService,
                         planningService,
-                        eventService);
+                        eventService,
+                        historyService);
 
         final ControlPlaneRegistrationConfig registrationConfig =
                 ControlPlaneRegistrationConfig.load();

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobHistoryResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobHistoryResponse.java
@@ -6,6 +6,7 @@ import com.link.up.server.runtime.JobSnapshot;
 import com.link.up.server.runtime.ServerJobStatus;
 import com.link.up.server.runtime.event.JobEventEnvelope;
 import com.link.up.server.runtime.event.JobEventPage;
+import com.link.up.server.runtime.event.JobExecutionFacts;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -13,13 +14,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Secret-safe execution history projection for one Worker Job.
- *
- * <p>The projection deliberately joins durable lifecycle events with the
- * latest persisted Attempt/Pipeline/Task read models instead of creating a
- * second event-sourced state machine. Raw exception messages, log paths,
- * connector table locations and current split details stay outside this
- * protocol.</p>
+ * Yak-Ops-friendly read projection joining lifecycle, Attempt and execution
+ * history without turning the event journal into the Job state source of truth.
  */
 public final class JobHistoryResponse {
 
@@ -37,18 +33,28 @@ public final class JobHistoryResponse {
     private final long endTimeMillis;
     private final long durationMillis;
     private final long checkpointVersion;
-    private final JobSnapshot.Metrics metrics;
-    private final Commit commitSummary;
     private final List<JobEventEnvelope> events;
     private final long nextSequence;
     private final boolean hasMore;
     private final List<Attempt> attempts;
-    private final List<Pipeline> pipelines;
+    private final JobExecutionFacts execution;
 
     public JobHistoryResponse(
             JobSnapshot snapshot,
             JobExecutionMetadata metadata,
             JobEventPage eventPage) {
+        this(
+                snapshot,
+                metadata,
+                eventPage,
+                JobExecutionFacts.from(snapshot));
+    }
+
+    public JobHistoryResponse(
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata,
+            JobEventPage eventPage,
+            JobExecutionFacts execution) {
 
         JobSnapshot safeSnapshot = Objects.requireNonNull(
                 snapshot,
@@ -77,17 +83,15 @@ public final class JobHistoryResponse {
         this.checkpointVersion = metadata == null
                 ? 0L
                 : metadata.getCheckpointVersion();
-        this.metrics = safeSnapshot.getMetrics();
-        this.commitSummary = Commit.from(
-                safeSnapshot.getCommitSummary());
         this.events = Collections.unmodifiableList(
                 new ArrayList<JobEventEnvelope>(
                         safeEventPage.getItems()));
         this.nextSequence = safeEventPage.getNextSequence();
         this.hasMore = safeEventPage.isHasMore();
         this.attempts = attempts(metadata);
-        this.pipelines = pipelines(
-                safeSnapshot.getPipelines());
+        this.execution = Objects.requireNonNull(
+                execution,
+                "execution must not be null");
     }
 
     private static List<Attempt> attempts(
@@ -104,87 +108,22 @@ public final class JobHistoryResponse {
         return Collections.unmodifiableList(result);
     }
 
-    private static List<Pipeline> pipelines(
-            List<JobSnapshot.Pipeline> pipelines) {
-
-        List<Pipeline> result = new ArrayList<Pipeline>();
-        for (JobSnapshot.Pipeline pipeline : pipelines) {
-            result.add(Pipeline.from(pipeline));
-        }
-        return Collections.unmodifiableList(result);
-    }
-
-    public String getApiVersion() {
-        return apiVersion;
-    }
-
-    public String getJobId() {
-        return jobId;
-    }
-
-    public String getJobName() {
-        return jobName;
-    }
-
-    public ServerJobStatus getStatus() {
-        return status;
-    }
-
-    public boolean isCompleted() {
-        return completed;
-    }
-
-    public boolean isCancellationRequested() {
-        return cancellationRequested;
-    }
-
-    public long getCreateTimeMillis() {
-        return createTimeMillis;
-    }
-
-    public long getStartTimeMillis() {
-        return startTimeMillis;
-    }
-
-    public long getEndTimeMillis() {
-        return endTimeMillis;
-    }
-
-    public long getDurationMillis() {
-        return durationMillis;
-    }
-
-    public long getCheckpointVersion() {
-        return checkpointVersion;
-    }
-
-    public JobSnapshot.Metrics getMetrics() {
-        return metrics;
-    }
-
-    public Commit getCommitSummary() {
-        return commitSummary;
-    }
-
-    public List<JobEventEnvelope> getEvents() {
-        return events;
-    }
-
-    public long getNextSequence() {
-        return nextSequence;
-    }
-
-    public boolean isHasMore() {
-        return hasMore;
-    }
-
-    public List<Attempt> getAttempts() {
-        return attempts;
-    }
-
-    public List<Pipeline> getPipelines() {
-        return pipelines;
-    }
+    public String getApiVersion() { return apiVersion; }
+    public String getJobId() { return jobId; }
+    public String getJobName() { return jobName; }
+    public ServerJobStatus getStatus() { return status; }
+    public boolean isCompleted() { return completed; }
+    public boolean isCancellationRequested() { return cancellationRequested; }
+    public long getCreateTimeMillis() { return createTimeMillis; }
+    public long getStartTimeMillis() { return startTimeMillis; }
+    public long getEndTimeMillis() { return endTimeMillis; }
+    public long getDurationMillis() { return durationMillis; }
+    public long getCheckpointVersion() { return checkpointVersion; }
+    public List<JobEventEnvelope> getEvents() { return events; }
+    public long getNextSequence() { return nextSequence; }
+    public boolean isHasMore() { return hasMore; }
+    public List<Attempt> getAttempts() { return attempts; }
+    public JobExecutionFacts getExecution() { return execution; }
 
     /** Stable Attempt history without raw failure text or log locations. */
     public static final class Attempt {
@@ -210,9 +149,7 @@ public final class JobHistoryResponse {
         private final boolean partialDataCommit;
         private final String commitScope;
 
-        private Attempt(
-                JobAttemptMetadata attempt) {
-
+        private Attempt(JobAttemptMetadata attempt) {
             this.attemptNumber = attempt.getAttemptNumber();
             this.attemptId = attempt.getAttemptId();
             this.status = attempt.getStatus().name();
@@ -227,431 +164,40 @@ public final class JobHistoryResponse {
             this.errorPhase = attempt.getErrorPhase();
             this.failureRetryable = attempt.isFailureRetryable();
             this.failureRetryScope = attempt.getFailureRetryScope();
-            this.commitEvidenceAvailable =
-                    attempt.isCommitEvidenceAvailable();
-            this.dataCommittedTaskCount =
-                    attempt.getDataCommittedTaskCount();
+            this.commitEvidenceAvailable = attempt.isCommitEvidenceAvailable();
+            this.dataCommittedTaskCount = attempt.getDataCommittedTaskCount();
             this.successfullyCommittedRecordCount =
                     attempt.getSuccessfullyCommittedRecordCount();
-            this.unknownStateRecordCount =
-                    attempt.getUnknownStateRecordCount();
+            this.unknownStateRecordCount = attempt.getUnknownStateRecordCount();
             this.partialDataCommit = attempt.isPartialDataCommit();
             this.commitScope = attempt.getCommitScope();
         }
 
-        private static Attempt from(
-                JobAttemptMetadata attempt) {
+        private static Attempt from(JobAttemptMetadata attempt) {
             return new Attempt(
                     Objects.requireNonNull(
                             attempt,
                             "attempt must not be null"));
         }
 
-        public int getAttemptNumber() {
-            return attemptNumber;
-        }
-
-        public String getAttemptId() {
-            return attemptId;
-        }
-
-        public String getStatus() {
-            return status;
-        }
-
-        public long getCreateTimeMillis() {
-            return createTimeMillis;
-        }
-
-        public long getQueuedTimeMillis() {
-            return queuedTimeMillis;
-        }
-
-        public long getStartTimeMillis() {
-            return startTimeMillis;
-        }
-
-        public long getEndTimeMillis() {
-            return endTimeMillis;
-        }
-
-        public String getRunId() {
-            return runId;
-        }
-
-        public String getFailureType() {
-            return failureType;
-        }
-
-        public String getErrorCode() {
-            return errorCode;
-        }
-
-        public String getErrorCategory() {
-            return errorCategory;
-        }
-
-        public String getErrorPhase() {
-            return errorPhase;
-        }
-
-        public boolean isFailureRetryable() {
-            return failureRetryable;
-        }
-
-        public String getFailureRetryScope() {
-            return failureRetryScope;
-        }
-
-        public boolean isCommitEvidenceAvailable() {
-            return commitEvidenceAvailable;
-        }
-
-        public int getDataCommittedTaskCount() {
-            return dataCommittedTaskCount;
-        }
-
-        public long getSuccessfullyCommittedRecordCount() {
-            return successfullyCommittedRecordCount;
-        }
-
-        public long getUnknownStateRecordCount() {
-            return unknownStateRecordCount;
-        }
-
-        public boolean isPartialDataCommit() {
-            return partialDataCommit;
-        }
-
-        public String getCommitScope() {
-            return commitScope;
-        }
-    }
-
-    /** Safe Pipeline projection with numeric execution facts only. */
-    public static final class Pipeline {
-
-        private final String pipelineId;
-        private final String dataSetId;
-        private final String status;
-        private final String sourceConnector;
-        private final int sourceTaskCount;
-        private final long sourceRecordCount;
-        private final long sourceReadBytes;
-        private final double sourceAverageQps;
-        private final String sinkConnector;
-        private final int sinkTaskCount;
-        private final long sinkAttemptedRecordCount;
-        private final long sinkSuccessRecordCount;
-        private final long sinkFailedRecordCount;
-        private final long sinkUnknownStateRecordCount;
-        private final long sinkWrittenBytes;
-        private final double sinkAverageQps;
-        private final Commit commitSummary;
-        private final List<Task> tasks;
-        private final List<Channel> channels;
-
-        private Pipeline(JobSnapshot.Pipeline pipeline) {
-            JobSnapshot.Source source = pipeline.getSource();
-            JobSnapshot.Sink sink = pipeline.getSink();
-
-            this.pipelineId = pipeline.getPipelineId();
-            this.dataSetId = pipeline.getDataSetId();
-            this.status = pipeline.getStatus();
-            this.sourceConnector = source.getConnector();
-            this.sourceTaskCount = source.getTaskCount();
-            this.sourceRecordCount = source.getRecordCount();
-            this.sourceReadBytes = source.getReadBytes();
-            this.sourceAverageQps = source.getAverageQps();
-            this.sinkConnector = sink.getConnector();
-            this.sinkTaskCount = sink.getTaskCount();
-            this.sinkAttemptedRecordCount =
-                    sink.getAttemptedRecordCount();
-            this.sinkSuccessRecordCount = sink.getSuccessRecordCount();
-            this.sinkFailedRecordCount = sink.getFailedRecordCount();
-            this.sinkUnknownStateRecordCount =
-                    sink.getUnknownStateRecordCount();
-            this.sinkWrittenBytes = sink.getWrittenBytes();
-            this.sinkAverageQps = sink.getAverageQps();
-            this.commitSummary = Commit.from(
-                    pipeline.getCommitSummary());
-            this.tasks = tasks(pipeline.getTasks());
-            this.channels = channels(pipeline.getChannels());
-        }
-
-        private static Pipeline from(JobSnapshot.Pipeline pipeline) {
-            return new Pipeline(
-                    Objects.requireNonNull(
-                            pipeline,
-                            "pipeline must not be null"));
-        }
-
-        private static List<Task> tasks(
-                List<JobSnapshot.Task> tasks) {
-            List<Task> result = new ArrayList<Task>();
-            for (JobSnapshot.Task task : tasks) {
-                result.add(Task.from(task));
-            }
-            return Collections.unmodifiableList(result);
-        }
-
-        private static List<Channel> channels(
-                List<JobSnapshot.Channel> channels) {
-            List<Channel> result = new ArrayList<Channel>();
-            for (JobSnapshot.Channel channel : channels) {
-                result.add(Channel.from(channel));
-            }
-            return Collections.unmodifiableList(result);
-        }
-
-        public String getPipelineId() {
-            return pipelineId;
-        }
-
-        public String getDataSetId() {
-            return dataSetId;
-        }
-
-        public String getStatus() {
-            return status;
-        }
-
-        public String getSourceConnector() {
-            return sourceConnector;
-        }
-
-        public int getSourceTaskCount() {
-            return sourceTaskCount;
-        }
-
-        public long getSourceRecordCount() {
-            return sourceRecordCount;
-        }
-
-        public long getSourceReadBytes() {
-            return sourceReadBytes;
-        }
-
-        public double getSourceAverageQps() {
-            return sourceAverageQps;
-        }
-
-        public String getSinkConnector() {
-            return sinkConnector;
-        }
-
-        public int getSinkTaskCount() {
-            return sinkTaskCount;
-        }
-
-        public long getSinkAttemptedRecordCount() {
-            return sinkAttemptedRecordCount;
-        }
-
-        public long getSinkSuccessRecordCount() {
-            return sinkSuccessRecordCount;
-        }
-
-        public long getSinkFailedRecordCount() {
-            return sinkFailedRecordCount;
-        }
-
-        public long getSinkUnknownStateRecordCount() {
-            return sinkUnknownStateRecordCount;
-        }
-
-        public long getSinkWrittenBytes() {
-            return sinkWrittenBytes;
-        }
-
-        public double getSinkAverageQps() {
-            return sinkAverageQps;
-        }
-
-        public Commit getCommitSummary() {
-            return commitSummary;
-        }
-
-        public List<Task> getTasks() {
-            return tasks;
-        }
-
-        public List<Channel> getChannels() {
-            return channels;
-        }
-    }
-
-    /** Task projection intentionally excludes currentTable/currentSplit. */
-    public static final class Task {
-
-        private final String taskId;
-        private final String pipelineId;
-        private final String taskType;
-        private final String state;
-        private final int subtaskIndex;
-        private final int parallelism;
-        private final long batchCount;
-        private final long receivedBatchCount;
-        private final long attemptedRecordCount;
-        private final long recordCount;
-        private final long failedRecordCount;
-        private final long unknownStateRecordCount;
-        private final long completedSplitCount;
-        private final double averageQps;
-        private final long durationMillis;
-
-        private Task(JobSnapshot.Task task) {
-            this.taskId = task.getTaskId();
-            this.pipelineId = task.getPipelineId();
-            this.taskType = task.getTaskType();
-            this.state = task.getState();
-            this.subtaskIndex = task.getSubtaskIndex();
-            this.parallelism = task.getParallelism();
-            this.batchCount = task.getBatchCount();
-            this.receivedBatchCount = task.getReceivedBatchCount();
-            this.attemptedRecordCount = task.getAttemptedRecordCount();
-            this.recordCount = task.getRecordCount();
-            this.failedRecordCount = task.getFailedRecordCount();
-            this.unknownStateRecordCount = task.getUnknownStateRecordCount();
-            this.completedSplitCount = task.getCompletedSplitCount();
-            this.averageQps = task.getAverageQps();
-            this.durationMillis = task.getDurationMillis();
-        }
-
-        private static Task from(JobSnapshot.Task task) {
-            return new Task(
-                    Objects.requireNonNull(
-                            task,
-                            "task must not be null"));
-        }
-
-        public String getTaskId() { return taskId; }
-        public String getPipelineId() { return pipelineId; }
-        public String getTaskType() { return taskType; }
-        public String getState() { return state; }
-        public int getSubtaskIndex() { return subtaskIndex; }
-        public int getParallelism() { return parallelism; }
-        public long getBatchCount() { return batchCount; }
-        public long getReceivedBatchCount() { return receivedBatchCount; }
-        public long getAttemptedRecordCount() { return attemptedRecordCount; }
-        public long getRecordCount() { return recordCount; }
-        public long getFailedRecordCount() { return failedRecordCount; }
-        public long getUnknownStateRecordCount() { return unknownStateRecordCount; }
-        public long getCompletedSplitCount() { return completedSplitCount; }
-        public double getAverageQps() { return averageQps; }
-        public long getDurationMillis() { return durationMillis; }
-    }
-
-    /** Channel pressure projection with no connector payload. */
-    public static final class Channel {
-
-        private final String channelId;
-        private final long enqueuedCount;
-        private final long dequeuedCount;
-        private final long currentBatches;
-        private final long currentRecords;
-        private final long currentBytes;
-        private final long maximumBatches;
-        private final long maximumRecords;
-        private final long maximumBytes;
-        private final long oversizedBatches;
-        private final double producerBackpressureRatio;
-        private final double consumerIdleRatio;
-        private final double rateLimitedRatio;
-
-        private Channel(JobSnapshot.Channel channel) {
-            this.channelId = channel.getChannelId();
-            this.enqueuedCount = channel.getEnqueuedCount();
-            this.dequeuedCount = channel.getDequeuedCount();
-            this.currentBatches = channel.getCurrentBatches();
-            this.currentRecords = channel.getCurrentRecords();
-            this.currentBytes = channel.getCurrentBytes();
-            this.maximumBatches = channel.getMaximumBatches();
-            this.maximumRecords = channel.getMaximumRecords();
-            this.maximumBytes = channel.getMaximumBytes();
-            this.oversizedBatches = channel.getOversizedBatches();
-            this.producerBackpressureRatio =
-                    channel.getProducerBackpressureRatio();
-            this.consumerIdleRatio = channel.getConsumerIdleRatio();
-            this.rateLimitedRatio = channel.getRateLimitedRatio();
-        }
-
-        private static Channel from(JobSnapshot.Channel channel) {
-            return new Channel(
-                    Objects.requireNonNull(
-                            channel,
-                            "channel must not be null"));
-        }
-
-        public String getChannelId() { return channelId; }
-        public long getEnqueuedCount() { return enqueuedCount; }
-        public long getDequeuedCount() { return dequeuedCount; }
-        public long getCurrentBatches() { return currentBatches; }
-        public long getCurrentRecords() { return currentRecords; }
-        public long getCurrentBytes() { return currentBytes; }
-        public long getMaximumBatches() { return maximumBatches; }
-        public long getMaximumRecords() { return maximumRecords; }
-        public long getMaximumBytes() { return maximumBytes; }
-        public long getOversizedBatches() { return oversizedBatches; }
-        public double getProducerBackpressureRatio() { return producerBackpressureRatio; }
-        public double getConsumerIdleRatio() { return consumerIdleRatio; }
-        public double getRateLimitedRatio() { return rateLimitedRatio; }
-    }
-
-    /** Commit evidence projection intentionally excludes retryAdvice text. */
-    public static final class Commit {
-
-        private final int totalTaskCount;
-        private final int finishedTaskCount;
-        private final int committedTaskCount;
-        private final int dataCommittedTaskCount;
-        private final int emptyCommittedTaskCount;
-        private final int failedOrUncommittedTaskCount;
-        private final long attemptedRecordCount;
-        private final long successfullyWrittenRecordCount;
-        private final long successfullyCommittedRecordCount;
-        private final long failedRecordCount;
-        private final long unknownStateRecordCount;
-        private final boolean partialTaskCommit;
-        private final boolean partialDataCommit;
-        private final String commitScope;
-
-        private Commit(JobSnapshot.Commit commit) {
-            this.totalTaskCount = commit.getTotalTaskCount();
-            this.finishedTaskCount = commit.getFinishedTaskCount();
-            this.committedTaskCount = commit.getCommittedTaskCount();
-            this.dataCommittedTaskCount = commit.getDataCommittedTaskCount();
-            this.emptyCommittedTaskCount = commit.getEmptyCommittedTaskCount();
-            this.failedOrUncommittedTaskCount =
-                    commit.getFailedOrUncommittedTaskCount();
-            this.attemptedRecordCount = commit.getAttemptedRecordCount();
-            this.successfullyWrittenRecordCount =
-                    commit.getSuccessfullyWrittenRecordCount();
-            this.successfullyCommittedRecordCount =
-                    commit.getSuccessfullyCommittedRecordCount();
-            this.failedRecordCount = commit.getFailedRecordCount();
-            this.unknownStateRecordCount = commit.getUnknownStateRecordCount();
-            this.partialTaskCommit = commit.isPartialTaskCommit();
-            this.partialDataCommit = commit.isPartialDataCommit();
-            this.commitScope = commit.getCommitScope();
-        }
-
-        private static Commit from(JobSnapshot.Commit commit) {
-            return commit == null ? null : new Commit(commit);
-        }
-
-        public int getTotalTaskCount() { return totalTaskCount; }
-        public int getFinishedTaskCount() { return finishedTaskCount; }
-        public int getCommittedTaskCount() { return committedTaskCount; }
+        public int getAttemptNumber() { return attemptNumber; }
+        public String getAttemptId() { return attemptId; }
+        public String getStatus() { return status; }
+        public long getCreateTimeMillis() { return createTimeMillis; }
+        public long getQueuedTimeMillis() { return queuedTimeMillis; }
+        public long getStartTimeMillis() { return startTimeMillis; }
+        public long getEndTimeMillis() { return endTimeMillis; }
+        public String getRunId() { return runId; }
+        public String getFailureType() { return failureType; }
+        public String getErrorCode() { return errorCode; }
+        public String getErrorCategory() { return errorCategory; }
+        public String getErrorPhase() { return errorPhase; }
+        public boolean isFailureRetryable() { return failureRetryable; }
+        public String getFailureRetryScope() { return failureRetryScope; }
+        public boolean isCommitEvidenceAvailable() { return commitEvidenceAvailable; }
         public int getDataCommittedTaskCount() { return dataCommittedTaskCount; }
-        public int getEmptyCommittedTaskCount() { return emptyCommittedTaskCount; }
-        public int getFailedOrUncommittedTaskCount() { return failedOrUncommittedTaskCount; }
-        public long getAttemptedRecordCount() { return attemptedRecordCount; }
-        public long getSuccessfullyWrittenRecordCount() { return successfullyWrittenRecordCount; }
         public long getSuccessfullyCommittedRecordCount() { return successfullyCommittedRecordCount; }
-        public long getFailedRecordCount() { return failedRecordCount; }
         public long getUnknownStateRecordCount() { return unknownStateRecordCount; }
-        public boolean isPartialTaskCommit() { return partialTaskCommit; }
         public boolean isPartialDataCommit() { return partialDataCommit; }
         public String getCommitScope() { return commitScope; }
     }

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobHistoryResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobHistoryResponse.java
@@ -1,0 +1,658 @@
+package com.link.up.server.dto;
+
+import com.link.up.server.runtime.JobAttemptMetadata;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobEventPage;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Secret-safe execution history projection for one Worker Job.
+ *
+ * <p>The projection deliberately joins durable lifecycle events with the
+ * latest persisted Attempt/Pipeline/Task read models instead of creating a
+ * second event-sourced state machine. Raw exception messages, log paths,
+ * connector table locations and current split details stay outside this
+ * protocol.</p>
+ */
+public final class JobHistoryResponse {
+
+    public static final String CURRENT_API_VERSION =
+            "link-up-job-history/v1";
+
+    private final String apiVersion;
+    private final String jobId;
+    private final String jobName;
+    private final ServerJobStatus status;
+    private final boolean completed;
+    private final boolean cancellationRequested;
+    private final long createTimeMillis;
+    private final long startTimeMillis;
+    private final long endTimeMillis;
+    private final long durationMillis;
+    private final long checkpointVersion;
+    private final JobSnapshot.Metrics metrics;
+    private final Commit commitSummary;
+    private final List<JobEventEnvelope> events;
+    private final long nextSequence;
+    private final boolean hasMore;
+    private final List<Attempt> attempts;
+    private final List<Pipeline> pipelines;
+
+    public JobHistoryResponse(
+            JobSnapshot snapshot,
+            JobExecutionMetadata metadata,
+            JobEventPage eventPage) {
+
+        JobSnapshot safeSnapshot = Objects.requireNonNull(
+                snapshot,
+                "snapshot must not be null");
+        JobEventPage safeEventPage = Objects.requireNonNull(
+                eventPage,
+                "eventPage must not be null");
+
+        if (!safeSnapshot.getJobId().equals(
+                safeEventPage.getJobId())) {
+            throw new IllegalArgumentException(
+                    "Job history identity mismatch");
+        }
+
+        this.apiVersion = CURRENT_API_VERSION;
+        this.jobId = safeSnapshot.getJobId();
+        this.jobName = safeSnapshot.getJobName();
+        this.status = safeSnapshot.getStatus();
+        this.completed = safeSnapshot.getStatus().isTerminal();
+        this.cancellationRequested = metadata != null
+                && metadata.isCancellationRequested();
+        this.createTimeMillis = safeSnapshot.getCreateTimeMillis();
+        this.startTimeMillis = safeSnapshot.getStartTimeMillis();
+        this.endTimeMillis = safeSnapshot.getEndTimeMillis();
+        this.durationMillis = safeSnapshot.getDurationMillis();
+        this.checkpointVersion = metadata == null
+                ? 0L
+                : metadata.getCheckpointVersion();
+        this.metrics = safeSnapshot.getMetrics();
+        this.commitSummary = Commit.from(
+                safeSnapshot.getCommitSummary());
+        this.events = Collections.unmodifiableList(
+                new ArrayList<JobEventEnvelope>(
+                        safeEventPage.getItems()));
+        this.nextSequence = safeEventPage.getNextSequence();
+        this.hasMore = safeEventPage.isHasMore();
+        this.attempts = attempts(metadata);
+        this.pipelines = pipelines(
+                safeSnapshot.getPipelines());
+    }
+
+    private static List<Attempt> attempts(
+            JobExecutionMetadata metadata) {
+
+        if (metadata == null) {
+            return Collections.emptyList();
+        }
+
+        List<Attempt> result = new ArrayList<Attempt>();
+        for (JobAttemptMetadata attempt : metadata.getAttempts()) {
+            result.add(Attempt.from(attempt));
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private static List<Pipeline> pipelines(
+            List<JobSnapshot.Pipeline> pipelines) {
+
+        List<Pipeline> result = new ArrayList<Pipeline>();
+        for (JobSnapshot.Pipeline pipeline : pipelines) {
+            result.add(Pipeline.from(pipeline));
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public String getJobName() {
+        return jobName;
+    }
+
+    public ServerJobStatus getStatus() {
+        return status;
+    }
+
+    public boolean isCompleted() {
+        return completed;
+    }
+
+    public boolean isCancellationRequested() {
+        return cancellationRequested;
+    }
+
+    public long getCreateTimeMillis() {
+        return createTimeMillis;
+    }
+
+    public long getStartTimeMillis() {
+        return startTimeMillis;
+    }
+
+    public long getEndTimeMillis() {
+        return endTimeMillis;
+    }
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+
+    public long getCheckpointVersion() {
+        return checkpointVersion;
+    }
+
+    public JobSnapshot.Metrics getMetrics() {
+        return metrics;
+    }
+
+    public Commit getCommitSummary() {
+        return commitSummary;
+    }
+
+    public List<JobEventEnvelope> getEvents() {
+        return events;
+    }
+
+    public long getNextSequence() {
+        return nextSequence;
+    }
+
+    public boolean isHasMore() {
+        return hasMore;
+    }
+
+    public List<Attempt> getAttempts() {
+        return attempts;
+    }
+
+    public List<Pipeline> getPipelines() {
+        return pipelines;
+    }
+
+    /** Stable Attempt history without raw failure text or log locations. */
+    public static final class Attempt {
+
+        private final int attemptNumber;
+        private final String attemptId;
+        private final String status;
+        private final long createTimeMillis;
+        private final long queuedTimeMillis;
+        private final long startTimeMillis;
+        private final long endTimeMillis;
+        private final String runId;
+        private final String failureType;
+        private final String errorCode;
+        private final String errorCategory;
+        private final String errorPhase;
+        private final boolean failureRetryable;
+        private final String failureRetryScope;
+        private final boolean commitEvidenceAvailable;
+        private final int dataCommittedTaskCount;
+        private final long successfullyCommittedRecordCount;
+        private final long unknownStateRecordCount;
+        private final boolean partialDataCommit;
+        private final String commitScope;
+
+        private Attempt(
+                JobAttemptMetadata attempt) {
+
+            this.attemptNumber = attempt.getAttemptNumber();
+            this.attemptId = attempt.getAttemptId();
+            this.status = attempt.getStatus().name();
+            this.createTimeMillis = attempt.getCreateTimeMillis();
+            this.queuedTimeMillis = attempt.getQueuedTimeMillis();
+            this.startTimeMillis = attempt.getStartTimeMillis();
+            this.endTimeMillis = attempt.getEndTimeMillis();
+            this.runId = attempt.getRunId();
+            this.failureType = attempt.getFailureType();
+            this.errorCode = attempt.getErrorCode();
+            this.errorCategory = attempt.getErrorCategory();
+            this.errorPhase = attempt.getErrorPhase();
+            this.failureRetryable = attempt.isFailureRetryable();
+            this.failureRetryScope = attempt.getFailureRetryScope();
+            this.commitEvidenceAvailable =
+                    attempt.isCommitEvidenceAvailable();
+            this.dataCommittedTaskCount =
+                    attempt.getDataCommittedTaskCount();
+            this.successfullyCommittedRecordCount =
+                    attempt.getSuccessfullyCommittedRecordCount();
+            this.unknownStateRecordCount =
+                    attempt.getUnknownStateRecordCount();
+            this.partialDataCommit = attempt.isPartialDataCommit();
+            this.commitScope = attempt.getCommitScope();
+        }
+
+        private static Attempt from(
+                JobAttemptMetadata attempt) {
+            return new Attempt(
+                    Objects.requireNonNull(
+                            attempt,
+                            "attempt must not be null"));
+        }
+
+        public int getAttemptNumber() {
+            return attemptNumber;
+        }
+
+        public String getAttemptId() {
+            return attemptId;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public long getCreateTimeMillis() {
+            return createTimeMillis;
+        }
+
+        public long getQueuedTimeMillis() {
+            return queuedTimeMillis;
+        }
+
+        public long getStartTimeMillis() {
+            return startTimeMillis;
+        }
+
+        public long getEndTimeMillis() {
+            return endTimeMillis;
+        }
+
+        public String getRunId() {
+            return runId;
+        }
+
+        public String getFailureType() {
+            return failureType;
+        }
+
+        public String getErrorCode() {
+            return errorCode;
+        }
+
+        public String getErrorCategory() {
+            return errorCategory;
+        }
+
+        public String getErrorPhase() {
+            return errorPhase;
+        }
+
+        public boolean isFailureRetryable() {
+            return failureRetryable;
+        }
+
+        public String getFailureRetryScope() {
+            return failureRetryScope;
+        }
+
+        public boolean isCommitEvidenceAvailable() {
+            return commitEvidenceAvailable;
+        }
+
+        public int getDataCommittedTaskCount() {
+            return dataCommittedTaskCount;
+        }
+
+        public long getSuccessfullyCommittedRecordCount() {
+            return successfullyCommittedRecordCount;
+        }
+
+        public long getUnknownStateRecordCount() {
+            return unknownStateRecordCount;
+        }
+
+        public boolean isPartialDataCommit() {
+            return partialDataCommit;
+        }
+
+        public String getCommitScope() {
+            return commitScope;
+        }
+    }
+
+    /** Safe Pipeline projection with numeric execution facts only. */
+    public static final class Pipeline {
+
+        private final String pipelineId;
+        private final String dataSetId;
+        private final String status;
+        private final String sourceConnector;
+        private final int sourceTaskCount;
+        private final long sourceRecordCount;
+        private final long sourceReadBytes;
+        private final double sourceAverageQps;
+        private final String sinkConnector;
+        private final int sinkTaskCount;
+        private final long sinkAttemptedRecordCount;
+        private final long sinkSuccessRecordCount;
+        private final long sinkFailedRecordCount;
+        private final long sinkUnknownStateRecordCount;
+        private final long sinkWrittenBytes;
+        private final double sinkAverageQps;
+        private final Commit commitSummary;
+        private final List<Task> tasks;
+        private final List<Channel> channels;
+
+        private Pipeline(JobSnapshot.Pipeline pipeline) {
+            JobSnapshot.Source source = pipeline.getSource();
+            JobSnapshot.Sink sink = pipeline.getSink();
+
+            this.pipelineId = pipeline.getPipelineId();
+            this.dataSetId = pipeline.getDataSetId();
+            this.status = pipeline.getStatus();
+            this.sourceConnector = source.getConnector();
+            this.sourceTaskCount = source.getTaskCount();
+            this.sourceRecordCount = source.getRecordCount();
+            this.sourceReadBytes = source.getReadBytes();
+            this.sourceAverageQps = source.getAverageQps();
+            this.sinkConnector = sink.getConnector();
+            this.sinkTaskCount = sink.getTaskCount();
+            this.sinkAttemptedRecordCount =
+                    sink.getAttemptedRecordCount();
+            this.sinkSuccessRecordCount = sink.getSuccessRecordCount();
+            this.sinkFailedRecordCount = sink.getFailedRecordCount();
+            this.sinkUnknownStateRecordCount =
+                    sink.getUnknownStateRecordCount();
+            this.sinkWrittenBytes = sink.getWrittenBytes();
+            this.sinkAverageQps = sink.getAverageQps();
+            this.commitSummary = Commit.from(
+                    pipeline.getCommitSummary());
+            this.tasks = tasks(pipeline.getTasks());
+            this.channels = channels(pipeline.getChannels());
+        }
+
+        private static Pipeline from(JobSnapshot.Pipeline pipeline) {
+            return new Pipeline(
+                    Objects.requireNonNull(
+                            pipeline,
+                            "pipeline must not be null"));
+        }
+
+        private static List<Task> tasks(
+                List<JobSnapshot.Task> tasks) {
+            List<Task> result = new ArrayList<Task>();
+            for (JobSnapshot.Task task : tasks) {
+                result.add(Task.from(task));
+            }
+            return Collections.unmodifiableList(result);
+        }
+
+        private static List<Channel> channels(
+                List<JobSnapshot.Channel> channels) {
+            List<Channel> result = new ArrayList<Channel>();
+            for (JobSnapshot.Channel channel : channels) {
+                result.add(Channel.from(channel));
+            }
+            return Collections.unmodifiableList(result);
+        }
+
+        public String getPipelineId() {
+            return pipelineId;
+        }
+
+        public String getDataSetId() {
+            return dataSetId;
+        }
+
+        public String getStatus() {
+            return status;
+        }
+
+        public String getSourceConnector() {
+            return sourceConnector;
+        }
+
+        public int getSourceTaskCount() {
+            return sourceTaskCount;
+        }
+
+        public long getSourceRecordCount() {
+            return sourceRecordCount;
+        }
+
+        public long getSourceReadBytes() {
+            return sourceReadBytes;
+        }
+
+        public double getSourceAverageQps() {
+            return sourceAverageQps;
+        }
+
+        public String getSinkConnector() {
+            return sinkConnector;
+        }
+
+        public int getSinkTaskCount() {
+            return sinkTaskCount;
+        }
+
+        public long getSinkAttemptedRecordCount() {
+            return sinkAttemptedRecordCount;
+        }
+
+        public long getSinkSuccessRecordCount() {
+            return sinkSuccessRecordCount;
+        }
+
+        public long getSinkFailedRecordCount() {
+            return sinkFailedRecordCount;
+        }
+
+        public long getSinkUnknownStateRecordCount() {
+            return sinkUnknownStateRecordCount;
+        }
+
+        public long getSinkWrittenBytes() {
+            return sinkWrittenBytes;
+        }
+
+        public double getSinkAverageQps() {
+            return sinkAverageQps;
+        }
+
+        public Commit getCommitSummary() {
+            return commitSummary;
+        }
+
+        public List<Task> getTasks() {
+            return tasks;
+        }
+
+        public List<Channel> getChannels() {
+            return channels;
+        }
+    }
+
+    /** Task projection intentionally excludes currentTable/currentSplit. */
+    public static final class Task {
+
+        private final String taskId;
+        private final String pipelineId;
+        private final String taskType;
+        private final String state;
+        private final int subtaskIndex;
+        private final int parallelism;
+        private final long batchCount;
+        private final long receivedBatchCount;
+        private final long attemptedRecordCount;
+        private final long recordCount;
+        private final long failedRecordCount;
+        private final long unknownStateRecordCount;
+        private final long completedSplitCount;
+        private final double averageQps;
+        private final long durationMillis;
+
+        private Task(JobSnapshot.Task task) {
+            this.taskId = task.getTaskId();
+            this.pipelineId = task.getPipelineId();
+            this.taskType = task.getTaskType();
+            this.state = task.getState();
+            this.subtaskIndex = task.getSubtaskIndex();
+            this.parallelism = task.getParallelism();
+            this.batchCount = task.getBatchCount();
+            this.receivedBatchCount = task.getReceivedBatchCount();
+            this.attemptedRecordCount = task.getAttemptedRecordCount();
+            this.recordCount = task.getRecordCount();
+            this.failedRecordCount = task.getFailedRecordCount();
+            this.unknownStateRecordCount = task.getUnknownStateRecordCount();
+            this.completedSplitCount = task.getCompletedSplitCount();
+            this.averageQps = task.getAverageQps();
+            this.durationMillis = task.getDurationMillis();
+        }
+
+        private static Task from(JobSnapshot.Task task) {
+            return new Task(
+                    Objects.requireNonNull(
+                            task,
+                            "task must not be null"));
+        }
+
+        public String getTaskId() { return taskId; }
+        public String getPipelineId() { return pipelineId; }
+        public String getTaskType() { return taskType; }
+        public String getState() { return state; }
+        public int getSubtaskIndex() { return subtaskIndex; }
+        public int getParallelism() { return parallelism; }
+        public long getBatchCount() { return batchCount; }
+        public long getReceivedBatchCount() { return receivedBatchCount; }
+        public long getAttemptedRecordCount() { return attemptedRecordCount; }
+        public long getRecordCount() { return recordCount; }
+        public long getFailedRecordCount() { return failedRecordCount; }
+        public long getUnknownStateRecordCount() { return unknownStateRecordCount; }
+        public long getCompletedSplitCount() { return completedSplitCount; }
+        public double getAverageQps() { return averageQps; }
+        public long getDurationMillis() { return durationMillis; }
+    }
+
+    /** Channel pressure projection with no connector payload. */
+    public static final class Channel {
+
+        private final String channelId;
+        private final long enqueuedCount;
+        private final long dequeuedCount;
+        private final long currentBatches;
+        private final long currentRecords;
+        private final long currentBytes;
+        private final long maximumBatches;
+        private final long maximumRecords;
+        private final long maximumBytes;
+        private final long oversizedBatches;
+        private final double producerBackpressureRatio;
+        private final double consumerIdleRatio;
+        private final double rateLimitedRatio;
+
+        private Channel(JobSnapshot.Channel channel) {
+            this.channelId = channel.getChannelId();
+            this.enqueuedCount = channel.getEnqueuedCount();
+            this.dequeuedCount = channel.getDequeuedCount();
+            this.currentBatches = channel.getCurrentBatches();
+            this.currentRecords = channel.getCurrentRecords();
+            this.currentBytes = channel.getCurrentBytes();
+            this.maximumBatches = channel.getMaximumBatches();
+            this.maximumRecords = channel.getMaximumRecords();
+            this.maximumBytes = channel.getMaximumBytes();
+            this.oversizedBatches = channel.getOversizedBatches();
+            this.producerBackpressureRatio =
+                    channel.getProducerBackpressureRatio();
+            this.consumerIdleRatio = channel.getConsumerIdleRatio();
+            this.rateLimitedRatio = channel.getRateLimitedRatio();
+        }
+
+        private static Channel from(JobSnapshot.Channel channel) {
+            return new Channel(
+                    Objects.requireNonNull(
+                            channel,
+                            "channel must not be null"));
+        }
+
+        public String getChannelId() { return channelId; }
+        public long getEnqueuedCount() { return enqueuedCount; }
+        public long getDequeuedCount() { return dequeuedCount; }
+        public long getCurrentBatches() { return currentBatches; }
+        public long getCurrentRecords() { return currentRecords; }
+        public long getCurrentBytes() { return currentBytes; }
+        public long getMaximumBatches() { return maximumBatches; }
+        public long getMaximumRecords() { return maximumRecords; }
+        public long getMaximumBytes() { return maximumBytes; }
+        public long getOversizedBatches() { return oversizedBatches; }
+        public double getProducerBackpressureRatio() { return producerBackpressureRatio; }
+        public double getConsumerIdleRatio() { return consumerIdleRatio; }
+        public double getRateLimitedRatio() { return rateLimitedRatio; }
+    }
+
+    /** Commit evidence projection intentionally excludes retryAdvice text. */
+    public static final class Commit {
+
+        private final int totalTaskCount;
+        private final int finishedTaskCount;
+        private final int committedTaskCount;
+        private final int dataCommittedTaskCount;
+        private final int emptyCommittedTaskCount;
+        private final int failedOrUncommittedTaskCount;
+        private final long attemptedRecordCount;
+        private final long successfullyWrittenRecordCount;
+        private final long successfullyCommittedRecordCount;
+        private final long failedRecordCount;
+        private final long unknownStateRecordCount;
+        private final boolean partialTaskCommit;
+        private final boolean partialDataCommit;
+        private final String commitScope;
+
+        private Commit(JobSnapshot.Commit commit) {
+            this.totalTaskCount = commit.getTotalTaskCount();
+            this.finishedTaskCount = commit.getFinishedTaskCount();
+            this.committedTaskCount = commit.getCommittedTaskCount();
+            this.dataCommittedTaskCount = commit.getDataCommittedTaskCount();
+            this.emptyCommittedTaskCount = commit.getEmptyCommittedTaskCount();
+            this.failedOrUncommittedTaskCount =
+                    commit.getFailedOrUncommittedTaskCount();
+            this.attemptedRecordCount = commit.getAttemptedRecordCount();
+            this.successfullyWrittenRecordCount =
+                    commit.getSuccessfullyWrittenRecordCount();
+            this.successfullyCommittedRecordCount =
+                    commit.getSuccessfullyCommittedRecordCount();
+            this.failedRecordCount = commit.getFailedRecordCount();
+            this.unknownStateRecordCount = commit.getUnknownStateRecordCount();
+            this.partialTaskCommit = commit.isPartialTaskCommit();
+            this.partialDataCommit = commit.isPartialDataCommit();
+            this.commitScope = commit.getCommitScope();
+        }
+
+        private static Commit from(JobSnapshot.Commit commit) {
+            return commit == null ? null : new Commit(commit);
+        }
+
+        public int getTotalTaskCount() { return totalTaskCount; }
+        public int getFinishedTaskCount() { return finishedTaskCount; }
+        public int getCommittedTaskCount() { return committedTaskCount; }
+        public int getDataCommittedTaskCount() { return dataCommittedTaskCount; }
+        public int getEmptyCommittedTaskCount() { return emptyCommittedTaskCount; }
+        public int getFailedOrUncommittedTaskCount() { return failedOrUncommittedTaskCount; }
+        public long getAttemptedRecordCount() { return attemptedRecordCount; }
+        public long getSuccessfullyWrittenRecordCount() { return successfullyWrittenRecordCount; }
+        public long getSuccessfullyCommittedRecordCount() { return successfullyCommittedRecordCount; }
+        public long getFailedRecordCount() { return failedRecordCount; }
+        public long getUnknownStateRecordCount() { return unknownStateRecordCount; }
+        public boolean isPartialTaskCommit() { return partialTaskCommit; }
+        public boolean isPartialDataCommit() { return partialDataCommit; }
+        public String getCommitScope() { return commitScope; }
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/http/JettyServer.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/JettyServer.java
@@ -11,6 +11,7 @@ import com.link.up.server.http.servlet.NodeServlet;
 import com.link.up.server.http.servlet.NotFoundServlet;
 import com.link.up.server.service.ConnectorRestService;
 import com.link.up.server.service.JobEventRestService;
+import com.link.up.server.service.JobHistoryRestService;
 import com.link.up.server.service.JobPlanningService;
 import com.link.up.server.service.JobRestService;
 import org.eclipse.jetty.server.Server;
@@ -42,6 +43,7 @@ public final class JettyServer implements AutoCloseable {
                         new ConnectorSchemaCatalog(
                                 Collections.emptyList())),
                 null,
+                null,
                 null);
     }
 
@@ -53,6 +55,7 @@ public final class JettyServer implements AutoCloseable {
                 config,
                 jobService,
                 connectorService,
+                null,
                 null,
                 null);
     }
@@ -67,6 +70,7 @@ public final class JettyServer implements AutoCloseable {
                 jobService,
                 connectorService,
                 planningService,
+                null,
                 null);
     }
 
@@ -76,6 +80,22 @@ public final class JettyServer implements AutoCloseable {
             ConnectorRestService connectorService,
             JobPlanningService planningService,
             JobEventRestService eventService) {
+        this(
+                config,
+                jobService,
+                connectorService,
+                planningService,
+                eventService,
+                null);
+    }
+
+    public JettyServer(
+            FluxServerConfig config,
+            JobRestService jobService,
+            ConnectorRestService connectorService,
+            JobPlanningService planningService,
+            JobEventRestService eventService,
+            JobHistoryRestService historyService) {
 
         int minimumThreads = Math.min(
                 4,
@@ -148,6 +168,7 @@ public final class JettyServer implements AutoCloseable {
                         new JobResourceServlet(
                                 jobService,
                                 eventService,
+                                historyService,
                                 config.getMaxRequestBytes())),
                 RestConstants.JOBS + "/*");
         context.addServlet(

--- a/link-up-server/src/main/java/com/link/up/server/http/servlet/JobResourceServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/servlet/JobResourceServlet.java
@@ -5,6 +5,7 @@ import com.link.up.server.dto.JobSubmitRequest;
 import com.link.up.server.http.FluxServlet;
 import com.link.up.server.http.RestException;
 import com.link.up.server.service.JobEventRestService;
+import com.link.up.server.service.JobHistoryRestService;
 import com.link.up.server.service.JobRestService;
 
 import javax.servlet.http.HttpServletRequest;
@@ -12,7 +13,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 
-/** Handles one offline Job resource, details, cancellation and explicit retry. */
+/** Handles one offline Job resource, details, history, cancellation and retry. */
 public final class JobResourceServlet
         extends FluxServlet {
 
@@ -21,11 +22,13 @@ public final class JobResourceServlet
 
     private final JobRestService service;
     private final JobEventRestService eventService;
+    private final JobHistoryRestService historyService;
     private final int maxRequestBytes;
 
     public JobResourceServlet(JobRestService service) {
         this(
                 service,
+                null,
                 null,
                 DEFAULT_MAX_REQUEST_BYTES);
     }
@@ -36,6 +39,7 @@ public final class JobResourceServlet
         this(
                 service,
                 null,
+                null,
                 maxRequestBytes);
     }
 
@@ -43,9 +47,22 @@ public final class JobResourceServlet
             JobRestService service,
             JobEventRestService eventService,
             int maxRequestBytes) {
+        this(
+                service,
+                eventService,
+                null,
+                maxRequestBytes);
+    }
+
+    public JobResourceServlet(
+            JobRestService service,
+            JobEventRestService eventService,
+            JobHistoryRestService historyService,
+            int maxRequestBytes) {
 
         this.service = service;
         this.eventService = eventService;
+        this.historyService = historyService;
         this.maxRequestBytes = maxRequestBytes;
     }
 
@@ -206,6 +223,30 @@ public final class JobResourceServlet
                     response,
                     200,
                     eventService.events(
+                            jobId,
+                            longParameter(
+                                    request,
+                                    "afterSequence",
+                                    0L),
+                            intParameter(
+                                    request,
+                                    "limit",
+                                    200)));
+            return;
+        }
+
+        if ("history".equals(resource)) {
+            if (historyService == null) {
+                throw new RestException(
+                        501,
+                        "FLUX-JOB-HISTORY-DISABLED",
+                        "Job execution history is not configured");
+            }
+
+            write(
+                    response,
+                    200,
+                    historyService.history(
                             jobId,
                             longParameter(
                                     request,

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/event/EventPublishingJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/event/EventPublishingJobRepository.java
@@ -10,6 +10,7 @@ import com.link.up.server.runtime.JobSnapshot;
 import com.link.up.server.runtime.JobStateTransition;
 import com.link.up.server.runtime.ServerJobStatus;
 import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobExecutionFacts;
 import com.link.up.server.runtime.event.JobRuntimeEvent;
 import com.link.up.server.runtime.event.JobRuntimeEventType;
 import org.apache.logging.log4j.LogManager;
@@ -227,7 +228,7 @@ public final class EventPublishingJobRepository
             }
 
             return statusEvent(
-                    snapshot.getStatus(),
+                    snapshot,
                     metadata,
                     attempt);
         }
@@ -243,7 +244,7 @@ public final class EventPublishingJobRepository
         if (previousSnapshot.getStatus()
                 != snapshot.getStatus()) {
             return statusEvent(
-                    snapshot.getStatus(),
+                    snapshot,
                     metadata,
                     attempt);
         }
@@ -266,10 +267,11 @@ public final class EventPublishingJobRepository
     }
 
     private JobRuntimeEvent statusEvent(
-            ServerJobStatus status,
+            JobSnapshot snapshot,
             JobExecutionMetadata metadata,
             JobAttemptMetadata attempt) {
 
+        ServerJobStatus status = snapshot.getStatus();
         if (status == ServerJobStatus.QUEUED) {
             return transitionEvent(
                     JobRuntimeEventType.JOB_QUEUED,
@@ -287,28 +289,32 @@ public final class EventPublishingJobRepository
                     JobRuntimeEventType.JOB_SUCCEEDED,
                     metadata,
                     status,
-                    null);
+                    null,
+                    snapshot);
         }
         if (status == ServerJobStatus.CANCELED) {
             return terminalEvent(
                     JobRuntimeEventType.JOB_CANCELED,
                     metadata,
                     status,
-                    null);
+                    null,
+                    snapshot);
         }
         if (status == ServerJobStatus.LOST) {
             return terminalEvent(
                     JobRuntimeEventType.JOB_LOST,
                     metadata,
                     status,
-                    attempt.getFailureType());
+                    attempt.getFailureType(),
+                    snapshot);
         }
         if (status == ServerJobStatus.FAILED) {
             return terminalEvent(
                     JobRuntimeEventType.JOB_FAILED,
                     metadata,
                     status,
-                    attempt.getFailureType());
+                    attempt.getFailureType(),
+                    snapshot);
         }
 
         return null;
@@ -339,7 +345,8 @@ public final class EventPublishingJobRepository
             JobRuntimeEventType type,
             JobExecutionMetadata metadata,
             ServerJobStatus fallbackStatus,
-            String failureType) {
+            String failureType,
+            JobSnapshot snapshot) {
 
         JobStateTransition transition =
                 latestTransition(metadata);
@@ -355,7 +362,8 @@ public final class EventPublishingJobRepository
                 transition == null
                         ? null
                         : transition.getReason(),
-                failureType);
+                failureType,
+                JobExecutionFacts.from(snapshot));
     }
 
     private long occurredAtMillis(

--- a/link-up-server/src/main/java/com/link/up/server/runtime/event/JobExecutionFacts.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/event/JobExecutionFacts.java
@@ -1,0 +1,514 @@
+package com.link.up.server.runtime.event;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.link.up.server.runtime.JobSnapshot;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Secret-safe execution facts captured at a durable Job checkpoint.
+ *
+ * <p>This model intentionally contains only stable identities, statuses and
+ * numeric execution facts. Connector table locations, current split details,
+ * SQL, log paths, exception messages and arbitrary payload maps are excluded.
+ * It can therefore be stored inside the append-only Job event journal.</p>
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class JobExecutionFacts {
+
+    private final Metrics metrics;
+    private final Commit commitSummary;
+    private final List<Pipeline> pipelines;
+    private final List<Task> tasks;
+
+    @JsonCreator
+    public JobExecutionFacts(
+            @JsonProperty("metrics") Metrics metrics,
+            @JsonProperty("commitSummary") Commit commitSummary,
+            @JsonProperty("pipelines") List<Pipeline> pipelines,
+            @JsonProperty("tasks") List<Task> tasks) {
+
+        this.metrics = Objects.requireNonNull(
+                metrics,
+                "metrics must not be null");
+        this.commitSummary = commitSummary;
+        this.pipelines = immutable(
+                pipelines,
+                "pipelines");
+        this.tasks = immutable(
+                tasks,
+                "tasks");
+    }
+
+    public static JobExecutionFacts from(
+            JobSnapshot snapshot) {
+
+        JobSnapshot safeSnapshot = Objects.requireNonNull(
+                snapshot,
+                "snapshot must not be null");
+        List<Pipeline> pipelines = new ArrayList<Pipeline>();
+        List<Task> tasks = new ArrayList<Task>();
+
+        for (JobSnapshot.Pipeline pipeline :
+                safeSnapshot.getPipelines()) {
+            pipelines.add(Pipeline.from(pipeline));
+            for (JobSnapshot.Task task : pipeline.getTasks()) {
+                tasks.add(Task.from(task));
+            }
+        }
+
+        return new JobExecutionFacts(
+                Metrics.from(safeSnapshot.getMetrics()),
+                Commit.from(safeSnapshot.getCommitSummary()),
+                pipelines,
+                tasks);
+    }
+
+    public boolean hasExecutionDetails() {
+        return !pipelines.isEmpty() || !tasks.isEmpty();
+    }
+
+    public Metrics getMetrics() {
+        return metrics;
+    }
+
+    public Commit getCommitSummary() {
+        return commitSummary;
+    }
+
+    public List<Pipeline> getPipelines() {
+        return pipelines;
+    }
+
+    public List<Task> getTasks() {
+        return tasks;
+    }
+
+    private static <T> List<T> immutable(
+            List<T> values,
+            String name) {
+
+        if (values == null) {
+            return Collections.emptyList();
+        }
+
+        List<T> copy = new ArrayList<T>(values.size());
+        for (T value : values) {
+            copy.add(
+                    Objects.requireNonNull(
+                            value,
+                            name + " must not contain null"));
+        }
+        return Collections.unmodifiableList(copy);
+    }
+
+    /** Aggregated numeric facts useful for History UI scorecards. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Metrics {
+
+        private final long sourceRecordCount;
+        private final long sourceReadBytes;
+        private final double sourceAverageQps;
+        private final long sinkAttemptedRecordCount;
+        private final long sinkSuccessRecordCount;
+        private final long sinkWrittenBytes;
+        private final double sinkAverageQps;
+        private final long failedRecordCount;
+        private final long skippedRecordCount;
+        private final long unknownStateRecordCount;
+        private final long totalSplitCount;
+        private final long completedSplitCount;
+        private final long failedSplitCount;
+        private final long databaseCommitMillis;
+        private final long sqlExecutionMillis;
+        private final double producerBackpressureRatio;
+        private final double consumerIdleRatio;
+        private final double rateLimitedRatio;
+
+        @JsonCreator
+        public Metrics(
+                @JsonProperty("sourceRecordCount") long sourceRecordCount,
+                @JsonProperty("sourceReadBytes") long sourceReadBytes,
+                @JsonProperty("sourceAverageQps") double sourceAverageQps,
+                @JsonProperty("sinkAttemptedRecordCount") long sinkAttemptedRecordCount,
+                @JsonProperty("sinkSuccessRecordCount") long sinkSuccessRecordCount,
+                @JsonProperty("sinkWrittenBytes") long sinkWrittenBytes,
+                @JsonProperty("sinkAverageQps") double sinkAverageQps,
+                @JsonProperty("failedRecordCount") long failedRecordCount,
+                @JsonProperty("skippedRecordCount") long skippedRecordCount,
+                @JsonProperty("unknownStateRecordCount") long unknownStateRecordCount,
+                @JsonProperty("totalSplitCount") long totalSplitCount,
+                @JsonProperty("completedSplitCount") long completedSplitCount,
+                @JsonProperty("failedSplitCount") long failedSplitCount,
+                @JsonProperty("databaseCommitMillis") long databaseCommitMillis,
+                @JsonProperty("sqlExecutionMillis") long sqlExecutionMillis,
+                @JsonProperty("producerBackpressureRatio") double producerBackpressureRatio,
+                @JsonProperty("consumerIdleRatio") double consumerIdleRatio,
+                @JsonProperty("rateLimitedRatio") double rateLimitedRatio) {
+
+            this.sourceRecordCount = sourceRecordCount;
+            this.sourceReadBytes = sourceReadBytes;
+            this.sourceAverageQps = sourceAverageQps;
+            this.sinkAttemptedRecordCount = sinkAttemptedRecordCount;
+            this.sinkSuccessRecordCount = sinkSuccessRecordCount;
+            this.sinkWrittenBytes = sinkWrittenBytes;
+            this.sinkAverageQps = sinkAverageQps;
+            this.failedRecordCount = failedRecordCount;
+            this.skippedRecordCount = skippedRecordCount;
+            this.unknownStateRecordCount = unknownStateRecordCount;
+            this.totalSplitCount = totalSplitCount;
+            this.completedSplitCount = completedSplitCount;
+            this.failedSplitCount = failedSplitCount;
+            this.databaseCommitMillis = databaseCommitMillis;
+            this.sqlExecutionMillis = sqlExecutionMillis;
+            this.producerBackpressureRatio = producerBackpressureRatio;
+            this.consumerIdleRatio = consumerIdleRatio;
+            this.rateLimitedRatio = rateLimitedRatio;
+        }
+
+        private static Metrics from(JobSnapshot.Metrics metrics) {
+            JobSnapshot.Metrics safe = Objects.requireNonNull(
+                    metrics,
+                    "snapshot metrics must not be null");
+            return new Metrics(
+                    safe.getSourceRecordCount(),
+                    safe.getSourceReadBytes(),
+                    safe.getSourceAverageQps(),
+                    safe.getSinkAttemptedRecordCount(),
+                    safe.getSinkSuccessRecordCount(),
+                    safe.getSinkWrittenBytes(),
+                    safe.getSinkAverageQps(),
+                    safe.getFailedRecordCount(),
+                    safe.getSkippedRecordCount(),
+                    safe.getUnknownStateRecordCount(),
+                    safe.getTotalSplitCount(),
+                    safe.getCompletedSplitCount(),
+                    safe.getFailedSplitCount(),
+                    safe.getDatabaseCommitMillis(),
+                    safe.getSqlExecutionMillis(),
+                    safe.getProducerBackpressureRatio(),
+                    safe.getConsumerIdleRatio(),
+                    safe.getRateLimitedRatio());
+        }
+
+        public long getSourceRecordCount() { return sourceRecordCount; }
+        public long getSourceReadBytes() { return sourceReadBytes; }
+        public double getSourceAverageQps() { return sourceAverageQps; }
+        public long getSinkAttemptedRecordCount() { return sinkAttemptedRecordCount; }
+        public long getSinkSuccessRecordCount() { return sinkSuccessRecordCount; }
+        public long getSinkWrittenBytes() { return sinkWrittenBytes; }
+        public double getSinkAverageQps() { return sinkAverageQps; }
+        public long getFailedRecordCount() { return failedRecordCount; }
+        public long getSkippedRecordCount() { return skippedRecordCount; }
+        public long getUnknownStateRecordCount() { return unknownStateRecordCount; }
+        public long getTotalSplitCount() { return totalSplitCount; }
+        public long getCompletedSplitCount() { return completedSplitCount; }
+        public long getFailedSplitCount() { return failedSplitCount; }
+        public long getDatabaseCommitMillis() { return databaseCommitMillis; }
+        public long getSqlExecutionMillis() { return sqlExecutionMillis; }
+        public double getProducerBackpressureRatio() { return producerBackpressureRatio; }
+        public double getConsumerIdleRatio() { return consumerIdleRatio; }
+        public double getRateLimitedRatio() { return rateLimitedRatio; }
+    }
+
+    /** Pipeline-level facts; physical table locations are intentionally omitted. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Pipeline {
+
+        private final String pipelineId;
+        private final String dataSetId;
+        private final String status;
+        private final String sourceConnector;
+        private final int sourceTaskCount;
+        private final long sourceRecordCount;
+        private final long sourceReadBytes;
+        private final double sourceAverageQps;
+        private final String sinkConnector;
+        private final int sinkTaskCount;
+        private final long sinkAttemptedRecordCount;
+        private final long sinkSuccessRecordCount;
+        private final long sinkFailedRecordCount;
+        private final long sinkUnknownStateRecordCount;
+        private final long sinkWrittenBytes;
+        private final double sinkAverageQps;
+        private final Commit commitSummary;
+
+        @JsonCreator
+        public Pipeline(
+                @JsonProperty("pipelineId") String pipelineId,
+                @JsonProperty("dataSetId") String dataSetId,
+                @JsonProperty("status") String status,
+                @JsonProperty("sourceConnector") String sourceConnector,
+                @JsonProperty("sourceTaskCount") int sourceTaskCount,
+                @JsonProperty("sourceRecordCount") long sourceRecordCount,
+                @JsonProperty("sourceReadBytes") long sourceReadBytes,
+                @JsonProperty("sourceAverageQps") double sourceAverageQps,
+                @JsonProperty("sinkConnector") String sinkConnector,
+                @JsonProperty("sinkTaskCount") int sinkTaskCount,
+                @JsonProperty("sinkAttemptedRecordCount") long sinkAttemptedRecordCount,
+                @JsonProperty("sinkSuccessRecordCount") long sinkSuccessRecordCount,
+                @JsonProperty("sinkFailedRecordCount") long sinkFailedRecordCount,
+                @JsonProperty("sinkUnknownStateRecordCount") long sinkUnknownStateRecordCount,
+                @JsonProperty("sinkWrittenBytes") long sinkWrittenBytes,
+                @JsonProperty("sinkAverageQps") double sinkAverageQps,
+                @JsonProperty("commitSummary") Commit commitSummary) {
+
+            this.pipelineId = requireText(pipelineId, "pipelineId");
+            this.dataSetId = requireText(dataSetId, "dataSetId");
+            this.status = requireText(status, "status");
+            this.sourceConnector = requireText(sourceConnector, "sourceConnector");
+            this.sourceTaskCount = sourceTaskCount;
+            this.sourceRecordCount = sourceRecordCount;
+            this.sourceReadBytes = sourceReadBytes;
+            this.sourceAverageQps = sourceAverageQps;
+            this.sinkConnector = requireText(sinkConnector, "sinkConnector");
+            this.sinkTaskCount = sinkTaskCount;
+            this.sinkAttemptedRecordCount = sinkAttemptedRecordCount;
+            this.sinkSuccessRecordCount = sinkSuccessRecordCount;
+            this.sinkFailedRecordCount = sinkFailedRecordCount;
+            this.sinkUnknownStateRecordCount = sinkUnknownStateRecordCount;
+            this.sinkWrittenBytes = sinkWrittenBytes;
+            this.sinkAverageQps = sinkAverageQps;
+            this.commitSummary = commitSummary;
+        }
+
+        private static Pipeline from(JobSnapshot.Pipeline pipeline) {
+            JobSnapshot.Source source = pipeline.getSource();
+            JobSnapshot.Sink sink = pipeline.getSink();
+            return new Pipeline(
+                    pipeline.getPipelineId(),
+                    pipeline.getDataSetId(),
+                    pipeline.getStatus(),
+                    source.getConnector(),
+                    source.getTaskCount(),
+                    source.getRecordCount(),
+                    source.getReadBytes(),
+                    source.getAverageQps(),
+                    sink.getConnector(),
+                    sink.getTaskCount(),
+                    sink.getAttemptedRecordCount(),
+                    sink.getSuccessRecordCount(),
+                    sink.getFailedRecordCount(),
+                    sink.getUnknownStateRecordCount(),
+                    sink.getWrittenBytes(),
+                    sink.getAverageQps(),
+                    Commit.from(pipeline.getCommitSummary()));
+        }
+
+        public String getPipelineId() { return pipelineId; }
+        public String getDataSetId() { return dataSetId; }
+        public String getStatus() { return status; }
+        public String getSourceConnector() { return sourceConnector; }
+        public int getSourceTaskCount() { return sourceTaskCount; }
+        public long getSourceRecordCount() { return sourceRecordCount; }
+        public long getSourceReadBytes() { return sourceReadBytes; }
+        public double getSourceAverageQps() { return sourceAverageQps; }
+        public String getSinkConnector() { return sinkConnector; }
+        public int getSinkTaskCount() { return sinkTaskCount; }
+        public long getSinkAttemptedRecordCount() { return sinkAttemptedRecordCount; }
+        public long getSinkSuccessRecordCount() { return sinkSuccessRecordCount; }
+        public long getSinkFailedRecordCount() { return sinkFailedRecordCount; }
+        public long getSinkUnknownStateRecordCount() { return sinkUnknownStateRecordCount; }
+        public long getSinkWrittenBytes() { return sinkWrittenBytes; }
+        public double getSinkAverageQps() { return sinkAverageQps; }
+        public Commit getCommitSummary() { return commitSummary; }
+    }
+
+    /** Task-level facts; current table/split values are intentionally omitted. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Task {
+
+        private final String taskId;
+        private final String pipelineId;
+        private final String taskType;
+        private final String state;
+        private final int subtaskIndex;
+        private final int parallelism;
+        private final long batchCount;
+        private final long receivedBatchCount;
+        private final long attemptedRecordCount;
+        private final long recordCount;
+        private final long failedRecordCount;
+        private final long unknownStateRecordCount;
+        private final long completedSplitCount;
+        private final double averageQps;
+        private final long durationMillis;
+
+        @JsonCreator
+        public Task(
+                @JsonProperty("taskId") String taskId,
+                @JsonProperty("pipelineId") String pipelineId,
+                @JsonProperty("taskType") String taskType,
+                @JsonProperty("state") String state,
+                @JsonProperty("subtaskIndex") int subtaskIndex,
+                @JsonProperty("parallelism") int parallelism,
+                @JsonProperty("batchCount") long batchCount,
+                @JsonProperty("receivedBatchCount") long receivedBatchCount,
+                @JsonProperty("attemptedRecordCount") long attemptedRecordCount,
+                @JsonProperty("recordCount") long recordCount,
+                @JsonProperty("failedRecordCount") long failedRecordCount,
+                @JsonProperty("unknownStateRecordCount") long unknownStateRecordCount,
+                @JsonProperty("completedSplitCount") long completedSplitCount,
+                @JsonProperty("averageQps") double averageQps,
+                @JsonProperty("durationMillis") long durationMillis) {
+
+            this.taskId = requireText(taskId, "taskId");
+            this.pipelineId = requireText(pipelineId, "pipelineId");
+            this.taskType = requireText(taskType, "taskType");
+            this.state = requireText(state, "state");
+            this.subtaskIndex = subtaskIndex;
+            this.parallelism = parallelism;
+            this.batchCount = batchCount;
+            this.receivedBatchCount = receivedBatchCount;
+            this.attemptedRecordCount = attemptedRecordCount;
+            this.recordCount = recordCount;
+            this.failedRecordCount = failedRecordCount;
+            this.unknownStateRecordCount = unknownStateRecordCount;
+            this.completedSplitCount = completedSplitCount;
+            this.averageQps = averageQps;
+            this.durationMillis = durationMillis;
+        }
+
+        private static Task from(JobSnapshot.Task task) {
+            return new Task(
+                    task.getTaskId(),
+                    task.getPipelineId(),
+                    task.getTaskType(),
+                    task.getState(),
+                    task.getSubtaskIndex(),
+                    task.getParallelism(),
+                    task.getBatchCount(),
+                    task.getReceivedBatchCount(),
+                    task.getAttemptedRecordCount(),
+                    task.getRecordCount(),
+                    task.getFailedRecordCount(),
+                    task.getUnknownStateRecordCount(),
+                    task.getCompletedSplitCount(),
+                    task.getAverageQps(),
+                    task.getDurationMillis());
+        }
+
+        public String getTaskId() { return taskId; }
+        public String getPipelineId() { return pipelineId; }
+        public String getTaskType() { return taskType; }
+        public String getState() { return state; }
+        public int getSubtaskIndex() { return subtaskIndex; }
+        public int getParallelism() { return parallelism; }
+        public long getBatchCount() { return batchCount; }
+        public long getReceivedBatchCount() { return receivedBatchCount; }
+        public long getAttemptedRecordCount() { return attemptedRecordCount; }
+        public long getRecordCount() { return recordCount; }
+        public long getFailedRecordCount() { return failedRecordCount; }
+        public long getUnknownStateRecordCount() { return unknownStateRecordCount; }
+        public long getCompletedSplitCount() { return completedSplitCount; }
+        public double getAverageQps() { return averageQps; }
+        public long getDurationMillis() { return durationMillis; }
+    }
+
+    /** Commit evidence without free-form retry advice. */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static final class Commit {
+
+        private final int totalTaskCount;
+        private final int finishedTaskCount;
+        private final int committedTaskCount;
+        private final int dataCommittedTaskCount;
+        private final int emptyCommittedTaskCount;
+        private final int failedOrUncommittedTaskCount;
+        private final long attemptedRecordCount;
+        private final long successfullyWrittenRecordCount;
+        private final long successfullyCommittedRecordCount;
+        private final long failedRecordCount;
+        private final long unknownStateRecordCount;
+        private final boolean partialTaskCommit;
+        private final boolean partialDataCommit;
+        private final String commitScope;
+
+        @JsonCreator
+        public Commit(
+                @JsonProperty("totalTaskCount") int totalTaskCount,
+                @JsonProperty("finishedTaskCount") int finishedTaskCount,
+                @JsonProperty("committedTaskCount") int committedTaskCount,
+                @JsonProperty("dataCommittedTaskCount") int dataCommittedTaskCount,
+                @JsonProperty("emptyCommittedTaskCount") int emptyCommittedTaskCount,
+                @JsonProperty("failedOrUncommittedTaskCount") int failedOrUncommittedTaskCount,
+                @JsonProperty("attemptedRecordCount") long attemptedRecordCount,
+                @JsonProperty("successfullyWrittenRecordCount") long successfullyWrittenRecordCount,
+                @JsonProperty("successfullyCommittedRecordCount") long successfullyCommittedRecordCount,
+                @JsonProperty("failedRecordCount") long failedRecordCount,
+                @JsonProperty("unknownStateRecordCount") long unknownStateRecordCount,
+                @JsonProperty("partialTaskCommit") boolean partialTaskCommit,
+                @JsonProperty("partialDataCommit") boolean partialDataCommit,
+                @JsonProperty("commitScope") String commitScope) {
+
+            this.totalTaskCount = totalTaskCount;
+            this.finishedTaskCount = finishedTaskCount;
+            this.committedTaskCount = committedTaskCount;
+            this.dataCommittedTaskCount = dataCommittedTaskCount;
+            this.emptyCommittedTaskCount = emptyCommittedTaskCount;
+            this.failedOrUncommittedTaskCount = failedOrUncommittedTaskCount;
+            this.attemptedRecordCount = attemptedRecordCount;
+            this.successfullyWrittenRecordCount = successfullyWrittenRecordCount;
+            this.successfullyCommittedRecordCount = successfullyCommittedRecordCount;
+            this.failedRecordCount = failedRecordCount;
+            this.unknownStateRecordCount = unknownStateRecordCount;
+            this.partialTaskCommit = partialTaskCommit;
+            this.partialDataCommit = partialDataCommit;
+            this.commitScope = commitScope;
+        }
+
+        private static Commit from(JobSnapshot.Commit commit) {
+            if (commit == null) {
+                return null;
+            }
+            return new Commit(
+                    commit.getTotalTaskCount(),
+                    commit.getFinishedTaskCount(),
+                    commit.getCommittedTaskCount(),
+                    commit.getDataCommittedTaskCount(),
+                    commit.getEmptyCommittedTaskCount(),
+                    commit.getFailedOrUncommittedTaskCount(),
+                    commit.getAttemptedRecordCount(),
+                    commit.getSuccessfullyWrittenRecordCount(),
+                    commit.getSuccessfullyCommittedRecordCount(),
+                    commit.getFailedRecordCount(),
+                    commit.getUnknownStateRecordCount(),
+                    commit.isPartialTaskCommit(),
+                    commit.isPartialDataCommit(),
+                    commit.getCommitScope());
+        }
+
+        public int getTotalTaskCount() { return totalTaskCount; }
+        public int getFinishedTaskCount() { return finishedTaskCount; }
+        public int getCommittedTaskCount() { return committedTaskCount; }
+        public int getDataCommittedTaskCount() { return dataCommittedTaskCount; }
+        public int getEmptyCommittedTaskCount() { return emptyCommittedTaskCount; }
+        public int getFailedOrUncommittedTaskCount() { return failedOrUncommittedTaskCount; }
+        public long getAttemptedRecordCount() { return attemptedRecordCount; }
+        public long getSuccessfullyWrittenRecordCount() { return successfullyWrittenRecordCount; }
+        public long getSuccessfullyCommittedRecordCount() { return successfullyCommittedRecordCount; }
+        public long getFailedRecordCount() { return failedRecordCount; }
+        public long getUnknownStateRecordCount() { return unknownStateRecordCount; }
+        public boolean isPartialTaskCommit() { return partialTaskCommit; }
+        public boolean isPartialDataCommit() { return partialDataCommit; }
+        public String getCommitScope() { return commitScope; }
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/runtime/event/JobRuntimeEvent.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/event/JobRuntimeEvent.java
@@ -11,9 +11,9 @@ import java.util.Objects;
 /**
  * Secret-safe lifecycle fact stored inside a {@link JobEventEnvelope}.
  *
- * <p>The event intentionally carries no Connector options, arbitrary payload
- * map or Throwable message. Failures are represented only by their Java type
- * until structured runtime errors are introduced.</p>
+ * <p>The optional execution payload is emitted only from durable checkpoints
+ * and contains a bounded, typed projection of Pipeline/Task facts. Connector
+ * options, arbitrary payload maps and Throwable messages remain excluded.</p>
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -25,6 +25,24 @@ public final class JobRuntimeEvent {
     private final String reason;
     private final String runId;
     private final String failureType;
+    private final JobExecutionFacts execution;
+
+    public JobRuntimeEvent(
+            JobRuntimeEventType type,
+            ServerJobStatus previousStatus,
+            ServerJobStatus status,
+            String reason,
+            String runId,
+            String failureType) {
+        this(
+                type,
+                previousStatus,
+                status,
+                reason,
+                runId,
+                failureType,
+                null);
+    }
 
     @JsonCreator
     public JobRuntimeEvent(
@@ -33,7 +51,8 @@ public final class JobRuntimeEvent {
             @JsonProperty("status") ServerJobStatus status,
             @JsonProperty("reason") String reason,
             @JsonProperty("runId") String runId,
-            @JsonProperty("failureType") String failureType) {
+            @JsonProperty("failureType") String failureType,
+            @JsonProperty("execution") JobExecutionFacts execution) {
 
         this.type = Objects.requireNonNull(
                 type,
@@ -43,6 +62,7 @@ public final class JobRuntimeEvent {
         this.reason = safeOptionalText(reason, 200);
         this.runId = safeOptionalText(runId, 200);
         this.failureType = safeOptionalText(failureType, 300);
+        this.execution = execution;
     }
 
     public static JobRuntimeEvent transition(
@@ -62,6 +82,7 @@ public final class JobRuntimeEvent {
                 status,
                 reason,
                 null,
+                null,
                 null);
     }
 
@@ -75,6 +96,7 @@ public final class JobRuntimeEvent {
                 status,
                 "job-log-created",
                 requireText(runId, "runId"),
+                null,
                 null);
     }
 
@@ -87,6 +109,7 @@ public final class JobRuntimeEvent {
                 status,
                 "cancellation-requested",
                 null,
+                null,
                 null);
     }
 
@@ -96,6 +119,23 @@ public final class JobRuntimeEvent {
             ServerJobStatus status,
             String reason,
             String failureType) {
+
+        return terminal(
+                type,
+                previousStatus,
+                status,
+                reason,
+                failureType,
+                null);
+    }
+
+    public static JobRuntimeEvent terminal(
+            JobRuntimeEventType type,
+            ServerJobStatus previousStatus,
+            ServerJobStatus status,
+            String reason,
+            String failureType,
+            JobExecutionFacts execution) {
 
         if (!isTerminalType(type)) {
             throw new IllegalArgumentException(
@@ -108,7 +148,8 @@ public final class JobRuntimeEvent {
                 status,
                 reason,
                 null,
-                failureType);
+                failureType,
+                execution);
     }
 
     private static boolean isTerminalType(
@@ -154,27 +195,11 @@ public final class JobRuntimeEvent {
         return normalized;
     }
 
-    public JobRuntimeEventType getType() {
-        return type;
-    }
-
-    public ServerJobStatus getPreviousStatus() {
-        return previousStatus;
-    }
-
-    public ServerJobStatus getStatus() {
-        return status;
-    }
-
-    public String getReason() {
-        return reason;
-    }
-
-    public String getRunId() {
-        return runId;
-    }
-
-    public String getFailureType() {
-        return failureType;
-    }
+    public JobRuntimeEventType getType() { return type; }
+    public ServerJobStatus getPreviousStatus() { return previousStatus; }
+    public ServerJobStatus getStatus() { return status; }
+    public String getReason() { return reason; }
+    public String getRunId() { return runId; }
+    public String getFailureType() { return failureType; }
+    public JobExecutionFacts getExecution() { return execution; }
 }

--- a/link-up-server/src/main/java/com/link/up/server/service/JobHistoryRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobHistoryRestService.java
@@ -5,7 +5,9 @@ import com.link.up.server.application.port.JobEventReader;
 import com.link.up.server.dto.JobHistoryResponse;
 import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.event.JobEventEnvelope;
 import com.link.up.server.runtime.event.JobEventPage;
+import com.link.up.server.runtime.event.JobExecutionFacts;
 
 import java.util.Objects;
 
@@ -46,10 +48,53 @@ public final class JobHistoryRestService {
                 afterSequence,
                 limit);
 
+        JobExecutionFacts execution =
+                JobExecutionFacts.from(snapshot);
+        if (!execution.hasExecutionDetails()) {
+            JobExecutionFacts retained =
+                    retainedExecution(normalizedJobId);
+            if (retained != null) {
+                execution = retained;
+            }
+        }
+
         return new JobHistoryResponse(
                 snapshot,
                 metadata,
-                events);
+                events,
+                execution);
+    }
+
+    private JobExecutionFacts retainedExecution(String jobId) {
+        long cursor = 0L;
+        JobExecutionFacts latest = null;
+
+        while (true) {
+            JobEventPage page = eventReader.read(
+                    jobId,
+                    cursor,
+                    MAX_PAGE_SIZE);
+
+            for (JobEventEnvelope envelope : page.getItems()) {
+                JobExecutionFacts execution =
+                        envelope.getEvent().getExecution();
+                if (execution != null
+                        && execution.hasExecutionDetails()) {
+                    latest = execution;
+                }
+            }
+
+            if (!page.isHasMore()) {
+                return latest;
+            }
+
+            long next = page.getNextSequence();
+            if (next <= cursor) {
+                throw new IllegalStateException(
+                        "Job event history cursor did not advance");
+            }
+            cursor = next;
+        }
     }
 
     private static void validatePage(

--- a/link-up-server/src/main/java/com/link/up/server/service/JobHistoryRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobHistoryRestService.java
@@ -1,6 +1,7 @@
 package com.link.up.server.service;
 
 import com.link.up.server.application.JobApplication;
+import com.link.up.server.application.port.JobEventHistoryException;
 import com.link.up.server.application.port.JobEventReader;
 import com.link.up.server.dto.JobHistoryResponse;
 import com.link.up.server.runtime.JobExecutionMetadata;
@@ -90,8 +91,9 @@ public final class JobHistoryRestService {
 
             long next = page.getNextSequence();
             if (next <= cursor) {
-                throw new IllegalStateException(
-                        "Job event history cursor did not advance");
+                throw new JobEventHistoryException(
+                        "Job event history cursor did not advance",
+                        null);
             }
             cursor = next;
         }

--- a/link-up-server/src/main/java/com/link/up/server/service/JobHistoryRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobHistoryRestService.java
@@ -1,0 +1,80 @@
+package com.link.up.server.service;
+
+import com.link.up.server.application.JobApplication;
+import com.link.up.server.application.port.JobEventReader;
+import com.link.up.server.dto.JobHistoryResponse;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.event.JobEventPage;
+
+import java.util.Objects;
+
+/** Read-only composition boundary for Spark-style Job execution history. */
+public final class JobHistoryRestService {
+
+    private static final int MAX_PAGE_SIZE = 1_000;
+
+    private final JobApplication jobApplication;
+    private final JobEventReader eventReader;
+
+    public JobHistoryRestService(
+            JobApplication jobApplication,
+            JobEventReader eventReader) {
+
+        this.jobApplication = Objects.requireNonNull(
+                jobApplication,
+                "jobApplication must not be null");
+        this.eventReader = Objects.requireNonNull(
+                eventReader,
+                "eventReader must not be null");
+    }
+
+    public JobHistoryResponse history(
+            String jobId,
+            long afterSequence,
+            int limit) {
+
+        String normalizedJobId = requireText(jobId, "jobId");
+        validatePage(afterSequence, limit);
+
+        JobSnapshot snapshot =
+                jobApplication.getJob(normalizedJobId);
+        JobExecutionMetadata metadata =
+                jobApplication.getMetadata(normalizedJobId);
+        JobEventPage events = eventReader.read(
+                normalizedJobId,
+                afterSequence,
+                limit);
+
+        return new JobHistoryResponse(
+                snapshot,
+                metadata,
+                events);
+    }
+
+    private static void validatePage(
+            long afterSequence,
+            int limit) {
+
+        if (afterSequence < 0L) {
+            throw new IllegalArgumentException(
+                    "afterSequence must not be negative");
+        }
+        if (limit <= 0 || limit > MAX_PAGE_SIZE) {
+            throw new IllegalArgumentException(
+                    "limit must be between 1 and "
+                            + MAX_PAGE_SIZE);
+        }
+    }
+
+    private static String requireText(
+            String value,
+            String name) {
+
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    name + " must not be blank");
+        }
+        return value.trim();
+    }
+}

--- a/link-up-server/src/main/java/com/link/up/server/service/JobHistoryRestService.java
+++ b/link-up-server/src/main/java/com/link/up/server/service/JobHistoryRestService.java
@@ -4,12 +4,14 @@ import com.link.up.server.application.JobApplication;
 import com.link.up.server.application.port.JobEventHistoryException;
 import com.link.up.server.application.port.JobEventReader;
 import com.link.up.server.dto.JobHistoryResponse;
+import com.link.up.server.runtime.JobAttemptMetadata;
 import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobSnapshot;
 import com.link.up.server.runtime.event.JobEventEnvelope;
 import com.link.up.server.runtime.event.JobEventPage;
 import com.link.up.server.runtime.event.JobExecutionFacts;
 
+import java.util.List;
 import java.util.Objects;
 
 /** Read-only composition boundary for Spark-style Job execution history. */
@@ -51,9 +53,14 @@ public final class JobHistoryRestService {
 
         JobExecutionFacts execution =
                 JobExecutionFacts.from(snapshot);
-        if (!execution.hasExecutionDetails()) {
-            JobExecutionFacts retained =
-                    retainedExecution(normalizedJobId);
+        String currentAttemptId = currentAttemptId(metadata);
+
+        if (!execution.hasExecutionDetails()
+                && snapshot.getStatus().isTerminal()
+                && currentAttemptId != null) {
+            JobExecutionFacts retained = retainedExecution(
+                    normalizedJobId,
+                    currentAttemptId);
             if (retained != null) {
                 execution = retained;
             }
@@ -66,7 +73,10 @@ public final class JobHistoryRestService {
                 execution);
     }
 
-    private JobExecutionFacts retainedExecution(String jobId) {
+    private JobExecutionFacts retainedExecution(
+            String jobId,
+            String attemptId) {
+
         long cursor = 0L;
         JobExecutionFacts latest = null;
 
@@ -77,6 +87,10 @@ public final class JobHistoryRestService {
                     MAX_PAGE_SIZE);
 
             for (JobEventEnvelope envelope : page.getItems()) {
+                if (!attemptId.equals(envelope.getAttemptId())) {
+                    continue;
+                }
+
                 JobExecutionFacts execution =
                         envelope.getEvent().getExecution();
                 if (execution != null
@@ -97,6 +111,21 @@ public final class JobHistoryRestService {
             }
             cursor = next;
         }
+    }
+
+    private static String currentAttemptId(
+            JobExecutionMetadata metadata) {
+
+        if (metadata == null) {
+            return null;
+        }
+
+        List<JobAttemptMetadata> attempts = metadata.getAttempts();
+        if (attempts.isEmpty()) {
+            return null;
+        }
+
+        return attempts.get(attempts.size() - 1).getAttemptId();
     }
 
     private static void validatePage(

--- a/link-up-server/src/test/java/com/link/up/server/runtime/JobHistoryResponseTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/runtime/JobHistoryResponseTest.java
@@ -5,6 +5,7 @@ import com.link.up.server.domain.JobAttemptStatus;
 import com.link.up.server.dto.JobHistoryResponse;
 import com.link.up.server.runtime.event.JobEventEnvelope;
 import com.link.up.server.runtime.event.JobEventPage;
+import com.link.up.server.runtime.event.JobExecutionFacts;
 import com.link.up.server.runtime.event.JobRuntimeEvent;
 import com.link.up.server.runtime.event.JobRuntimeEventType;
 import org.junit.Test;
@@ -13,6 +14,7 @@ import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 public class JobHistoryResponseTest {
@@ -38,14 +40,63 @@ public class JobHistoryResponseTest {
         assertEquals("job-history-1", response.getJobId());
         assertTrue(response.isCompleted());
         assertEquals(1, response.getAttempts().size());
-        assertEquals(1, response.getPipelines().size());
-        assertEquals(1, response.getPipelines().get(0).getTasks().size());
-        assertEquals(1, response.getPipelines().get(0).getChannels().size());
+        assertEquals(1,
+                response.getExecution().getPipelines().size());
+        assertEquals(1,
+                response.getExecution().getTasks().size());
         assertEquals("PLAN-006",
                 response.getAttempts().get(0).getErrorCode());
         assertTrue(json.contains("PLAN-006"));
         assertTrue(json.contains("pipeline-demo.orders"));
 
+        assertSecretSafe(json);
+    }
+
+    @Test
+    public void terminalExecutionFactsMustRoundTripThroughEventJson()
+            throws Exception {
+
+        JobRuntimeEvent terminal = JobRuntimeEvent.terminal(
+                JobRuntimeEventType.JOB_FAILED,
+                ServerJobStatus.RUNNING,
+                ServerJobStatus.FAILED,
+                "job-failed",
+                "SQLException",
+                JobExecutionFacts.from(snapshot()));
+        JobEventEnvelope envelope = JobEventEnvelope.create(
+                "job-history-1",
+                "job-history-1-attempt-1",
+                1,
+                5L,
+                5L,
+                terminal);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String json = mapper.writeValueAsString(envelope);
+        JobEventEnvelope restored = mapper.readValue(
+                json,
+                JobEventEnvelope.class);
+
+        assertSecretSafe(json);
+        assertNotNull(restored.getEvent().getExecution());
+        assertEquals(1,
+                restored.getEvent()
+                        .getExecution()
+                        .getPipelines()
+                        .size());
+        assertEquals(1,
+                restored.getEvent()
+                        .getExecution()
+                        .getTasks()
+                        .size());
+        assertEquals(98L,
+                restored.getEvent()
+                        .getExecution()
+                        .getMetrics()
+                        .getSinkSuccessRecordCount());
+    }
+
+    private static void assertSecretSafe(String json) {
         assertFalse(json.contains(SECRET));
         assertFalse(json.contains("jdbc:mysql://"));
         assertFalse(json.contains("SELECT * FROM secret_table"));

--- a/link-up-server/src/test/java/com/link/up/server/runtime/JobHistoryResponseTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/runtime/JobHistoryResponseTest.java
@@ -1,0 +1,223 @@
+package com.link.up.server.runtime;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.server.domain.JobAttemptStatus;
+import com.link.up.server.dto.JobHistoryResponse;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobEventPage;
+import com.link.up.server.runtime.event.JobRuntimeEvent;
+import com.link.up.server.runtime.event.JobRuntimeEventType;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class JobHistoryResponseTest {
+
+    private static final String SECRET =
+            "TEST_ONLY_SECRET";
+
+    @Test
+    public void historyProjectionMustKeepRawExecutionDetailsOutOfJson()
+            throws Exception {
+
+        JobHistoryResponse response = new JobHistoryResponse(
+                snapshot(),
+                metadata(),
+                events());
+
+        String json = new ObjectMapper()
+                .writeValueAsString(response);
+
+        assertEquals(
+                JobHistoryResponse.CURRENT_API_VERSION,
+                response.getApiVersion());
+        assertEquals("job-history-1", response.getJobId());
+        assertTrue(response.isCompleted());
+        assertEquals(1, response.getAttempts().size());
+        assertEquals(1, response.getPipelines().size());
+        assertEquals(1, response.getPipelines().get(0).getTasks().size());
+        assertEquals(1, response.getPipelines().get(0).getChannels().size());
+        assertEquals("PLAN-006",
+                response.getAttempts().get(0).getErrorCode());
+        assertTrue(json.contains("PLAN-006"));
+        assertTrue(json.contains("pipeline-demo.orders"));
+
+        assertFalse(json.contains(SECRET));
+        assertFalse(json.contains("jdbc:mysql://"));
+        assertFalse(json.contains("SELECT * FROM secret_table"));
+        assertFalse(json.contains("jobLogFile"));
+        assertFalse(json.contains("failureMessage"));
+        assertFalse(json.contains("retryAdvice"));
+        assertFalse(json.contains("currentTable"));
+        assertFalse(json.contains("currentSplit"));
+        assertFalse(json.contains("errorMessage"));
+    }
+
+    private static JobSnapshot snapshot() {
+        JobSnapshot.Metrics metrics = new JobSnapshot.Metrics(
+                4L, 100L, 1024L, 20D,
+                4L, 100L, 98L, 900L, 19D,
+                2L, 0L, 0L, 1L,
+                2L, 2L, 0L, 0L, 0L,
+                8L, 10L,
+                0.1D, 0.2D, 0D);
+
+        JobSnapshot.Commit commit = new JobSnapshot.Commit(
+                2, 2, 2, 2, 0, 0,
+                100L, 98L, 98L, 2L, 0L,
+                false, false,
+                "TASK_LOCAL",
+                "password=" + SECRET);
+
+        JobSnapshot.Task task = new JobSnapshot.Task(
+                "pipeline-demo.orders-source-0",
+                "pipeline-demo.orders",
+                "SOURCE",
+                "FINISHED",
+                0,
+                1,
+                4L,
+                0L,
+                100L,
+                100L,
+                0L,
+                0L,
+                2L,
+                20D,
+                1000L,
+                "jdbc:mysql://localhost/demo?password=" + SECRET,
+                "SELECT * FROM secret_table");
+
+        JobSnapshot.Channel channel = new JobSnapshot.Channel(
+                "pipeline-demo.orders-channel-0",
+                4L,
+                4L,
+                0L,
+                0L,
+                0L,
+                32L,
+                1000L,
+                1024L,
+                0L,
+                0.1D,
+                0.2D,
+                0D);
+
+        JobSnapshot.Source source = new JobSnapshot.Source(
+                "jdbc",
+                "jdbc:mysql://localhost/demo?password=" + SECRET,
+                1,
+                4L,
+                100L,
+                1024L,
+                2L,
+                2L,
+                0L,
+                20D);
+
+        JobSnapshot.Sink sink = new JobSnapshot.Sink(
+                "doris",
+                "password=" + SECRET,
+                1,
+                4L,
+                100L,
+                98L,
+                2L,
+                0L,
+                900L,
+                98L,
+                19D);
+
+        JobSnapshot.Pipeline pipeline = new JobSnapshot.Pipeline(
+                "pipeline-demo.orders",
+                "demo.orders",
+                "FAILED",
+                source,
+                sink,
+                commit,
+                Collections.singletonList(task),
+                Collections.singletonList(channel),
+                "password=" + SECRET);
+
+        return new JobSnapshot(
+                "job-history-1",
+                "history-test",
+                ServerJobStatus.FAILED,
+                1L,
+                2L,
+                3L,
+                1L,
+                metrics,
+                commit,
+                Collections.singletonList(pipeline),
+                "FLUX-JOB-FAILED",
+                "password=" + SECRET);
+    }
+
+    private static JobExecutionMetadata metadata() {
+        JobAttemptMetadata attempt = new JobAttemptMetadata(
+                1,
+                "job-history-1-attempt-1",
+                JobAttemptStatus.FAILED,
+                1L,
+                1L,
+                2L,
+                3L,
+                "run-history-1",
+                "logs/password=" + SECRET + ".log",
+                "java.sql.SQLException",
+                "password=" + SECRET,
+                "retry with password=" + SECRET,
+                "PLAN-006",
+                "PREPARATION",
+                "SOURCE_DISCOVERY",
+                true,
+                "JOB",
+                true,
+                0,
+                0L,
+                0L,
+                false,
+                "TASK_LOCAL");
+
+        return new JobExecutionMetadata(
+                "external-history-1",
+                "key-history-1",
+                1,
+                "digest-history-1",
+                1L,
+                1L,
+                5L,
+                5L,
+                false,
+                Collections.<JobStateTransition>emptyList(),
+                Collections.emptyMap(),
+                "run-history-1",
+                "logs/password=" + SECRET + ".log",
+                Collections.singletonList(attempt));
+    }
+
+    private static JobEventPage events() {
+        JobEventEnvelope event = JobEventEnvelope.create(
+                "job-history-1",
+                "job-history-1-attempt-1",
+                1,
+                1L,
+                1L,
+                JobRuntimeEvent.transition(
+                        JobRuntimeEventType.JOB_SUBMITTED,
+                        ServerJobStatus.CREATED,
+                        ServerJobStatus.SUBMITTED,
+                        "submission-accepted"));
+
+        return new JobEventPage(
+                "job-history-1",
+                Collections.singletonList(event),
+                1L,
+                false);
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/service/JobHistoryRestServiceTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/service/JobHistoryRestServiceTest.java
@@ -1,0 +1,245 @@
+package com.link.up.server.service;
+
+import com.link.up.framework.job.JobDefinition;
+import com.link.up.server.application.JobApplication;
+import com.link.up.server.application.port.JobEventReader;
+import com.link.up.server.domain.JobSubmission;
+import com.link.up.server.dto.JobHistoryResponse;
+import com.link.up.server.runtime.JobExecutionMetadata;
+import com.link.up.server.runtime.JobRecoverySnapshotFactory;
+import com.link.up.server.runtime.JobSnapshot;
+import com.link.up.server.runtime.JobStateTransition;
+import com.link.up.server.runtime.ServerJobStatus;
+import com.link.up.server.runtime.event.JobEventEnvelope;
+import com.link.up.server.runtime.event.JobEventPage;
+import com.link.up.server.runtime.event.JobExecutionFacts;
+import com.link.up.server.runtime.event.JobRuntimeEvent;
+import com.link.up.server.runtime.event.JobRuntimeEventType;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JobHistoryRestServiceTest {
+
+    @Test
+    public void shouldRecoverExecutionFactsFromJournalAfterRestart() {
+        JobSnapshot restoredSnapshot =
+                JobRecoverySnapshotFactory.restoreBasic(
+                        "job-history-restart",
+                        "history-restart",
+                        ServerJobStatus.SUCCEEDED,
+                        1L,
+                        2L,
+                        3L,
+                        null,
+                        null);
+        JobExecutionMetadata metadata =
+                new JobExecutionMetadata(
+                        "external-history-restart",
+                        "key-history-restart",
+                        1,
+                        "digest-history-restart",
+                        1L,
+                        1L,
+                        5L,
+                        5L,
+                        false,
+                        Collections.<JobStateTransition>emptyList(),
+                        Collections.emptyMap(),
+                        null,
+                        null,
+                        Collections.emptyList());
+
+        JobExecutionFacts retained = retainedExecutionFacts();
+        JobEventEnvelope terminal = JobEventEnvelope.create(
+                "job-history-restart",
+                "job-history-restart-attempt-1",
+                1,
+                5L,
+                5L,
+                JobRuntimeEvent.terminal(
+                        JobRuntimeEventType.JOB_SUCCEEDED,
+                        ServerJobStatus.RUNNING,
+                        ServerJobStatus.SUCCEEDED,
+                        "job-succeeded",
+                        null,
+                        retained));
+
+        JobHistoryRestService service =
+                new JobHistoryRestService(
+                        new StubJobApplication(
+                                restoredSnapshot,
+                                metadata),
+                        new StubEventReader(terminal));
+
+        JobHistoryResponse response = service.history(
+                "job-history-restart",
+                5L,
+                20);
+
+        assertTrue(response.isCompleted());
+        assertEquals(0, response.getEvents().size());
+        assertEquals(1,
+                response.getExecution().getPipelines().size());
+        assertEquals("pipeline-demo.orders",
+                response.getExecution()
+                        .getPipelines()
+                        .get(0)
+                        .getPipelineId());
+    }
+
+    private static JobExecutionFacts retainedExecutionFacts() {
+        JobExecutionFacts.Metrics metrics =
+                new JobExecutionFacts.Metrics(
+                        100L,
+                        1024L,
+                        20D,
+                        100L,
+                        100L,
+                        900L,
+                        19D,
+                        0L,
+                        0L,
+                        0L,
+                        2L,
+                        2L,
+                        0L,
+                        8L,
+                        10L,
+                        0.1D,
+                        0.2D,
+                        0D);
+        JobExecutionFacts.Pipeline pipeline =
+                new JobExecutionFacts.Pipeline(
+                        "pipeline-demo.orders",
+                        "demo.orders",
+                        "SUCCEEDED",
+                        "jdbc",
+                        1,
+                        100L,
+                        1024L,
+                        20D,
+                        "doris",
+                        1,
+                        100L,
+                        100L,
+                        0L,
+                        0L,
+                        900L,
+                        19D,
+                        null);
+
+        return new JobExecutionFacts(
+                metrics,
+                null,
+                Collections.singletonList(pipeline),
+                Collections.emptyList());
+    }
+
+    private static final class StubEventReader
+            implements JobEventReader {
+
+        private final JobEventEnvelope terminal;
+
+        private StubEventReader(JobEventEnvelope terminal) {
+            this.terminal = terminal;
+        }
+
+        @Override
+        public JobEventPage read(
+                String jobId,
+                long afterSequence,
+                int limit) {
+
+            if (afterSequence >= terminal.getSequence()) {
+                return JobEventPage.empty(
+                        jobId,
+                        afterSequence);
+            }
+
+            return new JobEventPage(
+                    jobId,
+                    Collections.singletonList(terminal),
+                    terminal.getSequence(),
+                    false);
+        }
+    }
+
+    private static final class StubJobApplication
+            implements JobApplication {
+
+        private final JobSnapshot snapshot;
+        private final JobExecutionMetadata metadata;
+
+        private StubJobApplication(
+                JobSnapshot snapshot,
+                JobExecutionMetadata metadata) {
+            this.snapshot = snapshot;
+            this.metadata = metadata;
+        }
+
+        @Override
+        public JobSnapshot submit(JobDefinition definition) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public JobSnapshot submit(JobSubmission submission) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public JobSnapshot getJob(String jobId) {
+            return snapshot;
+        }
+
+        @Override
+        public JobSnapshot getJobByExternalExecutionId(
+                String externalExecutionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public JobExecutionMetadata getMetadata(String jobId) {
+            return metadata;
+        }
+
+        @Override
+        public List<JobSnapshot> listJobs() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public JobSnapshot cancel(String jobId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getRunningJobCount() {
+            return 0;
+        }
+
+        @Override
+        public int getQueuedJobCount() {
+            return 0;
+        }
+
+        @Override
+        public int getActiveJobCount() {
+            return 0;
+        }
+
+        @Override
+        public boolean isClosed() {
+            return false;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/service/JobHistoryRestServiceTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/service/JobHistoryRestServiceTest.java
@@ -3,8 +3,10 @@ package com.link.up.server.service;
 import com.link.up.framework.job.JobDefinition;
 import com.link.up.server.application.JobApplication;
 import com.link.up.server.application.port.JobEventReader;
+import com.link.up.server.domain.JobAttemptStatus;
 import com.link.up.server.domain.JobSubmission;
 import com.link.up.server.dto.JobHistoryResponse;
+import com.link.up.server.runtime.JobAttemptMetadata;
 import com.link.up.server.runtime.JobExecutionMetadata;
 import com.link.up.server.runtime.JobRecoverySnapshotFactory;
 import com.link.up.server.runtime.JobSnapshot;
@@ -21,53 +23,18 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class JobHistoryRestServiceTest {
 
     @Test
-    public void shouldRecoverExecutionFactsFromJournalAfterRestart() {
-        JobSnapshot restoredSnapshot =
-                JobRecoverySnapshotFactory.restoreBasic(
-                        "job-history-restart",
-                        "history-restart",
-                        ServerJobStatus.SUCCEEDED,
-                        1L,
-                        2L,
-                        3L,
-                        null,
-                        null);
-        JobExecutionMetadata metadata =
-                new JobExecutionMetadata(
-                        "external-history-restart",
-                        "key-history-restart",
-                        1,
-                        "digest-history-restart",
-                        1L,
-                        1L,
-                        5L,
-                        5L,
-                        false,
-                        Collections.<JobStateTransition>emptyList(),
-                        Collections.emptyMap(),
-                        null,
-                        null,
-                        Collections.emptyList());
-
-        JobExecutionFacts retained = retainedExecutionFacts();
-        JobEventEnvelope terminal = JobEventEnvelope.create(
-                "job-history-restart",
-                "job-history-restart-attempt-1",
-                1,
-                5L,
-                5L,
-                JobRuntimeEvent.terminal(
-                        JobRuntimeEventType.JOB_SUCCEEDED,
-                        ServerJobStatus.RUNNING,
-                        ServerJobStatus.SUCCEEDED,
-                        "job-succeeded",
-                        null,
-                        retained));
+    public void shouldRecoverCurrentAttemptExecutionFactsFromJournalAfterRestart() {
+        JobSnapshot restoredSnapshot = restoredSnapshot();
+        JobExecutionMetadata metadata = metadata(
+                "job-history-restart-attempt-1");
+        JobEventEnvelope terminal = terminalEvent(
+                "job-history-restart-attempt-1");
 
         JobHistoryRestService service =
                 new JobHistoryRestService(
@@ -90,6 +57,96 @@ public class JobHistoryRestServiceTest {
                         .getPipelines()
                         .get(0)
                         .getPipelineId());
+    }
+
+    @Test
+    public void shouldNotReuseExecutionFactsFromPreviousAttempt() {
+        JobSnapshot restoredSnapshot = restoredSnapshot();
+        JobExecutionMetadata metadata = metadata(
+                "job-history-restart-attempt-2");
+        JobEventEnvelope staleTerminal = terminalEvent(
+                "job-history-restart-attempt-1");
+
+        JobHistoryRestService service =
+                new JobHistoryRestService(
+                        new StubJobApplication(
+                                restoredSnapshot,
+                                metadata),
+                        new StubEventReader(staleTerminal));
+
+        JobHistoryResponse response = service.history(
+                "job-history-restart",
+                0L,
+                20);
+
+        assertTrue(response.isCompleted());
+        assertEquals(1, response.getEvents().size());
+        assertFalse(response.getExecution().hasExecutionDetails());
+    }
+
+    private static JobSnapshot restoredSnapshot() {
+        return JobRecoverySnapshotFactory.restoreBasic(
+                "job-history-restart",
+                "history-restart",
+                ServerJobStatus.SUCCEEDED,
+                1L,
+                2L,
+                3L,
+                null,
+                null);
+    }
+
+    private static JobExecutionMetadata metadata(
+            String attemptId) {
+
+        JobAttemptMetadata attempt =
+                new JobAttemptMetadata(
+                        attemptId.endsWith("-2") ? 2 : 1,
+                        attemptId,
+                        JobAttemptStatus.SUCCEEDED,
+                        1L,
+                        1L,
+                        2L,
+                        3L,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null);
+
+        return new JobExecutionMetadata(
+                "external-history-restart",
+                "key-history-restart",
+                1,
+                "digest-history-restart",
+                1L,
+                1L,
+                5L,
+                5L,
+                false,
+                Collections.<JobStateTransition>emptyList(),
+                Collections.emptyMap(),
+                null,
+                null,
+                Collections.singletonList(attempt));
+    }
+
+    private static JobEventEnvelope terminalEvent(
+            String attemptId) {
+
+        return JobEventEnvelope.create(
+                "job-history-restart",
+                attemptId,
+                1,
+                5L,
+                5L,
+                JobRuntimeEvent.terminal(
+                        JobRuntimeEventType.JOB_SUCCEEDED,
+                        ServerJobStatus.RUNNING,
+                        ServerJobStatus.SUCCEEDED,
+                        "job-succeeded",
+                        null,
+                        retainedExecutionFacts()));
     }
 
     private static JobExecutionFacts retainedExecutionFacts() {


### PR DESCRIPTION
## Summary

This PR implements **PR 3: Execution Observability / History Projection**, closing the Spark-inspired sequence started by Plan/Explain, Runtime Events and Capability/Structured Errors.

It adds a Yak-Ops-friendly execution history view without turning Link-Up into an event-sourced or distributed runtime:

- adds `GET /api/v1/jobs/{jobId}/history?afterSequence=0&limit=200`;
- joins durable lifecycle events, Attempt history, structured errors, Commit Evidence and current/final Pipeline/Task execution facts;
- captures Secret-safe `JobExecutionFacts` inside existing terminal lifecycle events;
- restores retained Pipeline/Task facts from the JSONL Event Journal after a normal terminal Job is later reloaded from a basic Worker checkpoint;
- preserves the existing `JobSnapshot` / `JobExecutionMetadata` state source of truth and Retry/Commit semantics.

## Why this does not add Pipeline/Task event sequences

PR 1 established an important invariant:

```text
one durable checkpoint
  -> at most one Job lifecycle event
  -> sequence == checkpointVersion
```

Adding independent `TASK_STARTED`, `TASK_PROGRESS`, etc. records would break that ordering model or require a second sequence space.

Instead, terminal Job events now carry an optional typed `JobExecutionFacts` payload:

```text
JOB_SUCCEEDED / JOB_FAILED / JOB_CANCELED / JOB_LOST
  -> same checkpointVersion sequence
  -> execution.metrics
  -> execution.pipelines[]
  -> execution.tasks[]
  -> execution.commitSummary
```

No new event ID or sequence is invented. Old JSONL events without `execution` remain readable because the field is additive and optional.

## History API

```text
GET /api/v1/jobs/{jobId}/history?afterSequence=0&limit=200
```

Response protocol:

```text
apiVersion = link-up-job-history/v1
jobId / jobName / status / completed
checkpointVersion / cancellationRequested
events[]            # exclusive sequence cursor page
attempts[]          # safe structured error + commit evidence view
execution           # metrics + Pipeline + Task facts
nextSequence / hasMore
```

For an active Job, `execution` is projected from the current `JobSnapshot`.

For a terminal Job that is later reloaded after Worker restart, the basic checkpoint can legitimately contain no Pipeline/Task detail. In that case the History service scans the retained Event Journal and uses the latest non-empty terminal `JobExecutionFacts` payload.

This keeps the Event Journal observational: it does **not** replay events to rebuild the Job state machine.

## Security boundary

`JobExecutionFacts` and `JobHistoryResponse` deliberately exclude:

- JobSpec / HOCON;
- Connector options;
- SQL;
- passwords, tokens and other Secrets;
- raw exception / failure messages;
- `retryAdvice` free-form text;
- `jobLogFile` paths;
- Connector physical table locations;
- Task `currentTable` / `currentSplit`;
- arbitrary payload maps;
- Prepared Connector / ClassLoader / private Connector metadata.

The projection keeps only stable identities, statuses, structured error metadata, Commit Evidence and numeric runtime facts.

## Compatibility

- existing `JobRuntimeEvent` six-argument constructor remains available;
- existing `JobRuntimeEvent.terminal(...)` overload remains available;
- existing JettyServer constructor overloads remain available;
- existing JobResourceServlet constructor overloads remain available;
- Event envelope schema remains additive-compatible;
- no checkpoint format change is introduced;
- no changes are made to Job/Attempt/Retry/Commit state transitions.

## Tests added

`JobHistoryResponseTest` covers:

- History projection shape;
- Pipeline/Task fact projection;
- explicit Secret leakage assertions;
- terminal `JobExecutionFacts` JSON serialization/deserialization round trip.

`JobHistoryRestServiceTest` covers:

- Worker-restart style basic snapshot with no Pipeline/Task details;
- recovery of retained execution facts from the terminal Event Journal even when the requested event cursor has already passed the terminal event.

## Verification note

The branch is based directly on the latest merged `main` and GitHub compare reports no commits behind the base.

The current execution container cannot resolve `github.com`, so a fresh clone and full Maven build could not be executed here. I therefore do **not** claim `mvn clean verify` has passed in this environment.

Required pre-merge local verification:

```bash
mvn --batch-mode -pl link-up-server -am test
mvn --batch-mode clean verify
```

Recommended runtime smoke checks:

```text
1. Submit a successful Job and query /events + /history.
2. Confirm the terminal event contains execution facts but keeps the same checkpointVersion sequence.
3. Restart the Worker and query /history again; terminal Pipeline/Task facts should still be present.
4. Exercise afterSequence pagination independently from the top-level execution projection.
5. Inspect JSONL/history responses and verify no Connector options, SQL, failure message, log path or current split leaks.
```

## Out of scope

- event sourcing / event replay as state recovery;
- per-record or per-split event streams;
- a remote Spark-style History Server process;
- Kafka/MQ event transport;
- distributed scheduling;
- automatic Retry scheduling;
- Yak-Ops UI implementation itself.
