### PR TITLE
fix(server): allow ServletException from POST handlers

### DIFF
--- a/link-up-server/src/main/java/com/link/up/server/http/FluxServlet.java
+++ b/link-up-server/src/main/java/com/link/up/server/http/FluxServlet.java
@@ -1,5 +1,6 @@
 package com.link.up.server.http;
 
+import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -202,7 +203,7 @@ public abstract class FluxServlet
     protected void doPost(
             HttpServletRequest request,
             HttpServletResponse response)
-            throws IOException {
+            throws IOException, ServletException {
         throw methodNotAllowed(request);
     }
 


### PR DESCRIPTION
## Summary

Fixes the current `link-up-server` compilation error in `JobPlanningServlet#doPost(...)`.

`JobPlanningServlet` legitimately declares `ServletException` because `JobPlanningService#explain(...)` can throw a checked exception and the servlet adapter wraps it as `ServletException`. The problem was that Link-Up's intermediate base class `FluxServlet#doPost(...)` had narrowed the inherited `HttpServlet` contract to `IOException` only, so subclasses were no longer allowed to declare `ServletException`.

This PR restores the standard servlet checked-exception contract at the base adapter boundary:

```java
protected void doPost(
        HttpServletRequest request,
        HttpServletResponse response)
        throws IOException, ServletException
```

## Why fix FluxServlet instead of JobPlanningServlet

Changing `JobPlanningServlet` to wrap the checked planning failure as `IOException` would compile, but would misrepresent a servlet/request processing failure as transport I/O.

`HttpServlet#doPost(...)` already allows both `ServletException` and `IOException`; `FluxServlet` had unnecessarily narrowed that contract. Restoring the parent contract is the smallest and semantically correct fix, and existing subclasses that only throw `IOException` remain valid overrides.

## Scope

- adds the `ServletException` import to `FluxServlet`;
- restores `ServletException` to `FluxServlet#doPost(...)`;
- leaves Planning, Structured Error, Exception filter and runtime behavior unchanged.

## Verification

GitHub compare reports this branch as one commit ahead of `main`, zero commits behind, with exactly one changed file and 3 changed lines.

Please run locally before merge:

```bash
mvn --batch-mode -pl link-up-server -am compile
mvn --batch-mode -pl link-up-server -am test
```

The first command directly covers the reported override compilation failure.
