### PR TITLE
feat(jdbc): add OceanBase offline source and sink

### DIFF
--- a/CONNECTOR_ADAPTATION.md
+++ b/CONNECTOR_ADAPTATION.md
@@ -4,7 +4,7 @@ Yak Link Up 优先复用已有执行模型，再增加数据库差异层。新�
 
 ## JDBC 数据库适配
 
-以 MySQL、PostgreSQL、Oracle、SQL Server 为参考，一个新的 JDBC 数据库通常只需要补齐：
+以 MySQL、PostgreSQL、Oracle、SQL Server、OceanBase 为参考，一个新的 JDBC 数据库通常只需要补齐：
 
 1. **Driver**
    - 在 `link-up-connector-jdbc` 引入 JDBC Driver。
@@ -35,10 +35,12 @@ Yak Link Up 优先复用已有执行模型，再增加数据库差异层。新�
 
 ## 数据库差异不要强行抹平
 
-适配时保留真正影响正确性的差异。例如 PostgreSQL cursor fetch 需要事务；Oracle `DATE` 包含时分秒、UPSERT 使用 `MERGE`；SQL Server 使用 `database.schema.table`，`timestamp` 实际是 `rowversion`，`tinyint` 是 0~255，`datetimeoffset` 需要保留时区偏移。这些差异应放在 Dialect/TypeMapper/Catalog 中，而不是塞进公共 Source/Sink。
+适配时保留真正影响正确性的差异。例如 PostgreSQL cursor fetch 需要事务；Oracle `DATE` 包含时分秒、UPSERT 使用 `MERGE`；SQL Server 使用 `database.schema.table`，`timestamp` 实际是 `rowversion`，`tinyint` 是 0~255，`datetimeoffset` 需要保留时区偏移。
+
+OceanBase 同时提供 MySQL 与 Oracle 兼容模式。Yak Link Up 通过 `compatible_mode=mysql|oracle` 显式选择语义，不根据字段或 SQL 自动猜测。MySQL 模式复用 MySQL 类型、UPSERT 与 DDL 规则；Oracle 模式复用 Oracle 类型、`MERGE`、Schema 与 DDL 规则。兼容模式分流属于 Dialect/Catalog 差异，不进入公共 Source/Sink。
 
 ## 能力边界
 
 JDBC Offline Connector 默认只负责全量读取、分片读取和批量写入。
 
-CDC、Binlog/WAL、Oracle LogMiner/SCN、SQL Server CDC/Change Tracking、Replication Slot、流式 Checkpoint、XA / Exactly Once 等能力应作为独立 Stage 设计，不直接塞进离线 JDBC 方言。这样新增 DB2、达梦等数据库时，只需要实现数据库差异，而不需要重复执行框架。
+CDC、Binlog/WAL、Oracle LogMiner/SCN、SQL Server CDC/Change Tracking、OceanBase Binlog/LogProxy/CLog、Replication Slot、流式 Checkpoint、XA / Exactly Once 等能力应作为独立 Stage 设计，不直接塞进离线 JDBC 方言。这样新增 DB2、达梦等数据库时，只需要实现数据库差异，而不需要重复执行框架。

--- a/link-up-connectors/link-up-connector-jdbc/pom.xml
+++ b/link-up-connectors/link-up-connector-jdbc/pom.xml
@@ -68,6 +68,11 @@
             <artifactId>mssql-jdbc</artifactId>
             <version>9.2.1.jre8</version>
         </dependency>
