### PR TITLE
feat(jdbc): add SQL Server offline source and sink

### DIFF
--- a/CONNECTOR_ADAPTATION.md
+++ b/CONNECTOR_ADAPTATION.md
@@ -4,7 +4,7 @@ Yak Link Up 优先复用已有执行模型，再增加数据库差异层。新�
 
 ## JDBC 数据库适配
 
-以 MySQL、PostgreSQL、Oracle 为参考，一个新的 JDBC 数据库通常只需要补齐：
+以 MySQL、PostgreSQL、Oracle、SQL Server 为参考，一个新的 JDBC 数据库通常只需要补齐：
 
 1. **Driver**
    - 在 `link-up-connector-jdbc` 引入 JDBC Driver。
@@ -13,7 +13,7 @@ Yak Link Up 优先复用已有执行模型，再增加数据库差异层。新�
 2. **Dialect**
    - 在 `DatabaseIdentifier` 增加唯一标识。
    - 实现 `JdbcDialectFactory`，通过 SPI 注册。
-   - 实现 `JdbcDialect`：标识符引用、`schema.table` 规则、UPSERT、读取 PreparedStatement、Hash Split 等数据库差异。
+   - 实现 `JdbcDialect`：标识符引用、表路径规则、UPSERT、读取 PreparedStatement、Hash Split 等数据库差异。
 
 3. **Type Mapper / Row Converter**
    - JDBC 元数据转换为 Flux 类型。
@@ -35,10 +35,10 @@ Yak Link Up 优先复用已有执行模型，再增加数据库差异层。新�
 
 ## 数据库差异不要强行抹平
 
-适配时保留真正影响正确性的差异。例如 PostgreSQL cursor fetch 需要事务，Oracle `DATE` 包含时分秒、UPSERT 使用 `MERGE`，Oracle SQL 对象定位是 `schema.table`。这些差异应放在 Dialect/TypeMapper/Catalog 中，而不是塞进公共 Source/Sink。
+适配时保留真正影响正确性的差异。例如 PostgreSQL cursor fetch 需要事务；Oracle `DATE` 包含时分秒、UPSERT 使用 `MERGE`；SQL Server 使用 `database.schema.table`，`timestamp` 实际是 `rowversion`，`tinyint` 是 0~255，`datetimeoffset` 需要保留时区偏移。这些差异应放在 Dialect/TypeMapper/Catalog 中，而不是塞进公共 Source/Sink。
 
 ## 能力边界
 
 JDBC Offline Connector 默认只负责全量读取、分片读取和批量写入。
 
-CDC、Binlog/WAL、Oracle LogMiner/SCN、Replication Slot、流式 Checkpoint、XA / Exactly Once 等能力应作为独立 Stage 设计，不直接塞进离线 JDBC 方言。这样新增 SQL Server、DB2 等数据库时，只需要实现数据库差异，而不需要重复执行框架。
+CDC、Binlog/WAL、Oracle LogMiner/SCN、SQL Server CDC/Change Tracking、Replication Slot、流式 Checkpoint、XA / Exactly Once 等能力应作为独立 Stage 设计，不直接塞进离线 JDBC 方言。这样新增 DB2、达梦等数据库时，只需要实现数据库差异，而不需要重复执行框架。

--- a/link-up-connectors/link-up-connector-jdbc/pom.xml
+++ b/link-up-connectors/link-up-connector-jdbc/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>ojdbc8</artifactId>
             <version>12.2.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.microsoft.sqlserver</groupId>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>9.2.1.jre8</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCatalog.java
