### PR TITLE
refactor(runtime): clarify Worker state persistence semantics

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,6 +6,8 @@ Link-Up 是本地优先的离线数据同步引擎。架构只解决现在需要
 
 不复制 Flink/Spark 的分布式复杂度；只借鉴它们清晰的角色边界、计划先于执行和可解释运行模型。
 
+明确边界：**Link-Up 不做实时同步，不做 Flink 式数据 checkpoint/savepoint，也不从 Split/offset 自动恢复执行。**
+
 ## 模块依赖
 
 ```text
@@ -84,20 +86,7 @@ JobDefinition
 
 多表边界必须特别明确：Source Schema 发现出多个数据集时，`MULTI_TABLE` 会同时成为 Source 和 Sink 的派生 Required Capability。协商发生在 `SinkPreparer` 之前，因此不兼容任务不会先建表、清表再失败。
 
-协商输出：
-
-```text
-CapabilityNegotiation
-  ├── status: SATISFIED / DEGRADED / REJECTED
-  ├── source
-  │    ├── supported / required / preferred
-  │    ├── derivedRequired / observed
-  │    └── missingRequired / missingPreferred / undeclaredObserved
-  └── sink
-       └── same shape
-```
-
-第三方 Connector 的 `Factory#capabilities()` 默认仍为空集合，保持二进制和源码兼容；但当 Job 显式要求能力或实际拓扑需要能力时，空声明不能绕过协商。
+Capability 保持离线同步所需的有限集合，不演化为通用规则引擎。
 
 ## Plan / Explain
 
@@ -127,39 +116,17 @@ JobDefinition
 - 协商显式 Required/Preferred Capability；
 - 生成 LogicalJobPlan 和稳定 Fingerprint。
 
-`validate` 不可以：
-
-- 创建 Source/Sink；
-- 发现远端 Schema；
-- 枚举 Split；
-- 打开连接或执行外部 IO。
+`validate` 不创建 Source/Sink，不发现远端 Schema，不枚举 Split，也不打开外部连接。
 
 ### Explain 边界
 
-`explain` 可以：
+`explain` 可以创建 Source、发现 Source Schema、枚举 Split、应用字段映射并使用正式 JobPlanner 生成 JobGraph。
 
-- 创建 Source；
-- 发现 Source Schema；
-- 派生拓扑 Required Capability；
-- 枚举并校验 Source Split；
-- 应用字段映射；
-- 使用正式 JobPlanner 生成 JobGraph；
-- 投影 Pipeline/Task 数量、并行度、数据集和 CapabilityNegotiation。
-
-`explain` 不可以：
-
-- 调用 SinkPreparer；
-- 创建、删除或清空目标表；
-- 执行目标端 DDL；
-- 创建 SinkWriter；
-- 写入数据；
-- 序列化 Connector options、ReadonlyConfig、Prepared Connector、ClassLoader 或私有 metadata。
-
-完整 Connector 配置和 Capability Intent 只进入 SHA-256 Fingerprint 的内存计算。Fingerprint 能识别包括 Secret 在内的配置变化，但计划和诊断不输出原始值。
+`explain` 不调用 SinkPreparer，不创建/删除/清空目标表，不执行目标端 DDL，不创建 SinkWriter，也不写数据。
 
 ## Structured Error
 
-`FluxErrorCode` 是稳定错误目录，新增元数据：
+`FluxErrorCode` 是稳定错误目录，核心元数据：
 
 ```text
 code
@@ -171,27 +138,9 @@ retryScope
 
 规划边界使用 `PlanningException`，错误参数只允许 role、connectorId、capability、format、reason 等安全值。REST 返回元数据和参数，不直接输出 cause message。
 
-执行失败时，`JobExecutionAttempt` 会从异常 cause chain 中提取 `FluxRuntimeException`，持久化：
+执行失败时，`JobExecutionAttempt` 从异常 cause chain 中提取结构化错误信息。RetryPolicy 先看错误是否允许重试，再看 Commit Evidence 是否证明数据可安全重放。
 
-```text
-errorCode
-errorCategory
-errorPhase
-failureRetryable
-failureRetryScope
-```
-
-Checkpoint formatVersion 升级为 3，同时继续读取 v1/v2。RetryPolicy 的判断顺序：
-
-```text
-terminal outcome
-  -> structured error retryable?
-  -> commit evidence available?
-  -> unknown / partial / committed data?
-  -> allow or deny
-```
-
-错误可重试不等于数据可重放。即便 `retryable=true`，只要 Commit Evidence 不安全，仍然拒绝 Retry；反过来，明确的不可重试错误即使没有提交数据，也不会盲目重跑。
+错误可重试不等于数据可重放。
 
 ## Control Plane
 
@@ -209,29 +158,73 @@ HTTP / registration
   -> infrastructure adapters
 ```
 
-规划 API 是独立的只读控制边界：
+状态角色固定为：
 
 ```text
-HTTP
-  -> JobPlanningService
-  -> JobPlanExplainer
-  -> CapabilityNegotiator
-  -> ConnectorPreparer / JobPlanner
+JobExecutionState
+  = 内存中的唯一可变控制状态
+
+JobSnapshot + JobExecutionMetadata
+  = 持久化与查询投影
+
+Runtime Event
+  = 生命周期时间线事实
+
+History
+  = 面向 Yak-Ops 的只读聚合视图
 ```
 
-它不创建 Job、Attempt、Checkpoint，也不进入 JobRuntimeScheduler。
+不再新增 `JobCheckpointState`、`JobReplayState`、`JobHistoryState` 等平行状态模型。
+
+规划 API 是独立的只读控制边界，不创建 Job、Attempt 或 Worker state，也不进入 JobRuntimeScheduler。
 
 Domain 不持有 `Thread`、`Future`、`Semaphore`、`ExecutorService` 或 framework `JobExecution`。
 
-## Runtime Event Journal
+## Worker State Persistence
 