+        <dependency>
+            <groupId>com.oceanbase</groupId>
+            <artifactId>oceanbase-client</artifactId>
+            <version>2.4.12</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/oceanbase/OceanBaseCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/oceanbase/OceanBaseCatalog.java
@@ -1,0 +1,330 @@
+package com.link.up.connector.jdbc.catalog.oceanbase;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlCatalog;
+import com.link.up.connector.jdbc.core.dialect.oceanbase.OceanBaseCompatibleMode;
+import com.link.up.connector.jdbc.core.dialect.oceanbase.OceanBaseJdbcUrl;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * OceanBase mode-aware Catalog facade.
+ *
+ * <p>MySQL-compatible mode reuses the mature MySQL Catalog through the MySQL
+ * wire protocol. Oracle-compatible mode uses the Oracle metadata/DDL rules
+ * with the OceanBase JDBC driver.</p>
+ */
+public final class OceanBaseCatalog
+        implements WritableCatalog {
+
+    public static final String DIALECT = "oceanbase";
+
+    private static final String MYSQL_DRIVER =
+            "com.mysql.cj.jdbc.Driver";
+
+    private final String catalogName;
+    private final OceanBaseCompatibleMode mode;
+    private final String defaultDatabase;
+    private final WritableCatalog delegate;
+
+    public OceanBaseCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            OceanBaseCompatibleMode mode,
+            String defaultSchema) {
+
+        if (catalogName == null
+                || catalogName.trim().isEmpty()) {
+
+            throw new IllegalArgumentException(
+                    "catalogName must not be empty");
+        }
+
+        this.catalogName =
+                catalogName.trim();
+
+        this.mode =
+                Objects.requireNonNull(
+                        mode,
+                        "mode must not be null");
+
+        Objects.requireNonNull(
+                config,
+                "config must not be null");
+
+        this.defaultDatabase =
+                OceanBaseJdbcUrl.databaseName(
+                        config.getUrl());
+
+        if (mode.isMySql()) {
+            JdbcCatalogConfig mysqlConfig =
+                    new JdbcCatalogConfig(
+                            OceanBaseJdbcUrl.toMySqlUrl(
+                                    config.getUrl()),
+                            config.getUsername(),
+                            config.getPassword(),
+                            MYSQL_DRIVER,
+                            config.getProperties(),
+                            config.isIntTypeNarrowing());
+
+            this.delegate =
+                    new MySqlCatalog(
+                            catalogName,
+                            mysqlConfig);
+        } else {
+            this.delegate =
+                    new OceanBaseOracleCatalog(
+                            catalogName,
+                            config,
+                            defaultSchema);
+        }
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public void open()
+            throws CatalogException {
+
+        delegate.open();
+    }
+
+    @Override
+    public void close()
+            throws CatalogException {
+
+        delegate.close();
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase()
+            throws CatalogException {
+
+        return defaultDatabase == null
+                ? delegate.getDefaultDatabase()
+                : Optional.of(defaultDatabase);
+    }
+
+    @Override
+    public List<String> listDatabases()
+            throws CatalogException {
+
+        return delegate.listDatabases();
+    }
+
+    @Override
+    public List<String> listSchemas(
+            String databaseName)
+            throws CatalogException {
+
+        return delegate.listSchemas(
+                normalizeDatabase(
+                        databaseName));
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String databaseName,
+            String schemaName)
+            throws CatalogException {
+
+        if (mode.isMySql()) {
+            return delegate.listTables(
+                    normalizeDatabase(
+                            databaseName),
+                    null);
+        }
+
+        return delegate.listTables(
+                normalizeDatabase(
+                        databaseName),
+                schemaName);
+    }
+
+    @Override
+    public boolean tableExists(
+            TablePath tablePath)
+            throws CatalogException {
+
+        return delegate.tableExists(
+                normalizePath(
+                        tablePath));
+    }
+
+    @Override
+    public CatalogTable getTable(
+            TablePath tablePath)
+            throws CatalogException,
+            TableNotFoundException {
+
+        return delegate.getTable(
+                normalizePath(
+                        tablePath));
+    }
+
+    @Override
+    public void createDatabase(
+            String databaseName,
+            boolean ignoreIfExists)
+            throws CatalogException,
+            DatabaseAlreadyExistsException {
+
+        delegate.createDatabase(
+                databaseName,
+                ignoreIfExists);
+    }
+
+    @Override
+    public void dropDatabase(
+            String databaseName,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            DatabaseNotFoundException {
+
+        delegate.dropDatabase(
+                databaseName,
+                ignoreIfNotExists);
+    }
+
+    @Override
+    public void createTable(
+            CatalogTable table,
+            boolean ignoreIfExists)
+            throws CatalogException,
+            DatabaseNotFoundException,
+            TableAlreadyExistsException {
+
+        Objects.requireNonNull(
+                table,
+                "table must not be null");
+
+        TablePath targetPath =
+                normalizePath(
+                        table.getTablePath());
+
+        delegate.createTable(
+                table.getTablePath()
+                        .equals(targetPath)
+                        ? table
+                        : table.withPath(
+                                targetPath),
+                ignoreIfExists);
+    }
+
+    @Override
+    public void addColumn(
+            TablePath tablePath,
+            Column column)
+            throws CatalogException,
+            TableNotFoundException {
+
+        delegate.addColumn(
+                normalizePath(
+                        tablePath),
+                column);
+    }
+
+    @Override
+    public void dropTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            TableNotFoundException {
+
+        delegate.dropTable(
+                normalizePath(
+                        tablePath),
+                ignoreIfNotExists);
+    }
+
+    @Override
+    public void truncateTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            TableNotFoundException {
+
+        delegate.truncateTable(
+                normalizePath(
+                        tablePath),
+                ignoreIfNotExists);
+    }
+
+    private TablePath normalizePath(
+            TablePath tablePath) {
+
+        Objects.requireNonNull(
+                tablePath,
+                "tablePath must not be null");
+
+        if (mode.isOracle()) {
+            /*
+             * Oracle-compatible delegate resolves schema and guarantees that
+             * a foreign source database is not leaked into target SQL.
+             */
+            return tablePath;
+        }
+
+        String database =
+                defaultDatabase;
+
+        if (database == null
+                || database.trim().isEmpty()) {
+
+            database =
+                    tablePath.getDatabaseName();
+        }
+
+        if ((database == null
+                || database.trim().isEmpty())
+                && tablePath.getSchemaName()
+                != null) {
+
+            database =
+                    tablePath.getSchemaName();
+        }
+
+        if (database == null
+                || database.trim().isEmpty()) {
+
+            throw new IllegalArgumentException(
+                    "OceanBase MySQL 模式缺少目标 database，"
+                            + "请在 JDBC URL 或 table path 中指定");
+        }
+
+        return TablePath.of(
+                database.trim(),
+                tablePath.getTableName());
+    }
+
+    private String normalizeDatabase(
+            String requested) {
+
+        if (defaultDatabase == null
+                || defaultDatabase.trim().isEmpty()) {
+
+            return requested;
+        }
+
+        /*
+         * A configured URL database is the target/source database for this
+         * bounded connector instance. It also prevents a foreign source path
+         * from accidentally routing writes into another OceanBase database.
+         */
+        return defaultDatabase;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/oceanbase/OceanBaseCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/oceanbase/OceanBaseCatalogFactory.java
@@ -1,0 +1,94 @@
+package com.link.up.connector.jdbc.catalog.oceanbase;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.factory.Factory;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.config.JdbcCommonOptions;
+import com.link.up.connector.jdbc.core.dialect.oceanbase.OceanBaseCompatibleMode;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * OceanBase Catalog factory.
+ */
+@AutoService(Factory.class)
+public final class OceanBaseCatalogFactory
+        implements CatalogFactory {
+
+    private static final String DEFAULT_DRIVER =
+            "com.oceanbase.jdbc.Driver";
+
+    @Override
+    public String factoryIdentifier() {
+        return OceanBaseCatalog.DIALECT;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            ReadonlyConfig options) {
+
+        String url =
+                options.get(
+                        JdbcCommonOptions.URL);
+
+        String username =
+                options.getOptional(
+                        JdbcCommonOptions.USERNAME)
+                        .orElse(null);
+
+        String password =
+                options.getOptional(
+                        JdbcCommonOptions.PASSWORD)
+                        .orElse(null);
+
+        String driver =
+                options.getOptional(
+                        JdbcCommonOptions.DRIVER)
+                        .orElse(
+                                DEFAULT_DRIVER);
+
+        Map<String, String> properties =
+                options.getOptional(
+                        JdbcCommonOptions.PROPERTIES)
+                        .orElse(
+                                Collections.emptyMap());
+
+        boolean intTypeNarrowing =
+                options.getOptional(
+                        JdbcCommonOptions
+                                .INT_TYPE_NARROWING)
+                        .orElse(false);
+
+        String schema =
+                options.getOptional(
+                        JdbcCommonOptions.SCHEMA)
+                        .orElse(null);
+
+        OceanBaseCompatibleMode mode =
+                OceanBaseCompatibleMode.from(
+                        options.getOptional(
+                                JdbcCommonOptions
+                                        .COMPATIBLE_MODE)
+                                .orElse(null));
+
+        JdbcCatalogConfig config =
+                new JdbcCatalogConfig(
+                        url,
+                        username,
+                        password,
+                        driver,
+                        properties,
+                        intTypeNarrowing);
+
+        return new OceanBaseCatalog(
+                catalogName,
+                config,
+                mode,
+                schema);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/oceanbase/OceanBaseOracleCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/oceanbase/OceanBaseOracleCatalog.java
@@ -1,0 +1,810 @@
+package com.link.up.connector.jdbc.catalog.oceanbase;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.oracle.OracleCatalog;
+import com.link.up.connector.jdbc.catalog.oracle.OracleCreateTableSqlBuilder;
+import com.link.up.connector.jdbc.core.dialect.oceanbase.OceanBaseJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.oracle.OracleTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * OceanBase Oracle-compatible offline Catalog.
+ *
+ * <p>It deliberately contains only bounded metadata and startup DDL. Runtime
+ * schema events, LogProxy/CLog and CDC are outside this adapter.</p>
+ */
+final class OceanBaseOracleCatalog
+        implements WritableCatalog {
+
+    private static final String SELECT_COLUMNS_SQL =
+            "SELECT c.COLUMN_NAME, c.DATA_TYPE, c.DATA_LENGTH, c.CHAR_LENGTH, "
+                    + "c.DATA_PRECISION, c.DATA_SCALE, c.NULLABLE, c.DATA_DEFAULT, "
+                    + "cc.COMMENTS AS COLUMN_COMMENT "
+                    + "FROM ALL_TAB_COLUMNS c LEFT JOIN ALL_COL_COMMENTS cc "
+                    + "ON cc.OWNER=c.OWNER AND cc.TABLE_NAME=c.TABLE_NAME "
+                    + "AND cc.COLUMN_NAME=c.COLUMN_NAME "
+                    + "WHERE c.OWNER=? AND c.TABLE_NAME=? ORDER BY c.COLUMN_ID";
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String databaseName;
+    private final String defaultSchema;
+    private final OracleTypeMapper typeMapper =
+            new OracleTypeMapper();
+
+    private volatile boolean opened;
+
+    OceanBaseOracleCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            String defaultSchema) {
+
+        if (!hasText(catalogName)) {
+            throw new IllegalArgumentException(
+                    "catalogName must not be empty");
+        }
+
+        this.catalogName = catalogName.trim();
+        this.config =
+                Objects.requireNonNull(
+                        config,
+                        "config must not be null");
+
+        this.databaseName =
+                requireDatabase(
+                        OceanBaseJdbcUrl.databaseName(
+                                config.getUrl()));
+
+        this.defaultSchema =
+                defaultSchema(
+                        defaultSchema,
+                        config.getUsername());
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.of(databaseName);
+    }
+
+    @Override
+    public synchronized void open()
+            throws CatalogException {
+
+        if (opened) {
+            return;
+        }
+
+        loadDriver();
+
+        try (Connection connection = connection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException(
+                        "OceanBase Oracle Catalog 连接校验失败："
+                                + config.getUrl());
+            }
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "OceanBase Oracle Catalog 连接失败："
+                            + config.getUrl(),
+                    e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public List<String> listDatabases() {
+        checkOpened();
+        return Collections.singletonList(
+                databaseName);
+    }
+
+    @Override
+    public List<String> listSchemas(
+            String database)
+            throws CatalogException {
+
+        checkDatabase(database);
+        checkOpened();
+
+        try (Connection connection = connection();
+             ResultSet resultSet =
+                     connection.getMetaData()
+                             .getSchemas()) {
+
+            List<String> schemas =
+                    new ArrayList<String>();
+
+            while (resultSet.next()) {
+                String schema =
+                        normalize(
+                                resultSet.getString(
+                                        "TABLE_SCHEM"));
+
+                if (schema != null) {
+                    schemas.add(schema);
+                }
+            }
+
+            Collections.sort(schemas);
+            return schemas;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 OceanBase Oracle Schema 列表失败",
+                    e);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String database,
+            String schemaName)
+            throws CatalogException {
+
+        checkDatabase(database);
+        checkOpened();
+
+        String schema = schema(schemaName);
+
+        try (Connection connection = connection();
+             ResultSet resultSet =
+                     connection.getMetaData()
+                             .getTables(
+                                     null,
+                                     schema,
+                                     "%",
+                                     new String[]{"TABLE"})) {
+
+            List<TablePath> tables =
+                    new ArrayList<TablePath>();
+
+            while (resultSet.next()) {
+                String table =
+                        normalize(
+                                resultSet.getString(
+                                        "TABLE_NAME"));
+
+                if (table != null
+                        && !table.startsWith("BIN$")) {
+
+                    tables.add(
+                            TablePath.of(
+                                    databaseName,
+                                    schema,
+                                    table));
+                }
+            }
+
+            tables.sort(
+                    Comparator.comparing(
+                            TablePath::getTableName));
+
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 OceanBase Oracle 表列表失败，schema="
+                            + schema,
+                    e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(
+            TablePath tablePath)
+            throws CatalogException {
+
+        checkOpened();
+        TablePath path =
+                normalizePath(tablePath);
+
+        try (Connection connection = connection();
+             ResultSet resultSet =
+                     connection.getMetaData()
+                             .getTables(
+                                     null,
+                                     path.getSchemaName(),
+                                     path.getTableName(),
+                                     new String[]{"TABLE"})) {
+
+            return resultSet.next();
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "检查 OceanBase Oracle 表是否存在失败，table="
+                            + path,
+                    e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(
+            TablePath tablePath)
+            throws CatalogException,
+            TableNotFoundException {
+
+        checkOpened();
+        TablePath path =
+                normalizePath(tablePath);
+
+        try (Connection connection = connection()) {
+            List<Column> columns =
+                    columns(
+                            connection,
+                            path);
+
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(
+                        catalogName,
+                        path);
+            }
+
+            DatabaseMetaData metadata =
+                    connection.getMetaData();
+
+            TableSchema schema =
+                    TableSchema.builder()
+                            .columns(columns)
+                            .primaryKey(
+                                    primaryKey(
+                                            metadata,
+                                            path))
+                            .build();
+
+            CatalogTable.Builder table =
+                    CatalogTable.builder(
+                                    path,
+                                    schema)
+                            .option(
+                                    OracleCatalog
+                                            .TABLE_OPTION_DIALECT,
+                                    OracleCatalog.DIALECT);
+
+            String comment =
+                    tableComment(
+                            metadata,
+                            path);
+
+            if (hasText(comment)) {
+                table.comment(comment);
+            }
+
+            return table.build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 OceanBase Oracle 表结构失败，table="
+                            + path,
+                    e);
+        }
+    }
+
+    @Override
+    public void createDatabase(
+            String database,
+            boolean ignoreIfExists)
+            throws CatalogException,
+            DatabaseAlreadyExistsException {
+
+        throw new UnsupportedOperationException(
+                "OceanBase Oracle Offline Catalog 不负责 CREATE DATABASE");
+    }
+
+    @Override
+    public void dropDatabase(
+            String database,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            DatabaseNotFoundException {
+
+        throw new UnsupportedOperationException(
+                "OceanBase Oracle Offline Catalog 不负责 DROP DATABASE");
+    }
+
+    @Override
+    public void createTable(
+            CatalogTable table,
+            boolean ignoreIfExists)
+            throws CatalogException,
+            DatabaseNotFoundException,
+            TableAlreadyExistsException {
+
+        checkOpened();
+
+        TablePath path =
+                normalizePath(
+                        table.getTablePath());
+
+        if (tableExists(path)) {
+            if (ignoreIfExists) {
+                return;
+            }
+
+            throw new TableAlreadyExistsException(
+                    catalogName,
+                    path);
+        }
+
+        CatalogTable ddlTable =
+                table.getTablePath()
+                        .equals(path)
+                        ? table
+                        : table.withPath(path);
+
+        OracleCreateTableSqlBuilder builder =
+                new OracleCreateTableSqlBuilder(
+                        path,
+                        ddlTable,
+                        typeMapper);
+
+        try (Connection connection = connection()) {
+            for (String sql :
+                    builder.buildStatements()) {
+
+                execute(connection, sql);
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "创建 OceanBase Oracle 表失败，table="
+                            + path,
+                    e);
+        }
+    }
+
+    @Override
+    public void addColumn(
+            TablePath tablePath,
+            Column column)
+            throws CatalogException,
+            TableNotFoundException {
+
+        checkOpened();
+
+        TablePath path =
+                normalizePath(tablePath);
+
+        if (!tableExists(path)) {
+            throw new TableNotFoundException(
+                    catalogName,
+                    path);
+        }
+
+        CatalogTable table =
+                getTable(path);
+
+        String definition =
+                new OracleCreateTableSqlBuilder(
+                        path,
+                        table,
+                        typeMapper)
+                        .buildColumnDefinition(
+                                column,
+                                false);
+
+        try (Connection connection = connection()) {
+            execute(
+                    connection,
+                    "ALTER TABLE "
+                            + quoteTable(path)
+                            + " ADD "
+                            + definition);
+
+            if (hasText(column.getComment())) {
+                execute(
+                        connection,
+                        "COMMENT ON COLUMN "
+                                + quoteTable(path)
+                                + "."
+                                + quote(
+                                        column.getName())
+                                + " IS '"
+                                + literal(
+                                        column.getComment())
+                                + "'");
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "增加 OceanBase Oracle 字段失败，table="
+                            + path
+                            + ", column="
+                            + column.getName(),
+                    e);
+        }
+    }
+
+    @Override
+    public void dropTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            TableNotFoundException {
+
+        tableDdl(
+                tablePath,
+                ignoreIfNotExists,
+                "DROP TABLE ",
+                "删除");
+    }
+
+    @Override
+    public void truncateTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            TableNotFoundException {
+
+        tableDdl(
+                tablePath,
+                ignoreIfNotExists,
+                "TRUNCATE TABLE ",
+                "清空");
+    }
+
+    private void tableDdl(
+            TablePath tablePath,
+            boolean ignoreIfNotExists,
+            String prefix,
+            String operation)
+            throws CatalogException,
+            TableNotFoundException {
+
+        checkOpened();
+
+        TablePath path =
+                normalizePath(tablePath);
+
+        if (!tableExists(path)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+
+            throw new TableNotFoundException(
+                    catalogName,
+                    path);
+        }
+
+        try (Connection connection = connection()) {
+            execute(
+                    connection,
+                    prefix
+                            + quoteTable(path));
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    operation
+                            + " OceanBase Oracle 表失败，table="
+                            + path,
+                    e);
+        }
+    }
+
+    private List<Column> columns(
+            Connection connection,
+            TablePath path)
+            throws SQLException {
+
+        try (PreparedStatement statement =
+                     connection.prepareStatement(
+                             SELECT_COLUMNS_SQL)) {
+
+            statement.setString(
+                    1,
+                    path.getSchemaName());
+
+            statement.setString(
+                    2,
+                    path.getTableName());
+
+            try (ResultSet resultSet =
+                         statement.executeQuery()) {
+
+                List<Column> columns =
+                        new ArrayList<Column>();
+
+                while (resultSet.next()) {
+                    columns.add(
+                            typeMapper.toColumn(
+                                    resultSet));
+                }
+
+                return columns;
+            }
+        }
+    }
+
+    private PrimaryKey primaryKey(
+            DatabaseMetaData metadata,
+            TablePath path)
+            throws SQLException {
+
+        try (ResultSet resultSet =
+                     metadata.getPrimaryKeys(
+                             null,
+                             path.getSchemaName(),
+                             path.getTableName())) {
+
+            String name = null;
+            List<PrimaryKeyColumn> keys =
+                    new ArrayList<PrimaryKeyColumn>();
+
+            while (resultSet.next()) {
+                if (name == null) {
+                    name =
+                            resultSet.getString(
+                                    "PK_NAME");
+                }
+
+                keys.add(
+                        new PrimaryKeyColumn(
+                                resultSet.getShort(
+                                        "KEY_SEQ"),
+                                resultSet.getString(
+                                        "COLUMN_NAME")));
+            }
+
+            if (keys.isEmpty()) {
+                return null;
+            }
+
+            keys.sort(
+                    Comparator.comparingInt(
+                            PrimaryKeyColumn::position));
+
+            List<String> columns =
+                    new ArrayList<String>(
+                            keys.size());
+
+            for (PrimaryKeyColumn key : keys) {
+                columns.add(key.name);
+            }
+
+            return PrimaryKey.of(
+                    name,
+                    columns);
+        }
+    }
+
+    private String tableComment(
+            DatabaseMetaData metadata,
+            TablePath path)
+            throws SQLException {
+
+        try (ResultSet resultSet =
+                     metadata.getTables(
+                             null,
+                             path.getSchemaName(),
+                             path.getTableName(),
+                             new String[]{"TABLE"})) {
+
+            return resultSet.next()
+                    ? normalize(
+                    resultSet.getString(
+                            "REMARKS"))
+                    : null;
+        }
+    }
+
+    private TablePath normalizePath(
+            TablePath tablePath) {
+
+        Objects.requireNonNull(
+                tablePath,
+                "tablePath must not be null");
+
+        String sourceDatabase =
+                tablePath.getDatabaseName();
+
+        String targetSchema =
+                tablePath.getSchemaName();
+
+        if (!hasText(targetSchema)
+                || (hasText(sourceDatabase)
+                && !databaseName.equalsIgnoreCase(
+                sourceDatabase))) {
+
+            targetSchema = defaultSchema;
+        }
+
+        return TablePath.of(
+                databaseName,
+                targetSchema,
+                tablePath.getTableName());
+    }
+
+    private String schema(
+            String schemaName) {
+
+        return hasText(schemaName)
+                ? schemaName.trim()
+                : defaultSchema;
+    }
+
+    private void checkDatabase(
+            String requested) {
+
+        if (hasText(requested)
+                && !databaseName.equalsIgnoreCase(
+                requested.trim())) {
+
+            throw new IllegalArgumentException(
+                    "OceanBase JDBC 连接只支持当前 database："
+                            + databaseName
+                            + "，requested="
+                            + requested);
+        }
+    }
+
+    private Connection connection()
+            throws SQLException {
+
+        return DriverManager.getConnection(
+                config.getUrl(),
+                config.toConnectionProperties());
+    }
+
+    private void loadDriver() {
+        if (!hasText(
+                config.getDriverClass())) {
+            return;
+        }
+
+        try {
+            Class.forName(
+                    config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException(
+                    "找不到 OceanBase JDBC Driver："
+                            + config.getDriverClass(),
+                    e);
+        }
+    }
+
+    private static void execute(
+            Connection connection,
+            String sql)
+            throws SQLException {
+
+        try (PreparedStatement statement =
+                     connection.prepareStatement(sql)) {
+
+            statement.execute();
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException(
+                    "Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static String defaultSchema(
+            String configured,
+            String username) {
+
+        if (hasText(configured)) {
+            return configured.trim();
+        }
+
+        if (hasText(username)) {
+            return username.trim()
+                    .toUpperCase(
+                            Locale.ROOT);
+        }
+
+        throw new IllegalArgumentException(
+                "OceanBase Oracle 模式需要配置 schema 或 username");
+    }
+
+    private static String requireDatabase(
+            String database) {
+
+        if (!hasText(database)) {
+            throw new IllegalArgumentException(
+                    "OceanBase Oracle 模式 JDBC URL 必须包含 database");
+        }
+
+        return database.trim();
+    }
+
+    private static String quoteTable(
+            TablePath path) {
+
+        return quote(
+                path.getSchemaName())
+                + "."
+                + quote(
+                path.getTableName());
+    }
+
+    private static String quote(
+            String value) {
+
+        if (!hasText(value)) {
+            throw new IllegalArgumentException(
+                    "identifier must not be empty");
+        }
+
+        return "\""
+                + value.trim()
+                .replace("\"", "\"\"")
+                + "\"";
+    }
+
+    private static String literal(
+            String value) {
+
+        return value.replace(
+                "'",
+                "''");
+    }
+
+    private static boolean hasText(
+            String value) {
+
+        return normalize(value) != null;
+    }
+
+    private static String normalize(
+            String value) {
+
+        if (value == null) {
+            return null;
+        }
+
+        String normalized =
+                value.trim();
+
+        return normalized.isEmpty()
+                ? null
+                : normalized;
+    }
+
+    private static final class PrimaryKeyColumn {
+        private final int position;
+        private final String name;
+
+        private PrimaryKeyColumn(
+                int position,
+                String name) {
+
+            this.position = position;
+            this.name = name;
+        }
+
+        private int position() {
+            return position;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -11,6 +11,7 @@ public final class DatabaseIdentifier {
     public static final String POSTGRESQL = "postgresql";
     public static final String ORACLE = "oracle";
     public static final String SQLSERVER = "sqlserver";
+    public static final String OCEANBASE = "oceanbase";
 
     private DatabaseIdentifier() {
     }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseCompatibleMode.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseCompatibleMode.java
@@ -1,0 +1,46 @@
+package com.link.up.connector.jdbc.core.dialect.oceanbase;
+
+import java.util.Locale;
+
+/**
+ * OceanBase compatibility mode.
+ *
+ * <p>The mode is explicit because MySQL and Oracle modes differ in quoting,
+ * table paths, type mapping and UPSERT syntax. Guessing from data or SQL can
+ * silently generate incorrect statements.</p>
+ */
+public enum OceanBaseCompatibleMode {
+    MYSQL,
+    ORACLE;
+
+    public static OceanBaseCompatibleMode from(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "OceanBase 必须配置 compatible_mode=mysql|oracle");
+        }
+
+        String normalized =
+                value.trim().toUpperCase(Locale.ROOT);
+
+        if ("MYSQL".equals(normalized)) {
+            return MYSQL;
+        }
+
+        if ("ORACLE".equals(normalized)) {
+            return ORACLE;
+        }
+
+        throw new IllegalArgumentException(
+                "不支持的 OceanBase compatible_mode："
+                        + value
+                        + "，仅支持 mysql、oracle");
+    }
+
+    public boolean isMySql() {
+        return this == MYSQL;
+    }
+
+    public boolean isOracle() {
+        return this == ORACLE;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseDialect.java
@@ -1,0 +1,667 @@
+package com.link.up.connector.jdbc.core.dialect.oceanbase;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.oceanbase.OceanBaseCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.config.ReadConsistency;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+import com.link.up.connector.jdbc.core.dialect.mysql.MySqlJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.mysql.MySqlTypeMapper;
+import com.link.up.connector.jdbc.core.dialect.oracle.OracleJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.oracle.OracleTypeMapper;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * OceanBase bounded/offline JDBC dialect.
+ *
+ * <p>The connector stays OceanBase-aware at the SPI boundary while reusing
+ * the already-tested MySQL or Oracle value/type/SQL semantics selected by
+ * {@code compatible_mode}. CDC, LogProxy/CLog and streaming state are
+ * intentionally outside this dialect.</p>
+ */
+public final class OceanBaseDialect
+        implements JdbcDialect {
+
+    private static final int ORACLE_DEFAULT_FETCH_SIZE = 128;
+
+    private final JdbcConnectionConfig connectionConfig;
+    private final OceanBaseCompatibleMode mode;
+    private final JdbcTypeMapper typeMapper;
+    private final String databaseName;
+
+    public OceanBaseDialect(
+            JdbcConnectionConfig connectionConfig) {
+
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException(
+                    "connectionConfig must not be null");
+        }
+
+        if (!OceanBaseJdbcUrl.accepts(
+                connectionConfig.getUrl())) {
+
+            throw new IllegalArgumentException(
+                    "非法 OceanBase JDBC URL："
+                            + connectionConfig.getUrl());
+        }
+
+        this.connectionConfig =
+                connectionConfig;
+
+        this.mode =
+                OceanBaseCompatibleMode.from(
+                        connectionConfig
+                                .getCompatibleMode());
+
+        this.databaseName =
+                OceanBaseJdbcUrl.databaseName(
+                        connectionConfig.getUrl());
+
+        this.typeMapper =
+                mode.isMySql()
+                        ? new MySqlTypeMapper(false)
+                        : new OracleTypeMapper();
+    }
+
+    public OceanBaseCompatibleMode compatibleMode() {
+        return mode;
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.OCEANBASE;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+
+        OceanBaseCompatibleMode catalogMode =
+                OceanBaseCompatibleMode.from(
+                        connectionConfig
+                                .getCompatibleMode());
+
+        return new OceanBaseCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false),
+                catalogMode,
+                connectionConfig.getSchema());
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        JdbcRowConverter delegate =
+                mode.isMySql()
+                        ? new MySqlJdbcRowConverter()
+                        : new OracleJdbcRowConverter();
+
+        return new OceanBaseJdbcRowConverter(
+                delegate);
+    }
+
+    @Override
+    public Set<ReadConsistency>
+    supportedReadConsistencies() {
+
+        if (mode.isMySql()) {
+            return EnumSet.of(
+                    ReadConsistency.BEST_EFFORT,
+                    ReadConsistency
+                            .SINGLE_CONNECTION_SNAPSHOT);
+        }
+
+        return Collections.singleton(
+                ReadConsistency.BEST_EFFORT);
+    }
+
+    @Override
+    public TablePath parseTablePath(
+            String tablePath) {
+
+        if (mode.isMySql()) {
+            return TablePath.parse(tablePath);
+        }
+
+        if (!JdbcDialect.hasText(
+                tablePath)) {
+
+            throw new IllegalArgumentException(
+                    "tablePath must not be empty");
+        }
+
+        String[] parts =
+                tablePath.trim()
+                        .split("\\.");
+
+        switch (parts.length) {
+            case 1:
+                return TablePath.of(
+                        parts[0]);
+
+            case 2:
+                return TablePath.of(
+                        null,
+                        parts[0],
+                        parts[1]);
+
+            case 3:
+                return TablePath.of(
+                        parts[0],
+                        parts[1],
+                        parts[2]);
+
+            default:
+                throw new IllegalArgumentException(
+                        "非法 OceanBase Oracle 表路径："
+                                + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(
+            String identifier) {
+
+        if (!JdbcDialect.hasText(
+                identifier)) {
+
+            throw new IllegalArgumentException(
+                    "identifier must not be empty");
+        }
+
+        String value =
+                identifier.trim();
+
+        if (mode.isMySql()) {
+            return "`"
+                    + value.replace(
+                    "`",
+                    "``")
+                    + "`";
+        }
+
+        return "\""
+                + value.replace(
+                "\"",
+                "\"\"")
+                + "\"";
+    }
+
+    @Override
+    public String tableIdentifier(
+            TablePath tablePath) {
+
+        if (tablePath == null) {
+            throw new IllegalArgumentException(
+                    "tablePath must not be null");
+        }
+
+        if (mode.isMySql()) {
+            String database =
+                    resolveMySqlDatabase(
+                            tablePath);
+
+            return quoteIdentifier(
+                    database)
+                    + "."
+                    + quoteIdentifier(
+                    tablePath.getTableName());
+        }
+
+        return quoteIdentifier(
+                resolveOracleSchema(
+                        tablePath))
+                + "."
+                + quoteIdentifier(
+                tablePath.getTableName());
+    }
+
+    @Override
+    public Optional<String> buildUpsertSql(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+
+        return mode.isMySql()
+                ? buildMySqlUpsert(
+                tablePath,
+                fieldNames,
+                primaryKeys)
+                : buildOracleUpsert(
+                tablePath,
+                fieldNames,
+                primaryKeys);
+    }
+
+    private Optional<String> buildMySqlUpsert(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+
+        JdbcDialect.validateFields(
+                fieldNames);
+
+        Set<String> primaryKeySet =
+                JdbcDialect.normalizeFields(
+                        primaryKeys);
+
+        if (primaryKeySet.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "OceanBase MySQL UPSERT 必须配置主键字段");
+        }
+
+        validatePrimaryKeys(
+                fieldNames,
+                primaryKeys,
+                "OceanBase MySQL");
+
+        List<String> updateFields =
+                fieldNames.stream()
+                        .filter(
+                                field ->
+                                        !primaryKeySet.contains(
+                                                field))
+                        .collect(
+                                Collectors.toList());
+
+        if (updateFields.isEmpty()) {
+            updateFields =
+                    Collections.singletonList(
+                            primaryKeys.get(0));
+        }
+
+        String updateClause =
+                updateFields.stream()
+                        .map(
+                                field ->
+                                        quoteIdentifier(
+                                                field)
+                                                + " = VALUES("
+                                                + quoteIdentifier(
+                                                field)
+                                                + ")")
+                        .collect(
+                                Collectors.joining(
+                                        ", "));
+
+        return Optional.of(
+                buildInsertSql(
+                        tablePath,
+                        fieldNames)
+                        + " ON DUPLICATE KEY UPDATE "
+                        + updateClause);
+    }
+
+    private Optional<String> buildOracleUpsert(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+
+        JdbcDialect.validateFields(
+                fieldNames);
+
+        Set<String> primaryKeySet =
+                JdbcDialect.normalizeFields(
+                        primaryKeys);
+
+        if (primaryKeySet.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "OceanBase Oracle UPSERT 必须配置主键字段");
+        }
+
+        validatePrimaryKeys(
+                fieldNames,
+                primaryKeys,
+                "OceanBase Oracle");
+
+        String sourceProjection =
+                fieldNames.stream()
+                        .map(
+                                field ->
+                                        "? AS "
+                                                + quoteIdentifier(
+                                                field))
+                        .collect(
+                                Collectors.joining(
+                                        ", "));
+
+        String onClause =
+                primaryKeys.stream()
+                        .map(
+                                field ->
+                                        "TARGET."
+                                                + quoteIdentifier(
+                                                field)
+                                                + " = SOURCE."
+                                                + quoteIdentifier(
+                                                field))
+                        .collect(
+                                Collectors.joining(
+                                        " AND "));
+
+        List<String> updateFields =
+                fieldNames.stream()
+                        .filter(
+                                field ->
+                                        !primaryKeySet.contains(
+                                                field))
+                        .collect(
+                                Collectors.toList());
+
+        StringBuilder sql =
+                new StringBuilder()
+                        .append("MERGE INTO ")
+                        .append(
+                                tableIdentifier(
+                                        tablePath))
+                        .append(
+                                " TARGET USING (SELECT ")
+                        .append(
+                                sourceProjection)
+                        .append(
+                                " FROM DUAL) SOURCE ON (")
+                        .append(
+                                onClause)
+                        .append(")");
+
+        if (!updateFields.isEmpty()) {
+            String updateClause =
+                    updateFields.stream()
+                            .map(
+                                    field ->
+                                            "TARGET."
+                                                    + quoteIdentifier(
+                                                    field)
+                                                    + " = SOURCE."
+                                                    + quoteIdentifier(
+                                                    field))
+                            .collect(
+                                    Collectors.joining(
+                                            ", "));
+
+            sql.append(
+                    " WHEN MATCHED THEN UPDATE SET ")
+                    .append(
+                            updateClause);
+        }
+
+        String insertFields =
+                fieldNames.stream()
+                        .map(
+                                this::quoteIdentifier)
+                        .collect(
+                                Collectors.joining(
+                                        ", "));
+
+        String insertValues =
+                fieldNames.stream()
+                        .map(
+                                field ->
+                                        "SOURCE."
+                                                + quoteIdentifier(
+                                                field))
+                        .collect(
+                                Collectors.joining(
+                                        ", "));
+
+        sql.append(
+                " WHEN NOT MATCHED THEN INSERT (")
+                .append(
+                        insertFields)
+                .append(
+                        ") VALUES (")
+                .append(
+                        insertValues)
+                .append(")");
+
+        return Optional.of(
+                sql.toString());
+    }
+
+    @Override
+    public PreparedStatement prepareReadStatement(
+            Connection connection,
+            String sql,
+            int fetchSize)
+            throws SQLException {
+
+        PreparedStatement statement =
+                connection.prepareStatement(
+                        sql,
+                        ResultSet.TYPE_FORWARD_ONLY,
+                        ResultSet.CONCUR_READ_ONLY);
+
+        if (mode.isMySql()) {
+            /*
+             * OceanBase's MySQL-compatible JDBC path follows the MySQL
+             * streaming convention used by SeaTunnel's OceanBase dialect.
+             */
+            statement.setFetchSize(
+                    Integer.MIN_VALUE);
+            return statement;
+        }
+
+        statement.setFetchSize(
+                fetchSize > 0
+                        ? fetchSize
+                        : ORACLE_DEFAULT_FETCH_SIZE);
+
+        return statement;
+    }
+
+    @Override
+    public Map<String, String>
+    defaultConnectionProperties() {
+
+        if (mode.isOracle()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, String> result =
+                new LinkedHashMap<String, String>();
+
+        result.put(
+                "rewriteBatchedStatements",
+                "true");
+
+        result.put(
+                "allowMultiQueries",
+                "true");
+
+        return Collections.unmodifiableMap(
+                result);
+    }
+
+    @Override
+    public Optional<String>
+    buildHashPartitionPredicate(
+            Column column,
+            int bucket,
+            int bucketCount) {
+
+        if (column == null) {
+            throw new IllegalArgumentException(
+                    "column must not be null");
+        }
+
+        if (bucketCount <= 0) {
+            throw new IllegalArgumentException(
+                    "bucketCount must be greater than 0");
+        }
+
+        if (bucket < 0
+                || bucket >= bucketCount) {
+
+            throw new IllegalArgumentException(
+                    "bucket must be between 0 and bucketCount - 1");
+        }
+
+        String field =
+                quoteIdentifier(
+                        column.getName());
+
+        if (mode.isMySql()) {
+            return Optional.of(
+                    "MOD(CRC32(CAST("
+                            + field
+                            + " AS CHAR)), "
+                            + bucketCount
+                            + ") = "
+                            + bucket);
+        }
+
+        return Optional.of(
+                "MOD(ORA_HASH("
+                        + field
+                        + "), "
+                        + bucketCount
+                        + ") = "
+                        + bucket);
+    }
+
+    private String resolveMySqlDatabase(
+            TablePath tablePath) {
+
+        if (JdbcDialect.hasText(
+                databaseName)) {
+
+            return databaseName.trim();
+        }
+
+        if (JdbcDialect.hasText(
+                connectionConfig.getSchema())) {
+
+            return connectionConfig
+                    .getSchema()
+                    .trim();
+        }
+
+        if (JdbcDialect.hasText(
+                tablePath.getDatabaseName())) {
+
+            return tablePath
+                    .getDatabaseName()
+                    .trim();
+        }
+
+        if (JdbcDialect.hasText(
+                tablePath.getSchemaName())) {
+
+            return tablePath
+                    .getSchemaName()
+                    .trim();
+        }
+
+        throw new IllegalArgumentException(
+                "OceanBase MySQL 表路径缺少 database，"
+                        + "且 JDBC URL 未指定默认 database："
+                        + tablePath);
+    }
+
+    private String resolveOracleSchema(
+            TablePath tablePath) {
+
+        String pathDatabase =
+                tablePath.getDatabaseName();
+
+        String pathSchema =
+                tablePath.getSchemaName();
+
+        if (JdbcDialect.hasText(
+                pathSchema)
+                && (!JdbcDialect.hasText(
+                pathDatabase)
+                || (JdbcDialect.hasText(
+                databaseName)
+                && databaseName
+                .equalsIgnoreCase(
+                        pathDatabase)))) {
+
+            return pathSchema.trim();
+        }
+
+        if (JdbcDialect.hasText(
+                connectionConfig.getSchema())) {
+
+            return connectionConfig
+                    .getSchema()
+                    .trim();
+        }
+
+        if (JdbcDialect.hasText(
+                connectionConfig
+                        .getUsername())) {
+
+            return connectionConfig
+                    .getUsername()
+                    .trim()
+                    .toUpperCase(
+                            Locale.ROOT);
+        }
+
+        if (JdbcDialect.hasText(
+                pathSchema)) {
+
+            return pathSchema.trim();
+        }
+
+        throw new IllegalArgumentException(
+                "OceanBase Oracle 表路径缺少 schema，"
+                        + "且 connection schema/username 均未配置："
+                        + tablePath);
+    }
+
+    private static void validatePrimaryKeys(
+            List<String> fieldNames,
+            List<String> primaryKeys,
+            String database) {
+
+        Set<String> fields =
+                new HashSet<String>(
+                        fieldNames);
+
+        for (String primaryKey :
+                primaryKeys) {
+
+            if (!fields.contains(
+                    primaryKey)) {
+
+                throw new IllegalArgumentException(
+                        database
+                                + " UPSERT 主键字段不存在："
+                                + primaryKey);
+            }
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseDialectFactory.java
@@ -1,0 +1,33 @@
+package com.link.up.connector.jdbc.core.dialect.oceanbase;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/**
+ * OceanBase dialect SPI.
+ */
+@AutoService(JdbcDialectFactory.class)
+public final class OceanBaseDialectFactory
+        implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.OCEANBASE;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return OceanBaseJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(
+            JdbcConnectionConfig connectionConfig) {
+
+        return new OceanBaseDialect(
+                connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseJdbcRowConverter.java
@@ -1,0 +1,59 @@
+package com.link.up.connector.jdbc.core.dialect.oceanbase;
+
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Objects;
+
+/**
+ * Keeps the connector identity as OceanBase while delegating concrete value
+ * handling to the selected MySQL/Oracle row converter.
+ */
+public final class OceanBaseJdbcRowConverter
+        implements JdbcRowConverter {
+
+    private final JdbcRowConverter delegate;
+
+    public OceanBaseJdbcRowConverter(
+            JdbcRowConverter delegate) {
+
+        this.delegate =
+                Objects.requireNonNull(
+                        delegate,
+                        "delegate must not be null");
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.OCEANBASE;
+    }
+
+    @Override
+    public FluxRow read(
+            ResultSet resultSet,
+            TableSchema tableSchema)
+            throws SQLException {
+
+        return delegate.read(
+                resultSet,
+                tableSchema);
+    }
+
+    @Override
+    public void write(
+            PreparedStatement statement,
+            FluxRow row,
+            TableSchema tableSchema)
+            throws SQLException {
+
+        delegate.write(
+                statement,
+                row,
+                tableSchema);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseJdbcUrl.java
@@ -1,0 +1,81 @@
+package com.link.up.connector.jdbc.core.dialect.oceanbase;
+
+import java.util.Locale;
+
+/**
+ * Small parser for OceanBase network-style JDBC URLs.
+ */
+public final class OceanBaseJdbcUrl {
+
+    private static final String PREFIX = "jdbc:oceanbase:";
+
+    private OceanBaseJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return url != null
+                && url.trim()
+                .toLowerCase(Locale.ROOT)
+                .startsWith(PREFIX);
+    }
+
+    /**
+     * Extracts the database path from URLs such as:
+     * jdbc:oceanbase://127.0.0.1:2881/app?useUnicode=true
+     */
+    public static String databaseName(String url) {
+        if (!accepts(url)) {
+            throw new IllegalArgumentException(
+                    "非法 OceanBase JDBC URL：" + url);
+        }
+
+        String normalized = url.trim();
+        int protocol = normalized.indexOf("://");
+        if (protocol < 0) {
+            return null;
+        }
+
+        int slash = normalized.indexOf('/', protocol + 3);
+        if (slash < 0 || slash == normalized.length() - 1) {
+            return null;
+        }
+
+        int end = normalized.length();
+
+        int query = normalized.indexOf('?', slash + 1);
+        if (query >= 0) {
+            end = query;
+        }
+
+        int fragment = normalized.indexOf('#', slash + 1);
+        if (fragment >= 0 && fragment < end) {
+            end = fragment;
+        }
+
+        int semicolon = normalized.indexOf(';', slash + 1);
+        if (semicolon >= 0 && semicolon < end) {
+            end = semicolon;
+        }
+
+        String database =
+                normalized.substring(slash + 1, end).trim();
+
+        return database.isEmpty() ? null : database;
+    }
+
+    /**
+     * OceanBase MySQL mode speaks the MySQL protocol. The MySQL Catalog can
+     * therefore be reused by translating only the JDBC scheme while keeping
+     * host, port, database and query parameters unchanged.
+     */
+    public static String toMySqlUrl(String url) {
+        if (!accepts(url)) {
+            throw new IllegalArgumentException(
+                    "非法 OceanBase JDBC URL：" + url);
+        }
+
+        String normalized = url.trim();
+        return "jdbc:mysql:"
+                + normalized.substring(PREFIX.length());
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
@@ -10,6 +10,8 @@ import com.link.up.connector.jdbc.catalog.sqlserver.SqlServerCreateTableSqlBuild
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.oceanbase.OceanBaseCompatibleMode;
+import com.link.up.connector.jdbc.core.dialect.oceanbase.OceanBaseJdbcUrl;
 import com.link.up.connector.jdbc.core.dialect.oracle.OracleJdbcUrl;
 import com.link.up.connector.jdbc.core.dialect.oracle.OracleTypeMapper;
 import com.link.up.connector.jdbc.core.dialect.postgres.PostgresTypeMapper;
@@ -62,6 +64,46 @@ final class JdbcCreateTableSqlResolver {
                     targetPath,
                     ddlTable,
                     new MySqlTypeMapper(false))
+                    .build();
+        }
+
+        if (DatabaseIdentifier.OCEANBASE
+                .equalsIgnoreCase(
+                        dialect.name())) {
+
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
+            OceanBaseCompatibleMode mode =
+                    OceanBaseCompatibleMode.from(
+                            connectionConfig
+                                    .getCompatibleMode());
+
+            if (mode.isMySql()) {
+                return new MySqlCreateTableSqlBuilder(
+                        targetPath,
+                        ddlTable,
+                        new MySqlTypeMapper(false))
+                        .build();
+            }
+
+            return new OracleCreateTableSqlBuilder(
+                    targetPath,
+                    ddlTable,
+                    new OracleTypeMapper())
                     .build();
         }
 
@@ -161,6 +203,65 @@ final class JdbcCreateTableSqlResolver {
                 || tablePath == null) {
 
             return tablePath;
+        }
+
+        if (isOceanBase(
+                connectionConfig)) {
+
+            String database =
+                    OceanBaseJdbcUrl.databaseName(
+                            connectionConfig.getUrl());
+
+            OceanBaseCompatibleMode mode =
+                    OceanBaseCompatibleMode.from(
+                            connectionConfig
+                                    .getCompatibleMode());
+
+            if (mode.isOracle()) {
+                if (!hasText(database)) {
+                    return null;
+                }
+
+                String schema =
+                        resolveOracleSchema(
+                                connectionConfig,
+                                tablePath,
+                                database);
+
+                if (!hasText(schema)) {
+                    return null;
+                }
+
+                return TablePath.of(
+                        database,
+                        schema,
+                        tablePath.getTableName());
+            }
+
+            if (hasText(database)) {
+                return TablePath.of(
+                        database,
+                        tablePath.getTableName());
+            }
+
+            if (hasText(
+                    tablePath.getDatabaseName())) {
+
+                return TablePath.of(
+                        tablePath.getDatabaseName(),
+                        tablePath.getTableName());
+            }
+
+            if (hasText(
+                    connectionConfig.getSchema())) {
+
+                return TablePath.of(
+                        connectionConfig
+                                .getSchema(),
+                        tablePath.getTableName());
+            }
+
+            return null;
         }
 
         if (isSqlServer(
@@ -363,6 +464,20 @@ final class JdbcCreateTableSqlResolver {
                 .toLowerCase()
                 .startsWith(
                         "jdbc:postgresql:");
+    }
+
+    private static boolean isOceanBase(
+            JdbcConnectionConfig config) {
+
+        if (DatabaseIdentifier.OCEANBASE
+                .equalsIgnoreCase(
+                        config.getDialect())) {
+
+            return true;
+        }
+
+        return OceanBaseJdbcUrl.accepts(
+                config.getUrl());
     }
 
     private static boolean isOracle(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/oceanbase/OceanBaseCatalogFactoryTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/oceanbase/OceanBaseCatalogFactoryTest.java
@@ -1,0 +1,116 @@
+package com.link.up.connector.jdbc.catalog.oceanbase;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Catalog;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class OceanBaseCatalogFactoryTest {
+
+    @Test
+    public void createsMysqlCompatibleCatalog() {
+        Catalog catalog =
+                new OceanBaseCatalogFactory()
+                        .createCatalog(
+                                "oceanbase",
+                                config("mysql"));
+
+        assertTrue(
+                catalog
+                        instanceof OceanBaseCatalog);
+
+        assertEquals(
+                "app",
+                catalog.getDefaultDatabase()
+                        .get());
+    }
+
+    @Test
+    public void createsOracleCompatibleCatalog() {
+        Catalog catalog =
+                new OceanBaseCatalogFactory()
+                        .createCatalog(
+                                "oceanbase",
+                                config("oracle"));
+
+        assertTrue(
+                catalog
+                        instanceof OceanBaseCatalog);
+
+        assertEquals(
+                "app",
+                catalog.getDefaultDatabase()
+                        .get());
+    }
+
+    @Test
+    public void rejectsMissingCompatibleMode() {
+        Map<String, Object> values =
+                baseValues();
+
+        try {
+            new OceanBaseCatalogFactory()
+                    .createCatalog(
+                            "oceanbase",
+                            ReadonlyConfig.fromMap(
+                                    values));
+
+            fail(
+                    "missing compatible mode must fail");
+        } catch (IllegalArgumentException e) {
+            assertTrue(
+                    e.getMessage()
+                            .contains(
+                                    "compatible_mode"));
+        }
+    }
+
+    private static ReadonlyConfig config(
+            String mode) {
+
+        Map<String, Object> values =
+                baseValues();
+
+        values.put(
+                "compatible_mode",
+                mode);
+
+        return ReadonlyConfig.fromMap(
+                values);
+    }
+
+    private static Map<String, Object>
+    baseValues() {
+
+        Map<String, Object> values =
+                new LinkedHashMap<String, Object>();
+
+        values.put(
+                "url",
+                "jdbc:oceanbase://127.0.0.1:2881/app");
+
+        values.put(
+                "driver",
+                "com.oceanbase.jdbc.Driver");
+
+        values.put(
+                "username",
+                "app");
+
+        values.put(
+                "password",
+                "secret");
+
+        values.put(
+                "schema",
+                "APP");
+
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/oceanbase/OceanBaseDialectTest.java
@@ -1,0 +1,225 @@
+package com.link.up.connector.jdbc.core.dialect.oceanbase;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.mysql.MySqlTypeMapper;
+import com.link.up.connector.jdbc.core.dialect.oracle.OracleTypeMapper;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class OceanBaseDialectTest {
+
+    @Test
+    public void mysqlModeUsesOceanBaseIdentityAndMySqlSql() {
+        OceanBaseDialect dialect =
+                new OceanBaseDialect(
+                        config(
+                                "mysql",
+                                "APP"));
+
+        assertEquals(
+                DatabaseIdentifier.OCEANBASE,
+                dialect.name());
+
+        assertTrue(
+                dialect.typeMapper()
+                        instanceof MySqlTypeMapper);
+
+        assertEquals(
+                "`target_db`.`orders`",
+                dialect.tableIdentifier(
+                        TablePath.of(
+                                "source_db",
+                                "orders")));
+
+        String upsert =
+                dialect.buildUpsertSql(
+                                TablePath.of(
+                                        "source_db",
+                                        "orders"),
+                                Arrays.asList(
+                                        "id",
+                                        "name"),
+                                Arrays.asList(
+                                        "id"))
+                        .get();
+
+        assertTrue(
+                upsert.contains(
+                        "ON DUPLICATE KEY UPDATE"));
+
+        assertTrue(
+                upsert.contains(
+                        "VALUES(`name`)"));
+
+        assertEquals(
+                "oceanbase",
+                dialect.rowConverter()
+                        .name());
+    }
+
+    @Test
+    public void oracleModeUsesOracleSqlAndConfiguredSchema() {
+        OceanBaseDialect dialect =
+                new OceanBaseDialect(
+                        config(
+                                "oracle",
+                                "APP"));
+
+        assertTrue(
+                dialect.typeMapper()
+                        instanceof OracleTypeMapper);
+
+        assertEquals(
+                "\"APP\".\"orders\"",
+                dialect.tableIdentifier(
+                        TablePath.of(
+                                "source_db",
+                                "OTHER",
+                                "orders")));
+
+        String upsert =
+                dialect.buildUpsertSql(
+                                TablePath.of(
+                                        "source_db",
+                                        "OTHER",
+                                        "orders"),
+                                Arrays.asList(
+                                        "id",
+                                        "name"),
+                                Arrays.asList(
+                                        "id"))
+                        .get();
+
+        assertTrue(
+                upsert.startsWith(
+                        "MERGE INTO \"APP\".\"orders\""));
+
+        assertTrue(
+                upsert.contains(
+                        "FROM DUAL"));
+
+        assertTrue(
+                upsert.contains(
+                        "WHEN MATCHED THEN UPDATE SET"));
+    }
+
+    @Test
+    public void hashSplitFollowsCompatibleMode() {
+        Column column =
+                Column.builder(
+                                "id",
+                                BasicType.INT_TYPE)
+                        .build();
+
+        String mysql =
+                new OceanBaseDialect(
+                        config(
+                                "mysql",
+                                "APP"))
+                        .buildHashPartitionPredicate(
+                                column,
+                                1,
+                                4)
+                        .get();
+
+        assertEquals(
+                "MOD(CRC32(CAST(`id` AS CHAR)), 4) = 1",
+                mysql);
+
+        String oracle =
+                new OceanBaseDialect(
+                        config(
+                                "oracle",
+                                "APP"))
+                        .buildHashPartitionPredicate(
+                                column,
+                                1,
+                                4)
+                        .get();
+
+        assertEquals(
+                "MOD(ORA_HASH(\"id\"), 4) = 1",
+                oracle);
+    }
+
+    @Test
+    public void compatibleModeIsRequired() {
+        try {
+            new OceanBaseDialect(
+                    config(
+                            null,
+                            "APP"));
+            fail(
+                    "missing compatible mode must fail");
+        } catch (IllegalArgumentException e) {
+            assertTrue(
+                    e.getMessage()
+                            .contains(
+                                    "compatible_mode"));
+        }
+    }
+
+    @Test
+    public void urlParserKeepsDatabaseAndCanTranslateMysqlScheme() {
+        String url =
+                "jdbc:oceanbase://127.0.0.1:2881/app"
+                        + "?useUnicode=true";
+
+        assertEquals(
+                "app",
+                OceanBaseJdbcUrl.databaseName(
+                        url));
+
+        assertEquals(
+                "jdbc:mysql://127.0.0.1:2881/app"
+                        + "?useUnicode=true",
+                OceanBaseJdbcUrl.toMySqlUrl(
+                        url));
+    }
+
+    private static JdbcConnectionConfig config(
+            String compatibleMode,
+            String schema) {
+
+        Map<String, Object> values =
+                new LinkedHashMap<String, Object>();
+
+        values.put(
+                "url",
+                "jdbc:oceanbase://127.0.0.1:2881/target_db");
+
+        values.put(
+                "driver",
+                "com.oceanbase.jdbc.Driver");
+
+        values.put(
+                "username",
+                "app");
+
+        values.put(
+                "schema",
+                schema);
+
+        if (compatibleMode != null) {
+            values.put(
+                    "compatible_mode",
+                    compatibleMode);
+        }
+
+        return JdbcConnectionConfig.of(
+                ReadonlyConfig.fromMap(
+                        values));
+    }
+}


### PR DESCRIPTION
## Summary
- add OceanBase JDBC offline Source/Sink adaptation on top of the existing generic JDBC execution path
- require explicit `compatible_mode=mysql|oracle` and keep OceanBase as the SPI/dialect identity
- reuse existing MySQL type mapping, row conversion, `ON DUPLICATE KEY UPDATE`, hash split and DDL semantics in MySQL-compatible mode
- reuse existing Oracle type mapping, row conversion, `MERGE`, schema rules and DDL semantics in Oracle-compatible mode
- add `jdbc:oceanbase://` parsing, OceanBase JDBC driver dependency, mode-aware Catalog/DDL routing and target database/schema normalization
- keep `JdbcSource` / `JdbcSink` unchanged; database differences stay in Dialect/Catalog

## Compatibility modes
### MySQL
- backtick identifiers and `database.table`
- `ON DUPLICATE KEY UPDATE`
- MySQL-style hash partition predicate
- streaming read fetch convention
- MySQL Catalog/DDL semantics through the MySQL wire protocol

### Oracle
- quoted `schema.table`
- Oracle-style `MERGE ... FROM DUAL`
- Oracle type mapping and row conversion
- Oracle metadata/DDL rules using the OceanBase JDBC connection

## Scope
Offline/bounded JDBC only. This PR intentionally does **not** include OceanBase Binlog/LogProxy/CLog, CDC, runtime schema events, streaming checkpoint state, XA or exactly-once writers.

## Dependency
This PR is based on the current `feat/oracle-jdbc-offline` stacked base, which already contains the merged SQL Server #91 layer. The diff is OceanBase-only (1 commit).

## Validation
- Java 8 type compilation passed for the OceanBase production classes, resolver changes and added unit tests against stubs matching the inspected project APIs.
- Executed smoke checks for OceanBase JDBC URL parsing, MySQL URL translation and required compatibility-mode validation.
- Added unit coverage for MySQL/Oracle mode selection, identifier/table routing, UPSERT, hash split, Catalog creation and missing `compatible_mode`.
- Full Maven test suite was not run in this environment because the repository/dependency graph could not be checked out locally.