@@ -1,0 +1,513 @@
+package com.link.up.connector.jdbc.catalog.sqlserver;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/** SQL Server offline JDBC Catalog. */
+public final class SqlServerCatalog implements WritableCatalog {
+
+    public static final String DIALECT = "sqlserver";
+    public static final String TABLE_OPTION_DIALECT = "dialect";
+    private static final String DEFAULT_SCHEMA = "dbo";
+
+    private static final String LIST_DATABASES_SQL =
+            "SELECT name FROM sys.databases WHERE state = 0 ORDER BY name";
+    private static final String DATABASE_EXISTS_SQL =
+            "SELECT 1 FROM sys.databases WHERE name = ?";
+    private static final String LIST_SCHEMAS_SQL =
+            "SELECT name FROM sys.schemas ORDER BY name";
+    private static final String SELECT_COLUMNS_SQL =
+            "SELECT c.name AS COLUMN_NAME, t.name AS DATA_TYPE, "
+                    + "c.max_length AS MAX_LENGTH, c.precision AS NUMERIC_PRECISION, "
+                    + "c.scale AS NUMERIC_SCALE, c.is_nullable AS IS_NULLABLE, "
+                    + "dc.definition AS COLUMN_DEFAULT, c.is_identity AS IS_IDENTITY, "
+                    + "CAST(ep.value AS nvarchar(4000)) AS COLUMN_COMMENT "
+                    + "FROM sys.columns c "
+                    + "JOIN sys.tables tb ON c.object_id = tb.object_id "
+                    + "JOIN sys.schemas s ON tb.schema_id = s.schema_id "
+                    + "JOIN sys.types t ON c.user_type_id = t.user_type_id "
+                    + "LEFT JOIN sys.default_constraints dc ON c.default_object_id = dc.object_id "
+                    + "LEFT JOIN sys.extended_properties ep ON ep.major_id = c.object_id "
+                    + "AND ep.minor_id = c.column_id AND ep.name = 'MS_Description' "
+                    + "WHERE s.name = ? AND tb.name = ? ORDER BY c.column_id";
+    private static final String SELECT_TABLE_COMMENT_SQL =
+            "SELECT CAST(ep.value AS nvarchar(4000)) AS TABLE_COMMENT "
+                    + "FROM sys.tables tb JOIN sys.schemas s ON tb.schema_id=s.schema_id "
+                    + "LEFT JOIN sys.extended_properties ep ON ep.major_id=tb.object_id "
+                    + "AND ep.minor_id=0 AND ep.name='MS_Description' "
+                    + "WHERE s.name=? AND tb.name=?";
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String configuredSchema;
+    private final SqlServerTypeMapper typeMapper = new SqlServerTypeMapper();
+    private volatile String defaultDatabase;
+    private volatile boolean opened;
+
+    public SqlServerCatalog(
+            String catalogName, JdbcCatalogConfig config, String defaultSchema) {
+        if (!hasText(catalogName)) {
+            throw new IllegalArgumentException("catalogName must not be empty");
+        }
+        this.catalogName = catalogName.trim();
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.defaultDatabase = SqlServerJdbcUrl.databaseName(config.getUrl());
+        this.configuredSchema = hasText(defaultSchema) ? defaultSchema.trim() : DEFAULT_SCHEMA;
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.ofNullable(defaultDatabase);
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+        loadDriver();
+        try (Connection connection = connection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException("SQL Server Catalog 连接校验失败：" + config.getUrl());
+            }
+            if (!hasText(defaultDatabase)) {
+                defaultDatabase = normalize(connection.getCatalog());
+            }
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException("SQL Server Catalog 连接失败：" + config.getUrl(), e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        checkOpened();
+        try (Connection connection = connection();
+             PreparedStatement statement = connection.prepareStatement(LIST_DATABASES_SQL);
+             ResultSet rs = statement.executeQuery()) {
+            List<String> databases = new ArrayList<String>();
+            while (rs.next()) {
+                databases.add(rs.getString(1));
+            }
+            return databases;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 SQL Server 数据库列表失败", e);
+        }
+    }
+
+    public boolean databaseExists(String database) throws CatalogException {
+        if (!hasText(database)) {
+            return false;
+        }
+        checkOpened();
+        try (Connection connection = connection();
+             PreparedStatement statement = connection.prepareStatement(DATABASE_EXISTS_SQL)) {
+            statement.setString(1, database.trim());
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new CatalogException("检查 SQL Server 数据库失败，database=" + database, e);
+        }
+    }
+
+    @Override
+    public List<String> listSchemas(String database) throws CatalogException {
+        checkOpened();
+        String targetDatabase = resolveDatabase(database);
+        try (Connection connection = connection(targetDatabase);
+             PreparedStatement statement = connection.prepareStatement(LIST_SCHEMAS_SQL);
+             ResultSet rs = statement.executeQuery()) {
+            List<String> schemas = new ArrayList<String>();
+            while (rs.next()) {
+                schemas.add(rs.getString(1));
+            }
+            return schemas;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 SQL Server Schema 列表失败，database=" + targetDatabase, e);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(String database, String schemaName)
+            throws CatalogException {
+        checkOpened();
+        String targetDatabase = resolveDatabase(database);
+        String schema = resolveSchema(schemaName);
+        try (Connection connection = connection(targetDatabase);
+             ResultSet rs = connection.getMetaData().getTables(
+                     targetDatabase, schema, "%", new String[]{"TABLE"})) {
+            List<TablePath> tables = new ArrayList<TablePath>();
+            while (rs.next()) {
+                String table = normalize(rs.getString("TABLE_NAME"));
+                if (table != null) {
+                    tables.add(TablePath.of(targetDatabase, schema, table));
+                }
+            }
+            tables.sort(Comparator.comparing(TablePath::getTableName));
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 SQL Server 表列表失败，database=" + targetDatabase
+                            + ", schema=" + schema, e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        try (Connection connection = connection(path.getDatabaseName());
+             ResultSet rs = connection.getMetaData().getTables(
+                     path.getDatabaseName(), path.getSchemaName(), path.getTableName(),
+                     new String[]{"TABLE"})) {
+            return rs.next();
+        } catch (SQLException e) {
+            throw new CatalogException("检查 SQL Server 表失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        try (Connection connection = connection(path.getDatabaseName())) {
+            List<Column> columns = columns(connection, path);
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(catalogName, path);
+            }
+            DatabaseMetaData meta = connection.getMetaData();
+            TableSchema schema = TableSchema.builder()
+                    .columns(columns)
+                    .primaryKey(primaryKey(meta, path))
+                    .build();
+            CatalogTable.Builder table = CatalogTable.builder(path, schema)
+                    .option(TABLE_OPTION_DIALECT, DIALECT);
+            String comment = tableComment(connection, path);
+            if (hasText(comment)) {
+                table.comment(comment);
+            }
+            return table.build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 SQL Server 表结构失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public void createDatabase(String database, boolean ignoreIfExists)
+            throws CatalogException, DatabaseAlreadyExistsException {
+        checkOpened();
+        if (databaseExists(database)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new DatabaseAlreadyExistsException(catalogName, database);
+        }
+        try (Connection connection = masterConnection()) {
+            execute(connection, "CREATE DATABASE " + quote(database));
+        } catch (SQLException e) {
+            throw new CatalogException("创建 SQL Server 数据库失败，database=" + database, e);
+        }
+    }
+
+    @Override
+    public void dropDatabase(String database, boolean ignoreIfNotExists)
+            throws CatalogException, DatabaseNotFoundException {
+        checkOpened();
+        if (!databaseExists(database)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new DatabaseNotFoundException(catalogName, database);
+        }
+        try (Connection connection = masterConnection()) {
+            execute(connection, "DROP DATABASE " + quote(database));
+        } catch (SQLException e) {
+            throw new CatalogException("删除 SQL Server 数据库失败，database=" + database, e);
+        }
+    }
+
+    @Override
+    public void createTable(CatalogTable table, boolean ignoreIfExists)
+            throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+        checkOpened();
+        TablePath path = normalizePath(table.getTablePath());
+        if (!databaseExists(path.getDatabaseName())) {
+            throw new DatabaseNotFoundException(catalogName, path.getDatabaseName());
+        }
+        if (tableExists(path)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new TableAlreadyExistsException(catalogName, path);
+        }
+        CatalogTable ddlTable = table.getTablePath().equals(path)
+                ? table : table.withPath(path);
+        SqlServerCreateTableSqlBuilder builder =
+                new SqlServerCreateTableSqlBuilder(path, ddlTable, typeMapper);
+        try (Connection connection = connection(path.getDatabaseName())) {
+            for (String sql : builder.buildStatements()) {
+                execute(connection, sql);
+            }
+        } catch (SQLException e) {
+            throw new CatalogException("创建 SQL Server 表失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public void addColumn(TablePath tablePath, Column column)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        if (!tableExists(path)) {
+            throw new TableNotFoundException(catalogName, path);
+        }
+        CatalogTable table = getTable(path);
+        SqlServerCreateTableSqlBuilder builder =
+                new SqlServerCreateTableSqlBuilder(path, table, typeMapper);
+        String definition = builder.buildColumnDefinition(column, false);
+        try (Connection connection = connection(path.getDatabaseName())) {
+            execute(connection, "ALTER TABLE " + quoteTable(path) + " ADD " + definition);
+            if (hasText(column.getComment())) {
+                execute(connection, builder.buildColumnCommentStatement(column));
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "增加 SQL Server 字段失败，table=" + path
+                            + ", column=" + column.getName(), e);
+        }
+    }
+
+    @Override
+    public void dropTable(TablePath tablePath, boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        tableDdl(tablePath, ignoreIfNotExists, "DROP TABLE ", "删除");
+    }
+
+    @Override
+    public void truncateTable(TablePath tablePath, boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        tableDdl(tablePath, ignoreIfNotExists, "TRUNCATE TABLE ", "清空");
+    }
+
+    private void tableDdl(
+            TablePath tablePath, boolean ignoreIfNotExists, String prefix, String operation)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        if (!tableExists(path)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotFoundException(catalogName, path);
+        }
+        try (Connection connection = connection(path.getDatabaseName())) {
+            execute(connection, prefix + quoteTable(path));
+        } catch (SQLException e) {
+            throw new CatalogException(operation + " SQL Server 表失败，table=" + path, e);
+        }
+    }
+
+    private List<Column> columns(Connection connection, TablePath path) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_COLUMNS_SQL)) {
+            statement.setString(1, path.getSchemaName());
+            statement.setString(2, path.getTableName());
+            try (ResultSet rs = statement.executeQuery()) {
+                List<Column> result = new ArrayList<Column>();
+                while (rs.next()) {
+                    result.add(typeMapper.toColumn(rs));
+                }
+                return result;
+            }
+        }
+    }
+
+    private PrimaryKey primaryKey(DatabaseMetaData meta, TablePath path) throws SQLException {
+        try (ResultSet rs = meta.getPrimaryKeys(
+                path.getDatabaseName(), path.getSchemaName(), path.getTableName())) {
+            String name = null;
+            List<KeyColumn> keys = new ArrayList<KeyColumn>();
+            while (rs.next()) {
+                if (name == null) {
+                    name = rs.getString("PK_NAME");
+                }
+                keys.add(new KeyColumn(rs.getShort("KEY_SEQ"), rs.getString("COLUMN_NAME")));
+            }
+            if (keys.isEmpty()) {
+                return null;
+            }
+            keys.sort(Comparator.comparingInt(KeyColumn::position));
+            List<String> columns = new ArrayList<String>(keys.size());
+            for (KeyColumn key : keys) {
+                columns.add(key.name);
+            }
+            return PrimaryKey.of(name, columns);
+        }
+    }
+
+    private String tableComment(Connection connection, TablePath path) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_TABLE_COMMENT_SQL)) {
+            statement.setString(1, path.getSchemaName());
+            statement.setString(2, path.getTableName());
+            try (ResultSet rs = statement.executeQuery()) {
+                return rs.next() ? normalize(rs.getString("TABLE_COMMENT")) : null;
+            }
+        }
+    }
+
+    private TablePath normalizePath(TablePath tablePath) {
+        Objects.requireNonNull(tablePath, "tablePath must not be null");
+        String currentDatabase = resolveDatabase(null);
+        String sourceDatabase = tablePath.getDatabaseName();
+        String schema = tablePath.getSchemaName();
+        if (!hasText(sourceDatabase)) {
+            sourceDatabase = currentDatabase;
+            if (!hasText(schema)) {
+                schema = configuredSchema;
+            }
+        } else if (!currentDatabase.equalsIgnoreCase(sourceDatabase)) {
+            sourceDatabase = currentDatabase;
+            schema = configuredSchema;
+        } else if (!hasText(schema)) {
+            schema = configuredSchema;
+        }
+        return TablePath.of(sourceDatabase, schema, tablePath.getTableName());
+    }
+
+    private String resolveDatabase(String requested) {
+        if (hasText(requested)) {
+            return requested.trim();
+        }
+        if (hasText(defaultDatabase)) {
+            return defaultDatabase.trim();
+        }
+        try (Connection connection = connection()) {
+            String current = normalize(connection.getCatalog());
+            if (current != null) {
+                defaultDatabase = current;
+                return current;
+            }
+        } catch (SQLException e) {
+            throw new CatalogException("无法确定 SQL Server 当前数据库", e);
+        }
+        throw new IllegalArgumentException("SQL Server JDBC URL/Connection 未提供默认数据库");
+    }
+
+    private String resolveSchema(String schemaName) {
+        return hasText(schemaName) ? schemaName.trim() : configuredSchema;
+    }
+
+    private Connection connection() throws SQLException {
+        return DriverManager.getConnection(config.getUrl(), config.toConnectionProperties());
+    }
+
+    private Connection connection(String database) throws SQLException {
+        return DriverManager.getConnection(
+                SqlServerJdbcUrl.withDatabase(config.getUrl(), database),
+                config.toConnectionProperties());
+    }
+
+    private Connection masterConnection() throws SQLException {
+        return connection("master");
+    }
+
+    private void loadDriver() {
+        if (!hasText(config.getDriverClass())) {
+            return;
+        }
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException(
+                    "找不到 SQL Server JDBC Driver：" + config.getDriverClass(), e);
+        }
+    }
+
+    private static void execute(Connection connection, String sql) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static String quoteTable(TablePath path) {
+        return quote(path.getDatabaseName()) + "." + quote(path.getSchemaName())
+                + "." + quote(path.getTableName());
+    }
+
+    private static String quote(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "[" + value.trim().replace("]", "]]" ) + "]";
+    }
+
+    private static boolean hasText(String value) {
+        return normalize(value) != null;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static final class KeyColumn {
+        private final int position;
+        private final String name;
+
+        private KeyColumn(int position, String name) {
+            this.position = position;
+            this.name = name;
+        }
+
+        private int position() {
+            return position;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCatalogFactory.java
@@ -1,0 +1,40 @@
+package com.link.up.connector.jdbc.catalog.sqlserver;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.factory.Factory;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.config.JdbcCommonOptions;
+
+import java.util.Collections;
+import java.util.Map;
+
+/** SQL Server Catalog factory. */
+@AutoService(Factory.class)
+public final class SqlServerCatalogFactory implements CatalogFactory {
+
+    private static final String DEFAULT_DRIVER =
+            "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+
+    @Override
+    public String factoryIdentifier() {
+        return SqlServerCatalog.DIALECT;
+    }
+
+    @Override
+    public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
+        String url = options.get(JdbcCommonOptions.URL);
+        String username = options.getOptional(JdbcCommonOptions.USERNAME).orElse(null);
+        String password = options.getOptional(JdbcCommonOptions.PASSWORD).orElse(null);
+        String driver = options.getOptional(JdbcCommonOptions.DRIVER).orElse(DEFAULT_DRIVER);
+        Map<String, String> properties = options.getOptional(JdbcCommonOptions.PROPERTIES)
+                .orElse(Collections.emptyMap());
+        String schema = options.getOptional(JdbcCommonOptions.SCHEMA).orElse(null);
+
+        JdbcCatalogConfig config = new JdbcCatalogConfig(
+                url, username, password, driver, properties, false);
+        return new SqlServerCatalog(catalogName, config, schema);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCreateTableSqlBuilder.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCreateTableSqlBuilder.java
@@ -1,0 +1,187 @@
+package com.link.up.connector.jdbc.catalog.sqlserver;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerTypeMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** SQL Server CREATE TABLE builder for offline Sink preparation. */
+public final class SqlServerCreateTableSqlBuilder {
+
+    private static final Pattern NUMBER_PATTERN =
+            Pattern.compile("[-+]?\\d+(\\.\\d+)?");
+
+    private final TablePath tablePath;
+    private final CatalogTable catalogTable;
+    private final SqlServerTypeMapper typeMapper;
+
+    public SqlServerCreateTableSqlBuilder(
+            TablePath tablePath,
+            CatalogTable catalogTable,
+            SqlServerTypeMapper typeMapper) {
+        this.tablePath = tablePath;
+        this.catalogTable = catalogTable;
+        this.typeMapper = typeMapper;
+    }
+
+    public String build() {
+        return buildStatements().stream()
+                .map(sql -> sql.endsWith(";") ? sql : sql + ";")
+                .collect(Collectors.joining("\n"));
+    }
+
+    public List<String> buildStatements() {
+        TableSchema schema = catalogTable.getTableSchema();
+        boolean preserveSourceType = SqlServerCatalog.DIALECT.equalsIgnoreCase(
+                catalogTable.getOptions().get(SqlServerCatalog.TABLE_OPTION_DIALECT));
+        List<String> definitions = new ArrayList<String>();
+        for (Column column : schema.getColumns()) {
+            definitions.add(buildColumnDefinition(column, preserveSourceType));
+        }
+        PrimaryKey primaryKey = schema.getPrimaryKey();
+        if (primaryKey != null) {
+            definitions.add(buildPrimaryKey(primaryKey));
+        }
+
+        List<String> statements = new ArrayList<String>();
+        statements.add("CREATE TABLE " + quoteTable(tablePath) + " (\n    "
+                + String.join(",\n    ", definitions) + "\n)");
+        if (hasText(catalogTable.getComment())) {
+            statements.add(tableComment(catalogTable.getComment()));
+        }
+        for (Column column : schema.getColumns()) {
+            if (hasText(column.getComment())) {
+                statements.add(columnComment(column));
+            }
+        }
+        return statements;
+    }
+
+    public String buildColumnDefinition(Column column, boolean preserveSourceType) {
+        List<String> parts = new ArrayList<String>();
+        parts.add(quoteIdentifier(column.getName()));
+        parts.add(typeMapper.toDatabaseType(column, preserveSourceType));
+        if (column.isAutoIncrement()) {
+            parts.add("IDENTITY(1,1)");
+        } else if (column.getDefaultValue() != null) {
+            parts.add("DEFAULT " + formatDefaultValue(column, preserveSourceType));
+        }
+        parts.add(column.isNullable() ? "NULL" : "NOT NULL");
+        return String.join(" ", parts);
+    }
+
+    public String buildColumnCommentStatement(Column column) {
+        return columnComment(column);
+    }
+
+    private String buildPrimaryKey(PrimaryKey primaryKey) {
+        String name = primaryKey.getName();
+        if (!hasText(name)) {
+            name = "PK_" + tablePath.getTableName();
+        }
+        name = normalizeConstraintName(name);
+        String columns = primaryKey.getColumnNames().stream()
+                .map(SqlServerCreateTableSqlBuilder::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        return "CONSTRAINT " + quoteIdentifier(name) + " PRIMARY KEY (" + columns + ")";
+    }
+
+    private String formatDefaultValue(Column column, boolean preserveSourceType) {
+        Object value = column.getDefaultValue();
+        if (preserveSourceType) {
+            String expression = String.valueOf(value).trim();
+            if (hasText(expression)) {
+                return expression;
+            }
+        }
+        if (value instanceof Number) {
+            return value.toString();
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value ? "1" : "0";
+        }
+        String text = String.valueOf(value).trim();
+        String upper = text.toUpperCase(Locale.ROOT);
+        if ("NULL".equals(upper)
+                || "CURRENT_TIMESTAMP".equals(upper)
+                || "GETDATE()".equals(upper)
+                || "SYSDATETIME()".equals(upper)
+                || "SYSUTCDATETIME()".equals(upper)
+                || "NEWID()".equals(upper)
+                || "NEWSEQUENTIALID()".equals(upper)) {
+            return text;
+        }
+        SqlType sqlType = column.getDataType().getSqlType();
+        if (isNumeric(sqlType) && NUMBER_PATTERN.matcher(text).matches()) {
+            return text;
+        }
+        return "N'" + literal(text) + "'";
+    }
+
+    private String tableComment(String comment) {
+        return "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'"
+                + literal(comment)
+                + "', @level0type=N'SCHEMA', @level0name=N'" + literal(schema())
+                + "', @level1type=N'TABLE', @level1name=N'" + literal(tablePath.getTableName()) + "'";
+    }
+
+    private String columnComment(Column column) {
+        return "EXEC sys.sp_addextendedproperty @name=N'MS_Description', @value=N'"
+                + literal(column.getComment())
+                + "', @level0type=N'SCHEMA', @level0name=N'" + literal(schema())
+                + "', @level1type=N'TABLE', @level1name=N'" + literal(tablePath.getTableName())
+                + "', @level2type=N'COLUMN', @level2name=N'" + literal(column.getName()) + "'";
+    }
+
+    private String schema() {
+        return hasText(tablePath.getSchemaName()) ? tablePath.getSchemaName() : "dbo";
+    }
+
+    private static boolean isNumeric(SqlType sqlType) {
+        return sqlType == SqlType.TINYINT
+                || sqlType == SqlType.SMALLINT
+                || sqlType == SqlType.INT
+                || sqlType == SqlType.BIGINT
+                || sqlType == SqlType.FLOAT
+                || sqlType == SqlType.DOUBLE
+                || sqlType == SqlType.DECIMAL;
+    }
+
+    private static String normalizeConstraintName(String value) {
+        String normalized = value.trim().replaceAll("[^A-Za-z0-9_@$#]", "_");
+        return normalized.length() > 128 ? normalized.substring(0, 128) : normalized;
+    }
+
+    private static String quoteTable(TablePath path) {
+        String table = quoteIdentifier(path.getTableName());
+        String schema = hasText(path.getSchemaName())
+                ? quoteIdentifier(path.getSchemaName()) + "." : "";
+        String database = hasText(path.getDatabaseName())
+                ? quoteIdentifier(path.getDatabaseName()) + "." : "";
+        return database + schema + table;
+    }
+
+    private static String quoteIdentifier(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "[" + value.trim().replace("]", "]]" ) + "]";
+    }
+
+    private static String literal(String value) {
+        return value.replace("'", "''");
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -10,6 +10,7 @@ public final class DatabaseIdentifier {
     public static final String MYSQL = "mysql";
     public static final String POSTGRESQL = "postgresql";
     public static final String ORACLE = "oracle";
+    public static final String SQLSERVER = "sqlserver";
 
     private DatabaseIdentifier() {
     }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerDialect.java
@@ -1,0 +1,242 @@
+package com.link.up.connector.jdbc.core.dialect.sqlserver;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.sqlserver.SqlServerCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** SQL Server bounded/offline JDBC dialect. */
+public final class SqlServerDialect implements JdbcDialect {
+
+    private static final String DEFAULT_SCHEMA = "dbo";
+
+    private final JdbcConnectionConfig connectionConfig;
+    private final SqlServerTypeMapper typeMapper;
+    private final String databaseName;
+
+    public SqlServerDialect(JdbcConnectionConfig connectionConfig) {
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException("connectionConfig must not be null");
+        }
+        this.connectionConfig = connectionConfig;
+        this.typeMapper = new SqlServerTypeMapper();
+        this.databaseName = SqlServerJdbcUrl.databaseName(connectionConfig.getUrl());
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.SQLSERVER;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName, JdbcConnectionConfig connectionConfig) {
+        return new SqlServerCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false),
+                connectionConfig.getSchema());
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new SqlServerJdbcRowConverter();
+    }
+
+    /** One part is table, two parts are schema.table, three are database.schema.table. */
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        if (!JdbcDialect.hasText(tablePath)) {
+            throw new IllegalArgumentException("tablePath must not be empty");
+        }
+        String[] parts = tablePath.trim().split("\\.");
+        switch (parts.length) {
+            case 1:
+                return TablePath.of(parts[0]);
+            case 2:
+                return TablePath.of(null, parts[0], parts[1]);
+            case 3:
+                return TablePath.of(parts[0], parts[1], parts[2]);
+            default:
+                throw new IllegalArgumentException("非法 SQL Server 表路径：" + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        if (!JdbcDialect.hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "[" + identifier.trim().replace("]", "]]" ) + "]";
+    }
+
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        String database = resolveDatabase(tablePath);
+        String schema = resolveSchema(tablePath, database);
+        String table = quoteIdentifier(tablePath.getTableName());
+        return JdbcDialect.hasText(database)
+                ? quoteIdentifier(database) + "." + quoteIdentifier(schema) + "." + table
+                : quoteIdentifier(schema) + "." + table;
+    }
+
+    @Override
+    public Optional<String> buildUpsertSql(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+        JdbcDialect.validateFields(fieldNames);
+        Set<String> primaryKeySet = JdbcDialect.normalizeFields(primaryKeys);
+        if (primaryKeySet.isEmpty()) {
+            throw new IllegalArgumentException("SQL Server UPSERT 必须配置主键字段");
+        }
+        Set<String> fields = new HashSet<String>(fieldNames);
+        for (String primaryKey : primaryKeys) {
+            if (!fields.contains(primaryKey)) {
+                throw new IllegalArgumentException(
+                        "SQL Server UPSERT 主键字段不存在：" + primaryKey);
+            }
+        }
+
+        String placeholders = fieldNames.stream()
+                .map(field -> "?")
+                .collect(Collectors.joining(", "));
+        String sourceColumns = fieldNames.stream()
+                .map(this::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        String onClause = primaryKeys.stream()
+                .map(field -> "TARGET." + quoteIdentifier(field)
+                        + " = SOURCE." + quoteIdentifier(field))
+                .collect(Collectors.joining(" AND "));
+        List<String> updateFields = fieldNames.stream()
+                .filter(field -> !primaryKeySet.contains(field))
+                .collect(Collectors.toList());
+
+        StringBuilder sql = new StringBuilder()
+                .append("MERGE INTO ")
+                .append(tableIdentifier(tablePath))
+                .append(" AS TARGET USING (VALUES (")
+                .append(placeholders)
+                .append(")) AS SOURCE (")
+                .append(sourceColumns)
+                .append(") ON ")
+                .append(onClause);
+
+        if (!updateFields.isEmpty()) {
+            sql.append(" WHEN MATCHED THEN UPDATE SET ")
+                    .append(updateFields.stream()
+                            .map(field -> "TARGET." + quoteIdentifier(field)
+                                    + " = SOURCE." + quoteIdentifier(field))
+                            .collect(Collectors.joining(", ")));
+        }
+
+        sql.append(" WHEN NOT MATCHED THEN INSERT (")
+                .append(sourceColumns)
+                .append(") VALUES (")
+                .append(fieldNames.stream()
+                        .map(field -> "SOURCE." + quoteIdentifier(field))
+                        .collect(Collectors.joining(", ")))
+                .append(");");
+        return Optional.of(sql.toString());
+    }
+
+    @Override
+    public PreparedStatement prepareReadStatement(
+            Connection connection, String sql, int fetchSize) throws SQLException {
+        PreparedStatement statement = connection.prepareStatement(
+                sql, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
+        if (fetchSize > 0) {
+            statement.setFetchSize(fetchSize);
+        }
+        return statement;
+    }
+
+    @Override
+    public Map<String, String> defaultConnectionProperties() {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        result.put("responseBuffering", "adaptive");
+        return Collections.unmodifiableMap(result);
+    }
+
+    @Override
+    public Optional<String> buildHashPartitionPredicate(
+            Column column, int bucket, int bucketCount) {
+        if (column == null) {
+            throw new IllegalArgumentException("column must not be null");
+        }
+        if (bucketCount <= 0) {
+            throw new IllegalArgumentException("bucketCount must be greater than 0");
+        }
+        if (bucket < 0 || bucket >= bucketCount) {
+            throw new IllegalArgumentException(
+                    "bucket must be between 0 and bucketCount - 1");
+        }
+        return Optional.of(
+                "(ABS(CAST(CHECKSUM(CAST(" + quoteIdentifier(column.getName())
+                        + " AS NVARCHAR(4000))) AS BIGINT)) % "
+                        + bucketCount + ") = " + bucket);
+    }
+
+    private String resolveDatabase(TablePath tablePath) {
+        if (JdbcDialect.hasText(databaseName)) {
+            return databaseName.trim();
+        }
+        /*
+         * When databaseName is absent from the URL, rely on the connection's
+         * default database instead of leaking a source database into Sink SQL.
+         */
+        return null;
+    }
+
+    private String resolveSchema(TablePath tablePath, String resolvedDatabase) {
+        String pathDatabase = tablePath.getDatabaseName();
+        String pathSchema = tablePath.getSchemaName();
+        if (JdbcDialect.hasText(pathSchema)
+                && (!JdbcDialect.hasText(pathDatabase)
+                || !JdbcDialect.hasText(databaseName)
+                || databaseName.equalsIgnoreCase(pathDatabase))) {
+            return pathSchema.trim();
+        }
+        if (JdbcDialect.hasText(connectionConfig.getSchema())) {
+            return connectionConfig.getSchema().trim();
+        }
+        if (JdbcDialect.hasText(pathSchema)
+                && (!JdbcDialect.hasText(resolvedDatabase)
+                || resolvedDatabase.equalsIgnoreCase(pathDatabase))) {
+            return pathSchema.trim();
+        }
+        return DEFAULT_SCHEMA;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerDialectFactory.java
@@ -1,0 +1,29 @@
+package com.link.up.connector.jdbc.core.dialect.sqlserver;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/** Factory for the bounded SQL Server JDBC dialect. */
+@AutoService(JdbcDialectFactory.class)
+public final class SqlServerDialectFactory
+        implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.SQLSERVER;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return SqlServerJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(
+            JdbcConnectionConfig connectionConfig) {
+        return new SqlServerDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerJdbcRowConverter.java
@@ -1,0 +1,14 @@
+package com.link.up.connector.jdbc.core.dialect.sqlserver;
+
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+/** SQL Server JDBC row converter. */
+public final class SqlServerJdbcRowConverter
+        extends AbstractJdbcRowConverter {
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.SQLSERVER;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerJdbcUrl.java
@@ -1,0 +1,159 @@
+package com.link.up.connector.jdbc.core.dialect.sqlserver;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/** Minimal parser for Microsoft SQL Server JDBC URLs. */
+public final class SqlServerJdbcUrl {
+
+    private static final String PREFIX = "jdbc:sqlserver://";
+
+    private SqlServerJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return url != null
+                && url.trim().toLowerCase(Locale.ROOT).startsWith(PREFIX);
+    }
+
+    /** Returns databaseName/database from the URL, or null when the driver default is used. */
+    public static String databaseName(String url) {
+        Parsed parsed = parse(url);
+        for (String property : parsed.properties) {
+            int separator = property.indexOf('=');
+            if (separator <= 0) {
+                continue;
+            }
+            String key = property.substring(0, separator).trim();
+            if (!"databasename".equalsIgnoreCase(key)
+                    && !"database".equalsIgnoreCase(key)) {
+                continue;
+            }
+            String value = property.substring(separator + 1).trim();
+            return unescape(value);
+        }
+        return null;
+    }
+
+    /** Replaces or appends databaseName while preserving the other URL properties. */
+    public static String withDatabase(String url, String databaseName) {
+        if (!hasText(databaseName)) {
+            throw new IllegalArgumentException("databaseName must not be empty");
+        }
+        Parsed parsed = parse(url);
+        List<String> properties = new ArrayList<String>(parsed.properties.size() + 1);
+        boolean replaced = false;
+        for (String property : parsed.properties) {
+            int separator = property.indexOf('=');
+            if (separator > 0) {
+                String key = property.substring(0, separator).trim();
+                if ("databasename".equalsIgnoreCase(key)
+                        || "database".equalsIgnoreCase(key)) {
+                    if (!replaced) {
+                        properties.add("databaseName=" + escape(databaseName.trim()));
+                        replaced = true;
+                    }
+                    continue;
+                }
+            }
+            if (hasText(property)) {
+                properties.add(property);
+            }
+        }
+        if (!replaced) {
+            properties.add("databaseName=" + escape(databaseName.trim()));
+        }
+        StringBuilder result = new StringBuilder(parsed.serverPart);
+        for (String property : properties) {
+            result.append(';').append(property);
+        }
+        return result.toString();
+    }
+
+    private static Parsed parse(String url) {
+        if (!accepts(url)) {
+            throw new IllegalArgumentException("非法 SQL Server JDBC URL：" + url);
+        }
+        String normalized = url.trim();
+        int propertyStart = findPropertyStart(normalized);
+        if (propertyStart < 0) {
+            return new Parsed(normalized, new ArrayList<String>());
+        }
+        return new Parsed(
+                normalized.substring(0, propertyStart),
+                splitProperties(normalized.substring(propertyStart + 1)));
+    }
+
+    private static int findPropertyStart(String value) {
+        int braces = 0;
+        for (int i = PREFIX.length(); i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '{') {
+                braces++;
+            } else if (c == '}' && braces > 0) {
+                braces--;
+            } else if (c == ';' && braces == 0) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static List<String> splitProperties(String value) {
+        List<String> result = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+        int braces = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c == '{') {
+                braces++;
+                current.append(c);
+            } else if (c == '}' && braces > 0) {
+                braces--;
+                current.append(c);
+            } else if (c == ';' && braces == 0) {
+                result.add(current.toString().trim());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        if (current.length() > 0) {
+            result.add(current.toString().trim());
+        }
+        return result;
+    }
+
+    private static String escape(String value) {
+        if (value.indexOf(';') < 0
+                && value.indexOf('=') < 0
+                && value.indexOf('{') < 0
+                && value.indexOf('}') < 0) {
+            return value;
+        }
+        return "{" + value.replace("}", "}}") + "}";
+    }
+
+    private static String unescape(String value) {
+        if (value.length() >= 2 && value.charAt(0) == '{'
+                && value.charAt(value.length() - 1) == '}') {
+            return value.substring(1, value.length() - 1).replace("}}", "}").trim();
+        }
+        return value.trim();
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private static final class Parsed {
+        private final String serverPart;
+        private final List<String> properties;
+
+        private Parsed(String serverPart, List<String> properties) {
+            this.serverPart = serverPart;
+            this.properties = properties;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerTypeMapper.java
@@ -1,0 +1,405 @@
+package com.link.up.connector.jdbc.core.dialect.sqlserver;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
+
+/** SQL Server type mapping for bounded Source/Sink jobs. */
+public final class SqlServerTypeMapper implements JdbcTypeMapper {
+
+    private static final int MAX_DECIMAL_PRECISION = 38;
+    private static final int MAX_TEMPORAL_PRECISION = 7;
+    private static final long MAX_NVARCHAR_LENGTH = 4000L;
+    private static final long MAX_VARBINARY_LENGTH = 8000L;
+
+    @Override
+    public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+        String name = firstText(
+                metadata.getColumnLabel(columnIndex),
+                metadata.getColumnName(columnIndex));
+        String nativeType = metadata.getColumnTypeName(columnIndex);
+        int precision = metadata.getPrecision(columnIndex);
+        int scale = metadata.getScale(columnIndex);
+        FluxDataType<?> type = mapNativeType(
+                nativeType, metadata.getColumnType(columnIndex), precision, scale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(metadata.isNullable(columnIndex)
+                        != ResultSetMetaData.columnNoNulls)
+                .sourceType(buildMetadataSourceType(nativeType, precision, scale));
+        applyProperties(builder, type, nativeType, precision, precision, scale);
+        return builder.build();
+    }
+
+    /** Maps one sys.columns row returned by SqlServerCatalog. */
+    public Column toColumn(ResultSet row) throws SQLException {
+        String name = row.getString("COLUMN_NAME");
+        String nativeType = row.getString("DATA_TYPE");
+        Integer maxLength = integer(row, "MAX_LENGTH");
+        Integer precision = integer(row, "NUMERIC_PRECISION");
+        Integer scale = integer(row, "NUMERIC_SCALE");
+        int p = value(precision);
+        int s = value(scale);
+        FluxDataType<?> type = mapNativeType(nativeType, Types.OTHER, p, s);
+        long logicalLength = logicalLength(nativeType, maxLength);
+        String sourceType = buildCatalogSourceType(
+                nativeType, maxLength, precision, scale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(row.getBoolean("IS_NULLABLE"))
+                .defaultValue(row.getObject("COLUMN_DEFAULT"))
+                .autoIncrement(row.getBoolean("IS_IDENTITY"))
+                .comment(row.getString("COLUMN_COMMENT"))
+                .sourceType(sourceType);
+        applyProperties(builder, type, nativeType, logicalLength, p, s);
+        return builder.build();
+    }
+
+    @Override
+    public String toDatabaseType(Column column) {
+        return toDatabaseType(column, false);
+    }
+
+    public String toDatabaseType(Column column, boolean preserveSourceType) {
+        if (preserveSourceType && canPreserve(column.getSourceType())) {
+            return column.getSourceType().trim();
+        }
+
+        switch (column.getDataType().getSqlType()) {
+            case STRING:
+                return stringType(column);
+            case BOOLEAN:
+                return "BIT";
+            case TINYINT:
+            case SMALLINT:
+                return "SMALLINT";
+            case INT:
+                return "INT";
+            case BIGINT:
+                return "BIGINT";
+            case FLOAT:
+                return "REAL";
+            case DOUBLE:
+                return "FLOAT";
+            case DECIMAL:
+                return decimalType(column);
+            case BYTES:
+                return binaryType(column);
+            case DATE:
+                return "DATE";
+            case TIME:
+                return temporalType("TIME", column.getPrecision());
+            case TIMESTAMP:
+                return temporalType("DATETIME2", column.getPrecision());
+            case TIMESTAMP_TZ:
+                return temporalType("DATETIMEOFFSET", column.getPrecision());
+            default:
+                throw new IllegalArgumentException(
+                        "SQL Server 不支持 Flux 类型："
+                                + column.getDataType().getSqlType()
+                                + "，column=" + column.getName());
+        }
+    }
+
+    FluxDataType<?> mapNativeType(
+            String sourceType, int jdbcType, int precision, int scale) {
+        String type = baseType(sourceType);
+
+        if ("bit".equals(type)) {
+            return BasicType.BOOLEAN_TYPE;
+        }
+        if ("tinyint".equals(type)) {
+            // SQL Server TINYINT is unsigned (0..255); Java Byte is not lossless.
+            return BasicType.SHORT_TYPE;
+        }
+        if ("smallint".equals(type)) {
+            return BasicType.SHORT_TYPE;
+        }
+        if ("int".equals(type)) {
+            return BasicType.INT_TYPE;
+        }
+        if ("bigint".equals(type)) {
+            return BasicType.LONG_TYPE;
+        }
+        if ("real".equals(type)) {
+            return BasicType.FLOAT_TYPE;
+        }
+        if ("float".equals(type)) {
+            return precision > 0 && precision <= 24
+                    ? BasicType.FLOAT_TYPE
+                    : BasicType.DOUBLE_TYPE;
+        }
+        if ("decimal".equals(type) || "numeric".equals(type)) {
+            return decimal(precision, scale);
+        }
+        if ("money".equals(type)) {
+            return new DecimalType(19, 4);
+        }
+        if ("smallmoney".equals(type)) {
+            return new DecimalType(10, 4);
+        }
+        if ("date".equals(type)) {
+            return BasicType.DATE_TYPE;
+        }
+        if ("time".equals(type)) {
+            return BasicType.TIME_TYPE;
+        }
+        if ("datetimeoffset".equals(type)) {
+            return BasicType.TIMESTAMP_TZ_TYPE;
+        }
+        if ("datetime".equals(type)
+                || "datetime2".equals(type)
+                || "smalldatetime".equals(type)) {
+            return BasicType.TIMESTAMP_TYPE;
+        }
+        if ("timestamp".equals(type) || "rowversion".equals(type)) {
+            // SQL Server timestamp is rowversion, not a temporal value.
+            return BasicType.BYTES_TYPE;
+        }
+        if (isBinary(type)) {
+            return BasicType.BYTES_TYPE;
+        }
+        if (isString(type)) {
+            return BasicType.STRING_TYPE;
+        }
+
+        switch (jdbcType) {
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return BasicType.BOOLEAN_TYPE;
+            case Types.TINYINT:
+            case Types.SMALLINT:
+                return BasicType.SHORT_TYPE;
+            case Types.INTEGER:
+                return BasicType.INT_TYPE;
+            case Types.BIGINT:
+                return BasicType.LONG_TYPE;
+            case Types.REAL:
+                return BasicType.FLOAT_TYPE;
+            case Types.FLOAT:
+            case Types.DOUBLE:
+                return BasicType.DOUBLE_TYPE;
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return decimal(precision, scale);
+            case Types.DATE:
+                return BasicType.DATE_TYPE;
+            case Types.TIME:
+                return BasicType.TIME_TYPE;
+            case Types.TIMESTAMP:
+                return BasicType.TIMESTAMP_TYPE;
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return BasicType.TIMESTAMP_TZ_TYPE;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+            case Types.BLOB:
+                return BasicType.BYTES_TYPE;
+            default:
+                return BasicType.STRING_TYPE;
+        }
+    }
+
+    private static boolean isString(String type) {
+        return type.isEmpty()
+                || "char".equals(type)
+                || "varchar".equals(type)
+                || "nchar".equals(type)
+                || "nvarchar".equals(type)
+                || "text".equals(type)
+                || "ntext".equals(type)
+                || "xml".equals(type)
+                || "uniqueidentifier".equals(type)
+                || "sql_variant".equals(type)
+                || "geometry".equals(type)
+                || "geography".equals(type)
+                || "hierarchyid".equals(type);
+    }
+
+    private static boolean isBinary(String type) {
+        return "binary".equals(type)
+                || "varbinary".equals(type)
+                || "image".equals(type);
+    }
+
+    private static boolean canPreserve(String sourceType) {
+        String type = baseType(sourceType);
+        return "bit".equals(type)
+                || "tinyint".equals(type)
+                || "smallint".equals(type)
+                || "int".equals(type)
+                || "bigint".equals(type)
+                || "real".equals(type)
+                || "float".equals(type)
+                || "decimal".equals(type)
+                || "numeric".equals(type)
+                || "money".equals(type)
+                || "smallmoney".equals(type)
+                || "char".equals(type)
+                || "varchar".equals(type)
+                || "nchar".equals(type)
+                || "nvarchar".equals(type)
+                || "binary".equals(type)
+                || "varbinary".equals(type)
+                || "date".equals(type)
+                || "time".equals(type)
+                || "datetime".equals(type)
+                || "datetime2".equals(type)
+                || "smalldatetime".equals(type)
+                || "datetimeoffset".equals(type)
+                || "uniqueidentifier".equals(type)
+                || "xml".equals(type);
+    }
+
+    private static String stringType(Column column) {
+        Long length = column.getLength();
+        return length != null && length > 0 && length <= MAX_NVARCHAR_LENGTH
+                ? "NVARCHAR(" + length + ")"
+                : "NVARCHAR(MAX)";
+    }
+
+    private static String binaryType(Column column) {
+        Long length = column.getLength();
+        return length != null && length > 0 && length <= MAX_VARBINARY_LENGTH
+                ? "VARBINARY(" + length + ")"
+                : "VARBINARY(MAX)";
+    }
+
+    private static String decimalType(Column column) {
+        int precision = column.getPrecision() == null
+                ? MAX_DECIMAL_PRECISION : column.getPrecision();
+        int scale = column.getScale() == null ? 0 : column.getScale();
+        precision = Math.max(1, Math.min(precision, MAX_DECIMAL_PRECISION));
+        scale = Math.max(0, Math.min(scale, precision));
+        return "DECIMAL(" + precision + "," + scale + ")";
+    }
+
+    private static String temporalType(String type, Integer precision) {
+        if (precision == null || precision <= 0) {
+            return type;
+        }
+        return type + "(" + Math.min(precision, MAX_TEMPORAL_PRECISION) + ")";
+    }
+
+    private static DecimalType decimal(int precision, int scale) {
+        int p = precision <= 0 ? MAX_DECIMAL_PRECISION
+                : Math.min(precision, MAX_DECIMAL_PRECISION);
+        int s = Math.max(0, Math.min(scale, p));
+        return new DecimalType(p, s);
+    }
+
+    private static void applyProperties(
+            Column.Builder builder,
+            FluxDataType<?> dataType,
+            String nativeType,
+            long length,
+            int precision,
+            int scale) {
+        SqlType sqlType = dataType.getSqlType();
+        if (sqlType == SqlType.STRING || sqlType == SqlType.BYTES) {
+            if (length > 0) {
+                builder.length(length);
+            }
+        } else if (sqlType == SqlType.DECIMAL && dataType instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) dataType;
+            builder.precision(decimal.getPrecision());
+            builder.scale(decimal.getScale());
+        } else if (sqlType == SqlType.TIME
+                || sqlType == SqlType.TIMESTAMP
+                || sqlType == SqlType.TIMESTAMP_TZ) {
+            if (scale > 0) {
+                builder.precision(Math.min(scale, MAX_TEMPORAL_PRECISION));
+            }
+        }
+        if ("uniqueidentifier".equals(baseType(nativeType)) && length <= 0) {
+            builder.length(36L);
+        }
+    }
+
+    private static long logicalLength(String nativeType, Integer maxLength) {
+        if (maxLength == null || maxLength <= 0) {
+            return 0L;
+        }
+        String type = baseType(nativeType);
+        if ("nchar".equals(type) || "nvarchar".equals(type)) {
+            return maxLength / 2L;
+        }
+        return maxLength.longValue();
+    }
+
+    private static String buildMetadataSourceType(
+            String nativeType, int precision, int scale) {
+        String type = baseType(nativeType);
+        if ("decimal".equals(type) || "numeric".equals(type)) {
+            return nativeType + "(" + Math.max(1, precision) + "," + Math.max(0, scale) + ")";
+        }
+        if ("time".equals(type) || "datetime2".equals(type)
+                || "datetimeoffset".equals(type)) {
+            return scale > 0 ? nativeType + "(" + Math.min(scale, 7) + ")" : nativeType;
+        }
+        if ("char".equals(type) || "varchar".equals(type)
+                || "nchar".equals(type) || "nvarchar".equals(type)
+                || "binary".equals(type) || "varbinary".equals(type)) {
+            return precision > 0 ? nativeType + "(" + precision + ")" : nativeType;
+        }
+        return nativeType;
+    }
+
+    private static String buildCatalogSourceType(
+            String nativeType,
+            Integer maxLength,
+            Integer precision,
+            Integer scale) {
+        String type = baseType(nativeType);
+        if ("decimal".equals(type) || "numeric".equals(type)) {
+            return nativeType + "(" + Math.max(1, value(precision))
+                    + "," + Math.max(0, value(scale)) + ")";
+        }
+        if ("time".equals(type) || "datetime2".equals(type)
+                || "datetimeoffset".equals(type)) {
+            return value(scale) > 0
+                    ? nativeType + "(" + Math.min(value(scale), 7) + ")" : nativeType;
+        }
+        if ("char".equals(type) || "varchar".equals(type)
+                || "nchar".equals(type) || "nvarchar".equals(type)
+                || "binary".equals(type) || "varbinary".equals(type)) {
+            if (maxLength != null && maxLength == -1) {
+                return nativeType + "(max)";
+            }
+            long length = logicalLength(nativeType, maxLength);
+            return length > 0 ? nativeType + "(" + length + ")" : nativeType;
+        }
+        return nativeType;
+    }
+
+    private static String baseType(String sourceType) {
+        if (sourceType == null) {
+            return "";
+        }
+        String value = sourceType.trim().toLowerCase(Locale.ROOT);
+        int parenthesis = value.indexOf('(');
+        return parenthesis < 0 ? value : value.substring(0, parenthesis).trim();
+    }
+
+    private static Integer integer(ResultSet row, String name) throws SQLException {
+        Object value = row.getObject(name);
+        return value == null ? null : ((Number) value).intValue();
+    }
+
+    private static int value(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private static String firstText(String first, String second) {
+        return first != null && !first.trim().isEmpty() ? first : second;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
@@ -6,12 +6,15 @@ import com.link.up.connector.jdbc.catalog.mysql.MySqlCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.catalog.mysql.MySqlTypeMapper;
 import com.link.up.connector.jdbc.catalog.oracle.OracleCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.catalog.postgres.PostgresCreateTableSqlBuilder;
+import com.link.up.connector.jdbc.catalog.sqlserver.SqlServerCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.oracle.OracleJdbcUrl;
 import com.link.up.connector.jdbc.core.dialect.oracle.OracleTypeMapper;
 import com.link.up.connector.jdbc.core.dialect.postgres.PostgresTypeMapper;
+import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerTypeMapper;
 
 import java.util.Locale;
 
@@ -116,6 +119,33 @@ final class JdbcCreateTableSqlResolver {
                     .build();
         }
 
+        if (DatabaseIdentifier.SQLSERVER
+                .equalsIgnoreCase(
+                        dialect.name())) {
+
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
+            return new SqlServerCreateTableSqlBuilder(
+                    targetPath,
+                    ddlTable,
+                    new SqlServerTypeMapper())
+                    .build();
+        }
+
         /*
          * Future JDBC dialects can add their CREATE TABLE builder here
          * without changing the connector-neutral protocol.
@@ -131,6 +161,53 @@ final class JdbcCreateTableSqlResolver {
                 || tablePath == null) {
 
             return tablePath;
+        }
+
+        if (isSqlServer(
+                connectionConfig)) {
+
+            String database =
+                    SqlServerJdbcUrl.databaseName(
+                            connectionConfig.getUrl());
+
+            String pathDatabase =
+                    tablePath.getDatabaseName();
+
+            String pathSchema =
+                    tablePath.getSchemaName();
+
+            String schema;
+
+            if (!hasText(pathDatabase)) {
+                schema = hasText(pathSchema)
+                        ? pathSchema.trim()
+                        : resolveSqlServerSchema(
+                                connectionConfig);
+            } else if (hasText(database)
+                    && database.equalsIgnoreCase(
+                            pathDatabase)) {
+                schema = hasText(pathSchema)
+                        ? pathSchema.trim()
+                        : resolveSqlServerSchema(
+                                connectionConfig);
+            } else {
+                /*
+                 * Do not leak a MySQL/PostgreSQL/Oracle source database/schema
+                 * into an unqualified SQL Server target.
+                 */
+                schema = resolveSqlServerSchema(
+                        connectionConfig);
+            }
+
+            return hasText(database)
+                    ? TablePath.of(
+                            database,
+                            schema,
+                            tablePath.getTableName())
+                    : TablePath.of(
+                            null,
+                            schema,
+                            tablePath.getTableName());
         }
 
         if (isOracle(
@@ -213,6 +290,15 @@ final class JdbcCreateTableSqlResolver {
                 tablePath.getTableName());
     }
 
+    private static String resolveSqlServerSchema(
+            JdbcConnectionConfig config) {
+
+        return hasText(
+                config.getSchema())
+                ? config.getSchema().trim()
+                : "dbo";
+    }
+
     private static String resolveOracleSchema(
             JdbcConnectionConfig config,
             TablePath tablePath,
@@ -290,6 +376,20 @@ final class JdbcCreateTableSqlResolver {
         }
 
         return OracleJdbcUrl.accepts(
+                config.getUrl());
+    }
+
+    private static boolean isSqlServer(
+            JdbcConnectionConfig config) {
+
+        if (DatabaseIdentifier.SQLSERVER
+                .equalsIgnoreCase(
+                        config.getDialect())) {
+
+            return true;
+        }
+
+        return SqlServerJdbcUrl.accepts(
                 config.getUrl());
     }
 

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCatalogTest.java
@@ -1,0 +1,42 @@
+package com.link.up.connector.jdbc.catalog.sqlserver;
+
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerJdbcUrl;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class SqlServerCatalogTest {
+
+    @Test
+    public void parsesAndRewritesDatabaseName() {
+        String url = "jdbc:sqlserver://127.0.0.1:1433;databaseName=app;encrypt=false";
+        assertEquals("app", SqlServerJdbcUrl.databaseName(url));
+        assertEquals(
+                "jdbc:sqlserver://127.0.0.1:1433;databaseName=master;encrypt=false",
+                SqlServerJdbcUrl.withDatabase(url, "master"));
+    }
+
+    @Test
+    public void catalogExposesDefaultDatabaseBeforeOpen() {
+        SqlServerCatalog catalog = new SqlServerCatalog("sqlserver", config(), "sales");
+        assertEquals("app", catalog.getDefaultDatabase().get());
+    }
+
+    @Test
+    public void sqlServerPropertiesAreNotPollutedByMysqlOptions() {
+        Properties properties = config().toConnectionProperties();
+        assertFalse(properties.containsKey("tinyInt1isBit"));
+    }
+
+    private static JdbcCatalogConfig config() {
+        return new JdbcCatalogConfig(
+                "jdbc:sqlserver://127.0.0.1:1433;databaseName=app;encrypt=false",
+                "sa", "test", "com.microsoft.sqlserver.jdbc.SQLServerDriver",
+                Collections.<String, String>emptyMap(), false);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCreateTableSqlBuilderTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/sqlserver/SqlServerCreateTableSqlBuilderTest.java
@@ -1,0 +1,45 @@
+package com.link.up.connector.jdbc.catalog.sqlserver;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerTypeMapper;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SqlServerCreateTableSqlBuilderTest {
+
+    @Test
+    public void buildsOfflineCreateTableWithIdentityAndComments() {
+        TablePath path = TablePath.of("app", "dbo", "orders");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE)
+                        .nullable(false).autoIncrement(true).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE)
+                        .length(100L).comment("display name").build())
+                .primaryKey(PrimaryKey.of("PK_orders", Arrays.asList("id")))
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .comment("orders table")
+                .build();
+
+        List<String> statements = new SqlServerCreateTableSqlBuilder(
+                path, table, new SqlServerTypeMapper()).buildStatements();
+        String create = statements.get(0);
+        assertTrue(create.contains("CREATE TABLE [app].[dbo].[orders]"));
+        assertTrue(create.contains("[id] BIGINT IDENTITY(1,1) NOT NULL"));
+        assertTrue(create.contains("[name] NVARCHAR(100) NULL"));
+        assertTrue(create.contains("CONSTRAINT [PK_orders] PRIMARY KEY ([id])"));
+        assertEquals(3, statements.size());
+        assertTrue(statements.get(1).contains("sp_addextendedproperty"));
+        assertTrue(statements.get(2).contains("@level2name=N'name'"));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerDialectTest.java
@@ -1,0 +1,83 @@
+package com.link.up.connector.jdbc.core.dialect.sqlserver;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class SqlServerDialectTest {
+
+    @Test
+    public void parsesSchemaTableAndUsesTargetDatabase() {
+        SqlServerDialect dialect = dialect("dbo");
+        assertEquals(
+                TablePath.of(null, "sales", "orders"),
+                dialect.parseTablePath("sales.orders"));
+        assertEquals(
+                "[app].[sales].[orders]",
+                dialect.tableIdentifier(TablePath.of(null, "sales", "orders")));
+    }
+
+    @Test
+    public void foreignSourceDatabaseDoesNotLeakIntoTarget() {
+        SqlServerDialect dialect = dialect("warehouse");
+        assertEquals(
+                "[app].[warehouse].[orders]",
+                dialect.tableIdentifier(TablePath.of("source_db", "public", "orders")));
+    }
+
+    @Test
+    public void escapesBracketIdentifiers() {
+        assertEquals("[a]]b]", dialect(null).quoteIdentifier("a]b"));
+    }
+
+    @Test
+    public void buildsMergeWithJdbcPlaceholders() {
+        String sql = dialect("dbo").buildUpsertSql(
+                TablePath.of(null, "dbo", "orders"),
+                Arrays.asList("id", "name"),
+                Arrays.asList("id")).get();
+        assertTrue(sql.contains("MERGE INTO [app].[dbo].[orders] AS TARGET"));
+        assertTrue(sql.contains("USING (VALUES (?, ?))"));
+        assertTrue(sql.contains("WHEN MATCHED THEN UPDATE SET TARGET.[name] = SOURCE.[name]"));
+        assertTrue(sql.endsWith(";"));
+    }
+
+    @Test
+    public void allPrimaryKeyMergeSkipsUpdate() {
+        String sql = dialect("dbo").buildUpsertSql(
+                TablePath.of("orders"), Arrays.asList("id"), Arrays.asList("id")).get();
+        assertFalse(sql.contains("WHEN MATCHED"));
+        assertTrue(sql.contains("WHEN NOT MATCHED"));
+    }
+
+    @Test
+    public void hashPredicateUsesBigintChecksum() {
+        String predicate = dialect(null).buildHashPartitionPredicate(
+                Column.builder("id", BasicType.INT_TYPE).build(), 1, 4).get();
+        assertEquals(
+                "(ABS(CAST(CHECKSUM(CAST([id] AS NVARCHAR(4000))) AS BIGINT)) % 4) = 1",
+                predicate);
+    }
+
+    private static SqlServerDialect dialect(String schema) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", "jdbc:sqlserver://127.0.0.1:1433;databaseName=app;encrypt=false");
+        values.put("driver", "com.microsoft.sqlserver.jdbc.SQLServerDriver");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        return new SqlServerDialect(
+                JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values)));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/sqlserver/SqlServerTypeMapperTest.java
@@ -1,0 +1,47 @@
+package com.link.up.connector.jdbc.core.dialect.sqlserver;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import org.junit.Test;
+
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+
+public class SqlServerTypeMapperTest {
+
+    private final SqlServerTypeMapper mapper = new SqlServerTypeMapper();
+
+    @Test
+    public void mapsSqlServerNativeTypesWithoutLosingMeaning() {
+        assertEquals(BasicType.SHORT_TYPE,
+                mapper.mapNativeType("tinyint", Types.TINYINT, 3, 0));
+        assertEquals(BasicType.BYTES_TYPE,
+                mapper.mapNativeType("timestamp", Types.BINARY, 8, 0));
+        assertEquals(BasicType.TIMESTAMP_TZ_TYPE,
+                mapper.mapNativeType("datetimeoffset", Types.TIMESTAMP_WITH_TIMEZONE, 34, 7));
+        assertEquals(new DecimalType(19, 4),
+                mapper.mapNativeType("money", Types.DECIMAL, 19, 4));
+    }
+
+    @Test
+    public void mapsFluxTypesToWritableSqlServerTypes() {
+        assertEquals("NVARCHAR(200)", mapper.toDatabaseType(
+                Column.builder("name", BasicType.STRING_TYPE).length(200L).build()));
+        assertEquals("NVARCHAR(MAX)", mapper.toDatabaseType(
+                Column.builder("body", BasicType.STRING_TYPE).length(5000L).build()));
+        assertEquals("VARBINARY(MAX)", mapper.toDatabaseType(
+                Column.builder("payload", BasicType.BYTES_TYPE).length(9000L).build()));
+        assertEquals("DATETIMEOFFSET(7)", mapper.toDatabaseType(
+                Column.builder("created_at", BasicType.TIMESTAMP_TZ_TYPE)
+                        .precision(7).build()));
+    }
+
+    @Test
+    public void rowversionIsNotPreservedAsWritableTimestamp() {
+        assertEquals("VARBINARY(8)", mapper.toDatabaseType(
+                Column.builder("version", BasicType.BYTES_TYPE)
+                        .length(8L).sourceType("timestamp").build(), true));
+    }
+}


### PR DESCRIPTION
## Summary
- add SQL Server JDBC dialect, URL parsing, Catalog, type mapping and row conversion
- reuse the existing bounded `JdbcSource` / `JdbcSink` path for split reads and batch writes
- support SQL Server `database.schema.table` semantics, bracket quoting, `MERGE` UPSERT, hash partitioning and offline `CREATE TABLE`
- handle SQL Server `timestamp` / `rowversion` as bytes, unsigned `tinyint` as `Short`, and `datetimeoffset` as a timezone-aware timestamp
- add `IDENTITY`, extended-property comments, `databaseName` URL handling and target database/schema normalization
- extend the connector adaptation guide with SQL Server correctness notes

## Scope
Offline/bounded JDBC only. This PR intentionally does **not** include SQL Server CDC, Change Tracking, Debezium, streaming checkpoint state, XA/exactly-once writers, or runtime schema events.

## Dependency
This is a stacked PR on top of #90 (`feat/oracle-jdbc-offline`), which is stacked on #89. After #90 merges, this PR can be retargeted accordingly.

## Validation
- Java 8 type compilation passed for the SQL Server production classes, resolver changes, and added unit tests against stubs matching the inspected project APIs.
- Executed the SQL Server JDBC URL parsing / `databaseName` rewrite path locally.
- Added unit tests for dialect/MERGE/hash behavior, type mapping, Catalog URL/properties, and CREATE TABLE/identity/comments.
- Full Maven test suite was not run in this environment because the full repository/dependency graph was not checked out locally.