-Runtime Event 不替代现有状态模型，而是观察成功持久化的 checkpoint：
+Worker state persistence 用于保存控制面状态，不保存可恢复的数据处理位置：
 
 ```text
-JobRuntimeLifecycle
+JobRuntimeLifecycle.persistState
+  -> JobRepository.save(snapshot, metadata)
+  -> FileJobRepository
+  -> JobStateFileStore
+  -> <stateDirectory>/*.job.json
+```
+
+边界：
+
+```text
+Worker State Persistence
+!= Data Checkpoint
+!= Resume Point
+!= Savepoint
+```
+
+- `stateVersion`：只记录业务状态转换版本。
+- `stateRevision`：记录所有需要持久化的控制面变化，例如状态转换、日志身份、取消意图、Retry Attempt 创建。
+- `stateRevision` 单调递增，旧状态不能覆盖新状态。
+- 状态文件使用临时文件 + fsync + 原子替换。
+- Worker 重启时，遗留非终态 Job 转为 `LOST`，不从 Split/offset 继续。
+
+持久化格式：
+
+```text
+v1-v3  legacy: checkpointVersion
+v4+    stateRevision
+```
+
+新文件只写 `stateRevision`；读取端继续接受 v1/v2/v3 的 `checkpointVersion`。
+
+## Runtime Event Journal
+
+Runtime Event 观察成功持久化的 Worker state：
+
+```text
+JobRuntimeLifecycle.persistState
   -> JobRepository.save(snapshot, metadata)
   -> EventPublishingJobRepository
-       1. durable checkpoint
+       1. durable Worker state
        2. derive one lifecycle fact
        3. JobEventBus.publish
   -> JsonLineJobEventStore
@@ -242,11 +235,10 @@ JobRuntimeLifecycle
 
 - `JobSnapshot` / `JobExecutionMetadata` 仍是控制面状态真相。
 - Event Journal 只追加，不反向修改 Job 状态，不参与 Retry/Commit 决策。
-- 只有 checkpoint 成功后才派生事件。
-- `JobEventBus` 保持同一 Job 的同步顺序，并隔离 Listener 失败。
-- 每条事件使用 `checkpointVersion` 作为单 Job 序号，Retry 后继续递增。
+- 只有 Worker state 保存成功后才派生事件。
+- 每条事件使用 `stateRevision` 作为单 Job `sequence`，Retry 后继续递增。
 - Event JSON 不包含 JobSpec、Connector options、SQL、Secret、异常正文、Prepared Connector 或私有 metadata。
-- 当前只记录 Job/Attempt 生命周期；结构化错误元数据保存在 Attempt read model，Pipeline/Task 细粒度事件留给后续阶段。
+- Event Journal 保持 Job/Attempt 生命周期粒度，不扩成 Task/Split 事件总线。
 
 查询链路：
 
@@ -256,8 +248,6 @@ GET /api/v1/jobs/{jobId}/events?afterSequence=N&limit=M
   -> JobEventReader
   -> sequence-based page
 ```
-
-`afterSequence` 是排他游标。读取损坏或不支持版本的事件文件会返回稳定的 Event History 错误，但不会改变已运行任务的结果。
 
 ## Retry
 
@@ -297,4 +287,4 @@ JDBC `core/{converter,dialect,split}` 是历史兼容区，不允许继续扩张
 
 新增类时先问：**它是在描述计划、状态、协调、调度、执行，还是外部系统边界？**
 
-如果一个类同时回答了两个以上问题，通常应该拆。
+如果一个类同时回答了两个以上问题，通常应该拆；如果一个新类只是重复表达已有 Job 状态，则不应该增加。

--- a/DOMAIN.md
+++ b/DOMAIN.md
@@ -52,7 +52,7 @@ Worker 的 `jobId` 是稳定资源 ID。它不等于一次运行线程。
 Job
   ├── identity
   ├── lifecycle audit
-  ├── checkpointVersion
+  ├── stateRevision
   └── attempts[]
 ```
 
@@ -95,6 +95,26 @@ Attempt 记录：
 
 Attempt 不拥有线程和 framework 执行对象。
 
+## 状态模型边界
+
+只保留四个角色，不再新增平行的 Job state 模型：
+
+```text
+JobExecutionState
+  = 内存中的可变运行/控制状态
+
+JobSnapshot + JobExecutionMetadata
+  = Worker 持久化与查询所需的状态投影
+
+Runtime Event
+  = 已成功持久化后的生命周期时间线事实
+
+History
+  = 面向 Yak-Ops 的只读聚合视图
+```
+
+Runtime Event 和 History 都不能反向驱动 Job 状态机。
+
 ## Structured Error
 
 稳定错误由以下字段组成：
@@ -127,7 +147,7 @@ parameters
 
 ## Runtime Event
 
-Runtime Event 是一次已经持久化的 Worker 生命周期事实，不是新的状态机：
+Runtime Event 是一次已经成功持久化的 Worker 生命周期事实，不是新的状态机：
 
 ```text
 JobEventEnvelope
@@ -135,7 +155,7 @@ JobEventEnvelope
   ├── eventId
   ├── jobId
   ├── attemptId / attemptNumber
-  ├── sequence == checkpointVersion
+  ├── sequence == stateRevision
   ├── occurredAtMillis
   └── JobRuntimeEvent
 ```
@@ -157,13 +177,12 @@ JOB_LOST
 
 语义约束：
 
-- Event 只在对应 checkpoint 保存成功后发布。
+- Event 只在对应 Worker state 保存成功后发布。
 - 同一个 `jobId` 的 `sequence` 单调递增，Retry 不重置序号。
 - Event Journal 允许序号缺口，因为观察器写入失败不能反向让 Job 失败。
 - 重复或晚到的旧序号不会再次追加。
 - Event 不参与状态恢复、RetryPolicy 或 Commit 判定。
 - Event 不保存用户配置、SQL、Secret 或异常正文。
-- Event 继续保存生命周期事实；结构化错误细节从 Attempt read model 查询。
 
 ## Retry Decision
 
@@ -191,12 +210,18 @@ commit evidence proves zero committed / unknown data
 
 安全策略宁可拒绝，也不猜。
 
-## Checkpoint
+## Worker State Persistence
 
 `stateVersion` 只记录业务状态转换。
 
-`checkpointVersion` 记录所有需要持久化的变化，包括日志绑定、取消意图和 Retry Attempt 创建，用于防止旧 checkpoint 覆盖新状态，也作为 Runtime Event 的单 Job 序号。
+`stateRevision` 记录所有需要持久化的控制面变化，包括日志绑定、取消意图和 Retry Attempt 创建。它用于防止旧 Worker state 覆盖新状态，也作为 Runtime Event 的单 Job 序号。
 
-Checkpoint `formatVersion = 3` 增加 Attempt structured error metadata，并继续兼容读取 v1/v2。
+```text
+Worker State Persistence
+!= Flink Checkpoint
+!= Split/Offset Resume
+```
 
-Worker 重启后，遗留的非终态 Job 统一恢复为 `LOST`；不会自动执行 Retry。恢复生成的新 LOST checkpoint 同样会追加 `JOB_LOST` 事件。
+持久化 `formatVersion = 4` 开始写 `stateRevision`。v1/v2/v3 文件中的 `checkpointVersion` 只作为 legacy 字段兼容读取，不再作为新格式术语继续扩散。
+
+Worker 重启后，遗留的非终态 Job 统一恢复为 `LOST`；不会自动执行 Retry，也不会从 Split/offset 继续。

--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # Link-Up
 
-Link-Up 是一个轻量、可嵌入的离线数据同步引擎。它把数据同步拆成稳定的 API、运行时、Connector 和单节点 Worker 控制面，目标是：代码边界清楚、Connector 好扩展、任务可观察、失败可解释。
+Link-Up 是一个轻量、可嵌入的**离线批量数据同步引擎**。它把数据同步拆成稳定的 API、运行时、Connector 和单节点 Worker 控制面，目标是：代码边界清楚、Connector 好扩展、任务可观察、失败可解释。
+
+> Link-Up 不做实时同步，也不提供 Flink 式 checkpoint/savepoint 或 Split offset 自动恢复。
 
 ## 能做什么
 
 - JDBC / HTTP Source，JDBC / Doris Sink 等 Connector 扩展。
-- 单表、多表的有界批量同步。
+- 单表、多表的 bounded batch sync。
 - Source/Sink 并行执行、Split、Channel、Metrics、日志。
-- 单节点 Worker：提交、查询、取消、持久化状态、重启恢复。
+- 单节点 Worker：提交、查询、取消、状态持久化、重启 LOST 恢复。
 - Job / Attempt 模型：同一个 Job 可以保留多次执行尝试。
-- 安全手动重试：只有明确证明“没有已提交或未知数据”的 FAILED Attempt 才允许重试。
-- 提交前校验和 Explain：查看规范化逻辑计划、实际 Source Split/Task 拓扑与稳定指纹。
-- Required / Preferred Capability 协商：在 Connector I/O 和 Sink 副作用前发现不兼容任务。
-- 结构化错误：稳定 code、category、phase、retryable、retryScope 和安全参数。
-- 追加式 Runtime Event Journal：按 Job/Attempt 回看提交、排队、运行、取消与终态时间线。
-- Execution History：把 Event、Attempt、Pipeline、Task 和执行指标投影成 Yak-Ops 可直接消费的历史视图。
+- 安全手动 Retry：只有明确证明“没有已提交或未知数据”的 FAILED Attempt 才允许重试。
+- 提交前 Validate / Explain。
+- Required / Preferred Capability 检查。
+- 结构化错误。
+- Job / Attempt 级 Runtime Event Journal。
+- 面向 Yak-Ops 的 Execution History 只读投影。
 
 ## 核心模型
 
@@ -30,7 +32,7 @@ JobSpec
   -> JobResult
 ```
 
