### PR TITLE
feat(jdbc): add Dameng offline source and sink

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/pom.xml
+++ b/link-up-connectors/link-up-connector-jdbc/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>com.dameng</groupId>
             <artifactId>DmJdbcDriver18</artifactId>
-            <version>8.1.2.141</version>
+            <version>8.1.3.140</version>
         </dependency>
     </dependencies>
 

--- a/link-up-connectors/link-up-connector-jdbc/pom.xml
+++ b/link-up-connectors/link-up-connector-jdbc/pom.xml
@@ -78,6 +78,11 @@
             <artifactId>jcc</artifactId>
             <version>11.5.9.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.dameng</groupId>
+            <artifactId>DmJdbcDriver18</artifactId>
+            <version>8.1.2.141</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/dameng/DamengCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/dameng/DamengCatalog.java
@@ -1,0 +1,484 @@
+package com.link.up.connector.jdbc.catalog.dameng;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.dameng.DamengJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.dameng.DamengTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+/** Dameng DM8 offline JDBC Catalog. */
+public final class DamengCatalog implements WritableCatalog {
+
+    public static final String DIALECT = "dameng";
+    public static final String TABLE_OPTION_DIALECT = "dialect";
+    public static final String TABLE_OPTION_TABLESPACE = "tablespace";
+    public static final String TABLE_OPTION_FILLFACTOR = "fillfactor";
+
+    private static final String DATABASE_NAME_SQL = "SELECT NAME FROM V$DATABASE";
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String defaultSchema;
+    private final DamengTypeMapper typeMapper = new DamengTypeMapper();
+
+    private volatile boolean opened;
+    private volatile String databaseName;
+
+    public DamengCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            String configuredSchema) {
+        if (!hasText(catalogName)) {
+            throw new IllegalArgumentException("catalogName must not be empty");
+        }
+        this.catalogName = catalogName.trim();
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.defaultSchema = defaultSchema(
+                configuredSchema,
+                config.getUrl(),
+                config.getProperties(),
+                config.getUsername());
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.ofNullable(databaseName);
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+        loadDriver();
+        try (Connection connection = connection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException("Dameng Catalog 连接校验失败：" + config.getUrl());
+            }
+            databaseName = resolveDatabaseName(connection);
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException("Dameng Catalog 连接失败：" + config.getUrl(), e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public List<String> listDatabases() {
+        checkOpened();
+        return Collections.singletonList(databaseName);
+    }
+
+    @Override
+    public List<String> listSchemas(String database) throws CatalogException {
+        checkDatabase(database);
+        checkOpened();
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getSchemas()) {
+            List<String> schemas = new ArrayList<String>();
+            while (rs.next()) {
+                String schema = normalize(rs.getString("TABLE_SCHEM"));
+                if (schema != null) {
+                    schemas.add(schema);
+                }
+            }
+            Collections.sort(schemas);
+            return schemas;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 Dameng Schema 列表失败", e);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(String database, String schemaName)
+            throws CatalogException {
+        checkDatabase(database);
+        checkOpened();
+        String schema = schema(schemaName);
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getTables(
+                     null,
+                     schema,
+                     "%",
+                     new String[]{"TABLE"})) {
+            List<TablePath> tables = new ArrayList<TablePath>();
+            while (rs.next()) {
+                String table = normalize(rs.getString("TABLE_NAME"));
+                if (table != null) {
+                    tables.add(TablePath.of(databaseName, schema, table));
+                }
+            }
+            tables.sort(Comparator.comparing(TablePath::getTableName));
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 Dameng 表列表失败，schema=" + schema, e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getTables(
+                     null,
+                     path.getSchemaName(),
+                     path.getTableName(),
+                     new String[]{"TABLE"})) {
+            return rs.next();
+        } catch (SQLException e) {
+            throw new CatalogException("检查 Dameng 表是否存在失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        try (Connection connection = connection()) {
+            DatabaseMetaData meta = connection.getMetaData();
+            List<Column> columns = columns(meta, path);
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(catalogName, path);
+            }
+            TableSchema schema = TableSchema.builder()
+                    .columns(columns)
+                    .primaryKey(primaryKey(meta, path))
+                    .build();
+            CatalogTable.Builder table = CatalogTable.builder(path, schema)
+                    .option(TABLE_OPTION_DIALECT, DIALECT);
+            String comment = tableComment(meta, path);
+            if (hasText(comment)) {
+                table.comment(comment);
+            }
+            return table.build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 Dameng 表结构失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public void createDatabase(String database, boolean ignoreIfExists)
+            throws CatalogException, DatabaseAlreadyExistsException {
+        throw new UnsupportedOperationException(
+                "Dameng JDBC Offline Catalog 不负责 CREATE DATABASE");
+    }
+
+    @Override
+    public void dropDatabase(String database, boolean ignoreIfNotExists)
+            throws CatalogException, DatabaseNotFoundException {
+        throw new UnsupportedOperationException(
+                "Dameng JDBC Offline Catalog 不负责 DROP DATABASE");
+    }
+
+    @Override
+    public void createTable(CatalogTable table, boolean ignoreIfExists)
+            throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+        checkOpened();
+        TablePath path = normalizePath(table.getTablePath());
+        if (tableExists(path)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new TableAlreadyExistsException(catalogName, path);
+        }
+
+        CatalogTable ddlTable = table.getTablePath().equals(path)
+                ? table
+                : table.withPath(path);
+        DamengCreateTableSqlBuilder builder =
+                new DamengCreateTableSqlBuilder(path, ddlTable, typeMapper);
+        try (Connection connection = connection()) {
+            for (String sql : builder.buildStatements()) {
+                execute(connection, sql);
+            }
+        } catch (SQLException e) {
+            throw new CatalogException("创建 Dameng 表失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public void addColumn(TablePath tablePath, Column column)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        if (!tableExists(path)) {
+            throw new TableNotFoundException(catalogName, path);
+        }
+        CatalogTable current = getTable(path);
+        String definition = new DamengCreateTableSqlBuilder(path, current, typeMapper)
+                .buildColumnDefinition(column, false);
+        try (Connection connection = connection()) {
+            execute(connection, "ALTER TABLE " + quoteTable(path) + " ADD " + definition);
+            if (hasText(column.getComment())) {
+                execute(connection,
+                        "COMMENT ON COLUMN " + quoteTable(path) + "."
+                                + quote(column.getName()) + " IS '"
+                                + literal(column.getComment()) + "'");
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "增加 Dameng 字段失败，table=" + path + ", column=" + column.getName(), e);
+        }
+    }
+
+    @Override
+    public void dropTable(TablePath tablePath, boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        tableDdl(tablePath, ignoreIfNotExists, "DROP TABLE ", "删除");
+    }
+
+    @Override
+    public void truncateTable(TablePath tablePath, boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        tableDdl(tablePath, ignoreIfNotExists, "TRUNCATE TABLE ", "清空");
+    }
+
+    private void tableDdl(
+            TablePath tablePath,
+            boolean ignoreIfNotExists,
+            String prefix,
+            String operation) throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        if (!tableExists(path)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotFoundException(catalogName, path);
+        }
+        try (Connection connection = connection()) {
+            execute(connection, prefix + quoteTable(path));
+        } catch (SQLException e) {
+            throw new CatalogException(operation + " Dameng 表失败，table=" + path, e);
+        }
+    }
+
+    private List<Column> columns(DatabaseMetaData meta, TablePath path) throws SQLException {
+        try (ResultSet rs = meta.getColumns(
+                null,
+                path.getSchemaName(),
+                path.getTableName(),
+                "%")) {
+            List<Column> columns = new ArrayList<Column>();
+            while (rs.next()) {
+                columns.add(typeMapper.toColumn(rs));
+            }
+            return columns;
+        }
+    }
+
+    private PrimaryKey primaryKey(DatabaseMetaData meta, TablePath path) throws SQLException {
+        try (ResultSet rs = meta.getPrimaryKeys(
+                null,
+                path.getSchemaName(),
+                path.getTableName())) {
+            String name = null;
+            List<KeyColumn> keys = new ArrayList<KeyColumn>();
+            while (rs.next()) {
+                if (name == null) {
+                    name = rs.getString("PK_NAME");
+                }
+                keys.add(new KeyColumn(
+                        rs.getShort("KEY_SEQ"),
+                        rs.getString("COLUMN_NAME")));
+            }
+            if (keys.isEmpty()) {
+                return null;
+            }
+            keys.sort(Comparator.comparingInt(KeyColumn::position));
+            List<String> columns = new ArrayList<String>(keys.size());
+            for (KeyColumn key : keys) {
+                columns.add(key.name);
+            }
+            return PrimaryKey.of(name, columns);
+        }
+    }
+
+    private String tableComment(DatabaseMetaData meta, TablePath path) throws SQLException {
+        try (ResultSet rs = meta.getTables(
+                null,
+                path.getSchemaName(),
+                path.getTableName(),
+                new String[]{"TABLE"})) {
+            return rs.next() ? normalize(rs.getString("REMARKS")) : null;
+        }
+    }
+
+    private String resolveDatabaseName(Connection connection) throws SQLException {
+        String catalog = normalize(connection.getCatalog());
+        if (catalog != null) {
+            return catalog;
+        }
+        try (PreparedStatement statement = connection.prepareStatement(DATABASE_NAME_SQL);
+             ResultSet rs = statement.executeQuery()) {
+            if (!rs.next() || !hasText(rs.getString(1))) {
+                throw new SQLException("V$DATABASE did not return a Dameng database name");
+            }
+            return rs.getString(1).trim();
+        }
+    }
+
+    private TablePath normalizePath(TablePath tablePath) {
+        Objects.requireNonNull(tablePath, "tablePath must not be null");
+        String sourceDatabase = tablePath.getDatabaseName();
+        String targetSchema = tablePath.getSchemaName();
+        if (!hasText(targetSchema)
+                || (hasText(sourceDatabase)
+                && hasText(databaseName)
+                && !databaseName.equalsIgnoreCase(sourceDatabase))) {
+            targetSchema = defaultSchema;
+        }
+        return TablePath.of(databaseName, targetSchema, tablePath.getTableName());
+    }
+
+    private String schema(String schemaName) {
+        return hasText(schemaName) ? schemaName.trim() : defaultSchema;
+    }
+
+    private void checkDatabase(String requested) {
+        if (hasText(requested)
+                && hasText(databaseName)
+                && !databaseName.equalsIgnoreCase(requested.trim())) {
+            throw new IllegalArgumentException(
+                    "Dameng JDBC 连接只支持当前 database：" + databaseName
+                            + "，requested=" + requested);
+        }
+    }
+
+    private Connection connection() throws SQLException {
+        Properties properties = config.toConnectionProperties();
+        if (!containsPropertyIgnoreCase(properties, "schema")) {
+            properties.setProperty("schema", defaultSchema);
+        }
+        return DriverManager.getConnection(config.getUrl(), properties);
+    }
+
+    private void loadDriver() {
+        if (!hasText(config.getDriverClass())) {
+            return;
+        }
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException(
+                    "找不到 Dameng JDBC Driver：" + config.getDriverClass(), e);
+        }
+    }
+
+    private static void execute(Connection connection, String sql) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static String defaultSchema(
+            String configured,
+            String url,
+            java.util.Map<String, String> properties,
+            String username) {
+        if (hasText(configured)) {
+            return configured.trim();
+        }
+        String urlSchema = DamengJdbcUrl.schema(url, properties);
+        if (hasText(urlSchema)) {
+            return urlSchema.trim();
+        }
+        if (hasText(username)) {
+            return username.trim().toUpperCase(Locale.ROOT);
+        }
+        throw new IllegalArgumentException("Dameng 需要配置 schema、JDBC URL schema 或 username");
+    }
+
+    private static boolean containsPropertyIgnoreCase(Properties properties, String key) {
+        for (Object name : properties.keySet()) {
+            if (name != null && key.equalsIgnoreCase(String.valueOf(name))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String quoteTable(TablePath path) {
+        return quote(path.getSchemaName()) + "." + quote(path.getTableName());
+    }
+
+    private static String quote(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + value.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static String literal(String value) {
+        return value.replace("'", "''");
+    }
+
+    private static boolean hasText(String value) {
+        return normalize(value) != null;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static final class KeyColumn {
+        private final int position;
+        private final String name;
+
+        private KeyColumn(int position, String name) {
+            this.position = position;
+            this.name = name;
+        }
+
+        private int position() {
+            return position;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/dameng/DamengCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/dameng/DamengCatalogFactory.java
@@ -1,0 +1,44 @@
+package com.link.up.connector.jdbc.catalog.dameng;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.factory.Factory;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.config.JdbcCommonOptions;
+
+import java.util.Collections;
+import java.util.Map;
+
+/** Dameng DM8 Catalog factory. */
+@AutoService(Factory.class)
+public final class DamengCatalogFactory implements CatalogFactory {
+
+    private static final String DEFAULT_DRIVER = "dm.jdbc.driver.DmDriver";
+
+    @Override
+    public String factoryIdentifier() {
+        return DamengCatalog.DIALECT;
+    }
+
+    @Override
+    public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
+        String url = options.get(JdbcCommonOptions.URL);
+        String username = options.getOptional(JdbcCommonOptions.USERNAME).orElse(null);
+        String password = options.getOptional(JdbcCommonOptions.PASSWORD).orElse(null);
+        String driver = options.getOptional(JdbcCommonOptions.DRIVER).orElse(DEFAULT_DRIVER);
+        String schema = options.getOptional(JdbcCommonOptions.SCHEMA).orElse(null);
+        Map<String, String> properties = options.getOptional(JdbcCommonOptions.PROPERTIES)
+                .orElse(Collections.<String, String>emptyMap());
+
+        JdbcCatalogConfig config = new JdbcCatalogConfig(
+                url,
+                username,
+                password,
+                driver,
+                properties,
+                false);
+        return new DamengCatalog(catalogName, config, schema);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/dameng/DamengCreateTableSqlBuilder.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/dameng/DamengCreateTableSqlBuilder.java
@@ -1,0 +1,235 @@
+package com.link.up.connector.jdbc.catalog.dameng;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.dameng.DamengTypeMapper;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** Dameng DM8 offline CREATE TABLE builder. */
+public final class DamengCreateTableSqlBuilder {
+
+    private static final Pattern NUMBER_PATTERN =
+            Pattern.compile("[-+]?\\d+(\\.\\d+)?");
+    private static final Pattern TABLESPACE_PATTERN =
+            Pattern.compile("[A-Za-z0-9_$#]+(?:[A-Za-z0-9_$#-]*[A-Za-z0-9_$#])?");
+
+    private final TablePath tablePath;
+    private final CatalogTable catalogTable;
+    private final DamengTypeMapper typeMapper;
+
+    public DamengCreateTableSqlBuilder(
+            TablePath tablePath,
+            CatalogTable catalogTable,
+            DamengTypeMapper typeMapper) {
+        this.tablePath = tablePath;
+        this.catalogTable = catalogTable;
+        this.typeMapper = typeMapper;
+    }
+
+    public String build() {
+        return buildStatements().stream()
+                .map(sql -> sql.endsWith(";") ? sql : sql + ";")
+                .collect(Collectors.joining("\n"));
+    }
+
+    public List<String> buildStatements() {
+        TableSchema schema = catalogTable.getTableSchema();
+        PrimaryKey primaryKey = schema.getPrimaryKey();
+        Set<String> primaryKeyColumns = primaryKey == null
+                ? new HashSet<String>()
+                : new HashSet<String>(primaryKey.getColumnNames());
+        boolean preserveSourceType = DamengCatalog.DIALECT.equalsIgnoreCase(
+                catalogTable.getOptions().get(DamengCatalog.TABLE_OPTION_DIALECT));
+
+        List<String> definitions = new ArrayList<String>();
+        for (Column column : schema.getColumns()) {
+            definitions.add(buildColumnDefinition(
+                    column,
+                    preserveSourceType,
+                    primaryKeyColumns.contains(column.getName())));
+        }
+        if (primaryKey != null) {
+            definitions.add(buildPrimaryKey(primaryKey));
+        }
+
+        StringBuilder create = new StringBuilder()
+                .append("CREATE TABLE ")
+                .append(quoteTable(tablePath))
+                .append(" (\n    ")
+                .append(String.join(",\n    ", definitions))
+                .append("\n)");
+        appendStorageOptions(create);
+
+        List<String> statements = new ArrayList<String>();
+        statements.add(create.toString());
+        if (hasText(catalogTable.getComment())) {
+            statements.add(
+                    "COMMENT ON TABLE " + quoteTable(tablePath)
+                            + " IS '" + escapeLiteral(catalogTable.getComment()) + "'");
+        }
+        for (Column column : schema.getColumns()) {
+            if (hasText(column.getComment())) {
+                statements.add(
+                        "COMMENT ON COLUMN " + quoteTable(tablePath) + "."
+                                + quoteIdentifier(column.getName())
+                                + " IS '" + escapeLiteral(column.getComment()) + "'");
+            }
+        }
+        return statements;
+    }
+
+    public String buildColumnDefinition(Column column, boolean preserveSourceType) {
+        return buildColumnDefinition(column, preserveSourceType, false);
+    }
+
+    private String buildColumnDefinition(
+            Column column,
+            boolean preserveSourceType,
+            boolean primaryKeyColumn) {
+        List<String> parts = new ArrayList<String>();
+        parts.add(quoteIdentifier(column.getName()));
+        parts.add(typeMapper.toDatabaseType(column, preserveSourceType));
+
+        if (column.isAutoIncrement()) {
+            validateIdentityColumn(column);
+            parts.add("IDENTITY(1,1)");
+        } else if (column.getDefaultValue() != null) {
+            parts.add("DEFAULT " + formatDefaultValue(column, preserveSourceType));
+        }
+        if (!column.isNullable() || primaryKeyColumn) {
+            parts.add("NOT NULL");
+        }
+        return String.join(" ", parts);
+    }
+
+    private void appendStorageOptions(StringBuilder create) {
+        String fillfactor = catalogTable.getOptions().get(DamengCatalog.TABLE_OPTION_FILLFACTOR);
+        String tablespace = catalogTable.getOptions().get(DamengCatalog.TABLE_OPTION_TABLESPACE);
+        List<String> storage = new ArrayList<String>();
+        if (hasText(fillfactor)) {
+            int value;
+            try {
+                value = Integer.parseInt(fillfactor.trim());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("Dameng fillfactor 必须是 0-100 的整数：" + fillfactor, e);
+            }
+            if (value < 0 || value > 100) {
+                throw new IllegalArgumentException("Dameng fillfactor 必须是 0-100 的整数：" + fillfactor);
+            }
+            storage.add("FILLFACTOR " + value);
+        }
+        if (hasText(tablespace)) {
+            String value = tablespace.trim();
+            if (!TABLESPACE_PATTERN.matcher(value).matches()) {
+                throw new IllegalArgumentException("非法 Dameng tablespace：" + tablespace);
+            }
+            storage.add("ON " + quoteIdentifier(value));
+        }
+        if (!storage.isEmpty()) {
+            create.append("\nSTORAGE (")
+                    .append(String.join(", ", storage))
+                    .append(")");
+        }
+    }
+
+    private static void validateIdentityColumn(Column column) {
+        SqlType type = column.getDataType().getSqlType();
+        boolean supported = type == SqlType.INT || type == SqlType.BIGINT;
+        if (type == SqlType.DECIMAL) {
+            supported = column.getScale() == null || column.getScale() == 0;
+        }
+        if (!supported) {
+            throw new IllegalArgumentException(
+                    "Dameng IDENTITY 仅支持 INT/BIGINT/DECIMAL(scale=0)，column="
+                            + column.getName() + "，type=" + type);
+        }
+    }
+
+    private String buildPrimaryKey(PrimaryKey primaryKey) {
+        String columns = primaryKey.getColumnNames().stream()
+                .map(DamengCreateTableSqlBuilder::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        if (!hasText(primaryKey.getName())) {
+            return "PRIMARY KEY (" + columns + ")";
+        }
+        return "CONSTRAINT " + quoteIdentifier(primaryKey.getName())
+                + " PRIMARY KEY (" + columns + ")";
+    }
+
+    private String formatDefaultValue(Column column, boolean preserveSourceType) {
+        Object value = column.getDefaultValue();
+        if (preserveSourceType) {
+            String expression = String.valueOf(value).trim();
+            if (hasText(expression)) {
+                return expression;
+            }
+        }
+        if (value instanceof Number) {
+            return value.toString();
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value ? "1" : "0";
+        }
+
+        String text = String.valueOf(value).trim();
+        String upper = text.toUpperCase(Locale.ROOT);
+        if ("NULL".equals(upper)
+                || upper.startsWith("CURRENT ")
+                || upper.startsWith("CURRENT_")
+                || upper.startsWith("SYSDATE")
+                || upper.startsWith("SYSTIMESTAMP")
+                || "USER".equals(upper)) {
+            return text;
+        }
+        if (isNumeric(column.getDataType().getSqlType())
+                && NUMBER_PATTERN.matcher(text).matches()) {
+            return text;
+        }
+        return "'" + escapeLiteral(text) + "'";
+    }
+
+    private static boolean isNumeric(SqlType type) {
+        return type == SqlType.TINYINT
+                || type == SqlType.SMALLINT
+                || type == SqlType.INT
+                || type == SqlType.BIGINT
+                || type == SqlType.FLOAT
+                || type == SqlType.DOUBLE
+                || type == SqlType.DECIMAL;
+    }
+
+    private static String quoteTable(TablePath path) {
+        if (!hasText(path.getSchemaName())) {
+            throw new IllegalArgumentException("Dameng CREATE TABLE 需要 schema：" + path);
+        }
+        return quoteIdentifier(path.getSchemaName())
+                + "."
+                + quoteIdentifier(path.getTableName());
+    }
+
+    private static String quoteIdentifier(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + value.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static String escapeLiteral(String value) {
+        return value.replace("'", "''");
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -13,6 +13,7 @@ public final class DatabaseIdentifier {
     public static final String SQLSERVER = "sqlserver";
     public static final String OCEANBASE = "oceanbase";
     public static final String DB2 = "db2";
+    public static final String DAMENG = "dameng";
 
     private DatabaseIdentifier() {
     }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengDialect.java
@@ -1,0 +1,297 @@
+package com.link.up.connector.jdbc.core.dialect.dameng;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.dameng.DamengCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Dameng DM8 offline JDBC dialect.
+ *
+ * <p>Only bounded Source, batch Sink, Catalog and offline DDL are implemented.
+ * Redo/archive-log CDC, checkpoints and runtime schema events are intentionally
+ * outside this dialect.</p>
+ */
+public final class DamengDialect implements JdbcDialect {
+
+    private final JdbcConnectionConfig connectionConfig;
+    private final DamengTypeMapper typeMapper;
+
+    public DamengDialect(JdbcConnectionConfig connectionConfig) {
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException("connectionConfig must not be null");
+        }
+        if (!DamengJdbcUrl.accepts(connectionConfig.getUrl())) {
+            throw new IllegalArgumentException(
+                    "非法 Dameng JDBC URL：" + connectionConfig.getUrl());
+        }
+        this.connectionConfig = connectionConfig;
+        this.typeMapper = new DamengTypeMapper();
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.DAMENG;
+    }
+
+    @Override
+    public Catalog createCatalog(String catalogName, JdbcConnectionConfig connectionConfig) {
+        return new DamengCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false),
+                connectionConfig.getSchema());
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new DamengJdbcRowConverter();
+    }
+
+    /** Dameng SQL addresses schema.table; a three-part path keeps a logical DB for Catalog APIs. */
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        if (!JdbcDialect.hasText(tablePath)) {
+            throw new IllegalArgumentException("tablePath must not be empty");
+        }
+
+        List<String> parts = splitIdentifierPath(tablePath.trim());
+        switch (parts.size()) {
+            case 1:
+                return TablePath.of(normalizePathPart(parts.get(0)));
+            case 2:
+                return TablePath.of(
+                        null,
+                        normalizePathPart(parts.get(0)),
+                        normalizePathPart(parts.get(1)));
+            case 3:
+                return TablePath.of(
+                        normalizePathPart(parts.get(0)),
+                        normalizePathPart(parts.get(1)),
+                        normalizePathPart(parts.get(2)));
+            default:
+                throw new IllegalArgumentException("非法 Dameng 表路径：" + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        if (!JdbcDialect.hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + identifier.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        return quoteIdentifier(resolveSchema(tablePath))
+                + "."
+                + quoteIdentifier(tablePath.getTableName());
+    }
+
+    @Override
+    public Optional<String> buildUpsertSql(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+
+        JdbcDialect.validateFields(fieldNames);
+        Set<String> primaryKeySet = JdbcDialect.normalizeFields(primaryKeys);
+        if (primaryKeySet.isEmpty()) {
+            throw new IllegalArgumentException("Dameng UPSERT 必须配置主键字段");
+        }
+
+        Set<String> fieldSet = new HashSet<String>(fieldNames);
+        for (String primaryKey : primaryKeys) {
+            if (!fieldSet.contains(primaryKey)) {
+                throw new IllegalArgumentException(
+                        "Dameng UPSERT 主键字段不存在：" + primaryKey);
+            }
+        }
+
+        String sourceProjection = fieldNames.stream()
+                .map(field -> "? " + quoteIdentifier(field))
+                .collect(Collectors.joining(", "));
+        String onClause = primaryKeys.stream()
+                .map(field -> "TARGET." + quoteIdentifier(field)
+                        + " = SOURCE." + quoteIdentifier(field))
+                .collect(Collectors.joining(" AND "));
+        List<String> updateFields = fieldNames.stream()
+                .filter(field -> !primaryKeySet.contains(field))
+                .collect(Collectors.toList());
+
+        StringBuilder sql = new StringBuilder()
+                .append("MERGE INTO ")
+                .append(tableIdentifier(tablePath))
+                .append(" TARGET USING (SELECT ")
+                .append(sourceProjection)
+                .append(") SOURCE ON (")
+                .append(onClause)
+                .append(")");
+
+        if (!updateFields.isEmpty()) {
+            String updateClause = updateFields.stream()
+                    .map(field -> "TARGET." + quoteIdentifier(field)
+                            + " = SOURCE." + quoteIdentifier(field))
+                    .collect(Collectors.joining(", "));
+            sql.append(" WHEN MATCHED THEN UPDATE SET ").append(updateClause);
+        }
+
+        String insertFields = fieldNames.stream()
+                .map(this::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        String insertValues = fieldNames.stream()
+                .map(field -> "SOURCE." + quoteIdentifier(field))
+                .collect(Collectors.joining(", "));
+        sql.append(" WHEN NOT MATCHED THEN INSERT (")
+                .append(insertFields)
+                .append(") VALUES (")
+                .append(insertValues)
+                .append(")");
+        return Optional.of(sql.toString());
+    }
+
+    @Override
+    public PreparedStatement prepareReadStatement(
+            Connection connection,
+            String sql,
+            int fetchSize) throws SQLException {
+        PreparedStatement statement = connection.prepareStatement(
+                sql,
+                ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY);
+        if (fetchSize > 0) {
+            statement.setFetchSize(fetchSize);
+        }
+        return statement;
+    }
+
+    /** ORA_HASH returns a deterministic bucket from 0 through max_bucket inclusive. */
+    @Override
+    public Optional<String> buildHashPartitionPredicate(
+            Column column,
+            int bucket,
+            int bucketCount) {
+        if (column == null) {
+            throw new IllegalArgumentException("column must not be null");
+        }
+        if (bucketCount <= 0) {
+            throw new IllegalArgumentException("bucketCount must be greater than 0");
+        }
+        if (bucket < 0 || bucket >= bucketCount) {
+            throw new IllegalArgumentException("bucket must be between 0 and bucketCount - 1");
+        }
+        return Optional.of(
+                "ORA_HASH(" + quoteIdentifier(column.getName()) + ", "
+                        + (bucketCount - 1) + ") = " + bucket);
+    }
+
+    /** Explicit connector schema becomes the DM JDBC session schema unless user properties override it. */
+    @Override
+    public Map<String, String> defaultConnectionProperties() {
+        if (!JdbcDialect.hasText(connectionConfig.getSchema())) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        result.put("schema", connectionConfig.getSchema().trim());
+        return Collections.unmodifiableMap(result);
+    }
+
+    private String resolveSchema(TablePath tablePath) {
+        if (JdbcDialect.hasText(tablePath.getSchemaName())) {
+            return tablePath.getSchemaName().trim();
+        }
+        if (JdbcDialect.hasText(connectionConfig.getSchema())) {
+            return connectionConfig.getSchema().trim();
+        }
+        String schema = DamengJdbcUrl.schema(
+                connectionConfig.getUrl(),
+                connectionConfig.getProperties());
+        if (JdbcDialect.hasText(schema)) {
+            return schema.trim();
+        }
+        if (JdbcDialect.hasText(connectionConfig.getUsername())) {
+            return connectionConfig.getUsername().trim().toUpperCase(Locale.ROOT);
+        }
+        throw new IllegalArgumentException(
+                "Dameng 表路径缺少 schema，且 connection schema/JDBC URL schema/username 均未配置："
+                        + tablePath);
+    }
+
+    private static List<String> splitIdentifierPath(String path) {
+        List<String> parts = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '\"') {
+                current.append(c);
+                if (quoted && i + 1 < path.length() && path.charAt(i + 1) == '\"') {
+                    current.append('\"');
+                    i++;
+                } else {
+                    quoted = !quoted;
+                }
+                continue;
+            }
+            if (c == '.' && !quoted) {
+                if (current.length() == 0) {
+                    throw new IllegalArgumentException("非法 Dameng 表路径：" + path);
+                }
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        if (quoted || current.length() == 0) {
+            throw new IllegalArgumentException("非法 Dameng 表路径：" + path);
+        }
+        parts.add(current.toString());
+        return parts;
+    }
+
+    private static String normalizePathPart(String part) {
+        String value = part.trim();
+        if (value.length() >= 2
+                && value.charAt(0) == '\"'
+                && value.charAt(value.length() - 1) == '\"') {
+            return value.substring(1, value.length() - 1).replace("\"\"", "\"");
+        }
+        return value.toUpperCase(Locale.ROOT);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengDialectFactory.java
@@ -1,0 +1,27 @@
+package com.link.up.connector.jdbc.core.dialect.dameng;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/** Dameng DM8 dialect factory. */
+@AutoService(JdbcDialectFactory.class)
+public final class DamengDialectFactory implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.DAMENG;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return DamengJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(JdbcConnectionConfig connectionConfig) {
+        return new DamengDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengJdbcRowConverter.java
@@ -1,0 +1,130 @@
+package com.link.up.connector.jdbc.core.dialect.dameng;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
+
+/** Dameng row converter with LOB-safe writes. */
+public final class DamengJdbcRowConverter extends AbstractJdbcRowConverter {
+
+    private static final long INLINE_LIMIT = DamengTypeMapper.MAX_INLINE_BYTES;
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.DAMENG;
+    }
+
+    @Override
+    protected void writeNull(
+            PreparedStatement statement,
+            int index,
+            Column column) throws SQLException {
+
+        String sourceType = baseType(column.getSourceType());
+        SqlType sqlType = column.getDataType().getSqlType();
+
+        if (isCharacterLob(sourceType)
+                || (sqlType == SqlType.STRING
+                && (column.getLength() == null || exceedsInlineStringLength(column.getLength()))
+                && !isTimeWithTimezone(column.getSourceType()))) {
+            statement.setNull(index, Types.CLOB);
+            return;
+        }
+
+        if (isBinaryLob(sourceType)
+                || (sqlType == SqlType.BYTES
+                && (column.getLength() == null || column.getLength() > INLINE_LIMIT))) {
+            statement.setNull(index, Types.BLOB);
+            return;
+        }
+
+        super.writeNull(statement, index, column);
+    }
+
+    @Override
+    protected void writeValue(
+            PreparedStatement statement,
+            int index,
+            Object value,
+            Column column) throws SQLException {
+
+        String sourceType = baseType(column.getSourceType());
+        SqlType sqlType = column.getDataType().getSqlType();
+
+        if (isTimeWithTimezone(column.getSourceType()) && sqlType == SqlType.STRING) {
+            // Exact text is intentionally used because Flux has no TIME_TZ primitive.
+            statement.setString(index, asString(value));
+            return;
+        }
+
+        if (isCharacterLob(sourceType)
+                || (sqlType == SqlType.STRING
+                && (column.getLength() == null || exceedsInlineStringLength(column.getLength())))) {
+            String text = asString(value);
+            statement.setCharacterStream(index, new StringReader(text), text.length());
+            return;
+        }
+
+        if (isBinaryLob(sourceType)
+                || (sqlType == SqlType.BYTES
+                && (column.getLength() == null || column.getLength() > INLINE_LIMIT))) {
+            byte[] bytes = asBytes(value);
+            statement.setBinaryStream(index, new ByteArrayInputStream(bytes), bytes.length);
+            return;
+        }
+
+        super.writeValue(statement, index, value, column);
+    }
+
+    private static boolean exceedsInlineStringLength(long length) {
+        return length <= 0 || length > INLINE_LIMIT / 4L;
+    }
+
+    private static boolean isCharacterLob(String type) {
+        return "CLOB".equals(type)
+                || "TEXT".equals(type)
+                || "LONG".equals(type)
+                || "LONGVARCHAR".equals(type);
+    }
+
+    private static boolean isBinaryLob(String type) {
+        return "BLOB".equals(type)
+                || "IMAGE".equals(type)
+                || "LONGVARBINARY".equals(type);
+    }
+
+    private static boolean isTimeWithTimezone(String value) {
+        String type = normalize(value);
+        return type.startsWith("TIME")
+                && !type.startsWith("TIMESTAMP")
+                && type.contains("WITH TIME ZONE");
+    }
+
+    private static String baseType(String value) {
+        String type = normalize(value);
+        int parenthesis = type.indexOf('(');
+        int space = type.indexOf(' ');
+        int end = type.length();
+        if (parenthesis >= 0) {
+            end = Math.min(end, parenthesis);
+        }
+        if (space >= 0) {
+            end = Math.min(end, space);
+        }
+        return type.substring(0, end).trim();
+    }
+
+    private static String normalize(String value) {
+        return value == null
+                ? ""
+                : value.trim().toUpperCase(Locale.ROOT).replaceAll("\\s+", " ");
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengJdbcUrl.java
@@ -1,0 +1,97 @@
+package com.link.up.connector.jdbc.core.dialect.dameng;
+
+import java.util.Locale;
+import java.util.Map;
+
+/** Utilities for Dameng JDBC URLs. */
+public final class DamengJdbcUrl {
+
+    private static final String PREFIX = "jdbc:dm://";
+
+    private DamengJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return url != null
+                && url.trim().toLowerCase(Locale.ROOT).startsWith("jdbc:dm:");
+    }
+
+    /**
+     * Resolves the session/default schema from explicit connection properties,
+     * URL query properties and finally the optional /schemaName URL path.
+     */
+    public static String schema(String url, Map<String, String> properties) {
+        String propertySchema = property(properties, "schema");
+        if (hasText(propertySchema)) {
+            return propertySchema.trim();
+        }
+
+        String querySchema = queryProperty(url, "schema");
+        if (hasText(querySchema)) {
+            return querySchema.trim();
+        }
+
+        return pathSchema(url);
+    }
+
+    static String pathSchema(String url) {
+        if (!accepts(url)) {
+            return null;
+        }
+
+        String value = url.trim();
+        if (!value.toLowerCase(Locale.ROOT).startsWith(PREFIX)) {
+            return null;
+        }
+
+        int query = value.indexOf('?');
+        String main = query >= 0 ? value.substring(0, query) : value;
+        int authorityStart = PREFIX.length();
+        int slash = main.indexOf('/', authorityStart);
+        if (slash < 0 || slash == main.length() - 1) {
+            return null;
+        }
+
+        String schema = main.substring(slash + 1).trim();
+        return hasText(schema) ? schema : null;
+    }
+
+    private static String queryProperty(String url, String key) {
+        if (url == null) {
+            return null;
+        }
+        int query = url.indexOf('?');
+        if (query < 0 || query == url.length() - 1) {
+            return null;
+        }
+        String[] entries = url.substring(query + 1).split("&");
+        for (String entry : entries) {
+            int separator = entry.indexOf('=');
+            if (separator <= 0) {
+                continue;
+            }
+            String name = entry.substring(0, separator).trim();
+            if (key.equalsIgnoreCase(name)) {
+                String value = entry.substring(separator + 1).trim();
+                return hasText(value) ? value : null;
+            }
+        }
+        return null;
+    }
+
+    private static String property(Map<String, String> properties, String key) {
+        if (properties == null || properties.isEmpty()) {
+            return null;
+        }
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (entry.getKey() != null && key.equalsIgnoreCase(entry.getKey().trim())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengTypeMapper.java
@@ -1,0 +1,486 @@
+package com.link.up.connector.jdbc.core.dialect.dameng;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
+
+/** Dameng DM8 JDBC type mapper for bounded/offline jobs. */
+public final class DamengTypeMapper implements JdbcTypeMapper {
+
+    static final int MAX_DECIMAL_PRECISION = 38;
+    static final int DEFAULT_DECIMAL_SCALE = 18;
+    static final int MAX_TEMPORAL_PRECISION = 6;
+    static final long MAX_INLINE_BYTES = 1900L;
+
+    @Override
+    public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+        String name = firstText(
+                metadata.getColumnLabel(columnIndex),
+                metadata.getColumnName(columnIndex));
+        String sourceType = metadata.getColumnTypeName(columnIndex);
+        int precision = metadata.getPrecision(columnIndex);
+        int scale = metadata.getScale(columnIndex);
+        int jdbcType = metadata.getColumnType(columnIndex);
+
+        FluxDataType<?> type = mapType(jdbcType, sourceType, precision, scale);
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(metadata.isNullable(columnIndex) != ResultSetMetaData.columnNoNulls)
+                .sourceType(buildSourceType(sourceType, precision, scale));
+        applyProperties(builder, type, sourceType, precision, scale);
+        return builder.build();
+    }
+
+    /** Maps one DatabaseMetaData#getColumns row. */
+    public Column toColumn(ResultSet row) throws SQLException {
+        String name = row.getString("COLUMN_NAME");
+        String typeName = row.getString("TYPE_NAME");
+        Integer size = integer(row, "COLUMN_SIZE");
+        Integer scale = integer(row, "DECIMAL_DIGITS");
+        Integer nullableValue = integer(row, "NULLABLE");
+        int precision = value(size);
+        int safeScale = value(scale);
+
+        FluxDataType<?> type = mapType(
+                value(integer(row, "DATA_TYPE")),
+                typeName,
+                precision,
+                safeScale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(nullableValue == null
+                        || nullableValue != ResultSetMetaData.columnNoNulls)
+                .defaultValue(row.getObject("COLUMN_DEF"))
+                .comment(row.getString("REMARKS"))
+                .sourceType(buildSourceType(typeName, precision, safeScale));
+
+        String auto = safeString(row, "IS_AUTOINCREMENT");
+        builder.autoIncrement("YES".equalsIgnoreCase(auto));
+        applyProperties(builder, type, typeName, precision, safeScale);
+        return builder.build();
+    }
+
+    @Override
+    public String toDatabaseType(Column column) {
+        return toDatabaseType(column, false);
+    }
+
+    public String toDatabaseType(Column column, boolean preserveSourceType) {
+        if (preserveSourceType && canPreserve(column.getSourceType())) {
+            return column.getSourceType().trim();
+        }
+
+        SqlType type = column.getDataType().getSqlType();
+        switch (type) {
+            case BOOLEAN:
+                return "BIT";
+            case TINYINT:
+                return "TINYINT";
+            case SMALLINT:
+                return "SMALLINT";
+            case INT:
+                return "INT";
+            case BIGINT:
+                return "BIGINT";
+            case FLOAT:
+                return "REAL";
+            case DOUBLE:
+                return "DOUBLE";
+            case DECIMAL:
+                return decimalType(column);
+            case STRING:
+                return stringType(column);
+            case BYTES:
+                return binaryType(column);
+            case DATE:
+                return "DATE";
+            case TIME:
+                return temporalType("TIME", column.getPrecision());
+            case TIMESTAMP:
+                return temporalType("TIMESTAMP", column.getPrecision());
+            case TIMESTAMP_TZ:
+                return temporalType("DATETIME", column.getPrecision())
+                        + " WITH TIME ZONE";
+            default:
+                throw new IllegalArgumentException(
+                        "Dameng 不支持 Flux 类型：" + type + "，column=" + column.getName());
+        }
+    }
+
+    /** Package-visible for focused type contract tests. */
+    FluxDataType<?> mapType(
+            int jdbcType,
+            String sourceType,
+            int precision,
+            int scale) {
+
+        String normalized = normalizeType(sourceType);
+        String base = baseType(normalized);
+
+        if (normalized.contains("WITH TIME ZONE")) {
+            if (base.startsWith("TIME") && !base.startsWith("TIMESTAMP")) {
+                // Flux has no TIME WITH TIME ZONE primitive. Keep the exact textual value
+                // rather than silently discarding the offset.
+                return BasicType.STRING_TYPE;
+            }
+            return BasicType.TIMESTAMP_TZ_TYPE;
+        }
+
+        if (base.startsWith("TIMESTAMP") || "DATETIME".equals(base)) {
+            return BasicType.TIMESTAMP_TYPE;
+        }
+
+        switch (base) {
+            case "BIT":
+            case "BOOLEAN":
+                return BasicType.BOOLEAN_TYPE;
+            case "TINYINT":
+            case "BYTE":
+                return BasicType.BYTE_TYPE;
+            case "SMALLINT":
+                return BasicType.SHORT_TYPE;
+            case "INT":
+            case "INTEGER":
+            case "PLS_INTEGER":
+                return BasicType.INT_TYPE;
+            case "BIGINT":
+                return BasicType.LONG_TYPE;
+            case "REAL":
+                return BasicType.FLOAT_TYPE;
+            case "FLOAT":
+            case "DOUBLE":
+            case "DOUBLE PRECISION":
+                return BasicType.DOUBLE_TYPE;
+            case "NUMERIC":
+            case "NUMBER":
+            case "DECIMAL":
+            case "DEC":
+                return decimal(precision, scale);
+            case "CHAR":
+            case "CHARACTER":
+            case "VARCHAR":
+            case "VARCHAR2":
+            case "NCHAR":
+            case "NVARCHAR":
+            case "NVARCHAR2":
+            case "LONGVARCHAR":
+            case "CLOB":
+            case "TEXT":
+            case "LONG":
+            case "BFILE":
+            case "ROWID":
+                return BasicType.STRING_TYPE;
+            case "BINARY":
+            case "VARBINARY":
+            case "LONGVARBINARY":
+            case "BLOB":
+            case "IMAGE":
+                return BasicType.BYTES_TYPE;
+            case "DATE":
+                return BasicType.DATE_TYPE;
+            case "TIME":
+                return BasicType.TIME_TYPE;
+            default:
+                break;
+        }
+
+        switch (jdbcType) {
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return BasicType.BOOLEAN_TYPE;
+            case Types.TINYINT:
+                return BasicType.BYTE_TYPE;
+            case Types.SMALLINT:
+                return BasicType.SHORT_TYPE;
+            case Types.INTEGER:
+                return BasicType.INT_TYPE;
+            case Types.BIGINT:
+                return BasicType.LONG_TYPE;
+            case Types.REAL:
+                return BasicType.FLOAT_TYPE;
+            case Types.FLOAT:
+            case Types.DOUBLE:
+                return BasicType.DOUBLE_TYPE;
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return decimal(precision, scale);
+            case Types.DATE:
+                return BasicType.DATE_TYPE;
+            case Types.TIME:
+                return BasicType.TIME_TYPE;
+            case Types.TIMESTAMP:
+                return BasicType.TIMESTAMP_TYPE;
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return BasicType.TIMESTAMP_TZ_TYPE;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+            case Types.BLOB:
+                return BasicType.BYTES_TYPE;
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR:
+            case Types.CLOB:
+            case Types.NCLOB:
+                return BasicType.STRING_TYPE;
+            default:
+                throw new IllegalArgumentException(
+                        "暂不支持 Dameng 字段类型：" + sourceType + "，jdbcType=" + jdbcType);
+        }
+    }
+
+    private static DecimalType decimal(int precision, int scale) {
+        int safePrecision = precision <= 0 ? MAX_DECIMAL_PRECISION : precision;
+        int safeScale = precision <= 0 ? DEFAULT_DECIMAL_SCALE : Math.max(0, scale);
+        validateDecimal(safePrecision, safeScale, null);
+        return new DecimalType(safePrecision, safeScale);
+    }
+
+    private static String decimalType(Column column) {
+        Integer precisionValue = column.getPrecision();
+        Integer scaleValue = column.getScale();
+        if (column.getDataType() instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) column.getDataType();
+            if (precisionValue == null) {
+                precisionValue = decimal.getPrecision();
+            }
+            if (scaleValue == null) {
+                scaleValue = decimal.getScale();
+            }
+        }
+        int precision = precisionValue == null ? MAX_DECIMAL_PRECISION : precisionValue;
+        int scale = scaleValue == null ? 0 : scaleValue;
+        if (precision <= 0) {
+            precision = MAX_DECIMAL_PRECISION;
+        }
+        validateDecimal(precision, scale, column.getName());
+        return "DECIMAL(" + precision + "," + scale + ")";
+    }
+
+    private static void validateDecimal(int precision, int scale, String column) {
+        if (precision > MAX_DECIMAL_PRECISION) {
+            throw new IllegalArgumentException(
+                    "Dameng DECIMAL precision 最大为 38"
+                            + (column == null ? "" : "，column=" + column)
+                            + "，precision=" + precision);
+        }
+        if (precision <= 0 || scale < 0 || scale > precision) {
+            throw new IllegalArgumentException(
+                    "Dameng DECIMAL precision/scale 非法"
+                            + (column == null ? "" : "，column=" + column)
+                            + "，precision=" + precision + "，scale=" + scale);
+        }
+    }
+
+    private static String stringType(Column column) {
+        Long length = column.getLength();
+        if (length == null || length <= 0) {
+            return "TEXT";
+        }
+        long bytes = length > Long.MAX_VALUE / 4L ? Long.MAX_VALUE : length * 4L;
+        if (bytes <= MAX_INLINE_BYTES) {
+            return "VARCHAR2(" + Math.max(1L, bytes) + ")";
+        }
+        return "TEXT";
+    }
+
+    private static String binaryType(Column column) {
+        Long length = column.getLength();
+        if (length == null || length <= 0 || length > MAX_INLINE_BYTES) {
+            return "BLOB";
+        }
+        return "VARBINARY(" + Math.max(1L, length) + ")";
+    }
+
+    private static String temporalType(String type, Integer precision) {
+        if (precision == null || precision <= 0) {
+            return type;
+        }
+        if (precision > MAX_TEMPORAL_PRECISION) {
+            throw new IllegalArgumentException(
+                    "Dameng " + type + " precision 最大为 6，precision=" + precision);
+        }
+        return type + "(" + precision + ")";
+    }
+
+    private static void applyProperties(
+            Column.Builder builder,
+            FluxDataType<?> type,
+            String sourceType,
+            int precision,
+            int scale) {
+        SqlType sqlType = type.getSqlType();
+        if (sqlType == SqlType.STRING || sqlType == SqlType.BYTES) {
+            if (precision > 0) {
+                builder.length((long) precision);
+            }
+            return;
+        }
+        if (sqlType == SqlType.DECIMAL && type instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) type;
+            builder.precision(decimal.getPrecision());
+            builder.scale(decimal.getScale());
+            return;
+        }
+        if (sqlType == SqlType.TIME
+                || sqlType == SqlType.TIMESTAMP
+                || sqlType == SqlType.TIMESTAMP_TZ) {
+            int p = Math.max(0, Math.min(
+                    scale > 0 ? scale : precision,
+                    MAX_TEMPORAL_PRECISION));
+            if (p > 0) {
+                builder.precision(p);
+            }
+        }
+    }
+
+    private static String buildSourceType(String sourceType, int precision, int scale) {
+        String raw = sourceType == null ? "" : sourceType.trim();
+        if (raw.isEmpty() || raw.contains("(")) {
+            return raw;
+        }
+        String normalized = normalizeType(raw);
+        String base = baseType(normalized);
+        if (isDecimal(base)) {
+            return precision > 0
+                    ? raw + "(" + precision + "," + Math.max(0, scale) + ")"
+                    : raw;
+        }
+        if (isLengthType(base)) {
+            return precision > 0 ? raw + "(" + precision + ")" : raw;
+        }
+        if (normalized.contains("WITH TIME ZONE")) {
+            int p = Math.min(Math.max(0, scale), MAX_TEMPORAL_PRECISION);
+            if (p <= 0) {
+                return raw;
+            }
+            if (base.startsWith("TIME") && !base.startsWith("TIMESTAMP")) {
+                return "TIME(" + p + ") WITH TIME ZONE";
+            }
+            if ("DATETIME".equals(base)) {
+                return "DATETIME(" + p + ") WITH TIME ZONE";
+            }
+            return "TIMESTAMP(" + p + ") WITH TIME ZONE";
+        }
+        if (base.startsWith("TIMESTAMP") || "DATETIME".equals(base) || "TIME".equals(base)) {
+            return scale > 0 ? raw + "(" + Math.min(scale, MAX_TEMPORAL_PRECISION) + ")" : raw;
+        }
+        return raw;
+    }
+
+    private static boolean canPreserve(String sourceType) {
+        String type = normalizeType(sourceType);
+        if (type.isEmpty()) {
+            return false;
+        }
+        String base = baseType(type);
+        return "BIT".equals(base)
+                || "BOOLEAN".equals(base)
+                || "TINYINT".equals(base)
+                || "BYTE".equals(base)
+                || "SMALLINT".equals(base)
+                || "INT".equals(base)
+                || "INTEGER".equals(base)
+                || "PLS_INTEGER".equals(base)
+                || "BIGINT".equals(base)
+                || "REAL".equals(base)
+                || "FLOAT".equals(base)
+                || "DOUBLE".equals(base)
+                || "DOUBLE PRECISION".equals(base)
+                || isDecimal(base)
+                || isLengthType(base)
+                || "LONGVARCHAR".equals(base)
+                || "CLOB".equals(base)
+                || "TEXT".equals(base)
+                || "LONG".equals(base)
+                || "LONGVARBINARY".equals(base)
+                || "BLOB".equals(base)
+                || "IMAGE".equals(base)
+                || "DATE".equals(base)
+                || "TIME".equals(base)
+                || base.startsWith("TIMESTAMP")
+                || "DATETIME".equals(base)
+                || type.contains("WITH TIME ZONE");
+    }
+
+    private static boolean isDecimal(String base) {
+        return "NUMERIC".equals(base)
+                || "NUMBER".equals(base)
+                || "DECIMAL".equals(base)
+                || "DEC".equals(base);
+    }
+
+    private static boolean isLengthType(String base) {
+        return "CHAR".equals(base)
+                || "CHARACTER".equals(base)
+                || "VARCHAR".equals(base)
+                || "VARCHAR2".equals(base)
+                || "NCHAR".equals(base)
+                || "NVARCHAR".equals(base)
+                || "NVARCHAR2".equals(base)
+                || "BINARY".equals(base)
+                || "VARBINARY".equals(base);
+    }
+
+    private static String baseType(String type) {
+        int parenthesis = type.indexOf('(');
+        String value = parenthesis >= 0 ? type.substring(0, parenthesis).trim() : type;
+        if (value.startsWith("TIME ") && value.contains("WITH TIME ZONE")) {
+            return "TIME";
+        }
+        if (value.startsWith("DATETIME ") && value.contains("WITH TIME ZONE")) {
+            return "DATETIME";
+        }
+        if (value.startsWith("TIMESTAMP ") && value.contains("WITH TIME ZONE")) {
+            return "TIMESTAMP";
+        }
+        return value;
+    }
+
+    private static String normalizeType(String value) {
+        return value == null
+                ? ""
+                : value.trim().toUpperCase(Locale.ROOT).replaceAll("\\s+", " ");
+    }
+
+    private static String firstText(String first, String second) {
+        String value = normalize(first);
+        return value == null ? normalize(second) : value;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static Integer integer(ResultSet row, String name) throws SQLException {
+        Object value = row.getObject(name);
+        return value == null ? null : ((Number) value).intValue();
+    }
+
+    private static int value(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private static String safeString(ResultSet row, String name) {
+        try {
+            return row.getString(name);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
@@ -26,7 +26,9 @@ import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerTypeMapper;
 
 import java.util.Locale;
 
-/** Generates the CREATE TABLE statement used for offline sink preparation. */
+/**
+ * Generates the CREATE TABLE statement used for offline sink preparation.
+ */
 final class JdbcCreateTableSqlResolver {
 
     private JdbcCreateTableSqlResolver() {
@@ -37,60 +39,219 @@ final class JdbcCreateTableSqlResolver {
             JdbcConnectionConfig connectionConfig,
             CatalogTable table) {
 
-        if (dialect == null || connectionConfig == null || table == null) {
+        if (dialect == null
+                || connectionConfig == null
+                || table == null) {
+
             return null;
         }
 
-        TablePath targetPath = resolveTargetPath(connectionConfig, table.getTablePath());
-        if (targetPath == null) {
-            return null;
-        }
+        if (DatabaseIdentifier.MYSQL
+                .equalsIgnoreCase(
+                        dialect.name())) {
 
-        CatalogTable ddlTable = table.getTablePath().equals(targetPath)
-                ? table
-                : table.withPath(targetPath);
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
 
-        if (DatabaseIdentifier.MYSQL.equalsIgnoreCase(dialect.name())) {
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
             return new MySqlCreateTableSqlBuilder(
-                    targetPath, ddlTable, new MySqlTypeMapper(false)).build();
+                    targetPath,
+                    ddlTable,
+                    new MySqlTypeMapper(false))
+                    .build();
         }
 
-        if (DatabaseIdentifier.OCEANBASE.equalsIgnoreCase(dialect.name())) {
-            OceanBaseCompatibleMode mode = OceanBaseCompatibleMode.from(
-                    connectionConfig.getCompatibleMode());
+        if (DatabaseIdentifier.OCEANBASE
+                .equalsIgnoreCase(
+                        dialect.name())) {
+
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
+            OceanBaseCompatibleMode mode =
+                    OceanBaseCompatibleMode.from(
+                            connectionConfig
+                                    .getCompatibleMode());
+
             if (mode.isMySql()) {
                 return new MySqlCreateTableSqlBuilder(
-                        targetPath, ddlTable, new MySqlTypeMapper(false)).build();
+                        targetPath,
+                        ddlTable,
+                        new MySqlTypeMapper(false))
+                        .build();
             }
+
             return new OracleCreateTableSqlBuilder(
-                    targetPath, ddlTable, new OracleTypeMapper()).build();
+                    targetPath,
+                    ddlTable,
+                    new OracleTypeMapper())
+                    .build();
         }
 
-        if (DatabaseIdentifier.POSTGRESQL.equalsIgnoreCase(dialect.name())) {
+        if (DatabaseIdentifier.POSTGRESQL
+                .equalsIgnoreCase(
+                        dialect.name())) {
+
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
             return new PostgresCreateTableSqlBuilder(
-                    targetPath, ddlTable, new PostgresTypeMapper()).build();
+                    targetPath,
+                    ddlTable,
+                    new PostgresTypeMapper())
+                    .build();
         }
 
-        if (DatabaseIdentifier.ORACLE.equalsIgnoreCase(dialect.name())) {
+        if (DatabaseIdentifier.ORACLE
+                .equalsIgnoreCase(
+                        dialect.name())) {
+
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
             return new OracleCreateTableSqlBuilder(
-                    targetPath, ddlTable, new OracleTypeMapper()).build();
+                    targetPath,
+                    ddlTable,
+                    new OracleTypeMapper())
+                    .build();
         }
 
-        if (DatabaseIdentifier.SQLSERVER.equalsIgnoreCase(dialect.name())) {
+        if (DatabaseIdentifier.SQLSERVER
+                .equalsIgnoreCase(
+                        dialect.name())) {
+
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
             return new SqlServerCreateTableSqlBuilder(
-                    targetPath, ddlTable, new SqlServerTypeMapper()).build();
+                    targetPath,
+                    ddlTable,
+                    new SqlServerTypeMapper())
+                    .build();
         }
 
-        if (DatabaseIdentifier.DB2.equalsIgnoreCase(dialect.name())) {
+        if (DatabaseIdentifier.DB2
+                .equalsIgnoreCase(
+                        dialect.name())) {
+
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
             return new Db2CreateTableSqlBuilder(
-                    targetPath, ddlTable, new Db2TypeMapper()).build();
+                    targetPath,
+                    ddlTable,
+                    new Db2TypeMapper())
+                    .build();
         }
 
-        if (DatabaseIdentifier.DAMENG.equalsIgnoreCase(dialect.name())) {
+        if (DatabaseIdentifier.DAMENG
+                .equalsIgnoreCase(
+                        dialect.name())) {
+
+            TablePath targetPath =
+                    resolveTargetPath(
+                            connectionConfig,
+                            table.getTablePath());
+
+            if (targetPath == null) {
+                return null;
+            }
+
+            CatalogTable ddlTable =
+                    table.getTablePath()
+                            .equals(targetPath)
+                            ? table
+                            : table.withPath(
+                                    targetPath);
+
             return new DamengCreateTableSqlBuilder(
-                    targetPath, ddlTable, new DamengTypeMapper()).build();
+                    targetPath,
+                    ddlTable,
+                    new DamengTypeMapper())
+                    .build();
         }
 
+        /*
+         * Future JDBC dialects can add their CREATE TABLE builder here
+         * without changing the connector-neutral protocol.
+         */
         return null;
     }
 
@@ -98,146 +259,293 @@ final class JdbcCreateTableSqlResolver {
             JdbcConnectionConfig connectionConfig,
             TablePath tablePath) {
 
-        if (connectionConfig == null || tablePath == null) {
+        if (connectionConfig == null
+                || tablePath == null) {
+
             return tablePath;
         }
 
-        if (isDameng(connectionConfig)) {
-            String schema = resolveDamengSchema(connectionConfig, tablePath);
+        if (isDameng(
+                connectionConfig)) {
+
+            String schema =
+                    resolveDamengSchema(
+                            connectionConfig,
+                            tablePath);
+
             if (!hasText(schema)) {
                 return null;
             }
-            return TablePath.of(null, schema, tablePath.getTableName());
+
+            return TablePath.of(
+                    null,
+                    schema,
+                    tablePath.getTableName());
         }
 
-        if (isDb2(connectionConfig)) {
-            String database = Db2JdbcUrl.databaseName(connectionConfig.getUrl());
+        if (isDb2(
+                connectionConfig)) {
+
+            String database =
+                    Db2JdbcUrl.databaseName(
+                            connectionConfig.getUrl());
+
             if (!hasText(database)) {
                 return null;
             }
-            String schema = resolveDb2Schema(connectionConfig, tablePath, database);
+
+            String schema =
+                    resolveDb2Schema(
+                            connectionConfig,
+                            tablePath,
+                            database);
+
             if (!hasText(schema)) {
                 return null;
             }
-            return TablePath.of(database, schema, tablePath.getTableName());
+
+            return TablePath.of(
+                    database,
+                    schema,
+                    tablePath.getTableName());
         }
 
-        if (isOceanBase(connectionConfig)) {
-            String database = OceanBaseJdbcUrl.databaseName(connectionConfig.getUrl());
-            OceanBaseCompatibleMode mode = OceanBaseCompatibleMode.from(
-                    connectionConfig.getCompatibleMode());
+        if (isOceanBase(
+                connectionConfig)) {
+
+            String database =
+                    OceanBaseJdbcUrl.databaseName(
+                            connectionConfig.getUrl());
+
+            OceanBaseCompatibleMode mode =
+                    OceanBaseCompatibleMode.from(
+                            connectionConfig
+                                    .getCompatibleMode());
 
             if (mode.isOracle()) {
                 if (!hasText(database)) {
                     return null;
                 }
-                String schema = resolveOracleSchema(connectionConfig, tablePath, database);
+
+                String schema =
+                        resolveOracleSchema(
+                                connectionConfig,
+                                tablePath,
+                                database);
+
                 if (!hasText(schema)) {
                     return null;
                 }
-                return TablePath.of(database, schema, tablePath.getTableName());
+
+                return TablePath.of(
+                        database,
+                        schema,
+                        tablePath.getTableName());
             }
 
             if (hasText(database)) {
-                return TablePath.of(database, tablePath.getTableName());
+                return TablePath.of(
+                        database,
+                        tablePath.getTableName());
             }
-            if (hasText(tablePath.getDatabaseName())) {
-                return TablePath.of(tablePath.getDatabaseName(), tablePath.getTableName());
+
+            if (hasText(
+                    tablePath.getDatabaseName())) {
+
+                return TablePath.of(
+                        tablePath.getDatabaseName(),
+                        tablePath.getTableName());
             }
-            if (hasText(connectionConfig.getSchema())) {
-                return TablePath.of(connectionConfig.getSchema(), tablePath.getTableName());
+
+            if (hasText(
+                    connectionConfig.getSchema())) {
+
+                return TablePath.of(
+                        connectionConfig
+                                .getSchema(),
+                        tablePath.getTableName());
             }
+
             return null;
         }
 
-        if (isSqlServer(connectionConfig)) {
-            String database = SqlServerJdbcUrl.databaseName(connectionConfig.getUrl());
-            String pathDatabase = tablePath.getDatabaseName();
-            String pathSchema = tablePath.getSchemaName();
+        if (isSqlServer(
+                connectionConfig)) {
+
+            String database =
+                    SqlServerJdbcUrl.databaseName(
+                            connectionConfig.getUrl());
+
+            String pathDatabase =
+                    tablePath.getDatabaseName();
+
+            String pathSchema =
+                    tablePath.getSchemaName();
+
             String schema;
 
             if (!hasText(pathDatabase)) {
                 schema = hasText(pathSchema)
                         ? pathSchema.trim()
-                        : resolveSqlServerSchema(connectionConfig);
-            } else if (hasText(database) && database.equalsIgnoreCase(pathDatabase)) {
+                        : resolveSqlServerSchema(
+                                connectionConfig);
+            } else if (hasText(database)
+                    && database.equalsIgnoreCase(
+                            pathDatabase)) {
                 schema = hasText(pathSchema)
                         ? pathSchema.trim()
-                        : resolveSqlServerSchema(connectionConfig);
+                        : resolveSqlServerSchema(
+                                connectionConfig);
             } else {
-                schema = resolveSqlServerSchema(connectionConfig);
+                /*
+                 * Do not leak a MySQL/PostgreSQL/Oracle source database/schema
+                 * into an unqualified SQL Server target.
+                 */
+                schema = resolveSqlServerSchema(
+                        connectionConfig);
             }
 
             return hasText(database)
-                    ? TablePath.of(database, schema, tablePath.getTableName())
-                    : TablePath.of(null, schema, tablePath.getTableName());
+                    ? TablePath.of(
+                            database,
+                            schema,
+                            tablePath.getTableName())
+                    : TablePath.of(
+                            null,
+                            schema,
+                            tablePath.getTableName());
         }
 
-        if (isOracle(connectionConfig)) {
-            String database = OracleJdbcUrl.databaseName(connectionConfig.getUrl());
+        if (isOracle(
+                connectionConfig)) {
+
+            String database =
+                    OracleJdbcUrl.databaseName(
+                            connectionConfig.getUrl());
+
             if (!hasText(database)) {
                 return null;
             }
-            String schema = resolveOracleSchema(connectionConfig, tablePath, database);
+
+            String schema =
+                    resolveOracleSchema(
+                            connectionConfig,
+                            tablePath,
+                            database);
+
             if (!hasText(schema)) {
                 return null;
             }
-            return TablePath.of(database, schema, tablePath.getTableName());
+
+            return TablePath.of(
+                    database,
+                    schema,
+                    tablePath.getTableName());
         }
 
-        if (isPostgres(connectionConfig)) {
-            String database = databaseFromUrl(connectionConfig.getUrl());
+        if (isPostgres(
+                connectionConfig)) {
+
+            String database =
+                    databaseFromUrl(
+                            connectionConfig.getUrl());
+
             if (!hasText(database)) {
                 return null;
             }
-            String schema = tablePath.getSchemaName();
+
+            String schema =
+                    tablePath.getSchemaName();
+
             if (!hasText(schema)) {
-                schema = connectionConfig.getSchema();
+                schema =
+                        connectionConfig.getSchema();
             }
+
             if (!hasText(schema)) {
                 schema = "public";
             }
-            return TablePath.of(database, schema, tablePath.getTableName());
+
+            return TablePath.of(
+                    database,
+                    schema,
+                    tablePath.getTableName());
         }
 
-        if (hasText(tablePath.getDatabaseName())) {
+        if (hasText(
+                tablePath.getDatabaseName())) {
+
             return tablePath;
         }
 
-        String database = connectionConfig.getSchema();
+        String database =
+                connectionConfig.getSchema();
+
         if (!hasText(database)) {
-            database = databaseFromUrl(connectionConfig.getUrl());
+            database =
+                    databaseFromUrl(
+                            connectionConfig.getUrl());
         }
+
         if (!hasText(database)) {
             return null;
         }
-        return TablePath.of(database, tablePath.getTableName());
+
+        return TablePath.of(
+                database,
+                tablePath.getTableName());
     }
 
     private static String resolveDamengSchema(
             JdbcConnectionConfig config,
             TablePath tablePath) {
 
-        String pathSchema = tablePath.getSchemaName();
-        String pathDatabase = tablePath.getDatabaseName();
+        String pathSchema =
+                tablePath.getSchemaName();
 
-        // schema.table parsed from an explicit target mapping is safe to preserve.
-        // A three-part source path cannot be verified without opening the DM connection,
-        // so prefer target connection settings to avoid leaking source schema metadata.
-        if (hasText(pathSchema) && !hasText(pathDatabase)) {
+        String pathDatabase =
+                tablePath.getDatabaseName();
+
+        /*
+         * schema.table parsed from an explicit target mapping is safe to
+         * preserve. A three-part source path cannot be verified without a DM
+         * connection, so prefer target connection settings to avoid leaking
+         * source database/schema metadata into the target.
+         */
+        if (hasText(pathSchema)
+                && !hasText(pathDatabase)) {
+
             return pathSchema.trim();
         }
-        if (hasText(config.getSchema())) {
-            return config.getSchema().trim();
+
+        if (hasText(
+                config.getSchema())) {
+
+            return config.getSchema()
+                    .trim();
         }
-        String currentSchema = DamengJdbcUrl.schema(config.getUrl(), config.getProperties());
+
+        String currentSchema =
+                DamengJdbcUrl.schema(
+                        config.getUrl(),
+                        config.getProperties());
+
         if (hasText(currentSchema)) {
             return currentSchema.trim();
         }
-        if (hasText(config.getUsername())) {
-            return config.getUsername().trim().toUpperCase(Locale.ROOT);
+
+        if (hasText(
+                config.getUsername())) {
+
+            return config.getUsername()
+                    .trim()
+                    .toUpperCase(
+                            Locale.ROOT);
         }
-        return hasText(pathSchema) ? pathSchema.trim() : null;
+
+        return hasText(pathSchema)
+                ? pathSchema.trim()
+                : null;
     }
 
     private static String resolveDb2Schema(
@@ -245,30 +553,56 @@ final class JdbcCreateTableSqlResolver {
             TablePath tablePath,
             String currentDatabase) {
 
-        String pathSchema = tablePath.getSchemaName();
-        String pathDatabase = tablePath.getDatabaseName();
+        String pathSchema =
+                tablePath.getSchemaName();
+
+        String pathDatabase =
+                tablePath.getDatabaseName();
 
         if (hasText(pathSchema)
                 && (!hasText(pathDatabase)
-                || currentDatabase.equalsIgnoreCase(pathDatabase))) {
+                || currentDatabase
+                .equalsIgnoreCase(
+                        pathDatabase))) {
+
             return pathSchema.trim();
         }
-        if (hasText(config.getSchema())) {
-            return config.getSchema().trim();
+
+        if (hasText(
+                config.getSchema())) {
+
+            return config.getSchema()
+                    .trim();
         }
-        String currentSchema = Db2JdbcUrl.currentSchema(
-                config.getUrl(), config.getProperties());
+
+        String currentSchema =
+                Db2JdbcUrl.currentSchema(
+                        config.getUrl(),
+                        config.getProperties());
+
         if (hasText(currentSchema)) {
             return currentSchema.trim();
         }
-        if (hasText(config.getUsername())) {
-            return config.getUsername().trim().toUpperCase(Locale.ROOT);
+
+        if (hasText(
+                config.getUsername())) {
+
+            return config.getUsername()
+                    .trim()
+                    .toUpperCase(
+                            Locale.ROOT);
         }
+
         return null;
     }
 
-    private static String resolveSqlServerSchema(JdbcConnectionConfig config) {
-        return hasText(config.getSchema()) ? config.getSchema().trim() : "dbo";
+    private static String resolveSqlServerSchema(
+            JdbcConnectionConfig config) {
+
+        return hasText(
+                config.getSchema())
+                ? config.getSchema().trim()
+                : "dbo";
     }
 
     private static String resolveOracleSchema(
@@ -276,84 +610,209 @@ final class JdbcCreateTableSqlResolver {
             TablePath tablePath,
             String currentDatabase) {
 
-        String pathSchema = tablePath.getSchemaName();
-        String pathDatabase = tablePath.getDatabaseName();
+        String pathSchema =
+                tablePath.getSchemaName();
 
+        String pathDatabase =
+                tablePath.getDatabaseName();
+
+        /*
+         * A schema with no database is a target schema.table parsed by the
+         * Oracle dialect. Preserve it. Also preserve a three-part target path
+         * when its logical database matches this Oracle service.
+         */
         if (hasText(pathSchema)
                 && (!hasText(pathDatabase)
-                || currentDatabase.equalsIgnoreCase(pathDatabase))) {
+                || currentDatabase
+                .equalsIgnoreCase(
+                        pathDatabase))) {
+
             return pathSchema.trim();
         }
-        if (hasText(config.getSchema())) {
-            return config.getSchema().trim();
+
+        if (hasText(
+                config.getSchema())) {
+
+            return config.getSchema()
+                    .trim();
         }
-        if (hasText(config.getUsername())) {
-            return config.getUsername().trim().toUpperCase(Locale.ROOT);
+
+        if (hasText(
+                config.getUsername())) {
+
+            return config.getUsername()
+                    .trim()
+                    .toUpperCase(
+                            Locale.ROOT);
         }
-        return hasText(pathSchema) ? pathSchema.trim() : null;
+
+        return hasText(pathSchema)
+                ? pathSchema.trim()
+                : null;
     }
 
-    private static boolean isPostgres(JdbcConnectionConfig config) {
-        if (DatabaseIdentifier.POSTGRESQL.equalsIgnoreCase(config.getDialect())) {
+    private static boolean isPostgres(
+            JdbcConnectionConfig config) {
+
+        if (DatabaseIdentifier.POSTGRESQL
+                .equalsIgnoreCase(
+                        config.getDialect())) {
+
             return true;
         }
-        String url = config.getUrl();
+
+        String url =
+                config.getUrl();
+
         return url != null
-                && url.trim().toLowerCase(Locale.ROOT).startsWith("jdbc:postgresql:");
+                && url.trim()
+                .toLowerCase()
+                .startsWith(
+                        "jdbc:postgresql:");
     }
 
-    private static boolean isOceanBase(JdbcConnectionConfig config) {
-        return DatabaseIdentifier.OCEANBASE.equalsIgnoreCase(config.getDialect())
-                || OceanBaseJdbcUrl.accepts(config.getUrl());
+    private static boolean isOceanBase(
+            JdbcConnectionConfig config) {
+
+        if (DatabaseIdentifier.OCEANBASE
+                .equalsIgnoreCase(
+                        config.getDialect())) {
+
+            return true;
+        }
+
+        return OceanBaseJdbcUrl.accepts(
+                config.getUrl());
     }
 
-    private static boolean isOracle(JdbcConnectionConfig config) {
-        return DatabaseIdentifier.ORACLE.equalsIgnoreCase(config.getDialect())
-                || OracleJdbcUrl.accepts(config.getUrl());
+    private static boolean isOracle(
+            JdbcConnectionConfig config) {
+
+        if (DatabaseIdentifier.ORACLE
+                .equalsIgnoreCase(
+                        config.getDialect())) {
+
+            return true;
+        }
+
+        return OracleJdbcUrl.accepts(
+                config.getUrl());
     }
 
-    private static boolean isSqlServer(JdbcConnectionConfig config) {
-        return DatabaseIdentifier.SQLSERVER.equalsIgnoreCase(config.getDialect())
-                || SqlServerJdbcUrl.accepts(config.getUrl());
+    private static boolean isSqlServer(
+            JdbcConnectionConfig config) {
+
+        if (DatabaseIdentifier.SQLSERVER
+                .equalsIgnoreCase(
+                        config.getDialect())) {
+
+            return true;
+        }
+
+        return SqlServerJdbcUrl.accepts(
+                config.getUrl());
     }
 
-    private static boolean isDb2(JdbcConnectionConfig config) {
-        return DatabaseIdentifier.DB2.equalsIgnoreCase(config.getDialect())
-                || Db2JdbcUrl.accepts(config.getUrl());
+    private static boolean isDb2(
+            JdbcConnectionConfig config) {
+
+        if (DatabaseIdentifier.DB2
+                .equalsIgnoreCase(
+                        config.getDialect())) {
+
+            return true;
+        }
+
+        return Db2JdbcUrl.accepts(
+                config.getUrl());
     }
 
-    private static boolean isDameng(JdbcConnectionConfig config) {
-        return DatabaseIdentifier.DAMENG.equalsIgnoreCase(config.getDialect())
-                || DamengJdbcUrl.accepts(config.getUrl());
+    private static boolean isDameng(
+            JdbcConnectionConfig config) {
+
+        if (DatabaseIdentifier.DAMENG
+                .equalsIgnoreCase(
+                        config.getDialect())) {
+
+            return true;
+        }
+
+        return DamengJdbcUrl.accepts(
+                config.getUrl());
     }
 
-    private static String databaseFromUrl(String url) {
+    private static String databaseFromUrl(
+            String url) {
+
         if (!hasText(url)) {
             return null;
         }
-        String normalized = url.trim();
-        int protocolSeparator = normalized.indexOf("://");
+
+        String normalized =
+                url.trim();
+
+        int protocolSeparator =
+                normalized.indexOf(
+                        "://");
+
         if (protocolSeparator < 0) {
             return null;
         }
-        int databaseStart = normalized.indexOf('/', protocolSeparator + 3);
-        if (databaseStart < 0 || databaseStart == normalized.length() - 1) {
+
+        int databaseStart =
+                normalized.indexOf(
+                        '/',
+                        protocolSeparator + 3);
+
+        if (databaseStart < 0
+                || databaseStart
+                == normalized.length() - 1) {
+
             return null;
         }
-        int databaseEnd = normalized.length();
-        int queryStart = normalized.indexOf('?', databaseStart + 1);
+
+        int databaseEnd =
+                normalized.length();
+
+        int queryStart =
+                normalized.indexOf(
+                        '?',
+                        databaseStart + 1);
+
         if (queryStart >= 0) {
-            databaseEnd = queryStart;
+            databaseEnd =
+                    queryStart;
         }
-        int fragmentStart = normalized.indexOf('#', databaseStart + 1);
-        if (fragmentStart >= 0 && fragmentStart < databaseEnd) {
-            databaseEnd = fragmentStart;
+
+        int fragmentStart =
+                normalized.indexOf(
+                        '#',
+                        databaseStart + 1);
+
+        if (fragmentStart >= 0
+                && fragmentStart
+                < databaseEnd) {
+
+            databaseEnd =
+                    fragmentStart;
         }
-        String database = normalized.substring(databaseStart + 1, databaseEnd).trim();
-        return hasText(database) ? database : null;
+
+        String database =
+                normalized.substring(
+                        databaseStart + 1,
+                        databaseEnd)
+                        .trim();
+
+        return hasText(database)
+                ? database
+                : null;
     }
 
-    private static boolean hasText(String value) {
-        return value != null && !value.trim().isEmpty();
+    private static boolean hasText(
+            String value) {
+
+        return value != null
+                && !value.trim()
+                .isEmpty();
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcCreateTableSqlResolver.java
@@ -2,6 +2,7 @@ package com.link.up.connector.jdbc.sink;
 
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.dameng.DamengCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.catalog.db2.Db2CreateTableSqlBuilder;
 import com.link.up.connector.jdbc.catalog.mysql.MySqlCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.catalog.mysql.MySqlTypeMapper;
@@ -11,6 +12,8 @@ import com.link.up.connector.jdbc.catalog.sqlserver.SqlServerCreateTableSqlBuild
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.dameng.DamengJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.dameng.DamengTypeMapper;
 import com.link.up.connector.jdbc.core.dialect.db2.Db2JdbcUrl;
 import com.link.up.connector.jdbc.core.dialect.db2.Db2TypeMapper;
 import com.link.up.connector.jdbc.core.dialect.oceanbase.OceanBaseCompatibleMode;
@@ -23,9 +26,7 @@ import com.link.up.connector.jdbc.core.dialect.sqlserver.SqlServerTypeMapper;
 
 import java.util.Locale;
 
-/**
- * Generates the CREATE TABLE statement used for offline sink preparation.
- */
+/** Generates the CREATE TABLE statement used for offline sink preparation. */
 final class JdbcCreateTableSqlResolver {
 
     private JdbcCreateTableSqlResolver() {
@@ -36,192 +37,60 @@ final class JdbcCreateTableSqlResolver {
             JdbcConnectionConfig connectionConfig,
             CatalogTable table) {
 
-        if (dialect == null
-                || connectionConfig == null
-                || table == null) {
-
+        if (dialect == null || connectionConfig == null || table == null) {
             return null;
         }
 
-        if (DatabaseIdentifier.MYSQL
-                .equalsIgnoreCase(
-                        dialect.name())) {
-
-            TablePath targetPath =
-                    resolveTargetPath(
-                            connectionConfig,
-                            table.getTablePath());
-
-            if (targetPath == null) {
-                return null;
-            }
-
-            CatalogTable ddlTable =
-                    table.getTablePath()
-                            .equals(targetPath)
-                            ? table
-                            : table.withPath(
-                                    targetPath);
-
-            return new MySqlCreateTableSqlBuilder(
-                    targetPath,
-                    ddlTable,
-                    new MySqlTypeMapper(false))
-                    .build();
+        TablePath targetPath = resolveTargetPath(connectionConfig, table.getTablePath());
+        if (targetPath == null) {
+            return null;
         }
 
-        if (DatabaseIdentifier.OCEANBASE
-                .equalsIgnoreCase(
-                        dialect.name())) {
+        CatalogTable ddlTable = table.getTablePath().equals(targetPath)
+                ? table
+                : table.withPath(targetPath);
 
-            TablePath targetPath =
-                    resolveTargetPath(
-                            connectionConfig,
-                            table.getTablePath());
+        if (DatabaseIdentifier.MYSQL.equalsIgnoreCase(dialect.name())) {
+            return new MySqlCreateTableSqlBuilder(
+                    targetPath, ddlTable, new MySqlTypeMapper(false)).build();
+        }
 
-            if (targetPath == null) {
-                return null;
-            }
-
-            CatalogTable ddlTable =
-                    table.getTablePath()
-                            .equals(targetPath)
-                            ? table
-                            : table.withPath(
-                                    targetPath);
-
-            OceanBaseCompatibleMode mode =
-                    OceanBaseCompatibleMode.from(
-                            connectionConfig
-                                    .getCompatibleMode());
-
+        if (DatabaseIdentifier.OCEANBASE.equalsIgnoreCase(dialect.name())) {
+            OceanBaseCompatibleMode mode = OceanBaseCompatibleMode.from(
+                    connectionConfig.getCompatibleMode());
             if (mode.isMySql()) {
                 return new MySqlCreateTableSqlBuilder(
-                        targetPath,
-                        ddlTable,
-                        new MySqlTypeMapper(false))
-                        .build();
+                        targetPath, ddlTable, new MySqlTypeMapper(false)).build();
             }
-
             return new OracleCreateTableSqlBuilder(
-                    targetPath,
-                    ddlTable,
-                    new OracleTypeMapper())
-                    .build();
+                    targetPath, ddlTable, new OracleTypeMapper()).build();
         }
 
-        if (DatabaseIdentifier.POSTGRESQL
-                .equalsIgnoreCase(
-                        dialect.name())) {
-
-            TablePath targetPath =
-                    resolveTargetPath(
-                            connectionConfig,
-                            table.getTablePath());
-
-            if (targetPath == null) {
-                return null;
-            }
-
-            CatalogTable ddlTable =
-                    table.getTablePath()
-                            .equals(targetPath)
-                            ? table
-                            : table.withPath(
-                                    targetPath);
-
+        if (DatabaseIdentifier.POSTGRESQL.equalsIgnoreCase(dialect.name())) {
             return new PostgresCreateTableSqlBuilder(
-                    targetPath,
-                    ddlTable,
-                    new PostgresTypeMapper())
-                    .build();
+                    targetPath, ddlTable, new PostgresTypeMapper()).build();
         }
 
-        if (DatabaseIdentifier.ORACLE
-                .equalsIgnoreCase(
-                        dialect.name())) {
-
-            TablePath targetPath =
-                    resolveTargetPath(
-                            connectionConfig,
-                            table.getTablePath());
-
-            if (targetPath == null) {
-                return null;
-            }
-
-            CatalogTable ddlTable =
-                    table.getTablePath()
-                            .equals(targetPath)
-                            ? table
-                            : table.withPath(
-                                    targetPath);
-
+        if (DatabaseIdentifier.ORACLE.equalsIgnoreCase(dialect.name())) {
             return new OracleCreateTableSqlBuilder(
-                    targetPath,
-                    ddlTable,
-                    new OracleTypeMapper())
-                    .build();
+                    targetPath, ddlTable, new OracleTypeMapper()).build();
         }
 
-        if (DatabaseIdentifier.SQLSERVER
-                .equalsIgnoreCase(
-                        dialect.name())) {
-
-            TablePath targetPath =
-                    resolveTargetPath(
-                            connectionConfig,
-                            table.getTablePath());
-
-            if (targetPath == null) {
-                return null;
-            }
-
-            CatalogTable ddlTable =
-                    table.getTablePath()
-                            .equals(targetPath)
-                            ? table
-                            : table.withPath(
-                                    targetPath);
-
+        if (DatabaseIdentifier.SQLSERVER.equalsIgnoreCase(dialect.name())) {
             return new SqlServerCreateTableSqlBuilder(
-                    targetPath,
-                    ddlTable,
-                    new SqlServerTypeMapper())
-                    .build();
+                    targetPath, ddlTable, new SqlServerTypeMapper()).build();
         }
 
-        if (DatabaseIdentifier.DB2
-                .equalsIgnoreCase(
-                        dialect.name())) {
-
-            TablePath targetPath =
-                    resolveTargetPath(
-                            connectionConfig,
-                            table.getTablePath());
-
-            if (targetPath == null) {
-                return null;
-            }
-
-            CatalogTable ddlTable =
-                    table.getTablePath()
-                            .equals(targetPath)
-                            ? table
-                            : table.withPath(
-                                    targetPath);
-
+        if (DatabaseIdentifier.DB2.equalsIgnoreCase(dialect.name())) {
             return new Db2CreateTableSqlBuilder(
-                    targetPath,
-                    ddlTable,
-                    new Db2TypeMapper())
-                    .build();
+                    targetPath, ddlTable, new Db2TypeMapper()).build();
         }
 
-        /*
-         * Future JDBC dialects can add their CREATE TABLE builder here
-         * without changing the connector-neutral protocol.
-         */
+        if (DatabaseIdentifier.DAMENG.equalsIgnoreCase(dialect.name())) {
+            return new DamengCreateTableSqlBuilder(
+                    targetPath, ddlTable, new DamengTypeMapper()).build();
+        }
+
         return null;
     }
 
@@ -229,223 +98,146 @@ final class JdbcCreateTableSqlResolver {
             JdbcConnectionConfig connectionConfig,
             TablePath tablePath) {
 
-        if (connectionConfig == null
-                || tablePath == null) {
-
+        if (connectionConfig == null || tablePath == null) {
             return tablePath;
         }
 
-        if (isDb2(
-                connectionConfig)) {
-
-            String database =
-                    Db2JdbcUrl.databaseName(
-                            connectionConfig.getUrl());
-
-            if (!hasText(database)) {
-                return null;
-            }
-
-            String schema =
-                    resolveDb2Schema(
-                            connectionConfig,
-                            tablePath,
-                            database);
-
+        if (isDameng(connectionConfig)) {
+            String schema = resolveDamengSchema(connectionConfig, tablePath);
             if (!hasText(schema)) {
                 return null;
             }
-
-            return TablePath.of(
-                    database,
-                    schema,
-                    tablePath.getTableName());
+            return TablePath.of(null, schema, tablePath.getTableName());
         }
 
-        if (isOceanBase(
-                connectionConfig)) {
+        if (isDb2(connectionConfig)) {
+            String database = Db2JdbcUrl.databaseName(connectionConfig.getUrl());
+            if (!hasText(database)) {
+                return null;
+            }
+            String schema = resolveDb2Schema(connectionConfig, tablePath, database);
+            if (!hasText(schema)) {
+                return null;
+            }
+            return TablePath.of(database, schema, tablePath.getTableName());
+        }
 
-            String database =
-                    OceanBaseJdbcUrl.databaseName(
-                            connectionConfig.getUrl());
-
-            OceanBaseCompatibleMode mode =
-                    OceanBaseCompatibleMode.from(
-                            connectionConfig
-                                    .getCompatibleMode());
+        if (isOceanBase(connectionConfig)) {
+            String database = OceanBaseJdbcUrl.databaseName(connectionConfig.getUrl());
+            OceanBaseCompatibleMode mode = OceanBaseCompatibleMode.from(
+                    connectionConfig.getCompatibleMode());
 
             if (mode.isOracle()) {
                 if (!hasText(database)) {
                     return null;
                 }
-
-                String schema =
-                        resolveOracleSchema(
-                                connectionConfig,
-                                tablePath,
-                                database);
-
+                String schema = resolveOracleSchema(connectionConfig, tablePath, database);
                 if (!hasText(schema)) {
                     return null;
                 }
-
-                return TablePath.of(
-                        database,
-                        schema,
-                        tablePath.getTableName());
+                return TablePath.of(database, schema, tablePath.getTableName());
             }
 
             if (hasText(database)) {
-                return TablePath.of(
-                        database,
-                        tablePath.getTableName());
+                return TablePath.of(database, tablePath.getTableName());
             }
-
-            if (hasText(
-                    tablePath.getDatabaseName())) {
-
-                return TablePath.of(
-                        tablePath.getDatabaseName(),
-                        tablePath.getTableName());
+            if (hasText(tablePath.getDatabaseName())) {
+                return TablePath.of(tablePath.getDatabaseName(), tablePath.getTableName());
             }
-
-            if (hasText(
-                    connectionConfig.getSchema())) {
-
-                return TablePath.of(
-                        connectionConfig
-                                .getSchema(),
-                        tablePath.getTableName());
+            if (hasText(connectionConfig.getSchema())) {
+                return TablePath.of(connectionConfig.getSchema(), tablePath.getTableName());
             }
-
             return null;
         }
 
-        if (isSqlServer(
-                connectionConfig)) {
-
-            String database =
-                    SqlServerJdbcUrl.databaseName(
-                            connectionConfig.getUrl());
-
-            String pathDatabase =
-                    tablePath.getDatabaseName();
-
-            String pathSchema =
-                    tablePath.getSchemaName();
-
+        if (isSqlServer(connectionConfig)) {
+            String database = SqlServerJdbcUrl.databaseName(connectionConfig.getUrl());
+            String pathDatabase = tablePath.getDatabaseName();
+            String pathSchema = tablePath.getSchemaName();
             String schema;
 
             if (!hasText(pathDatabase)) {
                 schema = hasText(pathSchema)
                         ? pathSchema.trim()
-                        : resolveSqlServerSchema(
-                                connectionConfig);
-            } else if (hasText(database)
-                    && database.equalsIgnoreCase(
-                            pathDatabase)) {
+                        : resolveSqlServerSchema(connectionConfig);
+            } else if (hasText(database) && database.equalsIgnoreCase(pathDatabase)) {
                 schema = hasText(pathSchema)
                         ? pathSchema.trim()
-                        : resolveSqlServerSchema(
-                                connectionConfig);
+                        : resolveSqlServerSchema(connectionConfig);
             } else {
-                /*
-                 * Do not leak a MySQL/PostgreSQL/Oracle source database/schema
-                 * into an unqualified SQL Server target.
-                 */
-                schema = resolveSqlServerSchema(
-                        connectionConfig);
+                schema = resolveSqlServerSchema(connectionConfig);
             }
 
             return hasText(database)
-                    ? TablePath.of(
-                            database,
-                            schema,
-                            tablePath.getTableName())
-                    : TablePath.of(
-                            null,
-                            schema,
-                            tablePath.getTableName());
+                    ? TablePath.of(database, schema, tablePath.getTableName())
+                    : TablePath.of(null, schema, tablePath.getTableName());
         }
 
-        if (isOracle(
-                connectionConfig)) {
-
-            String database =
-                    OracleJdbcUrl.databaseName(
-                            connectionConfig.getUrl());
-
+        if (isOracle(connectionConfig)) {
+            String database = OracleJdbcUrl.databaseName(connectionConfig.getUrl());
             if (!hasText(database)) {
                 return null;
             }
-
-            String schema =
-                    resolveOracleSchema(
-                            connectionConfig,
-                            tablePath,
-                            database);
-
+            String schema = resolveOracleSchema(connectionConfig, tablePath, database);
             if (!hasText(schema)) {
                 return null;
             }
-
-            return TablePath.of(
-                    database,
-                    schema,
-                    tablePath.getTableName());
+            return TablePath.of(database, schema, tablePath.getTableName());
         }
 
-        if (isPostgres(
-                connectionConfig)) {
-
-            String database =
-                    databaseFromUrl(
-                            connectionConfig.getUrl());
-
+        if (isPostgres(connectionConfig)) {
+            String database = databaseFromUrl(connectionConfig.getUrl());
             if (!hasText(database)) {
                 return null;
             }
-
-            String schema =
-                    tablePath.getSchemaName();
-
+            String schema = tablePath.getSchemaName();
             if (!hasText(schema)) {
-                schema =
-                        connectionConfig.getSchema();
+                schema = connectionConfig.getSchema();
             }
-
             if (!hasText(schema)) {
                 schema = "public";
             }
-
-            return TablePath.of(
-                    database,
-                    schema,
-                    tablePath.getTableName());
+            return TablePath.of(database, schema, tablePath.getTableName());
         }
 
-        if (hasText(
-                tablePath.getDatabaseName())) {
-
+        if (hasText(tablePath.getDatabaseName())) {
             return tablePath;
         }
 
-        String database =
-                connectionConfig.getSchema();
-
+        String database = connectionConfig.getSchema();
         if (!hasText(database)) {
-            database =
-                    databaseFromUrl(
-                            connectionConfig.getUrl());
+            database = databaseFromUrl(connectionConfig.getUrl());
         }
-
         if (!hasText(database)) {
             return null;
         }
+        return TablePath.of(database, tablePath.getTableName());
+    }
 
-        return TablePath.of(
-                database,
-                tablePath.getTableName());
+    private static String resolveDamengSchema(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+
+        String pathSchema = tablePath.getSchemaName();
+        String pathDatabase = tablePath.getDatabaseName();
+
+        // schema.table parsed from an explicit target mapping is safe to preserve.
+        // A three-part source path cannot be verified without opening the DM connection,
+        // so prefer target connection settings to avoid leaking source schema metadata.
+        if (hasText(pathSchema) && !hasText(pathDatabase)) {
+            return pathSchema.trim();
+        }
+        if (hasText(config.getSchema())) {
+            return config.getSchema().trim();
+        }
+        String currentSchema = DamengJdbcUrl.schema(config.getUrl(), config.getProperties());
+        if (hasText(currentSchema)) {
+            return currentSchema.trim();
+        }
+        if (hasText(config.getUsername())) {
+            return config.getUsername().trim().toUpperCase(Locale.ROOT);
+        }
+        return hasText(pathSchema) ? pathSchema.trim() : null;
     }
 
     private static String resolveDb2Schema(
@@ -453,56 +245,30 @@ final class JdbcCreateTableSqlResolver {
             TablePath tablePath,
             String currentDatabase) {
 
-        String pathSchema =
-                tablePath.getSchemaName();
-
-        String pathDatabase =
-                tablePath.getDatabaseName();
+        String pathSchema = tablePath.getSchemaName();
+        String pathDatabase = tablePath.getDatabaseName();
 
         if (hasText(pathSchema)
                 && (!hasText(pathDatabase)
-                || currentDatabase
-                .equalsIgnoreCase(
-                        pathDatabase))) {
-
+                || currentDatabase.equalsIgnoreCase(pathDatabase))) {
             return pathSchema.trim();
         }
-
-        if (hasText(
-                config.getSchema())) {
-
-            return config.getSchema()
-                    .trim();
+        if (hasText(config.getSchema())) {
+            return config.getSchema().trim();
         }
-
-        String currentSchema =
-                Db2JdbcUrl.currentSchema(
-                        config.getUrl(),
-                        config.getProperties());
-
+        String currentSchema = Db2JdbcUrl.currentSchema(
+                config.getUrl(), config.getProperties());
         if (hasText(currentSchema)) {
             return currentSchema.trim();
         }
-
-        if (hasText(
-                config.getUsername())) {
-
-            return config.getUsername()
-                    .trim()
-                    .toUpperCase(
-                            Locale.ROOT);
+        if (hasText(config.getUsername())) {
+            return config.getUsername().trim().toUpperCase(Locale.ROOT);
         }
-
         return null;
     }
 
-    private static String resolveSqlServerSchema(
-            JdbcConnectionConfig config) {
-
-        return hasText(
-                config.getSchema())
-                ? config.getSchema().trim()
-                : "dbo";
+    private static String resolveSqlServerSchema(JdbcConnectionConfig config) {
+        return hasText(config.getSchema()) ? config.getSchema().trim() : "dbo";
     }
 
     private static String resolveOracleSchema(
@@ -510,195 +276,84 @@ final class JdbcCreateTableSqlResolver {
             TablePath tablePath,
             String currentDatabase) {
 
-        String pathSchema =
-                tablePath.getSchemaName();
+        String pathSchema = tablePath.getSchemaName();
+        String pathDatabase = tablePath.getDatabaseName();
 
-        String pathDatabase =
-                tablePath.getDatabaseName();
-
-        /*
-         * A schema with no database is a target schema.table parsed by the
-         * Oracle dialect. Preserve it. Also preserve a three-part target path
-         * when its logical database matches this Oracle service.
-         */
         if (hasText(pathSchema)
                 && (!hasText(pathDatabase)
-                || currentDatabase
-                .equalsIgnoreCase(
-                        pathDatabase))) {
-
+                || currentDatabase.equalsIgnoreCase(pathDatabase))) {
             return pathSchema.trim();
         }
-
-        if (hasText(
-                config.getSchema())) {
-
-            return config.getSchema()
-                    .trim();
+        if (hasText(config.getSchema())) {
+            return config.getSchema().trim();
         }
-
-        if (hasText(
-                config.getUsername())) {
-
-            return config.getUsername()
-                    .trim()
-                    .toUpperCase(
-                            Locale.ROOT);
+        if (hasText(config.getUsername())) {
+            return config.getUsername().trim().toUpperCase(Locale.ROOT);
         }
-
-        return hasText(pathSchema)
-                ? pathSchema.trim()
-                : null;
+        return hasText(pathSchema) ? pathSchema.trim() : null;
     }
 
-    private static boolean isPostgres(
-            JdbcConnectionConfig config) {
-
-        if (DatabaseIdentifier.POSTGRESQL
-                .equalsIgnoreCase(
-                        config.getDialect())) {
-
+    private static boolean isPostgres(JdbcConnectionConfig config) {
+        if (DatabaseIdentifier.POSTGRESQL.equalsIgnoreCase(config.getDialect())) {
             return true;
         }
-
-        String url =
-                config.getUrl();
-
+        String url = config.getUrl();
         return url != null
-                && url.trim()
-                .toLowerCase()
-                .startsWith(
-                        "jdbc:postgresql:");
+                && url.trim().toLowerCase(Locale.ROOT).startsWith("jdbc:postgresql:");
     }
 
-    private static boolean isOceanBase(
-            JdbcConnectionConfig config) {
-
-        if (DatabaseIdentifier.OCEANBASE
-                .equalsIgnoreCase(
-                        config.getDialect())) {
-
-            return true;
-        }
-
-        return OceanBaseJdbcUrl.accepts(
-                config.getUrl());
+    private static boolean isOceanBase(JdbcConnectionConfig config) {
+        return DatabaseIdentifier.OCEANBASE.equalsIgnoreCase(config.getDialect())
+                || OceanBaseJdbcUrl.accepts(config.getUrl());
     }
 
-    private static boolean isOracle(
-            JdbcConnectionConfig config) {
-
-        if (DatabaseIdentifier.ORACLE
-                .equalsIgnoreCase(
-                        config.getDialect())) {
-
-            return true;
-        }
-
-        return OracleJdbcUrl.accepts(
-                config.getUrl());
+    private static boolean isOracle(JdbcConnectionConfig config) {
+        return DatabaseIdentifier.ORACLE.equalsIgnoreCase(config.getDialect())
+                || OracleJdbcUrl.accepts(config.getUrl());
     }
 
-    private static boolean isSqlServer(
-            JdbcConnectionConfig config) {
-
-        if (DatabaseIdentifier.SQLSERVER
-                .equalsIgnoreCase(
-                        config.getDialect())) {
-
-            return true;
-        }
-
-        return SqlServerJdbcUrl.accepts(
-                config.getUrl());
+    private static boolean isSqlServer(JdbcConnectionConfig config) {
+        return DatabaseIdentifier.SQLSERVER.equalsIgnoreCase(config.getDialect())
+                || SqlServerJdbcUrl.accepts(config.getUrl());
     }
 
-    private static boolean isDb2(
-            JdbcConnectionConfig config) {
-
-        if (DatabaseIdentifier.DB2
-                .equalsIgnoreCase(
-                        config.getDialect())) {
-
-            return true;
-        }
-
-        return Db2JdbcUrl.accepts(
-                config.getUrl());
+    private static boolean isDb2(JdbcConnectionConfig config) {
+        return DatabaseIdentifier.DB2.equalsIgnoreCase(config.getDialect())
+                || Db2JdbcUrl.accepts(config.getUrl());
     }
 
-    private static String databaseFromUrl(
-            String url) {
+    private static boolean isDameng(JdbcConnectionConfig config) {
+        return DatabaseIdentifier.DAMENG.equalsIgnoreCase(config.getDialect())
+                || DamengJdbcUrl.accepts(config.getUrl());
+    }
 
+    private static String databaseFromUrl(String url) {
         if (!hasText(url)) {
             return null;
         }
-
-        String normalized =
-                url.trim();
-
-        int protocolSeparator =
-                normalized.indexOf(
-                        "://");
-
+        String normalized = url.trim();
+        int protocolSeparator = normalized.indexOf("://");
         if (protocolSeparator < 0) {
             return null;
         }
-
-        int databaseStart =
-                normalized.indexOf(
-                        '/',
-                        protocolSeparator + 3);
-
-        if (databaseStart < 0
-                || databaseStart
-                == normalized.length() - 1) {
-
+        int databaseStart = normalized.indexOf('/', protocolSeparator + 3);
+        if (databaseStart < 0 || databaseStart == normalized.length() - 1) {
             return null;
         }
-
-        int databaseEnd =
-                normalized.length();
-
-        int queryStart =
-                normalized.indexOf(
-                        '?',
-                        databaseStart + 1);
-
+        int databaseEnd = normalized.length();
+        int queryStart = normalized.indexOf('?', databaseStart + 1);
         if (queryStart >= 0) {
-            databaseEnd =
-                    queryStart;
+            databaseEnd = queryStart;
         }
-
-        int fragmentStart =
-                normalized.indexOf(
-                        '#',
-                        databaseStart + 1);
-
-        if (fragmentStart >= 0
-                && fragmentStart
-                < databaseEnd) {
-
-            databaseEnd =
-                    fragmentStart;
+        int fragmentStart = normalized.indexOf('#', databaseStart + 1);
+        if (fragmentStart >= 0 && fragmentStart < databaseEnd) {
+            databaseEnd = fragmentStart;
         }
-
-        String database =
-                normalized.substring(
-                        databaseStart + 1,
-                        databaseEnd)
-                        .trim();
-
-        return hasText(database)
-                ? database
-                : null;
+        String database = normalized.substring(databaseStart + 1, databaseEnd).trim();
+        return hasText(database) ? database : null;
     }
 
-    private static boolean hasText(
-            String value) {
-
-        return value != null
-                && !value.trim()
-                .isEmpty();
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -112,7 +112,15 @@ final class JdbcSinkPreparer implements SinkPreparer {
 
     private CatalogTable resolveTargetTable(CatalogTable source) {
         String path = config.resolveTargetTablePath(source.getTablePath());
-        return path == null ? source : source.withPath(dialect.parseTablePath(path));
+        CatalogTable mapped = path == null
+                ? source
+                : source.withPath(dialect.parseTablePath(path));
+        TablePath targetPath = JdbcCreateTableSqlResolver.resolveTargetPath(
+                config.getConnectionConfig(),
+                mapped.getTablePath());
+        return targetPath == null || mapped.getTablePath().equals(targetPath)
+                ? mapped
+                : mapped.withPath(targetPath);
     }
 
     private List<String> resolvePrimaryKeys(CatalogTable table) {

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/dameng/DamengCreateTableSqlBuilderTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/dameng/DamengCreateTableSqlBuilderTest.java
@@ -1,0 +1,67 @@
+package com.link.up.connector.jdbc.catalog.dameng;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.connector.jdbc.core.dialect.dameng.DamengTypeMapper;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+public class DamengCreateTableSqlBuilderTest {
+
+    @Test
+    public void buildsDamengCreateTableWithIdentityStorageAndComments() {
+        TablePath path = TablePath.of(null, "APP", "USERS");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("ID", BasicType.LONG_TYPE)
+                        .nullable(false)
+                        .autoIncrement(true)
+                        .build())
+                .column(Column.builder("NAME", BasicType.STRING_TYPE)
+                        .length(100L)
+                        .comment("display name")
+                        .build())
+                .column(Column.builder("AMOUNT", new DecimalType(38, 10))
+                        .build())
+                .primaryKey(PrimaryKey.of("PK_USERS", Arrays.asList("ID")))
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .comment("users table")
+                .option(DamengCatalog.TABLE_OPTION_TABLESPACE, "MAIN")
+                .option(DamengCatalog.TABLE_OPTION_FILLFACTOR, "80")
+                .build();
+
+        String ddl = new DamengCreateTableSqlBuilder(
+                path,
+                table,
+                new DamengTypeMapper())
+                .build();
+
+        assertTrue(ddl.contains("CREATE TABLE \"APP\".\"USERS\""));
+        assertTrue(ddl.contains("\"ID\" BIGINT IDENTITY(1,1) NOT NULL"));
+        assertTrue(ddl.contains("\"NAME\" VARCHAR2(400)"));
+        assertTrue(ddl.contains("\"AMOUNT\" DECIMAL(38,10)"));
+        assertTrue(ddl.contains("CONSTRAINT \"PK_USERS\" PRIMARY KEY (\"ID\")"));
+        assertTrue(ddl.contains("STORAGE (FILLFACTOR 80, ON \"MAIN\")"));
+        assertTrue(ddl.contains("COMMENT ON TABLE \"APP\".\"USERS\" IS 'users table'"));
+        assertTrue(ddl.contains(
+                "COMMENT ON COLUMN \"APP\".\"USERS\".\"NAME\" IS 'display name'"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void autoCreateFailsFastForDecimalPrecisionAboveDamengLimit() {
+        TablePath path = TablePath.of(null, "APP", "PAYMENTS");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("AMOUNT", new DecimalType(39, 10)).build())
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema).build();
+        new DamengCreateTableSqlBuilder(path, table, new DamengTypeMapper()).build();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengDialectTest.java
@@ -1,0 +1,149 @@
+package com.link.up.connector.jdbc.core.dialect.dameng;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class DamengDialectTest {
+
+    @Test
+    public void loadsDamengDialectFromJdbcUrlThroughSpi() {
+        JdbcDialect dialect = JdbcDialectLoader.load(config(null, baseUrl(), null, "SYSDBA"));
+        assertEquals(DatabaseIdentifier.DAMENG, dialect.name());
+    }
+
+    @Test
+    public void parsesUnquotedIdentifiersAsUppercaseAndPreservesQuotedCase() {
+        DamengDialect dialect = dialect("TARGET");
+        assertEquals(
+                TablePath.of(null, "APP", "ORDERS"),
+                dialect.parseTablePath("app.orders"));
+        assertEquals(
+                TablePath.of(null, "app", "orders"),
+                dialect.parseTablePath("\"app\".\"orders\""));
+    }
+
+    @Test
+    public void urlPathSchemaIsUsedForUnqualifiedTables() {
+        DamengDialect dialect = new DamengDialect(
+                config(null, baseUrl() + "/APP", null, "SYSDBA"));
+        assertEquals(
+                "\"APP\".\"ORDERS\"",
+                dialect.tableIdentifier(TablePath.of("ORDERS")));
+    }
+
+    @Test
+    public void schemaPropertyOverridesUrlSchema() {
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put("schema", "TARGET");
+        DamengDialect dialect = new DamengDialect(
+                config(null, baseUrl() + "/APP?logLevel=1", properties, "SYSDBA"));
+        assertEquals(
+                "\"TARGET\".\"ORDERS\"",
+                dialect.tableIdentifier(TablePath.of("ORDERS")));
+    }
+
+    @Test
+    public void usernameIsDefaultSchemaWhenNoSchemaIsConfigured() {
+        DamengDialect dialect = new DamengDialect(
+                config(null, baseUrl(), null, "app_user"));
+        assertEquals(
+                "\"APP_USER\".\"ORDERS\"",
+                dialect.tableIdentifier(TablePath.of("ORDERS")));
+    }
+
+    @Test
+    public void explicitSchemaBecomesDefaultConnectionProperty() {
+        assertEquals(
+                "TARGET",
+                dialect("TARGET").defaultConnectionProperties().get("schema"));
+    }
+
+    @Test
+    public void buildsNativeMergeWithOnlyNonPrimaryKeyUpdates() {
+        String sql = dialect("APP").buildUpsertSql(
+                TablePath.of(null, "APP", "USERS"),
+                Arrays.asList("ID", "NAME"),
+                Arrays.asList("ID")).get();
+
+        assertTrue(sql.startsWith(
+                "MERGE INTO \"APP\".\"USERS\" TARGET USING (SELECT ? \"ID\", ? \"NAME\") SOURCE"));
+        assertTrue(sql.contains(
+                "ON (TARGET.\"ID\" = SOURCE.\"ID\")"));
+        assertTrue(sql.contains(
+                "WHEN MATCHED THEN UPDATE SET TARGET.\"NAME\" = SOURCE.\"NAME\""));
+        assertFalse(sql.contains("UPDATE SET TARGET.\"ID\""));
+        assertTrue(sql.contains(
+                "WHEN NOT MATCHED THEN INSERT (\"ID\", \"NAME\")"));
+    }
+
+    @Test
+    public void allPrimaryKeyMergeSkipsMatchedUpdate() {
+        String sql = dialect("APP").buildUpsertSql(
+                TablePath.of(null, "APP", "USERS"),
+                Arrays.asList("ID"),
+                Arrays.asList("ID")).get();
+        assertFalse(sql.contains("WHEN MATCHED"));
+        assertTrue(sql.contains("WHEN NOT MATCHED"));
+    }
+
+    @Test
+    public void buildsOraHashBucketPredicate() {
+        Column column = Column.builder("CODE", BasicType.STRING_TYPE).build();
+        assertEquals(
+                "ORA_HASH(\"CODE\", 7) = 3",
+                dialect("APP").buildHashPartitionPredicate(column, 3, 8).get());
+    }
+
+    @Test
+    public void parsesSchemaFromUrlAndProperties() {
+        assertEquals(
+                "APP",
+                DamengJdbcUrl.schema(baseUrl() + "/APP?logLevel=1", null));
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put("SCHEMA", "TARGET");
+        assertEquals(
+                "TARGET",
+                DamengJdbcUrl.schema(baseUrl() + "/APP?schema=QUERY", properties));
+    }
+
+    private static DamengDialect dialect(String schema) {
+        return new DamengDialect(config(schema, baseUrl(), null, "SYSDBA"));
+    }
+
+    private static JdbcConnectionConfig config(
+            String schema,
+            String url,
+            Map<String, String> properties,
+            String username) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", "dm.jdbc.driver.DmDriver");
+        values.put("username", username);
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (properties != null) {
+            values.put("properties", properties);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:dm://127.0.0.1:5236";
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/dameng/DamengTypeMapperTest.java
@@ -1,0 +1,91 @@
+package com.link.up.connector.jdbc.core.dialect.dameng;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import org.junit.Test;
+
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+
+public class DamengTypeMapperTest {
+
+    private final DamengTypeMapper mapper = new DamengTypeMapper();
+
+    @Test
+    public void preservesMaximumSupportedDecimalPrecision() {
+        Column column = Column.builder("AMOUNT", new DecimalType(38, 10)).build();
+        assertEquals("DECIMAL(38,10)", mapper.toDatabaseType(column));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsDecimalPrecisionAboveDamengLimitInsteadOfTruncating() {
+        mapper.toDatabaseType(
+                Column.builder("AMOUNT", new DecimalType(39, 10)).build());
+    }
+
+    @Test
+    public void expandsGenericCharacterLengthToUtf8WorstCaseBytes() {
+        assertEquals(
+                "VARCHAR2(400)",
+                mapper.toDatabaseType(
+                        Column.builder("NAME", BasicType.STRING_TYPE)
+                                .length(100L)
+                                .build()));
+    }
+
+    @Test
+    public void movesLargeGenericStringsAndBytesToLobs() {
+        assertEquals(
+                "TEXT",
+                mapper.toDatabaseType(
+                        Column.builder("CONTENT", BasicType.STRING_TYPE)
+                                .length(500L)
+                                .build()));
+        assertEquals(
+                "BLOB",
+                mapper.toDatabaseType(
+                        Column.builder("PAYLOAD", BasicType.BYTES_TYPE)
+                                .length(5000L)
+                                .build()));
+    }
+
+    @Test
+    public void keepsTimeWithTimezoneAsExactTextInsteadOfDroppingOffset() {
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.OTHER, "TIME WITH TIME ZONE", 0, 6));
+    }
+
+    @Test
+    public void mapsDatetimeWithTimezoneToTimestampTz() {
+        assertEquals(
+                BasicType.TIMESTAMP_TZ_TYPE,
+                mapper.mapType(Types.OTHER, "DATETIME WITH TIME ZONE", 0, 6));
+    }
+
+    @Test
+    public void mapsDamengDateAsDateNotOracleStyleTimestamp() {
+        assertEquals(
+                BasicType.DATE_TYPE,
+                mapper.mapType(Types.DATE, "DATE", 0, 0));
+    }
+
+    @Test
+    public void preservesSameDamengSourceTypeWhenSafe() {
+        Column column = Column.builder("NAME", BasicType.STRING_TYPE)
+                .sourceType("VARCHAR2(120)")
+                .length(120L)
+                .build();
+        assertEquals("VARCHAR2(120)", mapper.toDatabaseType(column, true));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTimestampPrecisionAboveDamengLimit() {
+        mapper.toDatabaseType(
+                Column.builder("CREATED_AT", BasicType.TIMESTAMP_TYPE)
+                        .precision(7)
+                        .build());
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/JdbcDamengTargetPathTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/JdbcDamengTargetPathTest.java
@@ -1,0 +1,89 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.dameng.DamengDialect;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class JdbcDamengTargetPathTest {
+
+    @Test
+    public void foreignSourceDatabaseAndSchemaDoNotLeakIntoDamengTarget() {
+        JdbcConnectionConfig config = config("TARGET", baseUrl(), null, "SYSDBA");
+        assertEquals(
+                TablePath.of(null, "TARGET", "orders"),
+                JdbcCreateTableSqlResolver.resolveTargetPath(
+                        config,
+                        TablePath.of("source_db", "public", "orders")));
+    }
+
+    @Test
+    public void explicitTargetSchemaTableIsPreserved() {
+        JdbcConnectionConfig config = config("TARGET", baseUrl(), null, "SYSDBA");
+        assertEquals(
+                TablePath.of(null, "APP", "ORDERS"),
+                JdbcCreateTableSqlResolver.resolveTargetPath(
+                        config,
+                        TablePath.of(null, "APP", "ORDERS")));
+    }
+
+    @Test
+    public void urlSchemaIsUsedWhenConnectorSchemaIsAbsent() {
+        JdbcConnectionConfig config = config(null, baseUrl() + "/APP", null, "SYSDBA");
+        assertEquals(
+                TablePath.of(null, "APP", "ORDERS"),
+                JdbcCreateTableSqlResolver.resolveTargetPath(
+                        config,
+                        TablePath.of("mysql_db", "source", "ORDERS")));
+    }
+
+    @Test
+    public void resolverBuildsDamengTargetDdl() {
+        JdbcConnectionConfig config = config("APP", baseUrl(), null, "SYSDBA");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("ID", BasicType.LONG_TYPE).nullable(false).build())
+                .build();
+        CatalogTable source = CatalogTable.builder(
+                TablePath.of("source_db", "public", "USERS"),
+                schema).build();
+
+        String ddl = JdbcCreateTableSqlResolver.resolve(
+                new DamengDialect(config),
+                config,
+                source);
+        assertTrue(ddl.contains("CREATE TABLE \"APP\".\"USERS\""));
+    }
+
+    private static JdbcConnectionConfig config(
+            String schema,
+            String url,
+            Map<String, String> properties,
+            String username) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", "dm.jdbc.driver.DmDriver");
+        values.put("username", username);
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (properties != null) {
+            values.put("properties", properties);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:dm://127.0.0.1:5236";
+    }
+}


### PR DESCRIPTION
## Summary

Add Dameng DM8 offline JDBC support on top of the shared JDBC Source/Sink execution model.

### Dameng offline capabilities
- register the Dameng JDBC dialect through SPI
- package `com.dameng:DmJdbcDriver18:8.1.3.140`
- support DM JDBC default-schema semantics (`/schemaName`, `schema` connection property, then login user)
- discover database/schema/table/column/primary-key metadata through a Dameng catalog
- support bounded full reads and the shared numeric partition planner
- add `ORA_HASH` fallback for string partition columns
- support standard INSERT and native Dameng `MERGE` UPSERT
- support target table auto-create with PK, IDENTITY, comments, tablespace and fillfactor
- add CLOB/TEXT/BLOB/IMAGE/LONGVARBINARY-safe writes
- normalize the prepared sink target path so a source database/schema cannot leak into the Dameng target

### Type/data correctness
- support common Dameng integer, floating-point, NUMBER/NUMERIC/DECIMAL, character, binary, LOB and temporal types
- keep Dameng DECIMAL precision capped at 38 and fail fast when an incoming schema exceeds the database limit instead of silently narrowing it
- expand generic character lengths by the UTF-8 4-byte worst case before creating Dameng VARCHAR2 columns; use TEXT when the conservative 4K-page inline limit would be exceeded
- keep `TIME WITH TIME ZONE` as exact text because Flux currently has no TIME_TZ primitive, instead of silently dropping the offset
- map `DATETIME/TIMESTAMP WITH TIME ZONE` to Flux TIMESTAMP_TZ
- preserve native Dameng source types for Dameng-to-Dameng DDL where safe

### Tests added
- SPI/JDBC URL detection
- quoted/unquoted identifier and table-path behavior
- `/schemaName`, `schema` property and username schema fallback
- native MERGE SQL generation
- `ORA_HASH` string-bucket predicates
- DECIMAL(38) boundary and fail-fast behavior above 38
- UTF-8 VARCHAR expansion and LOB fallback
- TIME/DATETIME WITH TIME ZONE contracts
- CREATE TABLE / IDENTITY / storage / comments
- cross-database sink target-path normalization

## Design notes

This implementation follows the existing Yak Link Up JDBC offline architecture and cross-checks Dameng-specific behavior against the SeaTunnel Dameng connector and current Dameng JDBC/SQL documentation.

Two behaviors intentionally differ from SeaTunnel in favor of data correctness:
- over-limit DECIMAL precision is rejected instead of being silently narrowed
- TIME WITH TIME ZONE is carried as exact text instead of discarding its offset

Dameng JDBC URLs treat `/schemaName` as the login session's default schema rather than a database name. The connector therefore generates `schema.table` SQL and keeps database identity separate from target schema resolution.

## Scope

This PR is offline-only. Dameng redo/archive-log CDC, checkpoints and realtime schema-change handling are intentionally out of scope and should be implemented separately.

The shared JDBC connection contract still requires an explicit `driver` option; this PR packages the Dameng driver but does not change that global configuration contract.

## Validation

- branch is based on the current `main` and is not behind the base branch
- focused unit tests were added for dialect, type, DDL and sink-path contracts
- the repository currently has no `.github/workflows` directory, so there is no GitHub Actions run to report
- a live DM8 instance is not available in this tool session, so the new tests and end-to-end Dameng integration could not be executed here

Keep this PR as Draft until a real DM8 environment verifies at least: full read, numeric/string splits, INSERT, MERGE, CLOB/TEXT/BLOB/IMAGE, NUMBER/DECIMAL boundaries, TIME/DATETIME WITH TIME ZONE, `/schemaName`/`schema`, and automatic table creation.