### PR TITLE
feat(jdbc): add IRIS offline source and sink

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/pom.xml
+++ b/link-up-connectors/link-up-connector-jdbc/pom.xml
@@ -108,6 +108,11 @@
             <artifactId>HgdbJdbc</artifactId>
             <version>6.2.5</version>
         </dependency>
+        <dependency>
+            <groupId>com.intersystems</groupId>
+            <artifactId>intersystems-jdbc</artifactId>
+            <version>3.11.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/iris/IrisCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/iris/IrisCatalog.java
@@ -1,0 +1,474 @@
+package com.link.up.connector.jdbc.catalog.iris;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.iris.IrisJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.iris.IrisTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+
+/** InterSystems IRIS offline JDBC Catalog scoped to one namespace. */
+public final class IrisCatalog implements WritableCatalog {
+
+    public static final String DIALECT = "iris";
+    public static final String TABLE_OPTION_DIALECT = "dialect";
+    private static final String DEFAULT_SCHEMA = "SQLUser";
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String namespaceName;
+    private final String defaultSchema;
+    private final IrisTypeMapper typeMapper = new IrisTypeMapper();
+    private volatile boolean opened;
+
+    public IrisCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            String connectorSchema) {
+
+        if (!hasText(catalogName)) {
+            throw new IllegalArgumentException("catalogName must not be empty");
+        }
+        this.catalogName = catalogName.trim();
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.namespaceName = IrisJdbcUrl.namespaceName(config.getUrl());
+        if (!hasText(namespaceName)) {
+            throw new IllegalArgumentException(
+                    "IRIS JDBC URL 必须包含 namespace，例如 jdbc:IRIS://127.0.0.1:1972/USER");
+        }
+        this.defaultSchema = hasText(connectorSchema)
+                ? connectorSchema.trim()
+                : DEFAULT_SCHEMA;
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        // TablePath calls this logical level "database"; for IRIS it is the
+        // namespace selected by the JDBC URL.
+        return Optional.of(namespaceName);
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+        loadDriver();
+        try (Connection connection = connection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException(
+                        "IRIS Catalog 连接校验失败：" + config.getUrl());
+            }
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "IRIS Catalog 连接失败：" + config.getUrl(), e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public List<String> listDatabases() {
+        checkOpened();
+        return Collections.singletonList(namespaceName);
+    }
+
+    @Override
+    public List<String> listSchemas(String database) throws CatalogException {
+        checkNamespace(database);
+        checkOpened();
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getSchemas()) {
+            List<String> schemas = new ArrayList<String>();
+            while (rs.next()) {
+                String schema = normalize(rs.getString("TABLE_SCHEM"));
+                if (schema != null && !isSystemSchema(schema)) {
+                    schemas.add(schema);
+                }
+            }
+            Collections.sort(schemas);
+            return schemas;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 IRIS Schema 列表失败", e);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String database,
+            String schemaName) throws CatalogException {
+
+        checkNamespace(database);
+        checkOpened();
+        String schema = schema(schemaName);
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getTables(
+                     null, schema, "%", new String[]{"TABLE"})) {
+            List<TablePath> tables = new ArrayList<TablePath>();
+            while (rs.next()) {
+                String table = normalize(rs.getString("TABLE_NAME"));
+                String tableSchema = normalize(rs.getString("TABLE_SCHEM"));
+                if (table != null && !isSystemSchema(tableSchema)) {
+                    tables.add(TablePath.of(
+                            namespaceName,
+                            tableSchema == null ? schema : tableSchema,
+                            table));
+                }
+            }
+            tables.sort(Comparator.comparing(TablePath::getTableName));
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 IRIS 表列表失败，schema=" + schema, e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getTables(
+                     null,
+                     path.getSchemaName(),
+                     path.getTableName(),
+                     new String[]{"TABLE"})) {
+            return rs.next();
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "检查 IRIS 表是否存在失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        try (Connection connection = connection()) {
+            DatabaseMetaData meta = connection.getMetaData();
+            List<Column> columns = columns(meta, path);
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(catalogName, path);
+            }
+            PrimaryKey primaryKey = primaryKey(meta, path, columns);
+            TableSchema schema = TableSchema.builder()
+                    .columns(columns)
+                    .primaryKey(primaryKey)
+                    .build();
+            CatalogTable.Builder table = CatalogTable.builder(path, schema)
+                    .option(TABLE_OPTION_DIALECT, DIALECT);
+            String comment = tableComment(meta, path);
+            if (hasText(comment)) {
+                table.comment(comment);
+            }
+            return table.build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 IRIS 表结构失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public void createDatabase(String database, boolean ignoreIfExists)
+            throws CatalogException, DatabaseAlreadyExistsException {
+        throw new UnsupportedOperationException(
+                "IRIS JDBC Offline Catalog 不负责创建 Namespace；一个 job 固定使用 JDBC URL 中的 namespace");
+    }
+
+    @Override
+    public void dropDatabase(String database, boolean ignoreIfNotExists)
+            throws CatalogException, DatabaseNotFoundException {
+        throw new UnsupportedOperationException(
+                "IRIS JDBC Offline Catalog 不负责删除 Namespace；一个 job 固定使用 JDBC URL 中的 namespace");
+    }
+
+    @Override
+    public void createTable(CatalogTable table, boolean ignoreIfExists)
+            throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+
+        checkOpened();
+        TablePath path = normalizePath(table.getTablePath());
+        if (tableExists(path)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new TableAlreadyExistsException(catalogName, path);
+        }
+        CatalogTable ddlTable = table.getTablePath().equals(path)
+                ? table
+                : table.withPath(path);
+        IrisCreateTableSqlBuilder builder =
+                new IrisCreateTableSqlBuilder(path, ddlTable, typeMapper);
+        try (Connection connection = connection()) {
+            for (String sql : builder.buildStatements()) {
+                execute(connection, sql);
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "创建 IRIS 表失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public void addColumn(TablePath tablePath, Column column)
+            throws CatalogException, TableNotFoundException {
+
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        if (!tableExists(path)) {
+            throw new TableNotFoundException(catalogName, path);
+        }
+        CatalogTable current = getTable(path);
+        String definition = new IrisCreateTableSqlBuilder(
+                path, current, typeMapper)
+                .buildColumnDefinition(column, false);
+        try (Connection connection = connection()) {
+            execute(connection,
+                    "ALTER TABLE " + quoteTable(path)
+                            + " ADD COLUMN " + definition);
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "增加 IRIS 字段失败，table=" + path
+                            + "，column=" + column.getName(), e);
+        }
+    }
+
+    @Override
+    public void dropTable(TablePath tablePath, boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        tableDdl(tablePath, ignoreIfNotExists, "DROP TABLE ", "删除");
+    }
+
+    @Override
+    public void truncateTable(TablePath tablePath, boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        tableDdl(tablePath, ignoreIfNotExists, "TRUNCATE TABLE ", "清空");
+    }
+
+    private void tableDdl(
+            TablePath tablePath,
+            boolean ignoreIfNotExists,
+            String prefix,
+            String operation) throws CatalogException, TableNotFoundException {
+
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        if (!tableExists(path)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotFoundException(catalogName, path);
+        }
+        try (Connection connection = connection()) {
+            execute(connection, prefix + quoteTable(path));
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    operation + " IRIS 表失败，table=" + path, e);
+        }
+    }
+
+    private List<Column> columns(DatabaseMetaData meta, TablePath path)
+            throws SQLException {
+        try (ResultSet rs = meta.getColumns(
+                null,
+                path.getSchemaName(),
+                path.getTableName(),
+                "%")) {
+            List<Column> columns = new ArrayList<Column>();
+            while (rs.next()) {
+                columns.add(typeMapper.toColumn(rs));
+            }
+            return columns;
+        }
+    }
+
+    private PrimaryKey primaryKey(
+            DatabaseMetaData meta,
+            TablePath path,
+            List<Column> visibleColumns) throws SQLException {
+
+        Set<String> visible = new HashSet<String>();
+        for (Column column : visibleColumns) {
+            visible.add(column.getName().toUpperCase(Locale.ROOT));
+        }
+        try (ResultSet rs = meta.getPrimaryKeys(
+                null,
+                path.getSchemaName(),
+                path.getTableName())) {
+            String name = null;
+            List<KeyColumn> keys = new ArrayList<KeyColumn>();
+            while (rs.next()) {
+                String column = rs.getString("COLUMN_NAME");
+                if (!hasText(column)
+                        || !visible.contains(column.trim().toUpperCase(Locale.ROOT))) {
+                    // IRIS may expose a public RowID as an implicit JDBC PK. Do
+                    // not inject a hidden/non-selected RowID into Link Up schema.
+                    continue;
+                }
+                if (name == null) {
+                    name = rs.getString("PK_NAME");
+                }
+                keys.add(new KeyColumn(rs.getShort("KEY_SEQ"), column));
+            }
+            if (keys.isEmpty()) {
+                return null;
+            }
+            keys.sort(Comparator.comparingInt(KeyColumn::position));
+            List<String> columns = new ArrayList<String>(keys.size());
+            for (KeyColumn key : keys) {
+                columns.add(key.name);
+            }
+            return PrimaryKey.of(name, columns);
+        }
+    }
+
+    private String tableComment(DatabaseMetaData meta, TablePath path)
+            throws SQLException {
+        try (ResultSet rs = meta.getTables(
+                null,
+                path.getSchemaName(),
+                path.getTableName(),
+                new String[]{"TABLE"})) {
+            return rs.next() ? normalize(rs.getString("REMARKS")) : null;
+        }
+    }
+
+    private TablePath normalizePath(TablePath tablePath) {
+        Objects.requireNonNull(tablePath, "tablePath must not be null");
+        String sourceNamespace = tablePath.getDatabaseName();
+        String targetSchema = tablePath.getSchemaName();
+        if (!hasText(targetSchema)
+                || (hasText(sourceNamespace)
+                && !namespaceName.equalsIgnoreCase(sourceNamespace))) {
+            targetSchema = defaultSchema;
+        }
+        return TablePath.of(namespaceName, targetSchema, tablePath.getTableName());
+    }
+
+    private String schema(String schemaName) {
+        return hasText(schemaName) ? schemaName.trim() : defaultSchema;
+    }
+
+    private void checkNamespace(String requested) {
+        if (hasText(requested)
+                && !namespaceName.equalsIgnoreCase(requested.trim())) {
+            throw new IllegalArgumentException(
+                    "IRIS JDBC job 只支持 URL 当前 namespace：" + namespaceName
+                            + "，requested=" + requested);
+        }
+    }
+
+    private Connection connection() throws SQLException {
+        Properties properties = config.toConnectionProperties();
+        return DriverManager.getConnection(config.getUrl(), properties);
+    }
+
+    private void loadDriver() {
+        if (!hasText(config.getDriverClass())) {
+            return;
+        }
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException(
+                    "找不到 IRIS JDBC Driver：" + config.getDriverClass(), e);
+        }
+    }
+
+    private static void execute(Connection connection, String sql)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static boolean isSystemSchema(String schema) {
+        if (!hasText(schema)) {
+            return true;
+        }
+        String normalized = schema.toLowerCase(Locale.ROOT);
+        return normalized.startsWith("%")
+                || "information_schema".equals(normalized);
+    }
+
+    private static String quoteTable(TablePath path) {
+        return quote(path.getSchemaName()) + "." + quote(path.getTableName());
+    }
+
+    private static String quote(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + value.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static boolean hasText(String value) {
+        return normalize(value) != null;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static final class KeyColumn {
+        private final int position;
+        private final String name;
+
+        private KeyColumn(int position, String name) {
+            this.position = position;
+            this.name = name;
+        }
+
+        private int position() {
+            return position;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/iris/IrisCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/iris/IrisCatalogFactory.java
@@ -1,0 +1,46 @@
+package com.link.up.connector.jdbc.catalog.iris;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.factory.Factory;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.config.JdbcCommonOptions;
+
+import java.util.Collections;
+import java.util.Map;
+
+/** InterSystems IRIS Catalog factory. */
+@AutoService(Factory.class)
+public final class IrisCatalogFactory implements CatalogFactory {
+
+    private static final String DEFAULT_DRIVER = "com.intersystems.jdbc.IRISDriver";
+
+    @Override
+    public String factoryIdentifier() {
+        return IrisCatalog.DIALECT;
+    }
+
+    @Override
+    public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
+        String url = options.get(JdbcCommonOptions.URL);
+        String username = options.getOptional(JdbcCommonOptions.USERNAME).orElse(null);
+        String password = options.getOptional(JdbcCommonOptions.PASSWORD).orElse(null);
+        String driver = options.getOptional(JdbcCommonOptions.DRIVER).orElse(DEFAULT_DRIVER);
+        String schema = options.getOptional(JdbcCommonOptions.SCHEMA).orElse(null);
+        Map<String, String> properties = options.getOptional(JdbcCommonOptions.PROPERTIES)
+                .orElse(Collections.<String, String>emptyMap());
+
+        return new IrisCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        url,
+                        username,
+                        password,
+                        driver,
+                        properties,
+                        false),
+                schema);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/iris/IrisCreateTableSqlBuilder.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/iris/IrisCreateTableSqlBuilder.java
@@ -1,0 +1,216 @@
+package com.link.up.connector.jdbc.catalog.iris;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.iris.IrisTypeMapper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** Builds IRIS CREATE TABLE statements for offline sink preparation. */
+public final class IrisCreateTableSqlBuilder {
+
+    private static final Pattern NUMBER_PATTERN =
+            Pattern.compile("[-+]?\\d+(\\.\\d+)?");
+
+    private final TablePath tablePath;
+    private final CatalogTable catalogTable;
+    private final IrisTypeMapper typeMapper;
+
+    public IrisCreateTableSqlBuilder(
+            TablePath tablePath,
+            CatalogTable catalogTable,
+            IrisTypeMapper typeMapper) {
+
+        this.tablePath = tablePath;
+        this.catalogTable = catalogTable;
+        this.typeMapper = typeMapper;
+    }
+
+    public String build() {
+        return String.join("\n", buildStatements());
+    }
+
+    public List<String> buildStatements() {
+        return Collections.singletonList(buildCreateTable());
+    }
+
+    public String buildColumnDefinition(
+            Column column,
+            boolean preserveSourceType) {
+
+        List<String> parts = new ArrayList<String>();
+        parts.add(quote(column.getName()));
+
+        if (column.isAutoIncrement()
+                && isInteger(column.getDataType().getSqlType())
+                && !isReadOnlyRowVersion(column)) {
+            // SERIAL permits source IDs to be inserted explicitly, unlike
+            // IDENTITY, while still maintaining an automatic counter.
+            parts.add("SERIAL");
+        } else {
+            boolean preserve = preserveSourceType
+                    && shouldPreserveSourceType(column);
+            parts.add(typeMapper.toDatabaseType(column, preserve));
+        }
+
+        if (!column.isNullable()) {
+            parts.add("NOT NULL");
+        }
+
+        if (!column.isAutoIncrement()
+                && column.getDefaultValue() != null) {
+            parts.add("DEFAULT " + formatDefaultValue(column, preserveSourceType));
+        }
+
+        if (hasText(column.getComment())) {
+            parts.add("%DESCRIPTION '" + literal(column.getComment()) + "'");
+        }
+        return String.join(" ", parts);
+    }
+
+    private String buildCreateTable() {
+        TableSchema schema = catalogTable.getTableSchema();
+        List<String> definitions = new ArrayList<String>();
+
+        if (hasText(catalogTable.getComment())) {
+            definitions.add(
+                    "%DESCRIPTION '" + literal(catalogTable.getComment()) + "'");
+        }
+
+        boolean preserveSourceType = IrisCatalog.DIALECT.equalsIgnoreCase(
+                catalogTable.getOptions().get(IrisCatalog.TABLE_OPTION_DIALECT));
+
+        for (Column column : schema.getColumns()) {
+            definitions.add(buildColumnDefinition(column, preserveSourceType));
+        }
+
+        PrimaryKey primaryKey = schema.getPrimaryKey();
+        if (primaryKey != null) {
+            definitions.add(buildPrimaryKey(primaryKey));
+        }
+
+        return "CREATE TABLE "
+                + quoteTable(tablePath)
+                + " (\n    "
+                + String.join(",\n    ", definitions)
+                + "\n);";
+    }
+
+    private static boolean isReadOnlyRowVersion(Column column) {
+        return "rowversion".equals(baseSourceType(column));
+    }
+
+    private static boolean shouldPreserveSourceType(Column column) {
+        String base = baseSourceType(column);
+        boolean numericSource = "numeric".equals(base)
+                || "decimal".equals(base)
+                || "dec".equals(base)
+                || "money".equals(base)
+                || "smallmoney".equals(base);
+        // If IRIS metadata produced a numeric shape Flux cannot represent,
+        // IrisTypeMapper intentionally carries it as exact STRING. Recreating
+        // the same explicit type could reintroduce clamping, so use LONGVARCHAR.
+        return !(numericSource
+                && column.getDataType().getSqlType() == SqlType.STRING);
+    }
+
+    private static String baseSourceType(Column column) {
+        String sourceType = column.getSourceType();
+        if (!hasText(sourceType)) {
+            return "";
+        }
+        String normalized = sourceType.trim().toLowerCase(Locale.ROOT);
+        int parenthesis = normalized.indexOf('(');
+        return parenthesis >= 0
+                ? normalized.substring(0, parenthesis).trim()
+                : normalized;
+    }
+
+    private static String buildPrimaryKey(PrimaryKey primaryKey) {
+        String columns = primaryKey.getColumnNames().stream()
+                .map(IrisCreateTableSqlBuilder::quote)
+                .collect(Collectors.joining(", "));
+        if (hasText(primaryKey.getName())) {
+            return "CONSTRAINT " + quote(primaryKey.getName())
+                    + " PRIMARY KEY (" + columns + ")";
+        }
+        return "PRIMARY KEY (" + columns + ")";
+    }
+
+    private static String formatDefaultValue(
+            Column column,
+            boolean preserveSourceType) {
+
+        Object value = column.getDefaultValue();
+        if (value instanceof Number) {
+            return value.toString();
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value ? "1" : "0";
+        }
+
+        String text = String.valueOf(value).trim();
+        if (preserveSourceType) {
+            return text;
+        }
+        String upper = text.toUpperCase(Locale.ROOT);
+        if ("NULL".equals(upper)
+                || "CURRENT_TIMESTAMP".equals(upper)
+                || "CURRENT_DATE".equals(upper)
+                || "CURRENT_TIME".equals(upper)
+                || upper.startsWith("CURRENT_TIMESTAMP(")) {
+            return text;
+        }
+        if (isNumeric(column.getDataType().getSqlType())
+                && NUMBER_PATTERN.matcher(text).matches()) {
+            return text;
+        }
+        return "'" + literal(text) + "'";
+    }
+
+    private static boolean isInteger(SqlType type) {
+        return type == SqlType.TINYINT
+                || type == SqlType.SMALLINT
+                || type == SqlType.INT
+                || type == SqlType.BIGINT;
+    }
+
+    private static boolean isNumeric(SqlType type) {
+        return isInteger(type)
+                || type == SqlType.FLOAT
+                || type == SqlType.DOUBLE
+                || type == SqlType.DECIMAL;
+    }
+
+    private static String quoteTable(TablePath path) {
+        if (path == null || !hasText(path.getSchemaName())) {
+            throw new IllegalArgumentException(
+                    "IRIS tablePath must contain schema: " + path);
+        }
+        return quote(path.getSchemaName()) + "." + quote(path.getTableName());
+    }
+
+    private static String quote(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + value.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static String literal(String value) {
+        return value.replace("'", "''");
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -19,6 +19,7 @@ public final class DatabaseIdentifier {
     public static final String YASHANDB = "yashandb";
     public static final String DUCKDB = "duckdb";
     public static final String HIGHGO = "highgo";
+    public static final String IRIS = "iris";
 
     private DatabaseIdentifier() {
     }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisDialect.java
@@ -1,0 +1,242 @@
+package com.link.up.connector.jdbc.core.dialect.iris;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.iris.IrisCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** InterSystems IRIS offline JDBC dialect. */
+public final class IrisDialect implements JdbcDialect {
+
+    private static final int DEFAULT_FETCH_SIZE = 500;
+    private static final String DEFAULT_SCHEMA = "SQLUser";
+
+    private final JdbcConnectionConfig connectionConfig;
+    private final IrisTypeMapper typeMapper = new IrisTypeMapper();
+    private final String namespaceName;
+    private final String defaultSchema;
+
+    public IrisDialect(JdbcConnectionConfig connectionConfig) {
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException("connectionConfig must not be null");
+        }
+        this.connectionConfig = connectionConfig;
+        this.namespaceName = IrisJdbcUrl.namespaceName(connectionConfig.getUrl());
+        if (!JdbcDialect.hasText(namespaceName)) {
+            throw new IllegalArgumentException(
+                    "IRIS JDBC URL 必须包含 namespace，例如 jdbc:IRIS://127.0.0.1:1972/USER");
+        }
+        this.defaultSchema = JdbcDialect.hasText(connectionConfig.getSchema())
+                ? connectionConfig.getSchema().trim()
+                : DEFAULT_SCHEMA;
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.IRIS;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+
+        return new IrisCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false),
+                connectionConfig.getSchema());
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new IrisJdbcRowConverter();
+    }
+
+    /**
+     * IRIS SQL addresses schema.table; namespace is selected by the JDBC URL.
+     */
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        if (!JdbcDialect.hasText(tablePath)) {
+            throw new IllegalArgumentException("tablePath must not be empty");
+        }
+        List<String> parts = splitIdentifierPath(tablePath.trim());
+        switch (parts.size()) {
+            case 1:
+                return TablePath.of(normalizeIdentifier(parts.get(0)));
+            case 2:
+                return TablePath.of(
+                        null,
+                        normalizeIdentifier(parts.get(0)),
+                        normalizeIdentifier(parts.get(1)));
+            case 3:
+                String namespace = normalizeIdentifier(parts.get(0));
+                if (!namespaceName.equalsIgnoreCase(namespace)) {
+                    throw new IllegalArgumentException(
+                            "IRIS 表路径中的 namespace 与 JDBC URL 不一致，urlNamespace="
+                                    + namespaceName + "，pathNamespace=" + namespace);
+                }
+                return TablePath.of(
+                        namespaceName,
+                        normalizeIdentifier(parts.get(1)),
+                        normalizeIdentifier(parts.get(2)));
+            default:
+                throw new IllegalArgumentException("非法 IRIS 表路径：" + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        if (!JdbcDialect.hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + identifier.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        String database = tablePath.getDatabaseName();
+        if (JdbcDialect.hasText(database)
+                && !namespaceName.equalsIgnoreCase(database)) {
+            // Source metadata from another database is safe to ignore only at
+            // sink target normalization. Direct Source table paths must fail.
+            throw new IllegalArgumentException(
+                    "IRIS JDBC 连接只支持 URL namespace：" + namespaceName
+                            + "，requested=" + database);
+        }
+        String schema = JdbcDialect.hasText(tablePath.getSchemaName())
+                ? tablePath.getSchemaName().trim()
+                : defaultSchema;
+        return quoteIdentifier(schema)
+                + "."
+                + quoteIdentifier(tablePath.getTableName());
+    }
+
+    @Override
+    public Optional<String> buildUpsertSql(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+
+        JdbcDialect.validateFields(fieldNames);
+        Set<String> primaryKeySet = JdbcDialect.normalizeFields(primaryKeys);
+        if (primaryKeySet.isEmpty()) {
+            throw new IllegalArgumentException("IRIS UPSERT 必须配置主键字段");
+        }
+        Set<String> fields = new HashSet<String>(fieldNames);
+        for (String primaryKey : primaryKeys) {
+            if (!fields.contains(primaryKey)) {
+                throw new IllegalArgumentException(
+                        "IRIS UPSERT 主键字段不存在：" + primaryKey);
+            }
+        }
+
+        String columns = fieldNames.stream()
+                .map(this::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        String placeholders = fieldNames.stream()
+                .map(field -> "?")
+                .collect(Collectors.joining(", "));
+
+        // IRIS resolves INSERT OR UPDATE through the table's IDKey / primary
+        // key / unique constraints. Link Up requires configured PK metadata so
+        // auto-created targets have a deterministic conflict identity.
+        return Optional.of(
+                "INSERT OR UPDATE "
+                        + tableIdentifier(tablePath)
+                        + " (" + columns + ") VALUES ("
+                        + placeholders + ")");
+    }
+
+    @Override
+    public PreparedStatement prepareReadStatement(
+            Connection connection,
+            String sql,
+            int fetchSize) throws SQLException {
+
+        PreparedStatement statement = connection.prepareStatement(
+                sql,
+                ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY);
+        statement.setFetchSize(fetchSize > 0 ? fetchSize : DEFAULT_FETCH_SIZE);
+        return statement;
+    }
+
+    // String HASH partition intentionally remains unsupported. IRIS does not
+    // expose a stable hash/md5 scalar suitable for bucket predicates, and its
+    // default string collation is commonly SQLUPPER, so generic string RANGE
+    // partitioning is also left disabled by JdbcDialect's safe default.
+
+    private static List<String> splitIdentifierPath(String path) {
+        List<String> parts = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '\"') {
+                current.append(c);
+                if (quoted && i + 1 < path.length() && path.charAt(i + 1) == '\"') {
+                    current.append('\"');
+                    i++;
+                } else {
+                    quoted = !quoted;
+                }
+                continue;
+            }
+            if (c == '.' && !quoted) {
+                if (current.length() == 0) {
+                    throw new IllegalArgumentException("非法 IRIS 表路径：" + path);
+                }
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        if (quoted || current.length() == 0) {
+            throw new IllegalArgumentException("非法 IRIS 表路径：" + path);
+        }
+        parts.add(current.toString());
+        return parts;
+    }
+
+    private static String normalizeIdentifier(String part) {
+        String value = part.trim();
+        if (value.length() >= 2
+                && value.charAt(0) == '\"'
+                && value.charAt(value.length() - 1) == '\"') {
+            return value.substring(1, value.length() - 1).replace("\"\"", "\"");
+        }
+        return value;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisDialectFactory.java
@@ -1,0 +1,27 @@
+package com.link.up.connector.jdbc.core.dialect.iris;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/** InterSystems IRIS offline JDBC dialect factory. */
+@AutoService(JdbcDialectFactory.class)
+public final class IrisDialectFactory implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.IRIS;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return IrisJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(JdbcConnectionConfig connectionConfig) {
+        return new IrisDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisJdbcRowConverter.java
@@ -1,0 +1,158 @@
+package com.link.up.connector.jdbc.core.dialect.iris;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.LocalTime;
+import java.util.Locale;
+
+/** IRIS row converter with stream-safe LOB and precise temporal writes. */
+public final class IrisJdbcRowConverter extends AbstractJdbcRowConverter {
+
+    private static final String NATIVE_ATTRIBUTE = IrisTypeMapper.NATIVE_ATTRIBUTE;
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.IRIS;
+    }
+
+    @Override
+    protected void writeNull(
+            PreparedStatement statement,
+            int index,
+            Column column) throws SQLException {
+
+        SqlType sqlType = column.getDataType().getSqlType();
+        if (sqlType == SqlType.TIMESTAMP_TZ) {
+            statement.setNull(index, Types.VARCHAR);
+            return;
+        }
+        if (sqlType == SqlType.TIME) {
+            statement.setNull(index, Types.TIME);
+            return;
+        }
+        if (isNative(column)
+                && sqlType == SqlType.STRING
+                && isExactNumeric(column.getSourceType())) {
+            // Exact numeric values are carried as strings. VARCHAR null typing
+            // works both for an existing NUMERIC target and our LONGVARCHAR
+            // fallback used when the source numeric shape is not representable.
+            statement.setNull(index, Types.VARCHAR);
+            return;
+        }
+        if (sqlType == SqlType.STRING && isLongText(column)) {
+            statement.setNull(index, Types.LONGVARCHAR);
+            return;
+        }
+        if (sqlType == SqlType.BYTES && isLongBinary(column)) {
+            statement.setNull(index, Types.LONGVARBINARY);
+            return;
+        }
+        super.writeNull(statement, index, column);
+    }
+
+    @Override
+    protected void writeValue(
+            PreparedStatement statement,
+            int index,
+            Object value,
+            Column column) throws SQLException {
+
+        SqlType sqlType = column.getDataType().getSqlType();
+        if (sqlType == SqlType.TIMESTAMP_TZ) {
+            // IRIS core SQL has no offset-aware timestamp type; the type mapper
+            // creates VARCHAR(64) so the offset is preserved exactly.
+            statement.setString(index, String.valueOf(value));
+            return;
+        }
+        if (sqlType == SqlType.TIME) {
+            LocalTime time = value instanceof LocalTime
+                    ? (LocalTime) value
+                    : LocalTime.parse(String.valueOf(value));
+            statement.setObject(index, time);
+            return;
+        }
+        if (isNative(column)
+                && sqlType == SqlType.STRING
+                && isExactNumeric(column.getSourceType())) {
+            statement.setString(index, String.valueOf(value));
+            return;
+        }
+        if (sqlType == SqlType.STRING && isLongText(column)) {
+            String text = asString(value);
+            statement.setCharacterStream(
+                    index,
+                    new StringReader(text),
+                    text.length());
+            return;
+        }
+        if (sqlType == SqlType.BYTES && isLongBinary(column)) {
+            byte[] bytes = asBytes(value);
+            statement.setBinaryStream(
+                    index,
+                    new ByteArrayInputStream(bytes),
+                    bytes.length);
+            return;
+        }
+        super.writeValue(statement, index, value, column);
+    }
+
+    private static boolean isNative(Column column) {
+        return "true".equalsIgnoreCase(
+                column.getAttributes().get(NATIVE_ATTRIBUTE));
+    }
+
+    private static boolean isExactNumeric(String sourceType) {
+        String base = baseType(sourceType);
+        return "numeric".equals(base)
+                || "decimal".equals(base)
+                || "dec".equals(base)
+                || "number".equals(base)
+                || "money".equals(base)
+                || "smallmoney".equals(base);
+    }
+
+    private static boolean isLongText(Column column) {
+        String base = baseType(column.getSourceType());
+        return "longvarchar".equals(base)
+                || "long varchar".equals(base)
+                || "clob".equals(base)
+                || "ntext".equals(base)
+                || "text".equals(base)
+                || "longtext".equals(base)
+                || "mediumtext".equals(base)
+                || column.getLength() == null
+                || column.getLength() > IrisTypeMapper.MAX_BOUNDED_VARCHAR_LENGTH;
+    }
+
+    private static boolean isLongBinary(Column column) {
+        String base = baseType(column.getSourceType());
+        return "longvarbinary".equals(base)
+                || "blob".equals(base)
+                || "image".equals(base)
+                || "long binary".equals(base)
+                || "long raw".equals(base)
+                || column.getLength() == null
+                || column.getLength() > IrisTypeMapper.MAX_BOUNDED_BINARY_LENGTH;
+    }
+
+    private static String baseType(String value) {
+        if (value == null) {
+            return "";
+        }
+        String normalized = value.trim()
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", " ");
+        int parenthesis = normalized.indexOf('(');
+        return parenthesis >= 0
+                ? normalized.substring(0, parenthesis).trim()
+                : normalized;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisJdbcUrl.java
@@ -1,0 +1,42 @@
+package com.link.up.connector.jdbc.core.dialect.iris;
+
+import java.util.Locale;
+
+/** Utilities for InterSystems IRIS JDBC URL semantics. */
+public final class IrisJdbcUrl {
+
+    private static final String PREFIX = "jdbc:iris://";
+
+    private IrisJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return url != null
+                && url.trim().toLowerCase(Locale.ROOT).startsWith(PREFIX);
+    }
+
+    /**
+     * Returns the IRIS namespace selected by the JDBC URL.
+     *
+     * <p>IRIS uses jdbc:IRIS://host:port/namespace. Optional driver arguments
+     * may follow the namespace after another slash and are not part of the
+     * logical namespace/catalog name.</p>
+     */
+    public static String namespaceName(String url) {
+        if (!accepts(url)) {
+            return null;
+        }
+        String value = url.trim();
+        int start = PREFIX.length();
+        int firstSlash = value.indexOf('/', start);
+        if (firstSlash < 0 || firstSlash == value.length() - 1) {
+            return null;
+        }
+        int end = value.indexOf('/', firstSlash + 1);
+        String namespace = end < 0
+                ? value.substring(firstSlash + 1)
+                : value.substring(firstSlash + 1, end);
+        namespace = namespace.trim();
+        return namespace.isEmpty() ? null : namespace;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/iris/IrisTypeMapper.java
@@ -1,0 +1,549 @@
+package com.link.up.connector.jdbc.core.dialect.iris;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
+
+/** InterSystems IRIS JDBC type mapper for bounded/offline jobs. */
+public final class IrisTypeMapper implements JdbcTypeMapper {
+
+    static final int MAX_NUMERIC_SCALE = 18;
+    static final int DEFAULT_NUMERIC_PRECISION = 15;
+    static final int DEFAULT_NUMERIC_SCALE = 0;
+    static final int MAX_TIME_PRECISION = 9;
+    static final int MAX_POSIXTIME_PRECISION = 6;
+    static final long MAX_BOUNDED_VARCHAR_LENGTH = 32_767L;
+    static final long MAX_BOUNDED_BINARY_LENGTH = 32_749L;
+    static final String NATIVE_ATTRIBUTE = "iris_native";
+
+    @Override
+    public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+        String name = firstText(
+                metadata.getColumnLabel(columnIndex),
+                metadata.getColumnName(columnIndex));
+        String sourceType = metadata.getColumnTypeName(columnIndex);
+        int precision = metadata.getPrecision(columnIndex);
+        int scale = metadata.getScale(columnIndex);
+        FluxDataType<?> type = mapType(
+                metadata.getColumnType(columnIndex), sourceType, precision, scale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(metadata.isNullable(columnIndex)
+                        != ResultSetMetaData.columnNoNulls)
+                .sourceType(buildSourceType(sourceType, precision, scale))
+                .attribute(NATIVE_ATTRIBUTE, "true");
+        applyProperties(builder, type, sourceType, precision, scale);
+        return builder.build();
+    }
+
+    /** Maps a JDBC DatabaseMetaData#getColumns row. */
+    public Column toColumn(ResultSet row) throws SQLException {
+        String name = row.getString("COLUMN_NAME");
+        String typeName = row.getString("TYPE_NAME");
+        Integer size = integer(row, "COLUMN_SIZE");
+        Integer scale = integer(row, "DECIMAL_DIGITS");
+        Integer nullable = integer(row, "NULLABLE");
+        int jdbcType = value(integer(row, "DATA_TYPE"));
+        int precision = value(size);
+        int safeScale = value(scale);
+        FluxDataType<?> type = mapType(jdbcType, typeName, precision, safeScale);
+        Object defaultValue = safeObject(row, "COLUMN_DEF");
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(nullable == null
+                        || nullable != ResultSetMetaData.columnNoNulls)
+                .defaultValue(defaultValue)
+                .comment(safeString(row, "REMARKS"))
+                .sourceType(buildSourceType(typeName, precision, safeScale))
+                .attribute(NATIVE_ATTRIBUTE, "true");
+
+        String auto = safeString(row, "IS_AUTOINCREMENT");
+        boolean autoIncrement = "YES".equalsIgnoreCase(auto)
+                || isAutoIncrementType(typeName);
+        builder.autoIncrement(autoIncrement);
+        applyProperties(builder, type, typeName, precision, safeScale);
+        return builder.build();
+    }
+
+    @Override
+    public String toDatabaseType(Column column) {
+        return toDatabaseType(column, false);
+    }
+
+    public String toDatabaseType(Column column, boolean preserveSourceType) {
+        if (preserveSourceType && canPreserve(column.getSourceType())) {
+            return column.getSourceType().trim();
+        }
+
+        SqlType type = column.getDataType().getSqlType();
+        switch (type) {
+            case BOOLEAN:
+                return "BIT";
+            case TINYINT:
+                return "TINYINT";
+            case SMALLINT:
+                return "SMALLINT";
+            case INT:
+                return "INTEGER";
+            case BIGINT:
+                return "BIGINT";
+            case FLOAT:
+                return "FLOAT";
+            case DOUBLE:
+                return "DOUBLE";
+            case DECIMAL:
+                return decimalType(column);
+            case STRING:
+                return stringType(column);
+            case BYTES:
+                return binaryType(column);
+            case DATE:
+                return "DATE";
+            case TIME:
+                return timeType(column);
+            case TIMESTAMP:
+                return timestampType(column);
+            case TIMESTAMP_TZ:
+                // Core IRIS SQL has no offset-aware timestamp primitive. Keep
+                // the ISO-8601 value rather than silently dropping its offset.
+                return "VARCHAR(64)";
+            default:
+                throw new IllegalArgumentException(
+                        "IRIS 不支持 Flux 类型：" + type
+                                + "，column=" + column.getName());
+        }
+    }
+
+    /** Package-visible for focused type contract tests. */
+    FluxDataType<?> mapType(
+            int jdbcType,
+            String sourceType,
+            int precision,
+            int scale) {
+
+        String type = normalize(sourceType);
+        String base = baseType(type);
+
+        switch (base) {
+            case "null":
+                return BasicType.NULL_TYPE;
+            case "bit":
+            case "boolean":
+                return BasicType.BOOLEAN_TYPE;
+            case "tinyint":
+                return BasicType.BYTE_TYPE;
+            case "smallint":
+                return BasicType.SHORT_TYPE;
+            case "mediumint":
+            case "integer":
+            case "int":
+                return BasicType.INT_TYPE;
+            case "bigint":
+            case "serial":
+            case "auto_increment":
+            case "rowversion":
+                return BasicType.LONG_TYPE;
+            case "float":
+                return BasicType.FLOAT_TYPE;
+            case "double":
+            case "real":
+            case "double precision":
+                return BasicType.DOUBLE_TYPE;
+            case "numeric":
+            case "decimal":
+            case "dec":
+            case "money":
+            case "smallmoney":
+                return numericType(precision, scale, false);
+            case "number":
+                return numericType(precision, scale, true);
+            case "date":
+                return BasicType.DATE_TYPE;
+            case "time":
+                return BasicType.TIME_TYPE;
+            case "timestamp":
+            case "posixtime":
+            case "timestamp2":
+            case "datetime":
+            case "datetime2":
+            case "smalldatetime":
+                return BasicType.TIMESTAMP_TYPE;
+            case "binary":
+            case "binary varying":
+            case "varbinary":
+            case "raw":
+            case "longvarbinary":
+            case "blob":
+            case "image":
+            case "long binary":
+            case "long raw":
+                return BasicType.BYTES_TYPE;
+            default:
+                break;
+        }
+
+        if (isStringType(base)
+                || "guid".equals(base)
+                || "uniqueidentifier".equals(base)
+                || "vector".equals(base)
+                || "oref".equals(base)) {
+            return BasicType.STRING_TYPE;
+        }
+
+        switch (jdbcType) {
+            case Types.NULL:
+                return BasicType.NULL_TYPE;
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return BasicType.BOOLEAN_TYPE;
+            case Types.TINYINT:
+                return BasicType.BYTE_TYPE;
+            case Types.SMALLINT:
+                return BasicType.SHORT_TYPE;
+            case Types.INTEGER:
+                return BasicType.INT_TYPE;
+            case Types.BIGINT:
+                return BasicType.LONG_TYPE;
+            case Types.REAL:
+            case Types.FLOAT:
+                return BasicType.FLOAT_TYPE;
+            case Types.DOUBLE:
+                return BasicType.DOUBLE_TYPE;
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return numericType(precision, scale, false);
+            case Types.DATE:
+                return BasicType.DATE_TYPE;
+            case Types.TIME:
+                return BasicType.TIME_TYPE;
+            case Types.TIMESTAMP:
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return BasicType.TIMESTAMP_TYPE;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+            case Types.BLOB:
+                return BasicType.BYTES_TYPE;
+            default:
+                return BasicType.STRING_TYPE;
+        }
+    }
+
+    private static FluxDataType<?> numericType(
+            int precision,
+            int scale,
+            boolean numberAlias) {
+
+        if (precision <= 0) {
+            return numberAlias
+                    ? BasicType.LONG_TYPE
+                    : new DecimalType(
+                            DEFAULT_NUMERIC_PRECISION,
+                            DEFAULT_NUMERIC_SCALE);
+        }
+        if (!validNumericShape(precision, scale)) {
+            return BasicType.STRING_TYPE;
+        }
+        return new DecimalType(precision, scale);
+    }
+
+    private static boolean validNumericShape(int precision, int scale) {
+        return precision > 0
+                && scale >= 0
+                && scale <= MAX_NUMERIC_SCALE
+                && scale <= precision
+                && precision <= 19 + scale;
+    }
+
+    private static String decimalType(Column column) {
+        Integer precisionValue = column.getPrecision();
+        Integer scaleValue = column.getScale();
+        if (column.getDataType() instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) column.getDataType();
+            if (precisionValue == null) {
+                precisionValue = decimal.getPrecision();
+            }
+            if (scaleValue == null) {
+                scaleValue = decimal.getScale();
+            }
+        }
+
+        int precision = precisionValue == null
+                ? DEFAULT_NUMERIC_PRECISION
+                : precisionValue;
+        int scale = scaleValue == null
+                ? DEFAULT_NUMERIC_SCALE
+                : scaleValue;
+        if (!validNumericShape(precision, scale)) {
+            throw new IllegalArgumentException(
+                    "IRIS NUMERIC 必须满足 scale 0..18 且 precision <= 19 + scale，column="
+                            + column.getName() + "，precision=" + precision
+                            + "，scale=" + scale);
+        }
+        return "NUMERIC(" + precision + "," + scale + ")";
+    }
+
+    private static String stringType(Column column) {
+        Long length = column.getLength();
+        if (length == null || length <= 0
+                || length > MAX_BOUNDED_VARCHAR_LENGTH) {
+            return "LONGVARCHAR";
+        }
+        return "VARCHAR(" + length + ")";
+    }
+
+    private static String binaryType(Column column) {
+        Long length = column.getLength();
+        if (length == null || length <= 0
+                || length > MAX_BOUNDED_BINARY_LENGTH) {
+            return "LONGVARBINARY";
+        }
+        return "VARBINARY(" + length + ")";
+    }
+
+    private static String timeType(Column column) {
+        Integer precision = column.getPrecision();
+        if (precision == null || precision <= 0) {
+            return "TIME";
+        }
+        if (precision > MAX_TIME_PRECISION) {
+            throw new IllegalArgumentException(
+                    "IRIS TIME precision 最大为 9，column="
+                            + column.getName() + "，precision=" + precision);
+        }
+        return "TIME(" + precision + ")";
+    }
+
+    private static String timestampType(Column column) {
+        Integer precision = column.getPrecision();
+        if (precision != null && precision > MAX_TIME_PRECISION) {
+            throw new IllegalArgumentException(
+                    "IRIS TIMESTAMP2 precision 最大为 9，column="
+                            + column.getName() + "，precision=" + precision);
+        }
+        // TIMESTAMP2 maps to %Library.TimeStamp and can preserve nanoseconds;
+        // legacy TIMESTAMP/POSIXTIME only preserve up to microseconds.
+        return "TIMESTAMP2";
+    }
+
+    private static void applyProperties(
+            Column.Builder builder,
+            FluxDataType<?> dataType,
+            String sourceType,
+            int precision,
+            int scale) {
+
+        SqlType sqlType = dataType.getSqlType();
+        String base = baseType(normalize(sourceType));
+        if (sqlType == SqlType.STRING) {
+            if (isBoundedString(base) && precision > 0) {
+                builder.length((long) precision);
+            } else if (("guid".equals(base)
+                    || "uniqueidentifier".equals(base)) && precision > 0) {
+                builder.length((long) precision);
+            }
+            return;
+        }
+        if (sqlType == SqlType.BYTES) {
+            if (isBoundedBinary(base) && precision > 0) {
+                builder.length((long) precision);
+            }
+            return;
+        }
+        if (sqlType == SqlType.DECIMAL && dataType instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) dataType;
+            builder.precision(decimal.getPrecision());
+            builder.scale(decimal.getScale());
+            return;
+        }
+        if (sqlType == SqlType.TIME) {
+            if (scale > 0) {
+                builder.precision(Math.min(scale, MAX_TIME_PRECISION));
+            }
+            return;
+        }
+        if (sqlType == SqlType.TIMESTAMP) {
+            int max = "timestamp".equals(base) || "posixtime".equals(base)
+                    ? MAX_POSIXTIME_PRECISION
+                    : MAX_TIME_PRECISION;
+            if (scale > 0) {
+                builder.precision(Math.min(scale, max));
+            }
+        }
+    }
+
+    private static String buildSourceType(
+            String sourceType,
+            int precision,
+            int scale) {
+
+        String raw = sourceType == null ? "" : sourceType.trim();
+        String base = baseType(normalize(raw));
+        if (raw.isEmpty() || raw.contains("(")) {
+            return raw;
+        }
+        if (isNumericBase(base) && precision > 0) {
+            return raw + "(" + precision + "," + scale + ")";
+        }
+        if (isBoundedString(base) || isBoundedBinary(base)) {
+            return precision > 0 ? raw + "(" + precision + ")" : raw;
+        }
+        if ("time".equals(base) && scale > 0) {
+            return raw + "(" + Math.min(scale, MAX_TIME_PRECISION) + ")";
+        }
+        return raw;
+    }
+
+    private static boolean canPreserve(String sourceType) {
+        String type = normalize(sourceType);
+        String base = baseType(type);
+        if (type.isEmpty()
+                || "rowversion".equals(base)
+                || "identity".equals(base)
+                || "vector".equals(base)
+                || "oref".equals(base)) {
+            return false;
+        }
+        return "bit".equals(base)
+                || "tinyint".equals(base)
+                || "smallint".equals(base)
+                || "mediumint".equals(base)
+                || "integer".equals(base)
+                || "int".equals(base)
+                || "bigint".equals(base)
+                || "serial".equals(base)
+                || "float".equals(base)
+                || "double".equals(base)
+                || "real".equals(base)
+                || "double precision".equals(base)
+                || isNumericBase(base)
+                || isStringType(base)
+                || "guid".equals(base)
+                || "uniqueidentifier".equals(base)
+                || "date".equals(base)
+                || "time".equals(base)
+                || "timestamp".equals(base)
+                || "timestamp2".equals(base)
+                || "posixtime".equals(base)
+                || "datetime".equals(base)
+                || "datetime2".equals(base)
+                || "smalldatetime".equals(base)
+                || isBoundedBinary(base)
+                || isLongBinary(base);
+    }
+
+    private static boolean isNumericBase(String base) {
+        return "numeric".equals(base)
+                || "decimal".equals(base)
+                || "dec".equals(base)
+                || "number".equals(base)
+                || "money".equals(base)
+                || "smallmoney".equals(base);
+    }
+
+    private static boolean isStringType(String base) {
+        return isBoundedString(base)
+                || "ntext".equals(base)
+                || "clob".equals(base)
+                || "long varchar".equals(base)
+                || "long".equals(base)
+                || "longtext".equals(base)
+                || "mediumtext".equals(base)
+                || "text".equals(base)
+                || "longvarchar".equals(base)
+                || "sysname".equals(base);
+    }
+
+    private static boolean isBoundedString(String base) {
+        return "char".equals(base)
+                || "character".equals(base)
+                || "char varying".equals(base)
+                || "character varying".equals(base)
+                || "national char".equals(base)
+                || "national char varying".equals(base)
+                || "national character".equals(base)
+                || "national character varying".equals(base)
+                || "national varchar".equals(base)
+                || "nchar".equals(base)
+                || "nvarchar".equals(base)
+                || "varchar".equals(base)
+                || "varchar2".equals(base);
+    }
+
+    private static boolean isBoundedBinary(String base) {
+        return "binary".equals(base)
+                || "binary varying".equals(base)
+                || "varbinary".equals(base)
+                || "raw".equals(base);
+    }
+
+    private static boolean isLongBinary(String base) {
+        return "longvarbinary".equals(base)
+                || "blob".equals(base)
+                || "image".equals(base)
+                || "long binary".equals(base)
+                || "long raw".equals(base);
+    }
+
+    private static boolean isAutoIncrementType(String typeName) {
+        String base = baseType(normalize(typeName));
+        return "serial".equals(base)
+                || "identity".equals(base)
+                || "auto_increment".equals(base);
+    }
+
+    private static String baseType(String value) {
+        int parenthesis = value.indexOf('(');
+        return parenthesis >= 0
+                ? value.substring(0, parenthesis).trim()
+                : value;
+    }
+
+    private static String normalize(String value) {
+        return value == null
+                ? ""
+                : value.trim().toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
+    }
+
+    private static String firstText(String first, String second) {
+        return first != null && !first.trim().isEmpty() ? first : second;
+    }
+
+    private static Integer integer(ResultSet row, String name) {
+        try {
+            Object value = row.getObject(name);
+            return value == null ? null : ((Number) value).intValue();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static Object safeObject(ResultSet row, String name) {
+        try {
+            return row.getObject(name);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static String safeString(ResultSet row, String name) {
+        try {
+            return row.getString(name);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static int value(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/IrisSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/IrisSinkSupport.java
@@ -1,0 +1,78 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.iris.IrisCreateTableSqlBuilder;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.iris.IrisJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.iris.IrisTypeMapper;
+
+/** Small IRIS target-path/DDL adapter kept out of the generic resolver. */
+final class IrisSinkSupport {
+
+    private IrisSinkSupport() {
+    }
+
+    static boolean accepts(JdbcConnectionConfig config) {
+        return config != null
+                && (DatabaseIdentifier.IRIS.equalsIgnoreCase(config.getDialect())
+                || IrisJdbcUrl.accepts(config.getUrl()));
+    }
+
+    static TablePath resolveTargetPath(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+
+        if (config == null || tablePath == null) {
+            return tablePath;
+        }
+        String namespace = IrisJdbcUrl.namespaceName(config.getUrl());
+        if (!hasText(namespace)) {
+            return null;
+        }
+
+        String pathNamespace = tablePath.getDatabaseName();
+        String pathSchema = tablePath.getSchemaName();
+        String schema;
+        if (hasText(pathSchema)
+                && (!hasText(pathNamespace)
+                || namespace.equalsIgnoreCase(pathNamespace))) {
+            schema = pathSchema.trim();
+        } else {
+            schema = defaultSchema(config);
+        }
+        return TablePath.of(namespace, schema, tablePath.getTableName());
+    }
+
+    static String resolveCreateTableSql(
+            JdbcConnectionConfig config,
+            CatalogTable table) {
+
+        if (config == null || table == null) {
+            return null;
+        }
+        TablePath targetPath = resolveTargetPath(config, table.getTablePath());
+        if (targetPath == null) {
+            return null;
+        }
+        CatalogTable ddlTable = table.getTablePath().equals(targetPath)
+                ? table
+                : table.withPath(targetPath);
+        return new IrisCreateTableSqlBuilder(
+                targetPath,
+                ddlTable,
+                new IrisTypeMapper())
+                .build();
+    }
+
+    private static String defaultSchema(JdbcConnectionConfig config) {
+        return hasText(config.getSchema())
+                ? config.getSchema().trim()
+                : "SQLUser";
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -125,6 +125,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return HighGoSinkSupport.resolveTargetPath(
                     config.getConnectionConfig(), tablePath);
         }
+        if (IrisSinkSupport.accepts(config.getConnectionConfig())) {
+            return IrisSinkSupport.resolveTargetPath(
+                    config.getConnectionConfig(), tablePath);
+        }
         return JdbcCreateTableSqlResolver.resolveTargetPath(
                 config.getConnectionConfig(), tablePath);
     }
@@ -136,6 +140,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
         }
         if (HighGoSinkSupport.accepts(config.getConnectionConfig())) {
             return HighGoSinkSupport.resolveCreateTableSql(
+                    config.getConnectionConfig(), table);
+        }
+        if (IrisSinkSupport.accepts(config.getConnectionConfig())) {
+            return IrisSinkSupport.resolveCreateTableSql(
                     config.getConnectionConfig(), table);
         }
         return JdbcCreateTableSqlResolver.resolve(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/iris/IrisCreateTableSqlBuilderTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/iris/IrisCreateTableSqlBuilderTest.java
@@ -1,0 +1,128 @@
+package com.link.up.connector.jdbc.catalog.iris;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.connector.jdbc.core.dialect.iris.IrisTypeMapper;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+public class IrisCreateTableSqlBuilderTest {
+
+    @Test
+    public void buildsSerialPrimaryKeyDescriptionsAndLosslessTypes() {
+        TablePath path = TablePath.of("USER", "App", "Users");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("Id", BasicType.LONG_TYPE)
+                        .nullable(false)
+                        .autoIncrement(true)
+                        .build())
+                .column(Column.builder("Name", BasicType.STRING_TYPE)
+                        .length(64L)
+                        .comment("display name")
+                        .build())
+                .column(Column.builder("Amount", new DecimalType(37, 18)).build())
+                .column(Column.builder("Payload", BasicType.STRING_TYPE)
+                        .length(100_000L)
+                        .build())
+                .primaryKey(PrimaryKey.of("PK_Users", Arrays.asList("Id")))
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .comment("users table")
+                .build();
+
+        String ddl = new IrisCreateTableSqlBuilder(
+                path,
+                table,
+                new IrisTypeMapper())
+                .build();
+
+        assertTrue(ddl.contains("CREATE TABLE \"App\".\"Users\""));
+        assertTrue(ddl.contains("%DESCRIPTION 'users table'"));
+        assertTrue(ddl.contains("\"Id\" SERIAL NOT NULL"));
+        assertTrue(ddl.contains(
+                "\"Name\" VARCHAR(64) %DESCRIPTION 'display name'"));
+        assertTrue(ddl.contains("\"Amount\" NUMERIC(37,18)"));
+        assertTrue(ddl.contains("\"Payload\" LONGVARCHAR"));
+        assertTrue(ddl.contains(
+                "CONSTRAINT \"PK_Users\" PRIMARY KEY (\"Id\")"));
+    }
+
+    @Test
+    public void sameDialectPreservesGuidButNormalizesReadOnlyRowversion() {
+        TablePath path = TablePath.of("USER", "App", "Events");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("EventId", BasicType.STRING_TYPE)
+                        .sourceType("GUID")
+                        .length(36L)
+                        .build())
+                .column(Column.builder("Version", BasicType.LONG_TYPE)
+                        .sourceType("ROWVERSION")
+                        .autoIncrement(true)
+                        .build())
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .option(IrisCatalog.TABLE_OPTION_DIALECT, IrisCatalog.DIALECT)
+                .build();
+
+        String ddl = new IrisCreateTableSqlBuilder(
+                path,
+                table,
+                new IrisTypeMapper())
+                .build();
+
+        assertTrue(ddl.contains("\"EventId\" GUID"));
+        assertTrue(ddl.contains("\"Version\" BIGINT"));
+    }
+
+    @Test
+    public void unrepresentableSameDialectNumericFallsBackToLongVarchar() {
+        TablePath path = TablePath.of("USER", "App", "Amounts");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("Amount", BasicType.STRING_TYPE)
+                        .sourceType("NUMERIC(20,0)")
+                        .build())
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .option(IrisCatalog.TABLE_OPTION_DIALECT, IrisCatalog.DIALECT)
+                .build();
+
+        String ddl = new IrisCreateTableSqlBuilder(
+                path,
+                table,
+                new IrisTypeMapper())
+                .build();
+
+        assertTrue(ddl.contains("\"Amount\" LONGVARCHAR"));
+    }
+
+    @Test
+    public void escapesDescriptionsAsSqlLiterals() {
+        TablePath path = TablePath.of("USER", "App", "Notes");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("Body", BasicType.STRING_TYPE)
+                        .length(64L)
+                        .comment("doctor's note")
+                        .build())
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .comment("team's notes")
+                .build();
+
+        String ddl = new IrisCreateTableSqlBuilder(
+                path,
+                table,
+                new IrisTypeMapper())
+                .build();
+
+        assertTrue(ddl.contains("%DESCRIPTION 'team''s notes'"));
+        assertTrue(ddl.contains("%DESCRIPTION 'doctor''s note'"));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/iris/IrisDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/iris/IrisDialectTest.java
@@ -1,0 +1,124 @@
+package com.link.up.connector.jdbc.core.dialect.iris;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IrisDialectTest {
+
+    @Test
+    public void loadsIrisDialectFromJdbcUrlThroughSpi() {
+        JdbcDialect dialect = JdbcDialectLoader.load(config(null));
+        assertEquals(DatabaseIdentifier.IRIS, dialect.name());
+    }
+
+    @Test
+    public void parsesSchemaTableAndQuotedDots() {
+        IrisDialect dialect = dialect("SQLUser");
+        assertEquals(
+                TablePath.of(null, "App", "Orders"),
+                dialect.parseTablePath("App.Orders"));
+        assertEquals(
+                TablePath.of(null, "A.B", "Orders"),
+                dialect.parseTablePath("\"A.B\".\"Orders\""));
+    }
+
+    @Test
+    public void currentNamespaceThreePartPathIsAccepted() {
+        assertEquals(
+                TablePath.of("USER", "SQLUser", "Orders"),
+                dialect("SQLUser").parseTablePath("USER.SQLUser.Orders"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void foreignNamespaceThreePartPathIsRejected() {
+        dialect("SQLUser").parseTablePath("OTHER.SQLUser.Orders");
+    }
+
+    @Test
+    public void connectorSchemaIsUsedForUnqualifiedTables() {
+        assertEquals(
+                "\"App\".\"Orders\"",
+                dialect("App").tableIdentifier(TablePath.of("Orders")));
+    }
+
+    @Test
+    public void sqlUserIsDefaultSchema() {
+        assertEquals(
+                "\"SQLUser\".\"Orders\"",
+                new IrisDialect(config(null)).tableIdentifier(TablePath.of("Orders")));
+    }
+
+    @Test
+    public void buildsInsertOrUpdateWithJdbcPlaceholders() {
+        String sql = dialect("App").buildUpsertSql(
+                TablePath.of("USER", "App", "Users"),
+                Arrays.asList("Id", "Name"),
+                Arrays.asList("Id")).get();
+
+        assertEquals(
+                "INSERT OR UPDATE \"App\".\"Users\" (\"Id\", \"Name\") VALUES (?, ?)",
+                sql);
+        assertFalse(sql.contains(":Id"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void upsertRequiresPrimaryKeyContract() {
+        dialect("App").buildUpsertSql(
+                TablePath.of("USER", "App", "Users"),
+                Arrays.asList("Id", "Name"),
+                Arrays.<String>asList());
+    }
+
+    @Test
+    public void stringHashPartitionIsExplicitlyUnsupported() {
+        Column column = Column.builder("Code", BasicType.STRING_TYPE).build();
+        assertFalse(
+                dialect("App")
+                        .buildHashPartitionPredicate(column, 0, 4)
+                        .isPresent());
+    }
+
+    @Test
+    public void parsesNamespaceFromNetworkUrlAndIgnoresDriverArguments() {
+        assertTrue(IrisJdbcUrl.accepts(baseUrl()));
+        assertEquals("USER", IrisJdbcUrl.namespaceName(baseUrl()));
+        assertEquals(
+                "USER",
+                IrisJdbcUrl.namespaceName(
+                        "jdbc:IRIS://127.0.0.1:1972/USER/UTF-8/1"));
+    }
+
+    private static IrisDialect dialect(String schema) {
+        return new IrisDialect(config(schema));
+    }
+
+    private static JdbcConnectionConfig config(String schema) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", baseUrl());
+        values.put("driver", "com.intersystems.jdbc.IRISDriver");
+        values.put("username", "_SYSTEM");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:IRIS://127.0.0.1:1972/USER";
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/iris/IrisTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/iris/IrisTypeMapperTest.java
@@ -1,0 +1,200 @@
+package com.link.up.connector.jdbc.core.dialect.iris;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import org.junit.Test;
+
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+
+public class IrisTypeMapperTest {
+
+    private final IrisTypeMapper mapper = new IrisTypeMapper();
+
+    @Test
+    public void supportsIrisMaximumExplicitNumericShape() {
+        Column column = Column.builder("Amount", new DecimalType(37, 18)).build();
+        assertEquals("NUMERIC(37,18)", mapper.toDatabaseType(column));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsPrecisionAboveNineteenPlusScale() {
+        mapper.toDatabaseType(
+                Column.builder("Amount", new DecimalType(20, 0)).build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsScaleAboveEighteen() {
+        mapper.toDatabaseType(
+                Column.builder("Amount", new DecimalType(38, 19)).build());
+    }
+
+    @Test
+    public void invalidSourceNumericShapesStayExactText() {
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.NUMERIC, "NUMERIC", 20, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.NUMERIC, "DECIMAL", 30, 10));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.NUMERIC, "NUMERIC", 20, -2));
+    }
+
+    @Test
+    public void defaultNumericAndNumberSemanticsAreDeterministic() {
+        assertEquals(
+                new DecimalType(15, 0),
+                mapper.mapType(Types.NUMERIC, "NUMERIC", 0, 0));
+        assertEquals(
+                BasicType.LONG_TYPE,
+                mapper.mapType(Types.BIGINT, "NUMBER", 0, 0));
+    }
+
+    @Test
+    public void mapsIrisIntegerAndCounterTypes() {
+        assertEquals(
+                BasicType.BYTE_TYPE,
+                mapper.mapType(Types.TINYINT, "TINYINT", 3, 0));
+        assertEquals(
+                BasicType.SHORT_TYPE,
+                mapper.mapType(Types.SMALLINT, "SMALLINT", 5, 0));
+        assertEquals(
+                BasicType.INT_TYPE,
+                mapper.mapType(Types.INTEGER, "MEDIUMINT", 8, 0));
+        assertEquals(
+                BasicType.LONG_TYPE,
+                mapper.mapType(Types.BIGINT, "SERIAL", 19, 0));
+        assertEquals(
+                BasicType.LONG_TYPE,
+                mapper.mapType(Types.BIGINT, "ROWVERSION", 19, 0));
+    }
+
+    @Test
+    public void bitIsBooleanAndGuidIsText() {
+        assertEquals(
+                BasicType.BOOLEAN_TYPE,
+                mapper.mapType(Types.BIT, "BIT", 1, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.VARCHAR, "GUID", 36, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.VARCHAR, "UNIQUEIDENTIFIER", 36, 0));
+    }
+
+    @Test
+    public void mapsLobFamiliesWithoutTruncation() {
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.LONGVARCHAR, "LONGVARCHAR", Integer.MAX_VALUE, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.CLOB, "CLOB", Integer.MAX_VALUE, 0));
+        assertEquals(
+                BasicType.BYTES_TYPE,
+                mapper.mapType(Types.LONGVARBINARY, "LONGVARBINARY", Integer.MAX_VALUE, 0));
+        assertEquals(
+                BasicType.BYTES_TYPE,
+                mapper.mapType(Types.BLOB, "BLOB", Integer.MAX_VALUE, 0));
+    }
+
+    @Test
+    public void choosesBoundedAndStreamingTargetTypes() {
+        assertEquals(
+                "VARCHAR(1024)",
+                mapper.toDatabaseType(
+                        Column.builder("Name", BasicType.STRING_TYPE)
+                                .length(1024L)
+                                .build()));
+        assertEquals(
+                "LONGVARCHAR",
+                mapper.toDatabaseType(
+                        Column.builder("Payload", BasicType.STRING_TYPE)
+                                .length(100_000L)
+                                .build()));
+        assertEquals(
+                "VARBINARY(1024)",
+                mapper.toDatabaseType(
+                        Column.builder("Body", BasicType.BYTES_TYPE)
+                                .length(1024L)
+                                .build()));
+        assertEquals(
+                "LONGVARBINARY",
+                mapper.toDatabaseType(
+                        Column.builder("Body", BasicType.BYTES_TYPE)
+                                .length(100_000L)
+                                .build()));
+    }
+
+    @Test
+    public void mapsTemporalFamiliesAndUsesTimestamp2ForTarget() {
+        assertEquals(
+                BasicType.TIME_TYPE,
+                mapper.mapType(Types.TIME, "TIME", 0, 9));
+        assertEquals(
+                BasicType.TIMESTAMP_TYPE,
+                mapper.mapType(Types.TIMESTAMP, "POSIXTIME", 0, 6));
+        assertEquals(
+                BasicType.TIMESTAMP_TYPE,
+                mapper.mapType(Types.TIMESTAMP, "TIMESTAMP2", 0, 9));
+        assertEquals(
+                "TIME(9)",
+                mapper.toDatabaseType(
+                        Column.builder("EventTime", BasicType.TIME_TYPE)
+                                .precision(9)
+                                .build()));
+        assertEquals(
+                "TIMESTAMP2",
+                mapper.toDatabaseType(
+                        Column.builder("CreatedAt", BasicType.TIMESTAMP_TYPE)
+                                .precision(9)
+                                .build()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTimePrecisionAboveNine() {
+        mapper.toDatabaseType(
+                Column.builder("EventTime", BasicType.TIME_TYPE)
+                        .precision(10)
+                        .build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTimestampPrecisionAboveNine() {
+        mapper.toDatabaseType(
+                Column.builder("CreatedAt", BasicType.TIMESTAMP_TYPE)
+                        .precision(10)
+                        .build());
+    }
+
+    @Test
+    public void timestampWithOffsetUsesTextOnIrisTarget() {
+        assertEquals(
+                "VARCHAR(64)",
+                mapper.toDatabaseType(
+                        Column.builder("OccurredAt", BasicType.TIMESTAMP_TZ_TYPE).build()));
+    }
+
+    @Test
+    public void sameDialectPreservesSafeTypesButNotReadOnlyRowversionOrVector() {
+        Column guid = Column.builder("Id", BasicType.STRING_TYPE)
+                .sourceType("GUID")
+                .length(36L)
+                .build();
+        assertEquals("GUID", mapper.toDatabaseType(guid, true));
+
+        Column rowversion = Column.builder("Version", BasicType.LONG_TYPE)
+                .sourceType("ROWVERSION")
+                .build();
+        assertEquals("BIGINT", mapper.toDatabaseType(rowversion, true));
+
+        Column vector = Column.builder("Embedding", BasicType.STRING_TYPE)
+                .sourceType("VECTOR(DOUBLE,128)")
+                .build();
+        assertEquals("LONGVARCHAR", mapper.toDatabaseType(vector, true));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/JdbcIrisTargetPathTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/JdbcIrisTargetPathTest.java
@@ -1,0 +1,90 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class JdbcIrisTargetPathTest {
+
+    @Test
+    public void sourceNamespaceAndSchemaDoNotLeakIntoIrisTarget() {
+        TablePath target = IrisSinkSupport.resolveTargetPath(
+                config("Target"),
+                TablePath.of("source_db", "public", "Orders"));
+
+        assertEquals(
+                TablePath.of("USER", "Target", "Orders"),
+                target);
+    }
+
+    @Test
+    public void explicitTargetSchemaIsPreserved() {
+        TablePath target = IrisSinkSupport.resolveTargetPath(
+                config("Target"),
+                TablePath.of(null, "App", "Orders"));
+
+        assertEquals(
+                TablePath.of("USER", "App", "Orders"),
+                target);
+    }
+
+    @Test
+    public void currentNamespaceSchemaIsPreserved() {
+        TablePath target = IrisSinkSupport.resolveTargetPath(
+                config("Target"),
+                TablePath.of("USER", "Analytics", "Orders"));
+
+        assertEquals(
+                TablePath.of("USER", "Analytics", "Orders"),
+                target);
+    }
+
+    @Test
+    public void sqlUserIsDefaultTargetSchema() {
+        TablePath target = IrisSinkSupport.resolveTargetPath(
+                config(null),
+                TablePath.of("Orders"));
+
+        assertEquals(
+                TablePath.of("USER", "SQLUser", "Orders"),
+                target);
+    }
+
+    @Test
+    public void namespaceParserIsNotConfusedByDriverArguments() {
+        Map<String, Object> values = baseValues();
+        values.put("url", "jdbc:IRIS://127.0.0.1:1972/APP/UTF-8/1");
+        JdbcConnectionConfig config =
+                JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+
+        TablePath target = IrisSinkSupport.resolveTargetPath(
+                config,
+                TablePath.of("Orders"));
+
+        assertEquals(
+                TablePath.of("APP", "SQLUser", "Orders"),
+                target);
+    }
+
+    private static JdbcConnectionConfig config(String schema) {
+        Map<String, Object> values = baseValues();
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static Map<String, Object> baseValues() {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", "jdbc:IRIS://127.0.0.1:1972/USER");
+        values.put("driver", "com.intersystems.jdbc.IRISDriver");
+        values.put("username", "_SYSTEM");
+        return values;
+    }
+}


### PR DESCRIPTION
## Summary

Add InterSystems IRIS offline JDBC support on top of the shared JDBC Source/Sink execution model.

### IRIS offline capabilities
- register a dedicated IRIS dialect through SPI
- package `com.intersystems:intersystems-jdbc:3.11.0` and use `com.intersystems.jdbc.IRISDriver`
- support native `jdbc:IRIS://host:port/namespace` URLs and treat the URL path as an IRIS Namespace rather than a conventional database
- scope one JDBC job to the Namespace selected by the URL
- use explicit `schema.table` SQL identifiers, with connector `schema` or `SQLUser` as the default schema
- discover schemas, tables, columns, visible primary keys, auto-generated metadata and descriptions through JDBC `DatabaseMetaData`
- ignore implicit/public RowID primary-key metadata when that key is not present in the visible JDBC column set
- support bounded full reads and the shared numeric partition planner
- intentionally leave string HASH/RANGE partitioning disabled because IRIS does not expose a stable hash/md5 scalar for bucket predicates and common SQLUPPER collation is not Java binary lexical order
- support INSERT and native IRIS `INSERT OR UPDATE ... VALUES (?, ...)` UPSERT
- require a primary-key contract before enabling UPSERT so auto-created targets have deterministic row identity
- support automatic target table creation with `SERIAL`, named primary keys, defaults and `%DESCRIPTION` table/column descriptions
- normalize prepared target paths so source database/namespace/schema metadata cannot leak into the IRIS target
- add long text/binary streaming writes and JDBC 4.2 `LocalTime` binding

### Namespace / schema semantics
IRIS separates the JDBC Namespace from SQL Schemas:

- `jdbc:IRIS://127.0.0.1:1972/USER` selects Namespace `USER`
- physical table SQL is always `"schema"."table"`
- `namespace.schema.table` is accepted for Source only when the namespace matches the JDBC URL
- foreign source database/namespace/schema metadata is discarded when preparing an IRIS sink and replaced with the target URL namespace/default schema
- the connector uses explicit `schema` when configured, otherwise `SQLUser`

### Type/data correctness
- support IRIS scalar numeric, character, binary and temporal families plus common compatibility aliases
- enforce the IRIS explicit NUMERIC/DECIMAL contract instead of assuming a generic 38-digit decimal: scale must be `0..18` and precision must not exceed `19 + scale`
- carry source numeric shapes that Flux cannot represent losslessly as exact text instead of silently clamping them
- recreate such non-representable same-IRIS numerics as `LONGVARCHAR` so values are preserved rather than generating a lossy/invalid decimal definition
- map `NUMBER` without explicit precision to LONG using IRIS semantics
- map `BIT` to BOOLEAN; GUID/UNIQUEIDENTIFIER to text
- support `TINYINT`, `SMALLINT`, `MEDIUMINT`, `INTEGER`, `BIGINT`, `SERIAL`, `ROWVERSION`, FLOAT/DOUBLE families
- never recreate read-only `ROWVERSION` on copied targets; normalize it to writable BIGINT even if JDBC metadata marks it generated
- use bounded `VARCHAR` / `VARBINARY` only within conservative IRIS limits, otherwise use `LONGVARCHAR` / `LONGVARBINARY`
- stream long text and binary values instead of forcing them through bounded JDBC setters
- map generic timestamps to `TIMESTAMP2` so nanosecond-scale values can be retained; reject target temporal precision above 9 instead of silently rounding
- bind TIME values with JDBC 4.2 `LocalTime` rather than `java.sql.Time`, preserving fractional seconds
- IRIS core SQL has no Flux-equivalent offset-aware timestamp primitive, so cross-database TIMESTAMP_TZ values are stored as ISO text in `VARCHAR(64)` rather than silently dropping the offset
- avoid preserving VECTOR/OREF and other runtime-specific/read-only types when copied target semantics cannot be guaranteed

### Auto-increment behavior
Copied auto-increment integer columns use IRIS `SERIAL` rather than `IDENTITY`.

This is intentional for migration/synchronization: SERIAL can still accept explicit positive source IDs while maintaining an automatic counter for later inserts. `INSERT OR UPDATE` may advance the internal SERIAL counter and therefore create gaps, but it does not overwrite an existing SERIAL value.

### DDL metadata
IRIS descriptions use native `%DESCRIPTION` syntax inside CREATE TABLE / column definitions rather than PostgreSQL-style `COMMENT ON` statements.

### Sink integration
IRIS target normalization and DDL preview use a small `IrisSinkSupport` adapter routed from `JdbcSinkPreparer`. The already-large `JdbcCreateTableSqlResolver` remains unchanged; existing DuckDB and HighGo routing is preserved.

### Tests added
- SPI and native IRIS URL / Namespace parsing
- default `SQLUser` and explicit schema routing
- quoted schema/table parsing and foreign Namespace rejection
- `INSERT OR UPDATE` JDBC placeholder generation and required PK contract
- explicit unsupported string HASH partition contract
- IRIS NUMERIC precision/scale boundaries and exact-text fallback
- integer/counter, BIT, GUID and compatibility type mappings
- VARCHAR/LONGVARCHAR and VARBINARY/LONGVARBINARY selection
- TIME/POSIXTIME/TIMESTAMP2 precision contracts
- TIMESTAMP_TZ textual target contract
- SERIAL auto-increment, ROWVERSION normalization, named primary keys and `%DESCRIPTION`
- hidden RowID-safe Catalog behavior by filtering PK metadata to visible columns
- cross-database target path normalization

## Scope

This PR is offline-only. IRIS change-data capture, journal/event streaming, realtime schema events, Namespace lifecycle management and IRIS-specific bulk APIs are intentionally out of scope.

The shared JDBC connection contract still requires an explicit `driver` option; packaging the IRIS driver does not change that global option contract.

## Validation

- branch is based on current `main` after the HighGo connector merge and is not behind the base branch
- branch is squashed to one focused commit
- final diff contains 16 files; the generic DDL resolver is unchanged
- existing shared sink-flow changes are limited to an additive 8-line IRIS routing hook in `JdbcSinkPreparer`
- focused unit tests were added for dialect, URL/Namespace/schema, types, DDL and sink-target-path contracts
- the repository has no `.github/workflows` directory and the branch head has no status checks to report
- the current execution environment has no Maven and cannot resolve `github.com` for a local clone, so no local Maven/test pass is claimed
- a live InterSystems IRIS instance is not available in this tool session, so end-to-end JDBC execution is not claimed

Keep this PR as Draft until a real IRIS environment verifies at least: full read, numeric split, INSERT, `INSERT OR UPDATE`, SERIAL/primary-key behavior, NUMERIC boundaries, LONGVARCHAR/LONGVARBINARY, GUID, ROWVERSION, TIME(9), TIMESTAMP/POSIXTIME/TIMESTAMP2, cross-database offset timestamp text preservation, explicit/default schema routing, `%DESCRIPTION`, and tables that expose public/hidden RowID metadata.