-`JobGraph` 始终是正式物理执行计划。`PhysicalJobPlan` 只从同一个 `JobGraph` 投影出可序列化、Secret-safe 的 Explain 结果，不维护第二套执行真相。
+`JobGraph` 始终是正式物理执行计划。`PhysicalJobPlan` 只从同一个 `JobGraph` 投影出 Secret-safe 的 Explain 结果，不维护第二套执行真相。
 
 Worker 控制面：
 
@@ -43,19 +45,51 @@ HTTP
      -> JobRuntimeScheduler
      -> JobRepository
         -> JobSnapshot / JobExecutionMetadata
+        -> Worker State Files
         -> Runtime Event Journal (observer)
 ```
 
-一次安全重试不会创建新 Job：
+## Worker State Persistence
+
+这里最容易和流处理概念混淆，所以边界固定为：
 
 ```text
-job-100 / Attempt #1 FAILED
-          -> RetryPolicy: SAFE
-          -> Attempt #2 RUNNING
-          -> SUCCEEDED
+Worker State Persistence
+!= Data Checkpoint
+!= Resume Point
+!= Savepoint
 ```
 
-`LOST`、`CANCELED`、存在已提交数据、存在 unknown commit state、缺少 commit evidence，或者结构化错误明确声明不可重试时，默认拒绝 Retry。
+Worker state 只保存控制面事实，例如：
+
+```text
+Job status
+Attempt history
+stateRevision
+cancellationRequested
+runId / log identity
+structured error metadata
+commit evidence
+```
+
+`stateRevision` 是单 Job 的状态修订号。它用于阻止旧状态覆盖新状态，同时作为 Runtime Event 的顺序来源。
+
+Worker 重启时：
+
+```text
+RUNNING / QUEUED / SUBMITTED
+          -> LOST
+```
+
+不会：
+
+```text
+从 Split / offset / batch 继续执行
+自动重放 LOST Job
+跨 Worker failover
+```
+
+新状态文件格式为 v4，写 `stateRevision`。旧 v1/v2/v3 文件中的 `checkpointVersion` 仍兼容读取；`/history` 也暂时保留同名 legacy 字段，新的调用方应使用 `stateRevision`。
 
 ## Plan / Explain
 
@@ -64,101 +98,43 @@ POST /api/v1/jobs/validate
 POST /api/v1/jobs/explain
 ```
 
-两个接口都接收与结构化提交一致的 JSON 外壳，只要求 `jobSpec` 或 `hocon` 二选一；规划时不要求 `externalExecutionId`、`idempotencyKey` 和 `definitionVersion`。
-
-边界约束：
-
-- `validate` 做协议编译、Factory 发现、OptionRule 校验和显式 Capability 协商，不创建 Source/Sink，不访问外部系统。
+- `validate` 做协议编译、Factory 发现、OptionRule 校验和显式 Capability 检查，不创建 Source/Sink，不访问外部系统。
 - `explain` 会创建 Source、发现 Source Schema 并枚举 Split，以生成真实 `JobGraph`。
-- `explain` 不调用 `SinkPreparer`，因此不会建表、清表、执行 DDL、创建 Writer 或写数据。
-- 正式 Runtime 与 Validate/Explain 共用同一个 `CapabilityNegotiator`，不会出现控制面通过、运行时绕过的第二套规则。
-- Source Schema 发现后，如果实际拓扑是多表任务，会自动为 Source 和 Sink 派生 `MULTI_TABLE` Required Capability，并在 Sink DDL/清理之前拒绝不兼容组合。
-- Explain 响应不包含 Connector options、`ReadonlyConfig`、Prepared Connector、ClassLoader 或 Connector 私有 metadata。
-- Connector 完整配置和 Capability Intent 只参与 SHA-256 计划指纹，Secret 不会出现在逻辑计划、物理计划、诊断或文本 Explain 中。
+- `explain` 不调用 SinkPreparer，因此不会建表、清表、执行 DDL、创建 Writer 或写数据。
+- 正式 Runtime 与 Validate/Explain 共用同一套 Capability 判断。
+- Explain 不输出 Connector options、Secret、Prepared Connector、ClassLoader 或 Connector 私有 metadata。
 
-结构化提交可以声明 Required 和 Preferred Capability：
+## Capability
 
-```json
-{
-  "jobSpec": {
-    "apiVersion": "link-up/v1",
-    "kind": "BatchSyncJob",
-    "name": "orders-sync",
-    "source": {
-      "connectorId": "jdbc",
-      "options": {}
-    },
-    "sink": {
-      "connectorId": "doris",
-      "options": {}
-    },
-    "capabilities": {
-      "source": {
-        "required": ["TABLE_SCHEMA_DISCOVERY"],
-        "preferred": ["PARTITION_SPLIT"]
-      },
-      "sink": {
-        "required": ["TWO_PHASE_COMMIT"]
-      }
-    }
-  }
-}
+Job 可以声明：
+
+```text
+required  -> 缺失即拒绝
+preferred -> 缺失时允许降级并返回 Warning
 ```
 
-语义：
-
-- Required 缺失：返回结构化错误并拒绝规划/执行。
-- Preferred 缺失：计划仍然有效，状态为 `DEGRADED`，并返回 Warning Diagnostic。
-- 未声明但执行拓扑已经使用的能力：返回声明不完整 Warning，便于逐步收紧第三方 Connector Contract。
-
-HOCON 使用同样的路径：
-
-```hocon
-capabilities {
-  source.required = [TABLE_SCHEMA_DISCOVERY]
-  source.preferred = [PARTITION_SPLIT]
-  sink.required = [TWO_PHASE_COMMIT]
-}
-```
+Capability 只服务离线同步的真实执行语义，不演化成通用规则引擎。
 
 ## Structured Error
 
 规划和 Connector API 错误使用稳定元数据，而不是让调用方匹配异常字符串：
 
-```json
-{
-  "code": "PLAN-005",
-  "message": "A required Connector capability is missing",
-  "requestId": "...",
-  "category": "CAPABILITY",
-  "phase": "CAPABILITY_NEGOTIATION",
-  "retryable": false,
-  "retryScope": "NONE",
-  "parameters": {
-    "role": "SINK",
-    "connectorId": "doris",
-    "capability": "TWO_PHASE_COMMIT"
-  }
-}
+```text
+code
+category
+phase
+retryable
+retryScope
+parameters
 ```
 
-规则：
+错误参数只允许安全身份和枚举，不放 Connector options、SQL、Secret 或原始异常正文。
 
-- 稳定 code 用于控制面分支、聚合告警和兼容判断。
-- category / phase 描述问题边界。
-- retryable / retryScope 只描述错误本身是否值得重试；数据是否已经提交仍由 Commit Evidence 决定。
-- parameters 只允许安全身份和枚举，不放 Connector options、SQL、Secret 或原始异常正文。
-- Attempt 会持久化结构化错误元数据；Worker 重启后 RetryPolicy 仍能拒绝明确的不可重试错误。
+错误是否值得重试，与数据是否能安全重放是两个条件。最终 Retry 仍由 Commit Evidence 决定。
 
 ## Runtime Event Journal
 
-每次持久化生命周期 checkpoint 后，Worker 会把对应事实追加到：
-
-```text
-<stateDirectory>/job-events/<jobId>.jsonl
-```
-
-当前事件包括：
+Worker state 保存成功后，才派生对应的 Job 生命周期事件：
 
 ```text
 JOB_SUBMITTED
@@ -173,49 +149,61 @@ JOB_CANCELED
 JOB_LOST
 ```
 
-事件使用 `checkpointVersion` 作为单 Job 单调递增序号。查询接口采用排他游标：
+事件文件：
+
+```text
+<stateDirectory>/job-events/<jobId>.jsonl
+```
+
+Event `sequence` 使用同一个 Job 的 `stateRevision`。Event Journal 只负责时间线和最终执行事实，不反向驱动状态机，不参与 Retry/Commit 决策，也不继续扩成 Task/Split 级事件系统。
+
+查询：
 
 ```text
 GET /api/v1/jobs/{jobId}/events?afterSequence=0&limit=200
 ```
 
-当前阶段仍以 `JobSnapshot` 和 `JobExecutionMetadata` 为控制面状态真相。Event Journal 只负责可观察历史，不反向驱动状态机；事件监听器或文件写入失败会被隔离，不改变任务执行、Commit 或 Retry 语义。
-
-终态事件会附带一份 `JobExecutionFacts`：只保存 Pipeline/Task 身份、状态和数值指标，不新增事件序号。这样仍保持“一次 durable checkpoint = 一个 sequence”，同时正常结束的任务在 Worker 重启后仍能恢复最终执行事实。
-
-安全边界：事件不保存 JobSpec、Connector options、SQL、Secret、异常正文、日志路径、当前表/分片或 Connector 私有 metadata。
-
 ## Execution History
-
-History API 把事件时间线、Attempt 历史、结构化错误和最终/当前执行事实组合成一个稳定只读视图：
 
 ```text
 GET /api/v1/jobs/{jobId}/history?afterSequence=0&limit=200
 ```
 
-返回的 `apiVersion` 为 `link-up-job-history/v1`，核心内容包括：
+History 只是 Yak-Ops 的只读聚合视图：
 
 ```text
-events          # sequence 游标分页的 durable lifecycle facts
-attempts        # Attempt 状态、结构化错误和 Commit Evidence
-execution       # Metrics + Pipeline + Task 安全投影
-nextSequence
-hasMore
-completed
+events
+attempts
+execution metrics
+pipeline/task final facts
+structured error
+commit evidence
+stateRevision
 ```
 
-运行中的 Job 优先使用当前 `JobSnapshot` 生成 execution；Worker 重启后如果基础快照没有 Pipeline/Task 细节，则从终态 Event Journal 中恢复最近一次 `JobExecutionFacts`。History 是观察投影，不参与状态恢复、调度、Retry 或 Commit 决策。
+History 不参与状态恢复、调度、Retry 或 Commit 决策。
 
-为了保持协议可安全暴露给 Yak-Ops，History 不返回 failure message、retryAdvice、jobLogFile、Connector 物理表地址、currentTable/currentSplit、SQL 或任意 Connector options。
+## Safe Retry
+
+一次安全重试不会创建新 Job：
+
+```text
+job-100 / Attempt #1 FAILED
+          -> RetryPolicy: SAFE
+          -> Attempt #2 RUNNING
+          -> SUCCEEDED
+```
+
+`LOST`、`CANCELED`、存在 committed data、unknown state、缺少 commit evidence，或者结构化错误明确声明不可重试时，默认拒绝 Retry。
 
 ## 模块
 
 | 模块 | 职责 |
 | --- | --- |
 | `link-up-api` | Connector 扩展契约、Capability、Structured Error 公共模型 |
-| `link-up-framework` | Planning、Capability Negotiation、JobGraph、ExecutionGraph、本地执行运行时 |
+| `link-up-framework` | Planning、JobGraph、ExecutionGraph、本地执行运行时 |
 | `link-up-connectors` | JDBC / HTTP / Doris 等实现 |
-| `link-up-server` | Worker 控制面、REST、持久化、Attempt/Retry、Runtime Event Journal、Execution History |
+| `link-up-server` | Worker 控制面、REST、状态持久化、Attempt/Retry、Runtime Event、History |
 | `link-up-launcher` | 本地命令行组合入口 |
 | `link-up-dist` | 分发包 |
 | `link-up-bom` | 依赖版本管理 |
@@ -228,7 +216,7 @@ completed
 mvn --batch-mode clean verify
 ```
 
-本地直接运行示例：
+本地运行示例：
 
 ```bash
 mvn -pl link-up-launcher -am compile exec:java \
@@ -236,17 +224,15 @@ mvn -pl link-up-launcher -am compile exec:java \
   -Dexec.args=link-up-launcher/examples/jdbc-single-table.conf
 ```
 
-Standalone Worker 默认把控制面 checkpoint 保存到：
+Standalone Worker 默认把控制面状态保存到：
 
 ```text
 data/worker-state
 ```
 
-可通过 `--state-dir` 指定独立持久化目录。
+可通过 `--state-dir` 指定目录。
 
 ## Worker API
-
-常用接口：
 
 ```text
 POST   /api/v1/jobs/validate
@@ -263,11 +249,9 @@ GET    /api/v1/connectors
 GET    /api/v1/node
 ```
 
-Retry 请求必须重新携带与原 Job 完全一致的结构化提交内容。Worker 不会为了 Retry 或 History 把数据库密码、Token 或完整 JobSpec 写进 checkpoint 或 Runtime Event Journal。
+Retry 请求必须重新携带与原 Job 完全一致的结构化提交内容。Worker 不会为了 Retry 或 History 持久化数据库密码、Token 或完整 JobSpec。
 
 ## 文档
-
-只保留对开发真正有用的几份：
 
 - [ARCHITECTURE.md](ARCHITECTURE.md)：系统边界和主流程。
 - [DOMAIN.md](DOMAIN.md)：Job、Attempt、Capability、错误和状态语义。
@@ -275,5 +259,3 @@ Retry 请求必须重新携带与原 Job 完全一致的结构化提交内容。
 - [REQUIREMENTS.md](REQUIREMENTS.md)：项目范围和非目标。
 - [CODE_STYLE.md](CODE_STYLE.md)：代码和包命名规范。
 - [REVIEW.md](REVIEW.md)：提交前检查清单。
-
-文档原则：**写当前事实，不写历史流水账；能用一张图说清，就不要写十页。**

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -2,7 +2,7 @@
 
 ## 产品定位
 
-Link-Up 是离线批量数据同步引擎，不是通用分布式计算平台。
+Link-Up 是离线批量数据同步引擎，不是流处理引擎，也不是通用分布式计算平台。
 
 当前优先级：**可靠、清楚、可扩展**，高于“功能看起来很多”。
 
@@ -15,10 +15,25 @@ Link-Up 是离线批量数据同步引擎，不是通用分布式计算平台。
 - Source/Sink/Pipeline 并行度。
 - 任务取消、日志、Metrics、Pipeline/Task 查询。
 - Worker 幂等提交和 externalExecutionId 查询。
-- Worker checkpoint 持久化和重启 LOST 恢复。
+- Worker 状态持久化和重启 LOST 恢复。
 - Job / Attempt 历史。
 - 基于 commit evidence 的安全手动 Retry。
 - Connector Schema / preflight 能力。
+
+## Worker State Persistence
+
+Worker 状态持久化只保存控制面事实：Job 状态、Attempt、取消意图、日志身份、错误与 Commit Evidence。
+
+```text
+Worker State Persistence
+!= Data Checkpoint
+!= Resume Point
+!= Savepoint
+```
+
+`stateRevision` 是 Worker 状态文件的单调修订号，用于阻止旧状态覆盖新状态，并作为 Runtime Event 的单 Job 顺序来源。
+
+Worker 重启时，遗留非终态 Job 统一转为 `LOST`。Link-Up 不从某个 Split、offset 或 batch 自动继续执行。
 
 ## Retry 要求
 
@@ -34,6 +49,7 @@ Retry 必须满足：
 
 当前不做：
 
+- 实时同步 / CDC runtime；
 - 分布式 Scheduler / ResourceManager；
 - Flink 式 checkpoint/savepoint；
 - 从某个 Split offset 自动 resume；
@@ -49,7 +65,7 @@ Retry 必须满足：
 - Maven 3.8.1+。
 - Connector 不依赖 framework。
 - JobGraph 等计划模型不可持有运行时资源。
-- checkpoint 写入使用单调版本和原子替换。
+- Worker state 写入使用单调 `stateRevision`、fsync 和原子替换。
 - 日志不得输出密码、Token、完整 Connector options。
 - 关键状态行为必须有单元测试或边界测试。
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -11,6 +11,7 @@
 - [ ] HTTP 没有直接依赖 infrastructure。
 - [ ] Planner 没有创建线程、Reader、Channel、Split Queue。
 - [ ] 新类的角色能用一句话说清。
+- [ ] 没有新增与 `JobExecutionState` / `JobSnapshot` / `JobExecutionMetadata` 重复表达同一状态的平行模型。
 
 ## Job / Attempt / Retry
 
@@ -20,7 +21,14 @@
 - [ ] LOST/CANCELED 默认不可 Retry。
 - [ ] 有 committed data 或 unknown state 时不可 Retry。
 - [ ] 缺少 commit evidence 时不可猜测安全。
-- [ ] checkpointVersion 单调递增，旧写入不能覆盖新状态。
+- [ ] `stateRevision` 单调递增，旧写入不能覆盖新 Worker state。
+
+## Worker State
+
+- [ ] 新代码把 Worker state persistence 和数据 checkpoint/resume 明确区分。
+- [ ] Worker 重启后的非终态 Job 仍然转为 `LOST`，没有偷偷自动重放。
+- [ ] 没有新增 Split offset resume、savepoint、barrier 或跨 Worker failover。
+- [ ] 持久化格式升级能读取上一版本；legacy `checkpointVersion` 只用于兼容旧格式/协议。
 
 ## Connector
 
@@ -33,7 +41,7 @@
 ## 安全
 
 - [ ] 日志没有密码、Token、完整 Connector options。
-- [ ] checkpoint 没有持久化 JobSpec/密码/Token。
+- [ ] Worker state 没有持久化 JobSpec/密码/Token。
 - [ ] REST 错误没有直接暴露内部对象。
 - [ ] 文件路径由 Worker 自己生成，不接受任意路径读取。
 
@@ -54,7 +62,7 @@ mvn --batch-mode clean verify
 
 - [ ] 新行为有测试。
 - [ ] 架构守卫仍通过。
-- [ ] 没有残留旧包/旧类 import。
+- [ ] 没有残留会误导为数据恢复点的新 `checkpoint` 命名。
 - [ ] 文档只描述当前实现，不写过期计划。
 - [ ] PR 描述清楚兼容性、非目标和未执行的验证。
 

--- a/link-up-server/src/main/java/com/link/up/server/application/JobApplicationService.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobApplicationService.java
@@ -112,7 +112,7 @@ public final class JobApplicationService
                     state.getJobId(),
                     submission);
             state.markSubmitted();
-            lifecycle.checkpoint(state);
+            lifecycle.persistState(state);
             schedule(state, submission);
         } catch (RuntimeException failure) {
             rollbackSubmission(
@@ -186,7 +186,7 @@ public final class JobApplicationService
                             lifecycle.metadata(active)));
         }
 
-        lifecycle.checkpoint(state);
+        lifecycle.persistState(state);
 
         try {
             schedule(state, submission);
@@ -355,7 +355,7 @@ public final class JobApplicationService
         }
 
         state.requestCancellation();
-        lifecycle.checkpoint(state);
+        lifecycle.persistState(state);
         runtimeScheduler.cancel(normalizedJobId);
         return getJob(normalizedJobId);
     }
@@ -439,7 +439,7 @@ public final class JobApplicationService
                 previousSnapshot.getCreateTimeMillis(),
                 previousMetadata.getSubmittedTimeMillis(),
                 previousMetadata.getStateVersion(),
-                previousMetadata.getCheckpointVersion(),
+                previousMetadata.getStateRevision(),
                 previousSnapshot.getStatus(),
                 previousMetadata.getTransitions(),
                 previousAttempts);

--- a/link-up-server/src/main/java/com/link/up/server/application/JobRuntimeLifecycle.java
+++ b/link-up-server/src/main/java/com/link/up/server/application/JobRuntimeLifecycle.java
@@ -13,7 +13,8 @@ import com.link.up.server.runtime.ServerJobStatus;
 import java.util.Objects;
 
 /**
- * Applies runtime callbacks to domain state and persists lifecycle checkpoints.
+ * Applies runtime callbacks to domain state and persists Worker control-plane
+ * state. This persistence is not a data checkpoint or resume point.
  */
 final class JobRuntimeLifecycle {
 
@@ -47,7 +48,7 @@ final class JobRuntimeLifecycle {
         return JobExecutionMetadata.fromState(state);
     }
 
-    void checkpoint(JobExecutionState state) {
+    void persistState(JobExecutionState state) {
         repository.save(
                 snapshot(state),
                 metadata(state));
@@ -60,14 +61,14 @@ final class JobRuntimeLifecycle {
             @Override
             public void onQueued() {
                 state.markQueued();
-                checkpoint(state);
+                persistState(state);
             }
 
             @Override
             public boolean onStarting() {
                 boolean started = state.markRunning();
                 if (started) {
-                    checkpoint(state);
+                    persistState(state);
                 }
                 return started;
             }
@@ -80,7 +81,7 @@ final class JobRuntimeLifecycle {
                 state.bindLogIdentity(
                         runId,
                         jobLogFile);
-                checkpoint(state);
+                persistState(state);
             }
 
             @Override
@@ -124,9 +125,7 @@ final class JobRuntimeLifecycle {
         }
 
         state.failBeforeExecution(failure);
-        repository.save(
-                snapshot(state),
-                metadata(state));
+        persistState(state);
         activeJobs.remove(
                 state.getJobId(),
                 state);
@@ -150,9 +149,7 @@ final class JobRuntimeLifecycle {
             return;
         }
 
-        repository.save(
-                snapshot(state),
-                metadata(state));
+        persistState(state);
         activeJobs.remove(
                 state.getJobId(),
                 state);

--- a/link-up-server/src/main/java/com/link/up/server/domain/JobExecutionState.java
+++ b/link-up-server/src/main/java/com/link/up/server/domain/JobExecutionState.java
@@ -27,7 +27,7 @@ public final class JobExecutionState {
     private volatile long startTimeMillis;
     private volatile long endTimeMillis;
     private volatile long stateVersion;
-    private volatile long checkpointVersion;
+    private volatile long stateRevision;
     private volatile ServerJobStatus status = ServerJobStatus.CREATED;
     private volatile boolean cancellationRequested;
     private volatile JobResult result;
@@ -67,7 +67,7 @@ public final class JobExecutionState {
             long createTimeMillis,
             long submittedTimeMillis,
             long stateVersion,
-            long checkpointVersion,
+            long stateRevision,
             ServerJobStatus previousStatus,
             List<JobStateTransition> previousTransitions,
             List<JobExecutionAttempt> previousAttempts) {
@@ -87,7 +87,7 @@ public final class JobExecutionState {
                 createTimeMillis);
         state.submittedTimeMillis = submittedTimeMillis;
         state.stateVersion = stateVersion;
-        state.checkpointVersion = checkpointVersion;
+        state.stateRevision = stateRevision;
         state.status = previousStatus;
         state.transitions.addAll(previousTransitions);
         state.attempts.addAll(previousAttempts);
@@ -147,9 +147,11 @@ public final class JobExecutionState {
             String runId,
             String jobLogFile) {
         this.runId = requireText(runId, "runId");
-        this.jobLogFile = requireText(jobLogFile, "jobLogFile");
+        this.jobLogFile = requireText(
+                jobLogFile,
+                "jobLogFile");
         currentAttempt().bindLogIdentity(this.runId, this.jobLogFile);
-        checkpointVersion++;
+        stateRevision++;
     }
 
     public synchronized boolean requestCancellation() {
@@ -160,7 +162,7 @@ public final class JobExecutionState {
             return false;
         }
         cancellationRequested = true;
-        checkpointVersion++;
+        stateRevision++;
         return true;
     }
 
@@ -228,7 +230,7 @@ public final class JobExecutionState {
             ServerJobStatus target,
             String reason) {
         stateVersion++;
-        checkpointVersion++;
+        stateRevision++;
         status = target;
         transitions.add(
                 new JobStateTransition(
@@ -274,7 +276,15 @@ public final class JobExecutionState {
     public long getStartTimeMillis() { return startTimeMillis; }
     public long getEndTimeMillis() { return endTimeMillis; }
     public long getStateVersion() { return stateVersion; }
-    public long getCheckpointVersion() { return checkpointVersion; }
+    public long getStateRevision() { return stateRevision; }
+
+    /**
+     * @deprecated Worker state persistence is not a data checkpoint. Use
+     * {@link #getStateRevision()}.
+     */
+    @Deprecated
+    public long getCheckpointVersion() { return stateRevision; }
+
     public ServerJobStatus getStatus() { return status; }
     public boolean isCancellationRequested() { return cancellationRequested; }
     public JobResult getResult() { return result; }

--- a/link-up-server/src/main/java/com/link/up/server/dto/JobHistoryResponse.java
+++ b/link-up-server/src/main/java/com/link/up/server/dto/JobHistoryResponse.java
@@ -32,7 +32,7 @@ public final class JobHistoryResponse {
     private final long startTimeMillis;
     private final long endTimeMillis;
     private final long durationMillis;
-    private final long checkpointVersion;
+    private final long stateRevision;
     private final List<JobEventEnvelope> events;
     private final long nextSequence;
     private final boolean hasMore;
@@ -80,9 +80,9 @@ public final class JobHistoryResponse {
         this.startTimeMillis = safeSnapshot.getStartTimeMillis();
         this.endTimeMillis = safeSnapshot.getEndTimeMillis();
         this.durationMillis = safeSnapshot.getDurationMillis();
-        this.checkpointVersion = metadata == null
+        this.stateRevision = metadata == null
                 ? 0L
-                : metadata.getCheckpointVersion();
+                : metadata.getStateRevision();
         this.events = Collections.unmodifiableList(
                 new ArrayList<JobEventEnvelope>(
                         safeEventPage.getItems()));
@@ -118,7 +118,15 @@ public final class JobHistoryResponse {
     public long getStartTimeMillis() { return startTimeMillis; }
     public long getEndTimeMillis() { return endTimeMillis; }
     public long getDurationMillis() { return durationMillis; }
-    public long getCheckpointVersion() { return checkpointVersion; }
+    public long getStateRevision() { return stateRevision; }
+
+    /**
+     * @deprecated REST compatibility alias. New clients should use
+     * {@code stateRevision} because this value is not a data checkpoint.
+     */
+    @Deprecated
+    public long getCheckpointVersion() { return stateRevision; }
+
     public List<JobEventEnvelope> getEvents() { return events; }
     public long getNextSequence() { return nextSequence; }
     public boolean isHasMore() { return hasMore; }

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/event/EventPublishingJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/event/EventPublishingJobRepository.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Repository decorator that publishes one lifecycle fact after a durable
- * checkpoint succeeds.
+ * Repository decorator that publishes one lifecycle fact after durable Worker
+ * state persistence succeeds.
  *
  * <p>The wrapped repository remains the state source of truth. Event delivery
  * is best-effort and listener failures are isolated at this boundary.</p>
@@ -178,14 +178,14 @@ public final class EventPublishingJobRepository
             JobExecutionMetadata metadata) {
 
         if (metadata == null
-                || metadata.getCheckpointVersion() <= 0L
+                || metadata.getStateRevision() <= 0L
                 || !hasAttempt(metadata)) {
             return null;
         }
 
         if (previousMetadata != null
-                && metadata.getCheckpointVersion()
-                <= previousMetadata.getCheckpointVersion()) {
+                && metadata.getStateRevision()
+                <= previousMetadata.getStateRevision()) {
             return null;
         }
 
@@ -205,7 +205,7 @@ public final class EventPublishingJobRepository
                 snapshot.getJobId(),
                 attempt.getAttemptId(),
                 attempt.getAttemptNumber(),
-                metadata.getCheckpointVersion(),
+                metadata.getStateRevision(),
                 occurredAtMillis(
                         runtimeEvent,
                         metadata),

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/FileJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/FileJobRepository.java
@@ -17,11 +17,12 @@ import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 
 /**
- * Durable Worker checkpoint repository backed by versioned per-job JSON files.
+ * Durable Worker state repository backed by versioned per-job JSON files.
  *
- * <p>The repository owns the in-memory index, checkpoint revision ordering and
+ * <p>The repository owns the in-memory index, state-revision ordering and
  * terminal-history retention. File naming, JSON IO and atomic replacement
- * belong to {@link JobStateFileStore}.</p>
+ * belong to {@link JobStateFileStore}. This state is control-plane metadata,
+ * not a data checkpoint or resume position.</p>
  */
 public final class FileJobRepository
         implements JobRepository {
@@ -128,7 +129,7 @@ public final class FileJobRepository
             fileStore.delete(jobId);
         } catch (IOException failure) {
             throw persistenceFailure(
-                    "Could not delete Worker checkpoint for "
+                    "Could not delete Worker state for "
                             + jobId,
                     failure);
         }
@@ -222,7 +223,7 @@ public final class FileJobRepository
             fileStore.write(record);
         } catch (IOException failure) {
             throw persistenceFailure(
-                    "Could not persist Worker checkpoint for "
+                    "Could not persist Worker state for "
                             + jobId,
                     failure);
         }
@@ -276,8 +277,8 @@ public final class FileJobRepository
 
         return current != null
                 && candidate != null
-                && candidate.getCheckpointVersion()
-                < current.getCheckpointVersion();
+                && candidate.getStateRevision()
+                < current.getStateRevision();
     }
 
     private static void sortNewestFirst(

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/InMemoryJobRepository.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/InMemoryJobRepository.java
@@ -13,7 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ConcurrentMap;
 
-/** Bounded in-memory checkpoint/history adapter used by tests and embeddings. */
+/** Bounded in-memory Worker state/history adapter used by tests and embeddings. */
 public final class InMemoryJobRepository
         implements JobRepository {
 
@@ -107,8 +107,8 @@ public final class InMemoryJobRepository
             JobExecutionMetadata candidate) {
         return current != null
                 && candidate != null
-                && candidate.getCheckpointVersion()
-                < current.getCheckpointVersion();
+                && candidate.getStateRevision()
+                < current.getStateRevision();
     }
 
     private void trimTerminalHistory() {

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/JobStateFileStore.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/JobStateFileStore.java
@@ -15,7 +15,7 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 
-/** Owns Worker checkpoint file naming, JSON IO and atomic replacement. */
+/** Owns Worker state file naming, JSON IO and atomic replacement. */
 final class JobStateFileStore {
 
     private static final String FILE_SUFFIX = ".job.json";

--- a/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/StoredJobRecord.java
+++ b/link-up-server/src/main/java/com/link/up/server/infrastructure/persistence/StoredJobRecord.java
@@ -1,5 +1,6 @@
 package com.link.up.server.infrastructure.persistence;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.link.up.api.sink.TableDdl;
 import com.link.up.server.application.port.JobRepositoryEntry;
 import com.link.up.server.domain.JobAttemptStatus;
@@ -15,10 +16,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-/** Versioned JSON persistence model for one Worker Job checkpoint. */
+/** Versioned JSON persistence model for one Worker Job state record. */
 final class StoredJobRecord {
 
-    static final int CURRENT_FORMAT_VERSION = 3;
+    static final int CURRENT_FORMAT_VERSION = 4;
     static final int MIN_SUPPORTED_FORMAT_VERSION = 1;
 
     public int formatVersion;
@@ -96,7 +97,11 @@ final class StoredJobRecord {
         public long submittedTimeMillis;
         public long queuedTimeMillis;
         public long stateVersion;
-        public long checkpointVersion;
+
+        /** Reads the legacy v1-v3 checkpointVersion field without writing it. */
+        @JsonAlias("checkpointVersion")
+        public long stateRevision;
+
         public boolean cancellationRequested;
         public String runId;
         public String jobLogFile;
@@ -130,8 +135,8 @@ final class StoredJobRecord {
                     metadata.getQueuedTimeMillis();
             stored.stateVersion =
                     metadata.getStateVersion();
-            stored.checkpointVersion =
-                    metadata.getCheckpointVersion();
+            stored.stateRevision =
+                    metadata.getStateRevision();
             stored.cancellationRequested =
                     metadata.isCancellationRequested();
             stored.runId = metadata.getRunId();
@@ -177,7 +182,7 @@ final class StoredJobRecord {
                     submittedTimeMillis,
                     queuedTimeMillis,
                     stateVersion,
-                    checkpointVersion,
+                    stateRevision,
                     cancellationRequested,
                     restoredTransitions,
                     Collections.<String, TableDdl>emptyMap(),

--- a/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionMetadata.java
+++ b/link-up-server/src/main/java/com/link/up/server/runtime/JobExecutionMetadata.java
@@ -23,7 +23,7 @@ public final class JobExecutionMetadata {
     private final long submittedTimeMillis;
     private final long queuedTimeMillis;
     private final long stateVersion;
-    private final long checkpointVersion;
+    private final long stateRevision;
     private final boolean cancellationRequested;
     private final List<JobStateTransition> transitions;
     private final Map<String, TableDdl> tableDdlsByPipelineId;
@@ -124,7 +124,7 @@ public final class JobExecutionMetadata {
             long submittedTimeMillis,
             long queuedTimeMillis,
             long stateVersion,
-            long checkpointVersion,
+            long stateRevision,
             boolean cancellationRequested,
             List<JobStateTransition> transitions,
             Map<String, TableDdl> tableDdlsByPipelineId,
@@ -139,7 +139,7 @@ public final class JobExecutionMetadata {
         this.submittedTimeMillis = submittedTimeMillis;
         this.queuedTimeMillis = queuedTimeMillis;
         this.stateVersion = stateVersion;
-        this.checkpointVersion = checkpointVersion;
+        this.stateRevision = stateRevision;
         this.cancellationRequested = cancellationRequested;
         this.transitions = Collections.unmodifiableList(
                 new ArrayList<JobStateTransition>(transitions));
@@ -182,7 +182,7 @@ public final class JobExecutionMetadata {
                 state.getSubmittedTimeMillis(),
                 state.getQueuedTimeMillis(),
                 state.getStateVersion(),
-                state.getCheckpointVersion(),
+                state.getStateRevision(),
                 state.isCancellationRequested(),
                 state.getTransitions(),
                 tableDdls,
@@ -225,7 +225,7 @@ public final class JobExecutionMetadata {
                 submittedTimeMillis,
                 queuedTimeMillis,
                 stateVersion + 1L,
-                checkpointVersion + 1L,
+                stateRevision + 1L,
                 cancellationRequested,
                 recoveredTransitions,
                 tableDdlsByPipelineId,
@@ -241,7 +241,15 @@ public final class JobExecutionMetadata {
     public long getSubmittedTimeMillis() { return submittedTimeMillis; }
     public long getQueuedTimeMillis() { return queuedTimeMillis; }
     public long getStateVersion() { return stateVersion; }
-    public long getCheckpointVersion() { return checkpointVersion; }
+    public long getStateRevision() { return stateRevision; }
+
+    /**
+     * @deprecated Worker state persistence is not a data checkpoint. Use
+     * {@link #getStateRevision()}.
+     */
+    @Deprecated
+    public long getCheckpointVersion() { return stateRevision; }
+
     public boolean isCancellationRequested() { return cancellationRequested; }
     public List<JobStateTransition> getTransitions() { return transitions; }
     public Map<String, TableDdl> getTableDdlsByPipelineId() { return tableDdlsByPipelineId; }

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryBoundaryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryBoundaryTest.java
@@ -12,7 +12,7 @@ import java.util.Set;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-/** Architecture guards for durable checkpoint persistence roles. */
+/** Architecture guards for durable Worker state persistence roles. */
 public class FileJobRepositoryBoundaryTest {
 
     @Test

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryStructuredErrorTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryStructuredErrorTest.java
@@ -112,8 +112,14 @@ public class FileJobRepositoryStructuredErrorTest {
                             firstRegularFile(directory)
                                     .toFile());
             assertEquals(
-                    3,
+                    4,
                     persisted.get("formatVersion").asInt());
+            assertTrue(
+                    persisted.path("metadata")
+                            .has("stateRevision"));
+            assertFalse(
+                    persisted.path("metadata")
+                            .has("checkpointVersion"));
             assertEquals(
                     "PLAN-005",
                     persisted.path("metadata")
@@ -140,7 +146,7 @@ public class FileJobRepositoryStructuredErrorTest {
                     .findFirst()
                     .orElseThrow(
                             () -> new AssertionError(
-                                    "Expected persisted checkpoint file"));
+                                    "Expected persisted Worker state file"));
         }
     }
 

--- a/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/infrastructure/persistence/FileJobRepositoryTest.java
@@ -14,19 +14,24 @@ import com.link.up.server.runtime.JobSnapshotFactory;
 import com.link.up.server.runtime.ServerJobStatus;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class FileJobRepositoryTest {
 
     @Test
-    public void shouldReloadCheckpointAndRejectOlderRevision() throws Exception {
+    public void shouldReloadWorkerStateAndRejectOlderRevision()
+            throws Exception {
         Path directory = Files.createTempDirectory("link-up-state-");
         try {
             FileJobRepository first = new FileJobRepository(directory, 20);
@@ -39,6 +44,11 @@ public class FileJobRepositoryTest {
             first.save(
                     JobSnapshotFactory.create(state, null),
                     JobExecutionMetadata.fromState(state));
+
+            String persisted = readStateFile(directory, "job-file-1");
+            assertTrue(persisted.contains("\"formatVersion\" : 4"));
+            assertTrue(persisted.contains("\"stateRevision\""));
+            assertFalse(persisted.contains("\"checkpointVersion\""));
 
             JobExecutionState stale =
                     new JobExecutionState("job-file-1", submission());
@@ -65,7 +75,7 @@ public class FileJobRepositoryTest {
             assertEquals(
                     JobAttemptStatus.RUNNING,
                     metadata.getAttempts().get(0).getStatus());
-            assertEquals(3L, metadata.getCheckpointVersion());
+            assertEquals(3L, metadata.getStateRevision());
 
             reopened.delete("job-file-1");
             assertNull(reopened.get("job-file-1"));
@@ -76,6 +86,71 @@ public class FileJobRepositoryTest {
         } finally {
             deleteDirectory(directory);
         }
+    }
+
+    @Test
+    public void shouldReadLegacyCheckpointVersionAsStateRevision()
+            throws Exception {
+        Path directory = Files.createTempDirectory("link-up-legacy-state-");
+        try {
+            String jobId = "job-legacy-state-1";
+            String legacyJson =
+                    "{\n"
+                            + "  \"formatVersion\": 3,\n"
+                            + "  \"jobId\": \"" + jobId + "\",\n"
+                            + "  \"jobName\": \"legacy-state\",\n"
+                            + "  \"status\": \"FAILED\",\n"
+                            + "  \"createTimeMillis\": 1,\n"
+                            + "  \"startTimeMillis\": 2,\n"
+                            + "  \"endTimeMillis\": 3,\n"
+                            + "  \"metadata\": {\n"
+                            + "    \"externalExecutionId\": \"legacy-external\",\n"
+                            + "    \"idempotencyKey\": \"legacy-key\",\n"
+                            + "    \"definitionVersion\": 1,\n"
+                            + "    \"configDigest\": \"legacy-digest\",\n"
+                            + "    \"submittedTimeMillis\": 1,\n"
+                            + "    \"queuedTimeMillis\": 1,\n"
+                            + "    \"stateVersion\": 5,\n"
+                            + "    \"checkpointVersion\": 7,\n"
+                            + "    \"cancellationRequested\": false,\n"
+                            + "    \"transitions\": [],\n"
+                            + "    \"attempts\": []\n"
+                            + "  }\n"
+                            + "}";
+
+            Files.write(
+                    stateFile(directory, jobId),
+                    legacyJson.getBytes(StandardCharsets.UTF_8));
+
+            FileJobRepository repository =
+                    new FileJobRepository(directory, 20);
+
+            assertNotNull(repository.get(jobId));
+            assertEquals(
+                    7L,
+                    repository.getMetadata(jobId).getStateRevision());
+        } finally {
+            deleteDirectory(directory);
+        }
+    }
+
+    private static String readStateFile(
+            Path directory,
+            String jobId)
+            throws Exception {
+        return new String(
+                Files.readAllBytes(stateFile(directory, jobId)),
+                StandardCharsets.UTF_8);
+    }
+
+    private static Path stateFile(
+            Path directory,
+            String jobId) {
+        String encoded = Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(
+                        jobId.getBytes(StandardCharsets.UTF_8));
+        return directory.resolve(encoded + ".job.json");
     }
 
     private static JobSubmission submission() {


### PR DESCRIPTION
## Summary

Phase 1 of the offline-only simplification work.

- rename primary runtime `checkpointVersion` semantics to `stateRevision`;
- rename lifecycle persistence to `persistState`;
- keep Worker restart behavior as non-terminal Job -> `LOST`;
- make it explicit that Worker state persistence is not a data checkpoint/resume point;
- upgrade Worker state JSON format to v4 and write `stateRevision`;
- keep v1-v3 `checkpointVersion` readable through a legacy alias;
- add `stateRevision` to History while retaining deprecated `checkpointVersion` compatibility;
- document the fixed state-model boundary: `JobExecutionState` -> persisted snapshot/metadata -> event timeline -> read-only History.

Tests cover v4 output, stale revision rejection, v3 legacy state loading, and structured-error persistence compatibility.

No Job/Attempt, Retry, Commit Evidence, Pipeline/Task, Connector, Metrics or cancellation behavior is changed.

This PR does not add real-time sync, Flink-style checkpoint/savepoint, Split/offset resume, automatic LOST replay or cross-Worker failover.

Local pre-merge verification:

```bash
mvn --batch-mode -pl link-up-server -am test
mvn --batch-mode clean verify
```
