### PR TITLE
feat(jdbc): harden Xugu offline source and sink support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/pom.xml
+++ b/link-up-connectors/link-up-connector-jdbc/pom.xml
@@ -113,6 +113,11 @@
             <artifactId>intersystems-jdbc</artifactId>
             <version>3.11.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.xugudb</groupId>
+            <artifactId>xugu-jdbc</artifactId>
+            <version>12.3.8</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/JdbcCatalogUtils.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/JdbcCatalogUtils.java
@@ -9,12 +9,12 @@ import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.config.JdbcSourceConfig;
 import com.link.up.connector.jdbc.config.JdbcSourceTableConfig;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.internal.JdbcConnectionProvider;
 import com.link.up.connector.jdbc.options.MultiTableFailurePolicy;
 import com.link.up.connector.jdbc.source.JdbcSourceTable;
 import lombok.extern.slf4j.Slf4j;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -123,6 +123,7 @@ public final class JdbcCatalogUtils {
             catalogTable =
                     projectCatalogTableByQuery(
                             sourceConfig.getConnectionConfig(),
+                            dialect,
                             catalogTable,
                             tableConfig.getQuery());
         }
@@ -156,12 +157,13 @@ public final class JdbcCatalogUtils {
 
     private static CatalogTable projectCatalogTableByQuery(
             JdbcConnectionConfig connectionConfig,
+            JdbcDialect dialect,
             CatalogTable physicalTable,
             String query)
             throws Exception {
 
         validateQuery(query);
-        List<String> queryFields = readQueryFields(connectionConfig, query);
+        List<String> queryFields = readQueryFields(connectionConfig, dialect, query);
 
         if (queryFields.isEmpty()) {
             throw new IllegalArgumentException(
@@ -185,41 +187,43 @@ public final class JdbcCatalogUtils {
 
     private static List<String> readQueryFields(
             JdbcConnectionConfig config,
+            JdbcDialect dialect,
             String query)
             throws Exception {
 
-        loadDriver(config);
+        // Metadata discovery must use the same dialect-resolved connection
+        // properties as the runtime reader. Otherwise database-specific session
+        // settings (for example Xugu compatiblemode/current_schema) can differ
+        // between planning and execution.
+        try (JdbcConnectionProvider connectionProvider =
+                     new JdbcConnectionProvider(config, dialect)) {
+            Connection connection = connectionProvider.getOrEstablishConnection();
+            try (PreparedStatement statement = connection.prepareStatement(query)) {
 
-        try (Connection connection =
-                     DriverManager.getConnection(
-                             config.getUrl(),
-                             config.toProperties());
-             PreparedStatement statement =
-                     connection.prepareStatement(query)) {
+                ResultSetMetaData metadata = null;
+                try {
+                    metadata = statement.getMetaData();
+                } catch (SQLException metadataError) {
+                    log.debug(
+                            "PreparedStatement metadata is unavailable; falling back to ResultSet metadata, sql={}",
+                            abbreviate(query, 300),
+                            metadataError);
+                }
 
-            ResultSetMetaData metadata = null;
-            try {
-                metadata = statement.getMetaData();
-            } catch (SQLException metadataError) {
-                log.debug(
-                        "PreparedStatement metadata is unavailable; falling back to ResultSet metadata, sql={}",
-                        abbreviate(query, 300),
-                        metadataError);
-            }
+                if (metadata != null) {
+                    return readFieldNames(metadata);
+                }
 
-            if (metadata != null) {
-                return readFieldNames(metadata);
-            }
+                if (query.indexOf('?') >= 0) {
+                    throw new IllegalArgumentException(
+                            "Custom query contains parameter placeholders; catalog phase cannot discover result schema: "
+                                    + query);
+                }
 
-            if (query.indexOf('?') >= 0) {
-                throw new IllegalArgumentException(
-                        "Custom query contains parameter placeholders; catalog phase cannot discover result schema: "
-                                + query);
-            }
-
-            statement.setMaxRows(1);
-            try (ResultSet resultSet = statement.executeQuery()) {
-                return readFieldNames(resultSet.getMetaData());
+                statement.setMaxRows(1);
+                try (ResultSet resultSet = statement.executeQuery()) {
+                    return readFieldNames(resultSet.getMetaData());
+                }
             }
         } catch (SQLException e) {
             throw new CatalogException(
@@ -271,16 +275,6 @@ public final class JdbcCatalogUtils {
                 && !lower.startsWith("with\t")) {
             throw new IllegalArgumentException(
                     "JDBC Source query only allows SELECT or WITH statements");
-        }
-    }
-
-    private static void loadDriver(
-            JdbcConnectionConfig config)
-            throws ClassNotFoundException {
-
-        String driverName = config.getDriverName();
-        if (hasText(driverName)) {
-            Class.forName(driverName);
         }
     }
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalog.java
@@ -1,0 +1,532 @@
+package com.link.up.connector.jdbc.catalog.xugu;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.xugu.XuguJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.xugu.XuguTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+/** XuguDB offline JDBC Catalog scoped to the database selected by the URL. */
+public final class XuguCatalog implements WritableCatalog {
+
+    public static final String DIALECT = "xugu";
+    public static final String TABLE_OPTION_DIALECT = "dialect";
+
+    private static final String CURRENT_SCHEMA_SQL = "SELECT CURRENT_SCHEMA()";
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String databaseName;
+    private final String configuredSchema;
+    private final boolean connectorSchemaExplicit;
+    private final XuguTypeMapper typeMapper = new XuguTypeMapper();
+
+    private volatile String defaultSchema;
+    private volatile boolean opened;
+
+    public XuguCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            String connectorSchema) {
+
+        if (!hasText(catalogName)) {
+            throw new IllegalArgumentException("catalogName must not be empty");
+        }
+        this.catalogName = catalogName.trim();
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.databaseName = XuguJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(databaseName)) {
+            throw new IllegalArgumentException(
+                    "XuguDB JDBC URL 必须包含数据库名，例如 jdbc:xugu://127.0.0.1:5138/SYSTEM");
+        }
+
+        String jdbcMode = XuguJdbcUrl.compatibleMode(
+                config.getUrl(), config.getProperties());
+        String jdbcSchema = XuguJdbcUrl.currentSchema(
+                config.getUrl(), config.getProperties());
+        if (hasText(jdbcSchema)) {
+            this.configuredSchema = XuguJdbcUrl.normalizeSessionIdentifier(
+                    jdbcSchema, jdbcMode);
+            this.connectorSchemaExplicit = false;
+        } else if (hasText(connectorSchema)) {
+            // Connector schema is an explicit physical object name. Do not pass
+            // it back through current_schema, which would apply compatibility-
+            // mode case folding to an already-resolved identifier.
+            this.configuredSchema = connectorSchema.trim();
+            this.connectorSchemaExplicit = true;
+        } else {
+            this.configuredSchema = null;
+            this.connectorSchemaExplicit = false;
+        }
+        this.defaultSchema = hasText(configuredSchema)
+                ? configuredSchema
+                : fallbackSchema(config);
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.of(databaseName);
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+        loadDriver();
+        try (Connection connection = connection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException(
+                        "XuguDB Catalog 连接校验失败：" + config.getUrl());
+            }
+            if (!connectorSchemaExplicit) {
+                // URL/properties current_schema and implicit user defaults are
+                // session identifiers. Ask the server for the effective name so
+                // compatible-mode case folding is represented exactly.
+                String effectiveSchema = readCurrentSchema(connection);
+                if (hasText(effectiveSchema)) {
+                    defaultSchema = effectiveSchema;
+                }
+            }
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "XuguDB Catalog 连接失败：" + config.getUrl(), e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public List<String> listDatabases() {
+        checkOpened();
+        return Collections.singletonList(databaseName);
+    }
+
+    @Override
+    public List<String> listSchemas(String database) throws CatalogException {
+        checkDatabase(database);
+        checkOpened();
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getSchemas()) {
+            List<String> schemas = new ArrayList<String>();
+            while (rs.next()) {
+                String schema = normalize(rs.getString("TABLE_SCHEM"));
+                if (schema != null
+                        && !"INFORMATION_SCHEMA".equalsIgnoreCase(schema)) {
+                    schemas.add(schema);
+                }
+            }
+            Collections.sort(schemas);
+            return schemas;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 XuguDB Schema 列表失败", e);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String database,
+            String schemaName) throws CatalogException {
+
+        checkDatabase(database);
+        checkOpened();
+        String schema = schema(schemaName);
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getTables(
+                     null,
+                     schema,
+                     "%",
+                     new String[]{"TABLE"})) {
+            List<TablePath> tables = new ArrayList<TablePath>();
+            while (rs.next()) {
+                String table = normalize(rs.getString("TABLE_NAME"));
+                if (table != null) {
+                    tables.add(TablePath.of(databaseName, schema, table));
+                }
+            }
+            tables.sort(Comparator.comparing(TablePath::getTableName));
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 XuguDB 表列表失败，schema=" + schema, e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        try (Connection connection = connection();
+             ResultSet rs = connection.getMetaData().getTables(
+                     null,
+                     path.getSchemaName(),
+                     path.getTableName(),
+                     new String[]{"TABLE"})) {
+            return rs.next();
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "检查 XuguDB 表是否存在失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        try (Connection connection = connection()) {
+            DatabaseMetaData meta = connection.getMetaData();
+            List<Column> columns = columns(meta, path);
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(catalogName, path);
+            }
+            TableSchema schema = TableSchema.builder()
+                    .columns(columns)
+                    .primaryKey(primaryKey(meta, path))
+                    .build();
+            CatalogTable.Builder table = CatalogTable.builder(path, schema)
+                    .option(TABLE_OPTION_DIALECT, DIALECT);
+            String comment = tableComment(meta, path);
+            if (hasText(comment)) {
+                table.comment(comment);
+            }
+            return table.build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 XuguDB 表结构失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public void createDatabase(String database, boolean ignoreIfExists)
+            throws CatalogException, DatabaseAlreadyExistsException {
+        throw new UnsupportedOperationException(
+                "XuguDB JDBC Offline Catalog 不负责 CREATE DATABASE；一个 job 固定使用 JDBC URL 中的 database");
+    }
+
+    @Override
+    public void dropDatabase(String database, boolean ignoreIfNotExists)
+            throws CatalogException, DatabaseNotFoundException {
+        throw new UnsupportedOperationException(
+                "XuguDB JDBC Offline Catalog 不负责 DROP DATABASE；一个 job 固定使用 JDBC URL 中的 database");
+    }
+
+    @Override
+    public void createTable(CatalogTable table, boolean ignoreIfExists)
+            throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+
+        checkOpened();
+        TablePath path = normalizePath(table.getTablePath());
+        if (tableExists(path)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new TableAlreadyExistsException(catalogName, path);
+        }
+        CatalogTable ddlTable = table.getTablePath().equals(path)
+                ? table
+                : table.withPath(path);
+        XuguCreateTableSqlBuilder builder =
+                new XuguCreateTableSqlBuilder(path, ddlTable, typeMapper);
+        try (Connection connection = connection()) {
+            for (String sql : builder.buildStatements()) {
+                execute(connection, sql);
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "创建 XuguDB 表失败，table=" + path, e);
+        }
+    }
+
+    @Override
+    public void addColumn(TablePath tablePath, Column column)
+            throws CatalogException, TableNotFoundException {
+
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        if (!tableExists(path)) {
+            throw new TableNotFoundException(catalogName, path);
+        }
+        CatalogTable current = getTable(path);
+        String definition = new XuguCreateTableSqlBuilder(
+                path, current, typeMapper)
+                .buildColumnDefinition(column, false);
+        try (Connection connection = connection()) {
+            execute(connection,
+                    "ALTER TABLE " + quoteTable(path)
+                            + " ADD COLUMN " + definition);
+            if (hasText(column.getComment())) {
+                execute(connection,
+                        "COMMENT ON COLUMN " + quoteTable(path) + "."
+                                + quote(column.getName()) + " IS '"
+                                + literal(column.getComment()) + "'");
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "增加 XuguDB 字段失败，table=" + path
+                            + "，column=" + column.getName(), e);
+        }
+    }
+
+    @Override
+    public void dropTable(TablePath tablePath, boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        tableDdl(tablePath, ignoreIfNotExists, "DROP TABLE ", "删除");
+    }
+
+    @Override
+    public void truncateTable(TablePath tablePath, boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        tableDdl(tablePath, ignoreIfNotExists, "TRUNCATE TABLE ", "清空");
+    }
+
+    private void tableDdl(
+            TablePath tablePath,
+            boolean ignoreIfNotExists,
+            String prefix,
+            String operation) throws CatalogException, TableNotFoundException {
+
+        checkOpened();
+        TablePath path = normalizePath(tablePath);
+        if (!tableExists(path)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotFoundException(catalogName, path);
+        }
+        try (Connection connection = connection()) {
+            execute(connection, prefix + quoteTable(path));
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    operation + " XuguDB 表失败，table=" + path, e);
+        }
+    }
+
+    private List<Column> columns(DatabaseMetaData meta, TablePath path)
+            throws SQLException {
+        try (ResultSet rs = meta.getColumns(
+                null,
+                path.getSchemaName(),
+                path.getTableName(),
+                "%")) {
+            List<Column> columns = new ArrayList<Column>();
+            while (rs.next()) {
+                columns.add(typeMapper.toColumn(rs));
+            }
+            return columns;
+        }
+    }
+
+    private PrimaryKey primaryKey(DatabaseMetaData meta, TablePath path)
+            throws SQLException {
+        try (ResultSet rs = meta.getPrimaryKeys(
+                null,
+                path.getSchemaName(),
+                path.getTableName())) {
+            String name = null;
+            List<KeyColumn> keys = new ArrayList<KeyColumn>();
+            while (rs.next()) {
+                if (name == null) {
+                    name = rs.getString("PK_NAME");
+                }
+                String column = rs.getString("COLUMN_NAME");
+                if (hasText(column)) {
+                    keys.add(new KeyColumn(rs.getShort("KEY_SEQ"), column));
+                }
+            }
+            if (keys.isEmpty()) {
+                return null;
+            }
+            keys.sort(Comparator.comparingInt(KeyColumn::position));
+            List<String> columns = new ArrayList<String>(keys.size());
+            for (KeyColumn key : keys) {
+                columns.add(key.name);
+            }
+            return PrimaryKey.of(name, columns);
+        }
+    }
+
+    private String tableComment(DatabaseMetaData meta, TablePath path)
+            throws SQLException {
+        try (ResultSet rs = meta.getTables(
+                null,
+                path.getSchemaName(),
+                path.getTableName(),
+                new String[]{"TABLE"})) {
+            return rs.next() ? normalize(rs.getString("REMARKS")) : null;
+        }
+    }
+
+    private String readCurrentSchema(Connection connection) {
+        try (PreparedStatement statement = connection.prepareStatement(CURRENT_SCHEMA_SQL);
+             ResultSet rs = statement.executeQuery()) {
+            return rs.next() ? normalize(rs.getString(1)) : null;
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private TablePath normalizePath(TablePath tablePath) {
+        Objects.requireNonNull(tablePath, "tablePath must not be null");
+        String sourceDatabase = tablePath.getDatabaseName();
+        String targetSchema = tablePath.getSchemaName();
+        if (!hasText(targetSchema)
+                || (hasText(sourceDatabase)
+                && !databaseName.equalsIgnoreCase(sourceDatabase))) {
+            targetSchema = defaultSchema;
+        }
+        if (!hasText(targetSchema)) {
+            throw new IllegalArgumentException(
+                    "无法解析 XuguDB 默认 schema；请配置 schema/username/current_schema");
+        }
+        return TablePath.of(databaseName, targetSchema, tablePath.getTableName());
+    }
+
+    private String schema(String schemaName) {
+        String result = hasText(schemaName) ? schemaName.trim() : defaultSchema;
+        if (!hasText(result)) {
+            throw new IllegalArgumentException("XuguDB schema must not be empty");
+        }
+        return result;
+    }
+
+    private void checkDatabase(String requested) {
+        if (hasText(requested)
+                && !databaseName.equalsIgnoreCase(requested.trim())) {
+            throw new IllegalArgumentException(
+                    "XuguDB JDBC job 只支持 URL 当前 database：" + databaseName
+                            + "，requested=" + requested);
+        }
+    }
+
+    private Connection connection() throws SQLException {
+        Properties properties = config.toConnectionProperties();
+        if (!containsPropertyIgnoreCase(properties, "useLike")) {
+            properties.setProperty("useLike", "true");
+        }
+        return DriverManager.getConnection(config.getUrl(), properties);
+    }
+
+    private void loadDriver() {
+        if (!hasText(config.getDriverClass())) {
+            return;
+        }
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException(
+                    "找不到 XuguDB JDBC Driver：" + config.getDriverClass(), e);
+        }
+    }
+
+    private static void execute(Connection connection, String sql)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.execute();
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static String fallbackSchema(JdbcCatalogConfig config) {
+        String user = config.getUsername();
+        if (!hasText(user)) {
+            user = XuguJdbcUrl.user(config.getUrl(), config.getProperties());
+        }
+        String mode = XuguJdbcUrl.compatibleMode(
+                config.getUrl(), config.getProperties());
+        return XuguJdbcUrl.normalizeSessionIdentifier(user, mode);
+    }
+
+    private static boolean containsPropertyIgnoreCase(
+            Properties properties,
+            String key) {
+        for (Object propertyKey : properties.keySet()) {
+            if (propertyKey != null
+                    && key.equalsIgnoreCase(String.valueOf(propertyKey).trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String quoteTable(TablePath path) {
+        return quote(path.getSchemaName()) + "." + quote(path.getTableName());
+    }
+
+    private static String quote(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + value.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static String literal(String value) {
+        return value.replace("'", "''");
+    }
+
+    private static boolean hasText(String value) {
+        return normalize(value) != null;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static final class KeyColumn {
+        private final int position;
+        private final String name;
+
+        private KeyColumn(int position, String name) {
+            this.position = position;
+            this.name = name;
+        }
+
+        private int position() {
+            return position;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalog.java
@@ -163,21 +163,26 @@ public final class XuguCatalog implements WritableCatalog {
         checkDatabase(database);
         checkOpened();
         String schema = schema(schemaName);
-        try (Connection connection = connection();
-             ResultSet rs = connection.getMetaData().getTables(
-                     null,
-                     schema,
-                     "%",
-                     new String[]{"TABLE"})) {
-            List<TablePath> tables = new ArrayList<TablePath>();
-            while (rs.next()) {
-                String table = normalize(rs.getString("TABLE_NAME"));
-                if (table != null) {
-                    tables.add(TablePath.of(databaseName, schema, table));
+        try (Connection connection = connection()) {
+            DatabaseMetaData meta = connection.getMetaData();
+            String schemaPattern = exactMetadataPattern(meta, schema);
+            String tablePattern = metadataUsesLike() ? "%" : null;
+            try (ResultSet rs = meta.getTables(
+                    null,
+                    schemaPattern,
+                    tablePattern,
+                    new String[]{"TABLE"})) {
+                List<TablePath> tables = new ArrayList<TablePath>();
+                while (rs.next()) {
+                    String rowSchema = normalize(rs.getString("TABLE_SCHEM"));
+                    String table = normalize(rs.getString("TABLE_NAME"));
+                    if (table != null && schema.equals(rowSchema)) {
+                        tables.add(TablePath.of(databaseName, schema, table));
+                    }
                 }
+                tables.sort(Comparator.comparing(TablePath::getTableName));
+                return tables;
             }
-            tables.sort(Comparator.comparing(TablePath::getTableName));
-            return tables;
         } catch (SQLException e) {
             throw new CatalogException(
                     "获取 XuguDB 表列表失败，schema=" + schema, e);
@@ -188,13 +193,20 @@ public final class XuguCatalog implements WritableCatalog {
     public boolean tableExists(TablePath tablePath) throws CatalogException {
         checkOpened();
         TablePath path = normalizePath(tablePath);
-        try (Connection connection = connection();
-             ResultSet rs = connection.getMetaData().getTables(
-                     null,
-                     path.getSchemaName(),
-                     path.getTableName(),
-                     new String[]{"TABLE"})) {
-            return rs.next();
+        try (Connection connection = connection()) {
+            DatabaseMetaData meta = connection.getMetaData();
+            try (ResultSet rs = meta.getTables(
+                    null,
+                    exactMetadataPattern(meta, path.getSchemaName()),
+                    exactMetadataPattern(meta, path.getTableName()),
+                    new String[]{"TABLE"})) {
+                while (rs.next()) {
+                    if (metadataRowMatches(rs, path)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
         } catch (SQLException e) {
             throw new CatalogException(
                     "检查 XuguDB 表是否存在失败，table=" + path, e);
@@ -339,14 +351,17 @@ public final class XuguCatalog implements WritableCatalog {
 
     private List<Column> columns(DatabaseMetaData meta, TablePath path)
             throws SQLException {
+        String columnPattern = metadataUsesLike() ? "%" : null;
         try (ResultSet rs = meta.getColumns(
                 null,
-                path.getSchemaName(),
-                path.getTableName(),
-                "%")) {
+                exactMetadataPattern(meta, path.getSchemaName()),
+                exactMetadataPattern(meta, path.getTableName()),
+                columnPattern)) {
             List<Column> columns = new ArrayList<Column>();
             while (rs.next()) {
-                columns.add(typeMapper.toColumn(rs));
+                if (metadataRowMatches(rs, path)) {
+                    columns.add(typeMapper.toColumn(rs));
+                }
             }
             return columns;
         }
@@ -385,10 +400,15 @@ public final class XuguCatalog implements WritableCatalog {
             throws SQLException {
         try (ResultSet rs = meta.getTables(
                 null,
-                path.getSchemaName(),
-                path.getTableName(),
+                exactMetadataPattern(meta, path.getSchemaName()),
+                exactMetadataPattern(meta, path.getTableName()),
                 new String[]{"TABLE"})) {
-            return rs.next() ? normalize(rs.getString("REMARKS")) : null;
+            while (rs.next()) {
+                if (metadataRowMatches(rs, path)) {
+                    return normalize(rs.getString("REMARKS"));
+                }
+            }
+            return null;
         }
     }
 
@@ -404,10 +424,15 @@ public final class XuguCatalog implements WritableCatalog {
     private TablePath normalizePath(TablePath tablePath) {
         Objects.requireNonNull(tablePath, "tablePath must not be null");
         String sourceDatabase = tablePath.getDatabaseName();
+        if (hasText(sourceDatabase)
+                && !databaseName.equalsIgnoreCase(sourceDatabase)) {
+            throw new IllegalArgumentException(
+                    "XuguDB JDBC job 只支持 URL 当前 database：" + databaseName
+                            + "，requested=" + sourceDatabase);
+        }
+
         String targetSchema = tablePath.getSchemaName();
-        if (!hasText(targetSchema)
-                || (hasText(sourceDatabase)
-                && !databaseName.equalsIgnoreCase(sourceDatabase))) {
+        if (!hasText(targetSchema)) {
             targetSchema = defaultSchema;
         }
         if (!hasText(targetSchema)) {
@@ -432,6 +457,39 @@ public final class XuguCatalog implements WritableCatalog {
                     "XuguDB JDBC job 只支持 URL 当前 database：" + databaseName
                             + "，requested=" + requested);
         }
+    }
+
+    private boolean metadataUsesLike() {
+        String configured = propertyIgnoreCase(
+                config.toConnectionProperties(), "useLike");
+        return !hasText(configured)
+                || Boolean.parseBoolean(configured.trim());
+    }
+
+    private String exactMetadataPattern(
+            DatabaseMetaData meta,
+            String value) throws SQLException {
+        if (!metadataUsesLike()) {
+            return value;
+        }
+        return escapeMetadataPattern(value, meta.getSearchStringEscape());
+    }
+
+    static String escapeMetadataPattern(String value, String escape) {
+        if (!hasText(value) || !hasText(escape)) {
+            return value;
+        }
+        String escaped = value.replace(escape, escape + escape);
+        escaped = escaped.replace("%", escape + "%");
+        return escaped.replace("_", escape + "_");
+    }
+
+    private static boolean metadataRowMatches(ResultSet rs, TablePath path)
+            throws SQLException {
+        String rowSchema = normalize(rs.getString("TABLE_SCHEM"));
+        String rowTable = normalize(rs.getString("TABLE_NAME"));
+        return Objects.equals(path.getSchemaName(), rowSchema)
+                && Objects.equals(path.getTableName(), rowTable);
     }
 
     private Connection connection() throws SQLException {
@@ -487,6 +545,19 @@ public final class XuguCatalog implements WritableCatalog {
             }
         }
         return false;
+    }
+
+    private static String propertyIgnoreCase(
+            Properties properties,
+            String key) {
+        for (Object propertyKey : properties.keySet()) {
+            if (propertyKey != null
+                    && key.equalsIgnoreCase(String.valueOf(propertyKey).trim())) {
+                Object value = properties.get(propertyKey);
+                return value == null ? null : String.valueOf(value);
+            }
+        }
+        return null;
     }
 
     private static String quoteTable(TablePath path) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalog.java
@@ -21,6 +21,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -514,8 +515,8 @@ public final class XuguCatalog implements WritableCatalog {
 
     private static void execute(Connection connection, String sql)
             throws SQLException {
-        try (PreparedStatement statement = connection.prepareStatement(sql)) {
-            statement.execute();
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
         }
     }
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalogFactory.java
@@ -1,0 +1,70 @@
+package com.link.up.connector.jdbc.catalog.xugu;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.factory.Factory;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.config.JdbcCommonOptions;
+import com.link.up.connector.jdbc.core.dialect.xugu.XuguJdbcUrl;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** XuguDB Catalog factory. */
+@AutoService(Factory.class)
+public final class XuguCatalogFactory implements CatalogFactory {
+
+    private static final String DEFAULT_DRIVER = "com.xugu.cloudjdbc.Driver";
+
+    @Override
+    public String factoryIdentifier() {
+        return XuguCatalog.DIALECT;
+    }
+
+    @Override
+    public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
+        String url = options.get(JdbcCommonOptions.URL);
+        String username = options.getOptional(JdbcCommonOptions.USERNAME).orElse(null);
+        String password = options.getOptional(JdbcCommonOptions.PASSWORD).orElse(null);
+        String driver = options.getOptional(JdbcCommonOptions.DRIVER).orElse(DEFAULT_DRIVER);
+        String schema = options.getOptional(JdbcCommonOptions.SCHEMA).orElse(null);
+        String compatibleMode = options.getOptional(JdbcCommonOptions.COMPATIBLE_MODE).orElse(null);
+        Map<String, String> configured = options.getOptional(JdbcCommonOptions.PROPERTIES)
+                .orElse(Collections.<String, String>emptyMap());
+        Map<String, String> properties = new LinkedHashMap<String, String>(configured);
+        if (!containsIgnoreCase(properties, "useLike")) {
+            properties.put("useLike", "true");
+        }
+        if (hasText(compatibleMode)
+                && !hasText(XuguJdbcUrl.compatibleMode(url, properties))) {
+            properties.put("compatiblemode", compatibleMode.trim());
+        }
+
+        return new XuguCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        url,
+                        username,
+                        password,
+                        driver,
+                        properties,
+                        false),
+                schema);
+    }
+
+    private static boolean containsIgnoreCase(Map<String, String> properties, String key) {
+        for (String propertyKey : properties.keySet()) {
+            if (propertyKey != null && key.equalsIgnoreCase(propertyKey.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCreateTableSqlBuilder.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/xugu/XuguCreateTableSqlBuilder.java
@@ -1,0 +1,242 @@
+package com.link.up.connector.jdbc.catalog.xugu;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.xugu.XuguTypeMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/** Builds XuguDB CREATE TABLE statements for offline sink preparation. */
+public final class XuguCreateTableSqlBuilder {
+
+    private static final int MAX_IDENTIFIER_BYTES = 127;
+    private static final Pattern NUMBER_PATTERN =
+            Pattern.compile("[-+]?\\d+(\\.\\d+)?");
+
+    private final TablePath tablePath;
+    private final CatalogTable catalogTable;
+    private final XuguTypeMapper typeMapper;
+
+    public XuguCreateTableSqlBuilder(
+            TablePath tablePath,
+            CatalogTable catalogTable,
+            XuguTypeMapper typeMapper) {
+        this.tablePath = tablePath;
+        this.catalogTable = catalogTable;
+        this.typeMapper = typeMapper;
+    }
+
+    public String build() {
+        return String.join("\n", buildStatements());
+    }
+
+    public List<String> buildStatements() {
+        List<String> statements = new ArrayList<String>();
+        statements.add(buildCreateTable());
+        if (hasText(catalogTable.getComment())) {
+            statements.add(
+                    "COMMENT ON TABLE " + quoteTable(tablePath)
+                            + " IS '" + literal(catalogTable.getComment()) + "';");
+        }
+        for (Column column : catalogTable.getTableSchema().getColumns()) {
+            if (hasText(column.getComment())) {
+                statements.add(
+                        "COMMENT ON COLUMN " + quoteTable(tablePath) + "."
+                                + quote(column.getName()) + " IS '"
+                                + literal(column.getComment()) + "';");
+            }
+        }
+        return Collections.unmodifiableList(statements);
+    }
+
+    public String buildColumnDefinition(
+            Column column,
+            boolean preserveSourceType) {
+
+        List<String> parts = new ArrayList<String>();
+        parts.add(quote(column.getName()));
+        boolean preserve = preserveSourceType && shouldPreserveSourceType(column);
+        parts.add(typeMapper.toDatabaseType(column, preserve));
+
+        if (column.isAutoIncrement()
+                && isInteger(column.getDataType().getSqlType())) {
+            parts.add("IDENTITY(1,1)");
+        }
+        if (!column.isNullable()) {
+            parts.add("NOT NULL");
+        }
+        if (!column.isAutoIncrement()
+                && column.getDefaultValue() != null) {
+            parts.add("DEFAULT "
+                    + formatDefaultValue(column, preserve));
+        }
+        return String.join(" ", parts);
+    }
+
+    private String buildCreateTable() {
+        TableSchema schema = catalogTable.getTableSchema();
+        boolean preserveSourceType = XuguCatalog.DIALECT.equalsIgnoreCase(
+                catalogTable.getOptions().get(XuguCatalog.TABLE_OPTION_DIALECT));
+        List<String> definitions = new ArrayList<String>();
+        for (Column column : schema.getColumns()) {
+            definitions.add(buildColumnDefinition(column, preserveSourceType));
+        }
+        PrimaryKey primaryKey = schema.getPrimaryKey();
+        if (primaryKey != null) {
+            definitions.add(buildPrimaryKey(primaryKey));
+        }
+        return "CREATE TABLE " + quoteTable(tablePath)
+                + " (\n    " + String.join(",\n    ", definitions) + "\n);";
+    }
+
+    private static boolean shouldPreserveSourceType(Column column) {
+        String sourceType = column.getSourceType();
+        if (!hasText(sourceType)) {
+            return false;
+        }
+        String normalized = sourceType.trim()
+                .toLowerCase(Locale.ROOT)
+                .replaceAll("\\s+", " ");
+        int parenthesis = normalized.indexOf('(');
+        String base = parenthesis >= 0
+                ? normalized.substring(0, parenthesis).trim()
+                : normalized;
+        if (normalized.endsWith("[]")) {
+            return false;
+        }
+        return !"array".equals(base)
+                && !"rowid".equals(base)
+                && !"point".equals(base)
+                && !"line".equals(base)
+                && !"lseg".equals(base)
+                && !"box".equals(base)
+                && !"path".equals(base)
+                && !"polygon".equals(base)
+                && !"circle".equals(base)
+                && !"interval".equals(base)
+                && !base.startsWith("interval ");
+    }
+
+    private static String buildPrimaryKey(PrimaryKey primaryKey) {
+        String columns = primaryKey.getColumnNames().stream()
+                .map(XuguCreateTableSqlBuilder::quote)
+                .collect(Collectors.joining(", "));
+        if (hasText(primaryKey.getName())) {
+            return "CONSTRAINT " + quote(shortIdentifier(primaryKey.getName()))
+                    + " PRIMARY KEY (" + columns + ")";
+        }
+        return "PRIMARY KEY (" + columns + ")";
+    }
+
+    private static String formatDefaultValue(
+            Column column,
+            boolean preserveSourceType) {
+
+        Object value = column.getDefaultValue();
+        if (value instanceof Number) {
+            return value.toString();
+        }
+        if (value instanceof Boolean) {
+            return (Boolean) value ? "TRUE" : "FALSE";
+        }
+        String text = String.valueOf(value).trim();
+        if (preserveSourceType) {
+            return text;
+        }
+        String upper = text.toUpperCase(Locale.ROOT);
+        if ("NULL".equals(upper)
+                || "CURRENT_TIMESTAMP".equals(upper)
+                || "CURRENT_DATE".equals(upper)
+                || "CURRENT_TIME".equals(upper)
+                || "SYSDATE".equals(upper)
+                || "NOW()".equals(upper)
+                || upper.startsWith("CURRENT_TIMESTAMP(")) {
+            return text;
+        }
+        if (isNumeric(column.getDataType().getSqlType())
+                && NUMBER_PATTERN.matcher(text).matches()) {
+            return text;
+        }
+        return "'" + literal(text) + "'";
+    }
+
+    private static String shortIdentifier(String value) {
+        String normalized = value.trim();
+        if (normalized.getBytes(StandardCharsets.UTF_8).length
+                <= MAX_IDENTIFIER_BYTES) {
+            return normalized;
+        }
+
+        String hash = Integer.toHexString(normalized.hashCode());
+        while (hash.length() < 8) {
+            hash = "0" + hash;
+        }
+        if (hash.length() > 8) {
+            hash = hash.substring(hash.length() - 8);
+        }
+
+        // Reserve one byte for '_' and eight ASCII bytes for the stable hash.
+        int byteBudget = MAX_IDENTIFIER_BYTES - 9;
+        int usedBytes = 0;
+        StringBuilder prefix = new StringBuilder();
+        for (int offset = 0; offset < normalized.length();) {
+            int codePoint = normalized.codePointAt(offset);
+            String part = new String(Character.toChars(codePoint));
+            int partBytes = part.getBytes(StandardCharsets.UTF_8).length;
+            if (usedBytes + partBytes > byteBudget) {
+                break;
+            }
+            prefix.append(part);
+            usedBytes += partBytes;
+            offset += Character.charCount(codePoint);
+        }
+        return prefix.toString() + "_" + hash;
+    }
+
+    private static boolean isInteger(SqlType type) {
+        return type == SqlType.TINYINT
+                || type == SqlType.SMALLINT
+                || type == SqlType.INT
+                || type == SqlType.BIGINT;
+    }
+
+    private static boolean isNumeric(SqlType type) {
+        return isInteger(type)
+                || type == SqlType.FLOAT
+                || type == SqlType.DOUBLE
+                || type == SqlType.DECIMAL;
+    }
+
+    private static String quoteTable(TablePath path) {
+        if (path == null || !hasText(path.getSchemaName())) {
+            throw new IllegalArgumentException(
+                    "XuguDB tablePath must contain schema: " + path);
+        }
+        return quote(path.getSchemaName()) + "." + quote(path.getTableName());
+    }
+
+    private static String quote(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + value.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static String literal(String value) {
+        return value.replace("'", "''");
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -20,6 +20,7 @@ public final class DatabaseIdentifier {
     public static final String DUCKDB = "duckdb";
     public static final String HIGHGO = "highgo";
     public static final String IRIS = "iris";
+    public static final String XUGU = "xugu";
 
     private DatabaseIdentifier() {
     }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialect.java
@@ -220,15 +220,28 @@ public final class XuguDialect implements JdbcDialect {
     @Override
     public Map<String, String> defaultConnectionProperties() {
         Map<String, String> result = new LinkedHashMap<String, String>();
-        // Connector-level schema is an explicit physical object name. Since all
-        // Xugu SQL is schema-qualified, do not reinterpret it as current_schema;
-        // doing so could apply compatibility-mode case folding twice.
         if (JdbcDialect.hasText(connectionConfig.getCompatibleMode())
                 && !JdbcDialect.hasText(
                 XuguJdbcUrl.compatibleMode(
                         connectionConfig.getUrl(),
                         connectionConfig.getProperties()))) {
             result.put("compatiblemode", connectionConfig.getCompatibleMode().trim());
+        }
+
+        // Source-generated SQL is schema-qualified, but custom SQL is user-owned
+        // and may legitimately use unqualified table names. Keep the actual Xugu
+        // session schema aligned with the connector-level schema in that case.
+        // Connector schema is an already-resolved physical identifier, so quote
+        // it before passing it through current_schema to avoid compatibility-mode
+        // case folding changing the intended object name.
+        if (JdbcDialect.hasText(connectionConfig.getSchema())
+                && !JdbcDialect.hasText(
+                XuguJdbcUrl.currentSchema(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getProperties()))) {
+            result.put(
+                    "current_schema",
+                    quoteSessionIdentifier(connectionConfig.getSchema()));
         }
         return result;
     }
@@ -292,6 +305,11 @@ public final class XuguDialect implements JdbcDialect {
             result.put("compatiblemode", config.getCompatibleMode().trim());
         }
         return result;
+    }
+
+    private static String quoteSessionIdentifier(String identifier) {
+        String value = identifier.trim();
+        return "\"" + value.replace("\"", "\"\"") + "\"";
     }
 
     private static List<String> splitIdentifierPath(String path) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialect.java
@@ -1,0 +1,329 @@
+package com.link.up.connector.jdbc.core.dialect.xugu;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.xugu.XuguCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** XuguDB offline JDBC dialect. */
+public final class XuguDialect implements JdbcDialect {
+
+    private static final int DEFAULT_FETCH_SIZE = 500;
+
+    private final JdbcConnectionConfig connectionConfig;
+    private final XuguTypeMapper typeMapper = new XuguTypeMapper();
+    private final String databaseName;
+    private final String defaultSchema;
+    private final String compatibleMode;
+
+    public XuguDialect(JdbcConnectionConfig connectionConfig) {
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException("connectionConfig must not be null");
+        }
+        this.connectionConfig = connectionConfig;
+        this.databaseName = XuguJdbcUrl.databaseName(connectionConfig.getUrl());
+        if (!JdbcDialect.hasText(databaseName)) {
+            throw new IllegalArgumentException(
+                    "XuguDB JDBC URL 必须包含 database，例如 jdbc:xugu://127.0.0.1:5138/SYSTEM");
+        }
+        this.compatibleMode = resolveCompatibleMode(connectionConfig);
+        this.defaultSchema = resolveDefaultSchema(connectionConfig, compatibleMode);
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.XUGU;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+
+        return new XuguCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        resolvedCatalogProperties(connectionConfig),
+                        false),
+                connectionConfig.getSchema());
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new XuguJdbcRowConverter();
+    }
+
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        if (!JdbcDialect.hasText(tablePath)) {
+            throw new IllegalArgumentException("tablePath must not be empty");
+        }
+        List<String> parts = splitIdentifierPath(tablePath.trim());
+        switch (parts.size()) {
+            case 1:
+                return TablePath.of(normalizeIdentifier(parts.get(0)));
+            case 2:
+                return TablePath.of(
+                        null,
+                        normalizeIdentifier(parts.get(0)),
+                        normalizeIdentifier(parts.get(1)));
+            case 3:
+                String database = normalizeIdentifier(parts.get(0));
+                if (!databaseName.equalsIgnoreCase(database)) {
+                    throw new IllegalArgumentException(
+                            "XuguDB 表路径中的 database 与 JDBC URL 不一致，urlDatabase="
+                                    + databaseName + "，pathDatabase=" + database);
+                }
+                return TablePath.of(
+                        databaseName,
+                        normalizeIdentifier(parts.get(1)),
+                        normalizeIdentifier(parts.get(2)));
+            default:
+                throw new IllegalArgumentException("非法 XuguDB 表路径：" + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        if (!JdbcDialect.hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + identifier.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    /** Xugu SQL addresses schema.table; database is selected by the JDBC URL. */
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        String pathDatabase = tablePath.getDatabaseName();
+        if (JdbcDialect.hasText(pathDatabase)
+                && !databaseName.equalsIgnoreCase(pathDatabase)) {
+            throw new IllegalArgumentException(
+                    "XuguDB JDBC 连接只支持 URL database：" + databaseName
+                            + "，requested=" + pathDatabase);
+        }
+        String schema = JdbcDialect.hasText(tablePath.getSchemaName())
+                ? tablePath.getSchemaName().trim()
+                : defaultSchema;
+        if (!JdbcDialect.hasText(schema)) {
+            throw new IllegalArgumentException(
+                    "无法解析 XuguDB 默认 schema；请配置 schema、username 或 URL user/current_schema");
+        }
+        return quoteIdentifier(schema)
+                + "."
+                + quoteIdentifier(tablePath.getTableName());
+    }
+
+    @Override
+    public Optional<String> buildUpsertSql(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+
+        JdbcDialect.validateFields(fieldNames);
+        Set<String> primaryKeySet = JdbcDialect.normalizeFields(primaryKeys);
+        if (primaryKeySet.isEmpty()) {
+            throw new IllegalArgumentException("XuguDB UPSERT 必须配置主键字段");
+        }
+        Set<String> fields = new HashSet<String>(fieldNames);
+        for (String primaryKey : primaryKeys) {
+            if (!fields.contains(primaryKey)) {
+                throw new IllegalArgumentException(
+                        "XuguDB UPSERT 主键字段不存在：" + primaryKey);
+            }
+        }
+
+        String valuesBinding = fieldNames.stream()
+                .map(field -> "? " + quoteIdentifier(field))
+                .collect(Collectors.joining(", "));
+        String usingClause = "SELECT " + valuesBinding + " FROM DUAL";
+        String onConditions = primaryKeys.stream()
+                .map(field -> "TARGET." + quoteIdentifier(field)
+                        + "=SOURCE." + quoteIdentifier(field))
+                .collect(Collectors.joining(" AND "));
+        String updateClause = fieldNames.stream()
+                .filter(field -> !primaryKeySet.contains(field))
+                .map(field -> "TARGET." + quoteIdentifier(field)
+                        + "=SOURCE." + quoteIdentifier(field))
+                .collect(Collectors.joining(", "));
+        String insertFields = fieldNames.stream()
+                .map(this::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        String insertValues = fieldNames.stream()
+                .map(field -> "SOURCE." + quoteIdentifier(field))
+                .collect(Collectors.joining(", "));
+
+        StringBuilder sql = new StringBuilder()
+                .append("MERGE INTO ")
+                .append(tableIdentifier(tablePath))
+                .append(" TARGET USING (")
+                .append(usingClause)
+                .append(") SOURCE ON (")
+                .append(onConditions)
+                .append(")");
+        if (!updateClause.isEmpty()) {
+            sql.append(" WHEN MATCHED THEN UPDATE SET ")
+                    .append(updateClause);
+        }
+        sql.append(" WHEN NOT MATCHED THEN INSERT (")
+                .append(insertFields)
+                .append(") VALUES (")
+                .append(insertValues)
+                .append(")");
+        return Optional.of(sql.toString());
+    }
+
+    @Override
+    public PreparedStatement prepareReadStatement(
+            Connection connection,
+            String sql,
+            int fetchSize) throws SQLException {
+
+        PreparedStatement statement = connection.prepareStatement(
+                sql,
+                ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY);
+        statement.setFetchSize(fetchSize > 0 ? fetchSize : DEFAULT_FETCH_SIZE);
+        return statement;
+    }
+
+    @Override
+    public Map<String, String> defaultConnectionProperties() {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        // Connector-level schema is an explicit physical object name. Since all
+        // Xugu SQL is schema-qualified, do not reinterpret it as current_schema;
+        // doing so could apply compatibility-mode case folding twice.
+        if (JdbcDialect.hasText(connectionConfig.getCompatibleMode())
+                && !JdbcDialect.hasText(
+                XuguJdbcUrl.compatibleMode(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getProperties()))) {
+            result.put("compatiblemode", connectionConfig.getCompatibleMode().trim());
+        }
+        return result;
+    }
+
+    // String HASH partition intentionally remains unsupported. The current
+    // Xugu reference dialect exposes no stable hash predicate for JDBC splits;
+    // numeric MIN/MAX partitioning remains available through the shared planner.
+
+    private String normalizeIdentifier(String part) {
+        String value = part.trim();
+        if (value.length() >= 2
+                && value.charAt(0) == '\"'
+                && value.charAt(value.length() - 1) == '\"') {
+            return value.substring(1, value.length() - 1).replace("\"\"", "\"");
+        }
+        if ("POSTGRESQL".equals(compatibleMode)) {
+            return value.toLowerCase(Locale.ROOT);
+        }
+        if ("MYSQL".equals(compatibleMode)) {
+            return value;
+        }
+        return value.toUpperCase(Locale.ROOT);
+    }
+
+    private static String resolveDefaultSchema(
+            JdbcConnectionConfig config,
+            String compatibleMode) {
+        String currentSchema = XuguJdbcUrl.currentSchema(
+                config.getUrl(), config.getProperties());
+        if (JdbcDialect.hasText(currentSchema)) {
+            return XuguJdbcUrl.normalizeSessionIdentifier(
+                    currentSchema, compatibleMode);
+        }
+        if (JdbcDialect.hasText(config.getSchema())) {
+            return config.getSchema().trim();
+        }
+        String user = config.getUsername();
+        if (!JdbcDialect.hasText(user)) {
+            user = XuguJdbcUrl.user(config.getUrl(), config.getProperties());
+        }
+        return XuguJdbcUrl.normalizeSessionIdentifier(user, compatibleMode);
+    }
+
+    private static String resolveCompatibleMode(JdbcConnectionConfig config) {
+        String jdbcMode = XuguJdbcUrl.compatibleMode(
+                config.getUrl(), config.getProperties());
+        String mode = JdbcDialect.hasText(jdbcMode)
+                ? jdbcMode
+                : config.getCompatibleMode();
+        return JdbcDialect.hasText(mode)
+                ? mode.trim().toUpperCase(Locale.ROOT)
+                : "NONE";
+    }
+
+    private static Map<String, String> resolvedCatalogProperties(
+            JdbcConnectionConfig config) {
+        Map<String, String> result = new LinkedHashMap<String, String>(config.getProperties());
+        if (!JdbcDialect.hasText(
+                XuguJdbcUrl.compatibleMode(config.getUrl(), result))
+                && JdbcDialect.hasText(config.getCompatibleMode())) {
+            result.put("compatiblemode", config.getCompatibleMode().trim());
+        }
+        return result;
+    }
+
+    private static List<String> splitIdentifierPath(String path) {
+        List<String> parts = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '\"') {
+                current.append(c);
+                if (quoted && i + 1 < path.length() && path.charAt(i + 1) == '\"') {
+                    current.append('\"');
+                    i++;
+                } else {
+                    quoted = !quoted;
+                }
+                continue;
+            }
+            if (c == '.' && !quoted) {
+                if (current.length() == 0) {
+                    throw new IllegalArgumentException("非法 XuguDB 表路径：" + path);
+                }
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        if (quoted || current.length() == 0) {
+            throw new IllegalArgumentException("非法 XuguDB 表路径：" + path);
+        }
+        parts.add(current.toString());
+        return parts;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialectFactory.java
@@ -1,0 +1,27 @@
+package com.link.up.connector.jdbc.core.dialect.xugu;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/** XuguDB offline JDBC dialect factory. */
+@AutoService(JdbcDialectFactory.class)
+public final class XuguDialectFactory implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.XUGU;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return XuguJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(JdbcConnectionConfig connectionConfig) {
+        return new XuguDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguJdbcRowConverter.java
@@ -1,0 +1,195 @@
+package com.link.up.connector.jdbc.core.dialect.xugu;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+
+/** XuguDB row converter with lossless LOB/bit/timezone handling. */
+public final class XuguJdbcRowConverter extends AbstractJdbcRowConverter {
+
+    private static final String NATIVE_ATTRIBUTE = XuguTypeMapper.NATIVE_ATTRIBUTE;
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.XUGU;
+    }
+
+    @Override
+    protected LocalTime readTime(ResultSet resultSet, int index) throws SQLException {
+        // Xugu's java.sql.Time path does not expose fractional TIME precision.
+        // Reading textual TIME first keeps milliseconds when the driver returns them.
+        String text = resultSet.getString(index);
+        if (text == null) {
+            return null;
+        }
+        try {
+            return LocalTime.parse(text.trim());
+        } catch (DateTimeParseException ignored) {
+            return super.readTime(resultSet, index);
+        }
+    }
+
+    @Override
+    protected void writeTime(
+            PreparedStatement statement,
+            int index,
+            LocalTime value) throws SQLException {
+        // Xugu JDBC documents a precision-losing java.sql.Time output path.
+        // Bind ISO local-time text and let the target TIME column perform the
+        // database-native conversion so up to millisecond precision survives.
+        statement.setString(index, value.toString());
+    }
+
+    @Override
+    protected void writeNull(
+            PreparedStatement statement,
+            int index,
+            Column column) throws SQLException {
+
+        SqlType sqlType = column.getDataType().getSqlType();
+        if (sqlType == SqlType.TIMESTAMP_TZ) {
+            // Target mapping is VARCHAR(64) to avoid the Xugu JDBC offset-loss
+            // batch path documented by the upstream connector.
+            statement.setNull(index, Types.VARCHAR);
+            return;
+        }
+        if (isNative(column)
+                && sqlType == SqlType.STRING
+                && isExactNativeString(column.getSourceType())) {
+            // Exact-value textual transport (NUMERIC overflow, BIT strings,
+            // TIME WITH TIME ZONE, etc.) must not become a CLOB-typed null
+            // merely because the source metadata has no bounded length.
+            statement.setNull(index, Types.VARCHAR);
+            return;
+        }
+        if (sqlType == SqlType.STRING && isLongText(column)) {
+            statement.setNull(index, Types.CLOB);
+            return;
+        }
+        if (sqlType == SqlType.BYTES && isLongBinary(column)) {
+            statement.setNull(index, Types.BLOB);
+            return;
+        }
+        super.writeNull(statement, index, column);
+    }
+
+    @Override
+    protected void writeValue(
+            PreparedStatement statement,
+            int index,
+            Object value,
+            Column column) throws SQLException {
+
+        SqlType sqlType = column.getDataType().getSqlType();
+        if (sqlType == SqlType.TIMESTAMP_TZ) {
+            OffsetDateTime offsetDateTime = value instanceof OffsetDateTime
+                    ? (OffsetDateTime) value
+                    : OffsetDateTime.parse(String.valueOf(value));
+            statement.setString(index, offsetDateTime.toString());
+            return;
+        }
+        if (isNative(column)
+                && sqlType == SqlType.STRING
+                && isExactNativeString(column.getSourceType())) {
+            statement.setString(index, String.valueOf(value));
+            return;
+        }
+        if (sqlType == SqlType.STRING && isLongText(column)) {
+            String text = asString(value);
+            statement.setCharacterStream(
+                    index,
+                    new StringReader(text),
+                    text.length());
+            return;
+        }
+        if (sqlType == SqlType.BYTES && isLongBinary(column)) {
+            byte[] bytes = asBytes(value);
+            statement.setBinaryStream(
+                    index,
+                    new ByteArrayInputStream(bytes),
+                    bytes.length);
+            return;
+        }
+        super.writeValue(statement, index, value, column);
+    }
+
+    private static boolean isNative(Column column) {
+        return "true".equalsIgnoreCase(
+                column.getAttributes().get(NATIVE_ATTRIBUTE));
+    }
+
+    private static boolean isExactNativeString(String sourceType) {
+        String type = normalize(sourceType);
+        String base = baseType(type);
+        return "numeric".equals(base)
+                || "decimal".equals(base)
+                || "number".equals(base)
+                || "bit".equals(base)
+                || "varbit".equals(base)
+                || "bit varying".equals(base)
+                || "guid".equals(base)
+                || "uuid".equals(base)
+                || "json".equals(base)
+                || "xml".equals(base)
+                || "rowid".equals(base)
+                || "interval".equals(base)
+                || base.startsWith("interval ")
+                || isTimeWithTimeZone(type, base);
+    }
+
+    private static boolean isTimeWithTimeZone(String type, String base) {
+        return ("time".equals(base) || base.startsWith("time "))
+                && !base.startsWith("timestamp")
+                && type.contains("with time zone")
+                && !type.contains("without time zone");
+    }
+
+    private static boolean isLongText(Column column) {
+        String base = baseType(normalize(column.getSourceType()));
+        return "clob".equals(base)
+                || "nclob".equals(base)
+                || column.getLength() == null
+                || column.getLength() > XuguTypeMapper.MAX_VARCHAR_LENGTH;
+    }
+
+    private static boolean isLongBinary(Column column) {
+        String base = baseType(normalize(column.getSourceType()));
+        return "blob".equals(base)
+                || "longvarbinary".equals(base)
+                || "long varbinary".equals(base)
+                || column.getLength() == null
+                || column.getLength() > XuguTypeMapper.MAX_BINARY_LENGTH;
+    }
+
+    private static String baseType(String type) {
+        int parenthesis = type.indexOf('(');
+        if (parenthesis < 0) {
+            return type;
+        }
+        String before = type.substring(0, parenthesis).trim();
+        int close = type.indexOf(')', parenthesis + 1);
+        if (close >= 0 && close < type.length() - 1) {
+            String suffix = type.substring(close + 1).trim();
+            return suffix.isEmpty() ? before : before + " " + suffix;
+        }
+        return before;
+    }
+
+    private static String normalize(String value) {
+        return value == null
+                ? ""
+                : value.trim().toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguJdbcUrl.java
@@ -1,0 +1,156 @@
+package com.link.up.connector.jdbc.core.dialect.xugu;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+
+/** Utilities for XuguDB JDBC URL semantics. */
+public final class XuguJdbcUrl {
+
+    private static final String PREFIX = "jdbc:xugu://";
+
+    private XuguJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return url != null
+                && url.trim().toLowerCase(Locale.ROOT).startsWith(PREFIX);
+    }
+
+    public static String databaseName(String url) {
+        if (!accepts(url)) {
+            return null;
+        }
+        String normalized = url.trim();
+        int hostStart = PREFIX.length();
+        int slash = normalized.indexOf('/', hostStart);
+        if (slash < 0 || slash == normalized.length() - 1) {
+            return null;
+        }
+        int end = normalized.length();
+        int query = normalized.indexOf('?', slash + 1);
+        if (query >= 0) {
+            end = query;
+        }
+        String value = normalized.substring(slash + 1, end).trim();
+        return value.isEmpty() ? null : decode(value);
+    }
+
+    /** URL parameters take precedence over Properties, matching JDBC URL semantics. */
+    public static String currentSchema(String url, Map<String, String> properties) {
+        String fromUrl = queryValue(url, "current_schema");
+        if (hasText(fromUrl)) {
+            return firstSchema(fromUrl);
+        }
+        String property = propertyIgnoreCase(properties, "current_schema");
+        if (!hasText(property)) {
+            property = propertyIgnoreCase(properties, "schema");
+        }
+        return hasText(property) ? firstSchema(property) : null;
+    }
+
+    public static String user(String url, Map<String, String> properties) {
+        String fromUrl = queryValue(url, "user");
+        if (hasText(fromUrl)) {
+            return fromUrl.trim();
+        }
+        String property = propertyIgnoreCase(properties, "user");
+        return hasText(property) ? property.trim() : null;
+    }
+
+    public static String compatibleMode(String url, Map<String, String> properties) {
+        String fromUrl = queryValue(url, "compatiblemode");
+        if (hasText(fromUrl)) {
+            return fromUrl.trim();
+        }
+        String property = propertyIgnoreCase(properties, "compatiblemode");
+        return hasText(property) ? property.trim() : null;
+    }
+
+    /**
+     * Xugu session parameters such as CURRENT_SCHEMA are interpreted with the
+     * active compatibility-mode identifier rules. Quoted names remain exact.
+     */
+    public static String normalizeSessionIdentifier(
+            String value,
+            String compatibleMode) {
+
+        if (!hasText(value)) {
+            return null;
+        }
+        String normalized = value.trim();
+        if (normalized.length() >= 2
+                && normalized.charAt(0) == '\"'
+                && normalized.charAt(normalized.length() - 1) == '\"') {
+            return normalized.substring(1, normalized.length() - 1)
+                    .replace("\"\"", "\"");
+        }
+        String mode = hasText(compatibleMode)
+                ? compatibleMode.trim().toUpperCase(Locale.ROOT)
+                : "NONE";
+        if ("POSTGRESQL".equals(mode)) {
+            return normalized.toLowerCase(Locale.ROOT);
+        }
+        if ("MYSQL".equals(mode)) {
+            return normalized;
+        }
+        return normalized.toUpperCase(Locale.ROOT);
+    }
+
+    private static String queryValue(String url, String key) {
+        if (!accepts(url)) {
+            return null;
+        }
+        int query = url.indexOf('?');
+        if (query < 0 || query == url.length() - 1) {
+            return null;
+        }
+        String queryString = url.substring(query + 1);
+        for (String item : queryString.split("&")) {
+            int equals = item.indexOf('=');
+            if (equals <= 0) {
+                continue;
+            }
+            String itemKey = decode(item.substring(0, equals)).trim();
+            if (key.equalsIgnoreCase(itemKey)) {
+                String value = decode(item.substring(equals + 1)).trim();
+                return value.isEmpty() ? null : value;
+            }
+        }
+        return null;
+    }
+
+    private static String propertyIgnoreCase(Map<String, String> properties, String key) {
+        if (properties == null || properties.isEmpty()) {
+            return null;
+        }
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (entry.getKey() != null
+                    && key.equalsIgnoreCase(entry.getKey().trim())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String firstSchema(String value) {
+        String normalized = value.trim();
+        int comma = normalized.indexOf(',');
+        return comma >= 0
+                ? normalized.substring(0, comma).trim()
+                : normalized;
+    }
+
+    private static String decode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (Exception ignored) {
+            return value;
+        }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguTypeMapper.java
@@ -1,0 +1,550 @@
+package com.link.up.connector.jdbc.core.dialect.xugu;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
+
+/** XuguDB JDBC type mapper for bounded/offline jobs. */
+public final class XuguTypeMapper implements JdbcTypeMapper {
+
+    public static final int MAX_NUMERIC_PRECISION = 38;
+    public static final int DEFAULT_NUMERIC_PRECISION = 12;
+    public static final int DEFAULT_NUMERIC_SCALE = 0;
+    public static final int MAX_TIME_PRECISION = 3;
+    public static final int MAX_TIMESTAMP_PRECISION = 6;
+    public static final long MAX_VARCHAR_LENGTH = 60_000L;
+    public static final long MAX_BINARY_LENGTH = 60_000L;
+    public static final String NATIVE_ATTRIBUTE = "xugu_native";
+
+    @Override
+    public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+        String name = firstText(
+                metadata.getColumnLabel(columnIndex),
+                metadata.getColumnName(columnIndex));
+        String sourceType = metadata.getColumnTypeName(columnIndex);
+        int precision = metadata.getPrecision(columnIndex);
+        int scale = metadata.getScale(columnIndex);
+        FluxDataType<?> type = mapType(
+                metadata.getColumnType(columnIndex), sourceType, precision, scale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(metadata.isNullable(columnIndex)
+                        != ResultSetMetaData.columnNoNulls)
+                .sourceType(buildSourceType(sourceType, precision, scale))
+                .attribute(NATIVE_ATTRIBUTE, "true");
+        applyProperties(builder, type, sourceType, precision, scale);
+        return builder.build();
+    }
+
+    /** Maps one JDBC DatabaseMetaData#getColumns row. */
+    public Column toColumn(ResultSet row) throws SQLException {
+        String name = row.getString("COLUMN_NAME");
+        String typeName = row.getString("TYPE_NAME");
+        Integer size = integer(row, "COLUMN_SIZE");
+        Integer digits = integer(row, "DECIMAL_DIGITS");
+        Integer nullable = integer(row, "NULLABLE");
+        int jdbcType = value(integer(row, "DATA_TYPE"));
+        int precision = value(size);
+        int scale = value(digits);
+        FluxDataType<?> type = mapType(jdbcType, typeName, precision, scale);
+        Object defaultValue = safeObject(row, "COLUMN_DEF");
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(nullable == null
+                        || nullable != ResultSetMetaData.columnNoNulls)
+                .defaultValue(defaultValue)
+                .comment(safeString(row, "REMARKS"))
+                .sourceType(buildSourceType(typeName, precision, scale))
+                .attribute(NATIVE_ATTRIBUTE, "true");
+
+        String auto = safeString(row, "IS_AUTOINCREMENT");
+        builder.autoIncrement("YES".equalsIgnoreCase(auto)
+                || isIdentityDefault(defaultValue));
+        applyProperties(builder, type, typeName, precision, scale);
+        return builder.build();
+    }
+
+    @Override
+    public String toDatabaseType(Column column) {
+        return toDatabaseType(column, false);
+    }
+
+    public String toDatabaseType(Column column, boolean preserveSourceType) {
+        if (preserveSourceType && canPreserve(column)) {
+            return column.getSourceType().trim();
+        }
+
+        SqlType type = column.getDataType().getSqlType();
+        switch (type) {
+            case BOOLEAN:
+                return "BOOLEAN";
+            case TINYINT:
+                return "TINYINT";
+            case SMALLINT:
+                return "SMALLINT";
+            case INT:
+                return "INTEGER";
+            case BIGINT:
+                return "BIGINT";
+            case FLOAT:
+                return "FLOAT";
+            case DOUBLE:
+                return "DOUBLE";
+            case DECIMAL:
+                return decimalType(column);
+            case STRING:
+                // TIME WITH TIME ZONE has a compact exact-text representation;
+                // avoid allocating an unbounded CLOB merely because Flux has no
+                // TIME_TZ primitive.
+                return isOffsetTimeSource(column) ? "VARCHAR(64)" : stringType(column);
+            case BYTES:
+                return binaryType(column);
+            case DATE:
+                return "DATE";
+            case TIME:
+                return temporal("TIME", column, MAX_TIME_PRECISION);
+            case TIMESTAMP:
+                return temporal("TIMESTAMP", column, MAX_TIMESTAMP_PRECISION);
+            case TIMESTAMP_TZ:
+                // Xugu JDBC batch binding of offset-aware timestamp values has a
+                // known driver failure path. Preserve the offset as ISO text
+                // instead of silently writing a wall-clock TIMESTAMP.
+                return "VARCHAR(64)";
+            default:
+                throw new IllegalArgumentException(
+                        "XuguDB 不支持 Flux 类型：" + type
+                                + "，column=" + column.getName());
+        }
+    }
+
+    /** Package-visible for focused contract tests. */
+    FluxDataType<?> mapType(
+            int jdbcType,
+            String sourceType,
+            int precision,
+            int scale) {
+
+        String type = normalize(sourceType);
+        String base = baseType(type);
+
+        if (isTimeWithTimeZone(type, base)) {
+            return BasicType.STRING_TYPE;
+        }
+        if (isTimestampWithTimeZone(type, base)) {
+            return BasicType.TIMESTAMP_TZ_TYPE;
+        }
+        if (type.startsWith("timestamp")
+                || type.startsWith("datetime")) {
+            return BasicType.TIMESTAMP_TYPE;
+        }
+
+        switch (base) {
+            case "boolean":
+            case "bool":
+                return BasicType.BOOLEAN_TYPE;
+            case "tinyint":
+                return BasicType.BYTE_TYPE;
+            case "smallint":
+            case "short":
+                return BasicType.SHORT_TYPE;
+            case "integer":
+            case "int":
+            case "pls_integer":
+            case "binary_integer":
+                return BasicType.INT_TYPE;
+            case "bigint":
+            case "longint":
+                return BasicType.LONG_TYPE;
+            case "float":
+            case "real":
+                return BasicType.FLOAT_TYPE;
+            case "double":
+            case "double precision":
+                return BasicType.DOUBLE_TYPE;
+            case "numeric":
+            case "decimal":
+            case "number":
+                return numericType(precision, scale);
+            case "date":
+                return BasicType.DATE_TYPE;
+            case "time":
+                return BasicType.TIME_TYPE;
+            case "binary":
+            case "varbinary":
+            case "longvarbinary":
+            case "long varbinary":
+            case "blob":
+            case "raw":
+                return BasicType.BYTES_TYPE;
+            case "bit":
+            case "varbit":
+            case "bit varying":
+                // BIT/VARBIT are bit strings up to 60,000 bits, not Boolean/Byte.
+                return BasicType.STRING_TYPE;
+            default:
+                break;
+        }
+
+        if (isStringLike(type, base)) {
+            return BasicType.STRING_TYPE;
+        }
+
+        switch (jdbcType) {
+            case Types.BOOLEAN:
+                return BasicType.BOOLEAN_TYPE;
+            case Types.TINYINT:
+                return BasicType.BYTE_TYPE;
+            case Types.SMALLINT:
+                return BasicType.SHORT_TYPE;
+            case Types.INTEGER:
+                return BasicType.INT_TYPE;
+            case Types.BIGINT:
+                return BasicType.LONG_TYPE;
+            case Types.FLOAT:
+            case Types.REAL:
+                return BasicType.FLOAT_TYPE;
+            case Types.DOUBLE:
+                return BasicType.DOUBLE_TYPE;
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return numericType(precision, scale);
+            case Types.DATE:
+                return BasicType.DATE_TYPE;
+            case Types.TIME:
+                return BasicType.TIME_TYPE;
+            case Types.TIME_WITH_TIMEZONE:
+                return BasicType.STRING_TYPE;
+            case Types.TIMESTAMP:
+                return BasicType.TIMESTAMP_TYPE;
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return BasicType.TIMESTAMP_TZ_TYPE;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+            case Types.BLOB:
+                return BasicType.BYTES_TYPE;
+            case Types.BIT:
+                return BasicType.STRING_TYPE;
+            default:
+                return BasicType.STRING_TYPE;
+        }
+    }
+
+    private static FluxDataType<?> numericType(int precision, int scale) {
+        int p = precision <= 0 ? DEFAULT_NUMERIC_PRECISION : precision;
+        int s = precision <= 0 ? DEFAULT_NUMERIC_SCALE : scale;
+        if (p <= 0 || p > MAX_NUMERIC_PRECISION
+                || s < 0 || s > p) {
+            return BasicType.STRING_TYPE;
+        }
+        return new DecimalType(p, s);
+    }
+
+    private static String decimalType(Column column) {
+        Integer precisionValue = column.getPrecision();
+        Integer scaleValue = column.getScale();
+        if (column.getDataType() instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) column.getDataType();
+            if (precisionValue == null) {
+                precisionValue = decimal.getPrecision();
+            }
+            if (scaleValue == null) {
+                scaleValue = decimal.getScale();
+            }
+        }
+        int precision = precisionValue == null
+                ? DEFAULT_NUMERIC_PRECISION : precisionValue;
+        int scale = scaleValue == null
+                ? DEFAULT_NUMERIC_SCALE : scaleValue;
+        if (precision <= 0 || precision > MAX_NUMERIC_PRECISION) {
+            throw new IllegalArgumentException(
+                    "XuguDB NUMERIC precision 必须在 1..38，column="
+                            + column.getName() + "，precision=" + precision);
+        }
+        if (scale < 0 || scale > precision) {
+            throw new IllegalArgumentException(
+                    "XuguDB NUMERIC scale 非法，column=" + column.getName()
+                            + "，precision=" + precision + "，scale=" + scale);
+        }
+        return "NUMERIC(" + precision + "," + scale + ")";
+    }
+
+    private static String stringType(Column column) {
+        Long length = column.getLength();
+        if (length == null || length <= 0 || length > MAX_VARCHAR_LENGTH) {
+            return "CLOB";
+        }
+        return "VARCHAR(" + length + ")";
+    }
+
+    private static String binaryType(Column column) {
+        Long length = column.getLength();
+        if (length == null || length <= 0 || length > MAX_BINARY_LENGTH) {
+            return "BLOB";
+        }
+        return "BINARY(" + length + ")";
+    }
+
+    private static String temporal(String type, Column column, int maxPrecision) {
+        Integer precision = column.getPrecision();
+        if (precision == null || precision <= 0) {
+            return type;
+        }
+        if (precision > maxPrecision) {
+            throw new IllegalArgumentException(
+                    "XuguDB " + type + " precision 最大为 " + maxPrecision
+                            + "，column=" + column.getName()
+                            + "，precision=" + precision);
+        }
+        return type + "(" + precision + ")";
+    }
+
+    private static void applyProperties(
+            Column.Builder builder,
+            FluxDataType<?> dataType,
+            String sourceType,
+            int precision,
+            int scale) {
+
+        SqlType sqlType = dataType.getSqlType();
+        String type = normalize(sourceType);
+        String base = baseType(type);
+
+        if (sqlType == SqlType.STRING || sqlType == SqlType.BYTES) {
+            if (!isNumericBase(base)
+                    && !isTimeWithTimeZone(type, base)
+                    && !isTimestampWithTimeZone(type, base)
+                    && precision > 0) {
+                builder.length((long) precision);
+            }
+            return;
+        }
+        if (sqlType == SqlType.DECIMAL && dataType instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) dataType;
+            builder.precision(decimal.getPrecision());
+            builder.scale(decimal.getScale());
+            return;
+        }
+        if (sqlType == SqlType.TIME) {
+            int p = Math.max(0, Math.min(scale > 0 ? scale : precision,
+                    MAX_TIME_PRECISION));
+            if (p > 0) {
+                builder.precision(p);
+            }
+            return;
+        }
+        if (sqlType == SqlType.TIMESTAMP
+                || sqlType == SqlType.TIMESTAMP_TZ) {
+            int p = Math.max(0, Math.min(scale > 0 ? scale : precision,
+                    MAX_TIMESTAMP_PRECISION));
+            if (p > 0) {
+                builder.precision(p);
+            }
+        }
+    }
+
+    private static String buildSourceType(String sourceType, int precision, int scale) {
+        String raw = sourceType == null ? "" : sourceType.trim();
+        String normalized = normalize(raw);
+        String base = baseType(normalized);
+        if (raw.isEmpty() || raw.contains("(")) {
+            return raw;
+        }
+        if (isNumericBase(base)) {
+            int p = precision <= 0 ? DEFAULT_NUMERIC_PRECISION : precision;
+            int s = precision <= 0 ? DEFAULT_NUMERIC_SCALE : scale;
+            return raw + "(" + p + "," + s + ")";
+        }
+        if (isLengthType(base)
+                || "bit".equals(base)
+                || "varbit".equals(base)
+                || "bit varying".equals(base)) {
+            return precision > 0 ? raw + "(" + precision + ")" : raw;
+        }
+        if (isTimeWithTimeZone(normalized, base)) {
+            return scale > 0
+                    ? "TIME(" + Math.min(scale, MAX_TIME_PRECISION) + ") WITH TIME ZONE"
+                    : raw;
+        }
+        if (isTimestampWithTimeZone(normalized, base)) {
+            return scale > 0
+                    ? "TIMESTAMP(" + Math.min(scale, MAX_TIMESTAMP_PRECISION)
+                    + ") WITH TIME ZONE"
+                    : raw;
+        }
+        if (("time".equals(base) || base.startsWith("timestamp"))
+                && scale > 0) {
+            return raw + "(" + scale + ")";
+        }
+        return raw;
+    }
+
+    private static boolean canPreserve(Column column) {
+        String sourceType = column.getSourceType();
+        if (sourceType == null || sourceType.trim().isEmpty()) {
+            return false;
+        }
+        String type = normalize(sourceType);
+        String base = baseType(type);
+        if (isTimestampWithTimeZone(type, base)
+                || isTimeWithTimeZone(type, base)) {
+            return false;
+        }
+        if (isNumericBase(base)
+                && column.getDataType().getSqlType() == SqlType.STRING) {
+            return false;
+        }
+        return "boolean".equals(base)
+                || "bool".equals(base)
+                || "tinyint".equals(base)
+                || "smallint".equals(base)
+                || "short".equals(base)
+                || "integer".equals(base)
+                || "int".equals(base)
+                || "bigint".equals(base)
+                || "longint".equals(base)
+                || "float".equals(base)
+                || "real".equals(base)
+                || "double".equals(base)
+                || "double precision".equals(base)
+                || isNumericBase(base)
+                || isStringLike(type, base)
+                || "binary".equals(base)
+                || "varbinary".equals(base)
+                || "longvarbinary".equals(base)
+                || "long varbinary".equals(base)
+                || "blob".equals(base)
+                || "raw".equals(base)
+                || "bit".equals(base)
+                || "varbit".equals(base)
+                || "bit varying".equals(base)
+                || "date".equals(base)
+                || "time".equals(base)
+                || base.startsWith("timestamp")
+                || "datetime".equals(base);
+    }
+
+    private static boolean isOffsetTimeSource(Column column) {
+        String type = normalize(column.getSourceType());
+        return isTimeWithTimeZone(type, baseType(type));
+    }
+
+    private static boolean isStringLike(String type, String base) {
+        return type.isEmpty()
+                || base.contains("char")
+                || "text".equals(base)
+                || "clob".equals(base)
+                || "nclob".equals(base)
+                || "json".equals(base)
+                || "xml".equals(base)
+                || "guid".equals(base)
+                || "uuid".equals(base)
+                || "rowid".equals(base)
+                || "interval".equals(base)
+                || base.startsWith("interval ")
+                || "point".equals(base)
+                || "line".equals(base)
+                || "lseg".equals(base)
+                || "box".equals(base)
+                || "path".equals(base)
+                || "polygon".equals(base)
+                || "circle".equals(base)
+                || "array".equals(base)
+                || type.endsWith("[]");
+    }
+
+    private static boolean isLengthType(String base) {
+        return base.contains("char")
+                || "binary".equals(base)
+                || "varbinary".equals(base);
+    }
+
+    private static boolean isNumericBase(String base) {
+        return "numeric".equals(base)
+                || "decimal".equals(base)
+                || "number".equals(base);
+    }
+
+    private static boolean isTimeWithTimeZone(String type, String base) {
+        return ("time".equals(base) || base.startsWith("time "))
+                && !base.startsWith("timestamp")
+                && type.contains("with time zone")
+                && !type.contains("without time zone");
+    }
+
+    private static boolean isTimestampWithTimeZone(String type, String base) {
+        return (base.startsWith("timestamp") || base.startsWith("datetime"))
+                && type.contains("with time zone")
+                && !type.contains("without time zone");
+    }
+
+    private static String baseType(String type) {
+        int parenthesis = type.indexOf('(');
+        if (parenthesis < 0) {
+            return type;
+        }
+        String before = type.substring(0, parenthesis).trim();
+        int close = type.indexOf(')', parenthesis + 1);
+        if (close >= 0 && close < type.length() - 1) {
+            String suffix = type.substring(close + 1).trim();
+            return suffix.isEmpty() ? before : before + " " + suffix;
+        }
+        return before;
+    }
+
+    private static boolean isIdentityDefault(Object defaultValue) {
+        if (defaultValue == null) {
+            return false;
+        }
+        String value = String.valueOf(defaultValue).toLowerCase(Locale.ROOT);
+        return value.contains("identity") || value.contains("auto_increment");
+    }
+
+    private static String normalize(String value) {
+        return value == null
+                ? ""
+                : value.trim().toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
+    }
+
+    private static String firstText(String first, String second) {
+        return first != null && !first.trim().isEmpty() ? first : second;
+    }
+
+    private static Integer integer(ResultSet row, String name) {
+        try {
+            Object value = row.getObject(name);
+            return value == null ? null : ((Number) value).intValue();
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static Object safeObject(ResultSet row, String name) {
+        try {
+            return row.getObject(name);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static String safeString(ResultSet row, String name) {
+        try {
+            return row.getString(name);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static int value(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -129,6 +129,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return IrisSinkSupport.resolveTargetPath(
                     config.getConnectionConfig(), tablePath);
         }
+        if (XuguSinkSupport.accepts(config.getConnectionConfig())) {
+            return XuguSinkSupport.resolveTargetPath(
+                    config.getConnectionConfig(), tablePath);
+        }
         return JdbcCreateTableSqlResolver.resolveTargetPath(
                 config.getConnectionConfig(), tablePath);
     }
@@ -144,6 +148,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
         }
         if (IrisSinkSupport.accepts(config.getConnectionConfig())) {
             return IrisSinkSupport.resolveCreateTableSql(
+                    config.getConnectionConfig(), table);
+        }
+        if (XuguSinkSupport.accepts(config.getConnectionConfig())) {
+            return XuguSinkSupport.resolveCreateTableSql(
                     config.getConnectionConfig(), table);
         }
         return JdbcCreateTableSqlResolver.resolve(

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/XuguSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/XuguSinkSupport.java
@@ -1,0 +1,96 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.xugu.XuguCreateTableSqlBuilder;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.xugu.XuguJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.xugu.XuguTypeMapper;
+
+/** Small XuguDB target-path/DDL adapter kept out of the generic resolver. */
+final class XuguSinkSupport {
+
+    private XuguSinkSupport() {
+    }
+
+    static boolean accepts(JdbcConnectionConfig config) {
+        return config != null
+                && (DatabaseIdentifier.XUGU.equalsIgnoreCase(config.getDialect())
+                || XuguJdbcUrl.accepts(config.getUrl()));
+    }
+
+    static TablePath resolveTargetPath(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+
+        if (config == null || tablePath == null) {
+            return tablePath;
+        }
+        String database = XuguJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(database)) {
+            return null;
+        }
+
+        String pathDatabase = tablePath.getDatabaseName();
+        String pathSchema = tablePath.getSchemaName();
+        String schema;
+        if (hasText(pathSchema)
+                && (!hasText(pathDatabase)
+                || database.equalsIgnoreCase(pathDatabase))) {
+            schema = pathSchema.trim();
+        } else {
+            schema = defaultSchema(config);
+        }
+        return hasText(schema)
+                ? TablePath.of(database, schema, tablePath.getTableName())
+                : null;
+    }
+
+    static String resolveCreateTableSql(
+            JdbcConnectionConfig config,
+            CatalogTable table) {
+
+        if (config == null || table == null) {
+            return null;
+        }
+        TablePath targetPath = resolveTargetPath(config, table.getTablePath());
+        if (targetPath == null) {
+            return null;
+        }
+        CatalogTable ddlTable = table.getTablePath().equals(targetPath)
+                ? table
+                : table.withPath(targetPath);
+        return new XuguCreateTableSqlBuilder(
+                targetPath,
+                ddlTable,
+                new XuguTypeMapper())
+                .build();
+    }
+
+    private static String defaultSchema(JdbcConnectionConfig config) {
+        String jdbcMode = XuguJdbcUrl.compatibleMode(
+                config.getUrl(), config.getProperties());
+        String mode = hasText(jdbcMode) ? jdbcMode : config.getCompatibleMode();
+
+        String jdbcSchema = XuguJdbcUrl.currentSchema(
+                config.getUrl(), config.getProperties());
+        if (hasText(jdbcSchema)) {
+            return XuguJdbcUrl.normalizeSessionIdentifier(jdbcSchema, mode);
+        }
+        if (hasText(config.getSchema())) {
+            // Connector schema is an explicit physical object name and is not
+            // reinterpreted as an unquoted SQL token.
+            return config.getSchema().trim();
+        }
+        String user = config.getUsername();
+        if (!hasText(user)) {
+            user = XuguJdbcUrl.user(config.getUrl(), config.getProperties());
+        }
+        return XuguJdbcUrl.normalizeSessionIdentifier(user, mode);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/xugu/XuguCatalogTest.java
@@ -1,0 +1,33 @@
+package com.link.up.connector.jdbc.catalog.xugu;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class XuguCatalogTest {
+
+    @Test
+    public void escapesMetadataWildcardCharactersForExactLookup() {
+        assertEquals(
+                "APP\\_DATA\\%2026",
+                XuguCatalog.escapeMetadataPattern(
+                        "APP_DATA%2026",
+                        "\\"));
+    }
+
+    @Test
+    public void escapesExistingSearchEscapeBeforeWildcards() {
+        assertEquals(
+                "APP\\\\ARCHIVE\\_2026",
+                XuguCatalog.escapeMetadataPattern(
+                        "APP\\ARCHIVE_2026",
+                        "\\"));
+    }
+
+    @Test
+    public void leavesExactValueUntouchedWhenDriverHasNoEscape() {
+        assertEquals(
+                "APP_DATA",
+                XuguCatalog.escapeMetadataPattern("APP_DATA", null));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/xugu/XuguCreateTableSqlBuilderTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/xugu/XuguCreateTableSqlBuilderTest.java
@@ -1,0 +1,154 @@
+package com.link.up.connector.jdbc.catalog.xugu;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.connector.jdbc.core.dialect.xugu.XuguTypeMapper;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+public class XuguCreateTableSqlBuilderTest {
+
+    @Test
+    public void buildsIdentityPrimaryKeyLobsAndComments() {
+        TablePath path = TablePath.of("SYSTEM", "APP", "USERS");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("ID", BasicType.LONG_TYPE)
+                        .nullable(false)
+                        .autoIncrement(true)
+                        .build())
+                .column(Column.builder("NAME", BasicType.STRING_TYPE)
+                        .length(64L)
+                        .comment("display name")
+                        .build())
+                .column(Column.builder("AMOUNT", new DecimalType(38, 18)).build())
+                .column(Column.builder("PAYLOAD", BasicType.STRING_TYPE)
+                        .length(100_000L)
+                        .build())
+                .primaryKey(PrimaryKey.of("PK_USERS", Arrays.asList("ID")))
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .comment("users table")
+                .build();
+
+        String ddl = new XuguCreateTableSqlBuilder(
+                path,
+                table,
+                new XuguTypeMapper())
+                .build();
+
+        assertTrue(ddl.contains("CREATE TABLE \"APP\".\"USERS\""));
+        assertTrue(ddl.contains("\"ID\" BIGINT IDENTITY(1,1) NOT NULL"));
+        assertTrue(ddl.contains("\"NAME\" VARCHAR(64)"));
+        assertTrue(ddl.contains("\"AMOUNT\" NUMERIC(38,18)"));
+        assertTrue(ddl.contains("\"PAYLOAD\" CLOB"));
+        assertTrue(ddl.contains(
+                "CONSTRAINT \"PK_USERS\" PRIMARY KEY (\"ID\")"));
+        assertTrue(ddl.contains(
+                "COMMENT ON TABLE \"APP\".\"USERS\" IS 'users table'"));
+        assertTrue(ddl.contains(
+                "COMMENT ON COLUMN \"APP\".\"USERS\".\"NAME\" IS 'display name'"));
+    }
+
+    @Test
+    public void sameDialectPreservesSafeScalarsButNormalizesUnsafeTypes() {
+        TablePath path = TablePath.of("SYSTEM", "APP", "EVENTS");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("PAYLOAD", BasicType.STRING_TYPE)
+                        .sourceType("JSON")
+                        .build())
+                .column(Column.builder("FLAGS", BasicType.STRING_TYPE)
+                        .sourceType("BIT(8)")
+                        .length(8L)
+                        .build())
+                .column(Column.builder("AMOUNT", BasicType.STRING_TYPE)
+                        .sourceType("NUMERIC(39,2)")
+                        .build())
+                .column(Column.builder("EVENT_AT", BasicType.TIMESTAMP_TZ_TYPE)
+                        .sourceType("TIMESTAMP(6) WITH TIME ZONE")
+                        .precision(6)
+                        .build())
+                .column(Column.builder("ITEMS", BasicType.STRING_TYPE)
+                        .sourceType("ARRAY")
+                        .build())
+                .column(Column.builder("RID", BasicType.STRING_TYPE)
+                        .sourceType("ROWID")
+                        .build())
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .option(XuguCatalog.TABLE_OPTION_DIALECT, XuguCatalog.DIALECT)
+                .build();
+
+        String ddl = new XuguCreateTableSqlBuilder(
+                path,
+                table,
+                new XuguTypeMapper())
+                .build();
+
+        assertTrue(ddl.contains("\"PAYLOAD\" JSON"));
+        assertTrue(ddl.contains("\"FLAGS\" BIT(8)"));
+        assertTrue(ddl.contains("\"AMOUNT\" CLOB"));
+        assertTrue(ddl.contains("\"EVENT_AT\" VARCHAR(64)"));
+        assertTrue(ddl.contains("\"ITEMS\" CLOB"));
+        assertTrue(ddl.contains("\"RID\" CLOB"));
+    }
+
+    @Test
+    public void longMultibytePrimaryKeyNameStaysWithinXuguByteLimit() {
+        StringBuilder name = new StringBuilder("PK_");
+        for (int i = 0; i < 80; i++) {
+            name.append('主');
+        }
+
+        TablePath path = TablePath.of("SYSTEM", "APP", "LONG_KEYS");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("ID", BasicType.LONG_TYPE).build())
+                .primaryKey(PrimaryKey.of(name.toString(), Arrays.asList("ID")))
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema).build();
+
+        String ddl = new XuguCreateTableSqlBuilder(
+                path,
+                table,
+                new XuguTypeMapper())
+                .build();
+
+        String marker = "CONSTRAINT \"";
+        int start = ddl.indexOf(marker) + marker.length();
+        int end = ddl.indexOf("\" PRIMARY KEY", start);
+        String constraintName = ddl.substring(start, end);
+        assertTrue(constraintName.getBytes(StandardCharsets.UTF_8).length <= 127);
+        assertTrue(constraintName.matches(".*_[0-9a-f]{8}$"));
+    }
+
+    @Test
+    public void escapesCommentLiterals() {
+        TablePath path = TablePath.of("SYSTEM", "APP", "NOTES");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("BODY", BasicType.STRING_TYPE)
+                        .length(64L)
+                        .comment("doctor's note")
+                        .build())
+                .build();
+        CatalogTable table = CatalogTable.builder(path, schema)
+                .comment("team's notes")
+                .build();
+
+        String ddl = new XuguCreateTableSqlBuilder(
+                path,
+                table,
+                new XuguTypeMapper())
+                .build();
+
+        assertTrue(ddl.contains("IS 'team''s notes'"));
+        assertTrue(ddl.contains("IS 'doctor''s note'"));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialectTest.java
@@ -99,6 +99,43 @@ public class XuguDialectTest {
     }
 
     @Test
+    public void connectorSchemaBecomesQuotedCurrentSchemaConnectionDefault() {
+        XuguDialect dialect = new XuguDialect(config(
+                "AppSchema",
+                null,
+                baseUrl(),
+                null));
+
+        assertEquals(
+                "\"AppSchema\"",
+                dialect.defaultConnectionProperties().get("current_schema"));
+    }
+
+    @Test
+    public void urlCurrentSchemaIsNotOverriddenByConnectorSchemaDefault() {
+        XuguDialect dialect = new XuguDialect(config(
+                "FROM_CONNECTOR",
+                null,
+                baseUrl() + "?current_schema=FROM_URL",
+                null));
+
+        assertFalse(dialect.defaultConnectionProperties().containsKey("current_schema"));
+    }
+
+    @Test
+    public void propertyCurrentSchemaIsNotOverriddenByConnectorSchemaDefault() {
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put("current_schema", "FROM_PROPERTIES");
+        XuguDialect dialect = new XuguDialect(config(
+                "FROM_CONNECTOR",
+                null,
+                baseUrl(),
+                properties));
+
+        assertFalse(dialect.defaultConnectionProperties().containsKey("current_schema"));
+    }
+
+    @Test
     public void usernameSchemaIsUsedWhenNoSchemaConfigured() {
         XuguDialect dialect = new XuguDialect(config(null, null, baseUrl(), null));
         assertEquals(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguDialectTest.java
@@ -1,0 +1,210 @@
+package com.link.up.connector.jdbc.core.dialect.xugu;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class XuguDialectTest {
+
+    @Test
+    public void loadsXuguDialectFromJdbcUrlThroughSpi() {
+        JdbcDialect dialect = JdbcDialectLoader.load(config(null, null, baseUrl(), null));
+        assertEquals(DatabaseIdentifier.XUGU, dialect.name());
+    }
+
+    @Test
+    public void defaultModeUppercasesUnquotedIdentifiersAndPreservesQuotedCase() {
+        XuguDialect dialect = dialect("APP", null);
+        assertEquals(
+                TablePath.of(null, "APP", "ORDERS"),
+                dialect.parseTablePath("app.orders"));
+        assertEquals(
+                TablePath.of(null, "App", "Orders"),
+                dialect.parseTablePath("\"App\".\"Orders\""));
+    }
+
+    @Test
+    public void postgresModeLowercasesAndMysqlModePreservesIdentifiers() {
+        assertEquals(
+                TablePath.of(null, "app", "orders"),
+                dialect("app", "POSTGRESQL").parseTablePath("APP.Orders"));
+        assertEquals(
+                TablePath.of(null, "App", "Orders"),
+                dialect("App", "MYSQL").parseTablePath("App.Orders"));
+    }
+
+    @Test
+    public void currentDatabaseThreePartPathIsAccepted() {
+        assertEquals(
+                TablePath.of("SYSTEM", "APP", "ORDERS"),
+                dialect("SYSDBA", null)
+                        .parseTablePath("system.app.orders"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void foreignDatabaseThreePartPathIsRejected() {
+        dialect("SYSDBA", null).parseTablePath("other.app.orders");
+    }
+
+    @Test
+    public void urlCurrentSchemaHasHighestPrecedence() {
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put("current_schema", "FROM_PROPERTIES");
+        XuguDialect dialect = new XuguDialect(config(
+                "FROM_CONNECTOR",
+                null,
+                baseUrl() + "?current_schema=FROM_URL",
+                properties));
+        assertEquals(
+                "\"FROM_URL\".\"ORDERS\"",
+                dialect.tableIdentifier(TablePath.of("ORDERS")));
+    }
+
+    @Test
+    public void defaultModeFoldsLowercaseUrlCurrentSchemaToUppercase() {
+        XuguDialect dialect = new XuguDialect(config(
+                null,
+                null,
+                baseUrl() + "?current_schema=app_schema",
+                null));
+        assertEquals(
+                "\"APP_SCHEMA\".\"ORDERS\"",
+                dialect.tableIdentifier(TablePath.of("ORDERS")));
+    }
+
+    @Test
+    public void quotedUrlCurrentSchemaPreservesExactCase() {
+        XuguDialect dialect = new XuguDialect(config(
+                null,
+                null,
+                baseUrl() + "?current_schema=%22AppSchema%22",
+                null));
+        assertEquals(
+                "\"AppSchema\".\"ORDERS\"",
+                dialect.tableIdentifier(TablePath.of("ORDERS")));
+    }
+
+    @Test
+    public void usernameSchemaIsUsedWhenNoSchemaConfigured() {
+        XuguDialect dialect = new XuguDialect(config(null, null, baseUrl(), null));
+        assertEquals(
+                "\"SYSDBA\".\"ORDERS\"",
+                dialect.tableIdentifier(TablePath.of("ORDERS")));
+    }
+
+    @Test
+    public void postgresModeNormalizesUsernameDefaultSchema() {
+        XuguDialect dialect = new XuguDialect(
+                configWithUsername(null, "POSTGRESQL", "AppUser"));
+        assertEquals(
+                "\"appuser\".\"orders\"",
+                dialect.tableIdentifier(dialect.parseTablePath("orders")));
+    }
+
+    @Test
+    public void buildsMergeUpsertWithJdbcPlaceholders() {
+        String sql = dialect("APP", null).buildUpsertSql(
+                TablePath.of("SYSTEM", "APP", "USERS"),
+                Arrays.asList("ID", "NAME"),
+                Arrays.asList("ID")).get();
+
+        assertTrue(sql.startsWith(
+                "MERGE INTO \"APP\".\"USERS\" TARGET USING (SELECT ? \"ID\", ? \"NAME\" FROM DUAL) SOURCE"));
+        assertTrue(sql.contains(
+                "ON (TARGET.\"ID\"=SOURCE.\"ID\")"));
+        assertTrue(sql.contains(
+                "WHEN MATCHED THEN UPDATE SET TARGET.\"NAME\"=SOURCE.\"NAME\""));
+        assertTrue(sql.contains(
+                "WHEN NOT MATCHED THEN INSERT (\"ID\", \"NAME\") VALUES (SOURCE.\"ID\", SOURCE.\"NAME\")"));
+        assertFalse(sql.contains("TARGET.\"ID\"=SOURCE.\"ID\", TARGET.\"NAME\""));
+    }
+
+    @Test
+    public void primaryKeyOnlyMergeUsesInsertOnlyBranch() {
+        String sql = dialect("APP", null).buildUpsertSql(
+                TablePath.of("SYSTEM", "APP", "USERS"),
+                Arrays.asList("ID"),
+                Arrays.asList("ID")).get();
+        assertFalse(sql.contains("WHEN MATCHED THEN UPDATE"));
+        assertTrue(sql.contains(
+                "WHEN NOT MATCHED THEN INSERT (\"ID\") VALUES (SOURCE.\"ID\")"));
+    }
+
+    @Test
+    public void stringHashPartitionRemainsUnsupported() {
+        Column column = Column.builder("CODE", BasicType.STRING_TYPE).build();
+        assertFalse(dialect("APP", null)
+                .buildHashPartitionPredicate(column, 0, 4)
+                .isPresent());
+    }
+
+    @Test
+    public void parsesDatabaseSchemaAndUserFromUrl() {
+        String url = baseUrl()
+                + "?USER=guest&current_schema=analytics&compatiblemode=postgresql";
+        assertEquals("SYSTEM", XuguJdbcUrl.databaseName(url));
+        assertEquals("analytics", XuguJdbcUrl.currentSchema(url, null));
+        assertEquals("guest", XuguJdbcUrl.user(url, null));
+        assertEquals("postgresql", XuguJdbcUrl.compatibleMode(url, null));
+    }
+
+    private static XuguDialect dialect(String schema, String compatibleMode) {
+        return new XuguDialect(config(schema, compatibleMode, baseUrl(), null));
+    }
+
+    private static JdbcConnectionConfig config(
+            String schema,
+            String compatibleMode,
+            String url,
+            Map<String, String> properties) {
+        return configWithUsername(schema, compatibleMode, "SYSDBA", url, properties);
+    }
+
+    private static JdbcConnectionConfig configWithUsername(
+            String schema,
+            String compatibleMode,
+            String username) {
+        return configWithUsername(schema, compatibleMode, username, baseUrl(), null);
+    }
+
+    private static JdbcConnectionConfig configWithUsername(
+            String schema,
+            String compatibleMode,
+            String username,
+            String url,
+            Map<String, String> properties) {
+
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", "com.xugu.cloudjdbc.Driver");
+        values.put("username", username);
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (compatibleMode != null) {
+            values.put("compatible_mode", compatibleMode);
+        }
+        if (properties != null) {
+            values.put("properties", properties);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:xugu://127.0.0.1:5138/SYSTEM";
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguJdbcIntegrationTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguJdbcIntegrationTest.java
@@ -1,0 +1,308 @@
+package com.link.up.connector.jdbc.core.dialect.xugu;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.xugu.XuguCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.internal.JdbcConnectionProvider;
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Opt-in integration coverage for a real XuguDB instance.
+ *
+ * <p>The test is skipped unless {@code XUGU_JDBC_URL} is present. Typical
+ * environment variables:</p>
+ *
+ * <pre>
+ * XUGU_JDBC_URL=jdbc:xugu://127.0.0.1:5138/SYSTEM
+ * XUGU_JDBC_USER=SYSDBA
+ * XUGU_JDBC_PASSWORD=...
+ * XUGU_JDBC_SCHEMA=SYSDBA
+ * </pre>
+ */
+public class XuguJdbcIntegrationTest {
+
+    private static final String DRIVER = "com.xugu.cloudjdbc.Driver";
+
+    @Test
+    public void catalogMetadataMergeAndSessionSchemaRoundTrip() throws Exception {
+        String url = environment("XUGU_JDBC_URL");
+        Assume.assumeTrue("XUGU_JDBC_URL is not configured", hasText(url));
+
+        String username = environment("XUGU_JDBC_USER");
+        String password = environment("XUGU_JDBC_PASSWORD");
+        String schema = environment("XUGU_JDBC_SCHEMA");
+        String compatibleMode = environment("XUGU_COMPATIBLE_MODE");
+
+        Class.forName(DRIVER);
+        if (!hasText(schema)) {
+            try (Connection connection = openRawConnection(url, username, password);
+                 PreparedStatement statement =
+                         connection.prepareStatement("SELECT CURRENT_SCHEMA()");
+                 ResultSet rs = statement.executeQuery()) {
+                assertTrue(rs.next());
+                schema = rs.getString(1);
+            }
+        }
+        assertTrue("Unable to resolve Xugu current schema", hasText(schema));
+
+        String database = XuguJdbcUrl.databaseName(url);
+        assertNotNull(database);
+
+        String suffix = Long.toHexString(System.nanoTime())
+                .toUpperCase(Locale.ROOT);
+        String tableName = "XGIT" + suffix + "_A_B";
+        // When metadata table names are treated as LIKE patterns, _A_B also
+        // matches XAYB. Keeping a deliberate decoy makes the integration test
+        // catch wildcard leakage in getColumns/getTables.
+        String decoyName = "XGIT" + suffix + "XAYB";
+        TablePath tablePath = TablePath.of(database, schema, tableName);
+
+        Map<String, String> catalogProperties =
+                new LinkedHashMap<String, String>();
+        catalogProperties.put("useLike", "true");
+        if (hasText(compatibleMode)) {
+            catalogProperties.put("compatiblemode", compatibleMode);
+        }
+
+        JdbcCatalogConfig catalogConfig = new JdbcCatalogConfig(
+                url,
+                username,
+                password,
+                DRIVER,
+                catalogProperties,
+                false);
+        XuguCatalog catalog = new XuguCatalog(
+                "xugu-integration",
+                catalogConfig,
+                schema);
+
+        JdbcConnectionConfig connectionConfig = connectionConfig(
+                url,
+                username,
+                password,
+                schema,
+                compatibleMode);
+        XuguDialect dialect = new XuguDialect(connectionConfig);
+
+        try {
+            catalog.open();
+
+            TableSchema tableSchema = TableSchema.builder()
+                    .column(Column.builder("ID", BasicType.LONG_TYPE)
+                            .nullable(false)
+                            .build())
+                    .column(Column.builder("NAME", BasicType.STRING_TYPE)
+                            .length(64L)
+                            .build())
+                    .primaryKey(PrimaryKey.of(
+                            "PK_XGIT_" + suffix,
+                            Arrays.asList("ID")))
+                    .build();
+            catalog.createTable(
+                    CatalogTable.builder(tablePath, tableSchema).build(),
+                    false);
+
+            try (Connection connection = openRawConnection(url, username, password);
+                 Statement statement = connection.createStatement()) {
+                statement.execute(
+                        "CREATE TABLE " + qualified(schema, decoyName)
+                                + " (\"DECOY_ONLY\" INTEGER)");
+            }
+
+            assertTrue(catalog.tableExists(tablePath));
+            CatalogTable discovered = catalog.getTable(tablePath);
+            assertEquals(2, discovered.getTableSchema().getColumnCount());
+            assertTrue(discovered.getTableSchema().contains("ID"));
+            assertTrue(discovered.getTableSchema().contains("NAME"));
+            assertFalse(discovered.getTableSchema().contains("DECOY_ONLY"));
+
+            try (Connection connection = openRawConnection(url, username, password);
+                 PreparedStatement insert = connection.prepareStatement(
+                         "INSERT INTO " + qualified(schema, tableName)
+                                 + " (\"ID\", \"NAME\") VALUES (?, ?)")) {
+                insert.setLong(1, 1L);
+                insert.setString(2, "before");
+                insert.executeUpdate();
+            }
+
+            String mergeSql = dialect.buildUpsertSql(
+                    tablePath,
+                    Arrays.asList("ID", "NAME"),
+                    Collections.singletonList("ID"))
+                    .get();
+            try (Connection connection = openRawConnection(url, username, password);
+                 PreparedStatement merge = connection.prepareStatement(mergeSql)) {
+                merge.setLong(1, 1L);
+                merge.setString(2, "after");
+                merge.executeUpdate();
+            }
+
+            // The connector-level schema must also become the real Xugu session
+            // current_schema so user custom SQL can use unqualified table names.
+            try (JdbcConnectionProvider provider =
+                         new JdbcConnectionProvider(connectionConfig, dialect)) {
+                Connection connection = provider.getOrEstablishConnection();
+                try (PreparedStatement query = connection.prepareStatement(
+                        "SELECT \"NAME\" FROM " + quote(tableName)
+                                + " WHERE \"ID\" = 1");
+                     ResultSet rs = query.executeQuery()) {
+                    assertTrue(rs.next());
+                    assertEquals("after", rs.getString(1));
+                }
+            }
+        } finally {
+            catalog.close();
+            bestEffortDrop(url, username, password, schema, tableName);
+            bestEffortDrop(url, username, password, schema, decoyName);
+        }
+    }
+
+    @Test
+    public void optionalTimeFractionCheckDocumentsDriverBehavior() throws Exception {
+        String url = environment("XUGU_JDBC_URL");
+        boolean enabled = Boolean.parseBoolean(
+                environment("XUGU_IT_CHECK_TIME_PRECISION"));
+        Assume.assumeTrue(
+                "Set XUGU_IT_CHECK_TIME_PRECISION=true with XUGU_JDBC_URL to verify TIME(3)",
+                enabled && hasText(url));
+
+        String username = environment("XUGU_JDBC_USER");
+        String password = environment("XUGU_JDBC_PASSWORD");
+        String schema = environment("XUGU_JDBC_SCHEMA");
+        Class.forName(DRIVER);
+
+        if (!hasText(schema)) {
+            try (Connection connection = openRawConnection(url, username, password);
+                 PreparedStatement statement =
+                         connection.prepareStatement("SELECT CURRENT_SCHEMA()");
+                 ResultSet rs = statement.executeQuery()) {
+                assertTrue(rs.next());
+                schema = rs.getString(1);
+            }
+        }
+
+        String tableName = "XGITTIME"
+                + Long.toHexString(System.nanoTime()).toUpperCase(Locale.ROOT);
+        try {
+            try (Connection connection = openRawConnection(url, username, password);
+                 Statement statement = connection.createStatement()) {
+                statement.execute(
+                        "CREATE TABLE " + qualified(schema, tableName)
+                                + " (\"T\" TIME(3))");
+                statement.execute(
+                        "INSERT INTO " + qualified(schema, tableName)
+                                + " (\"T\") VALUES ('12:34:56.123')");
+            }
+
+            try (Connection connection = openRawConnection(url, username, password);
+                 PreparedStatement statement = connection.prepareStatement(
+                         "SELECT \"T\" FROM " + qualified(schema, tableName));
+                 ResultSet rs = statement.executeQuery()) {
+                assertTrue(rs.next());
+                assertEquals(
+                        "Xugu JDBC TIME(3) text output lost fractional precision",
+                        "12:34:56.123",
+                        rs.getString(1));
+            }
+        } finally {
+            bestEffortDrop(url, username, password, schema, tableName);
+        }
+    }
+
+    private static JdbcConnectionConfig connectionConfig(
+            String url,
+            String username,
+            String password,
+            String schema,
+            String compatibleMode) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", DRIVER);
+        if (hasText(username)) {
+            values.put("username", username);
+        }
+        if (password != null) {
+            values.put("password", password);
+        }
+        if (hasText(schema)) {
+            values.put("schema", schema);
+        }
+        if (hasText(compatibleMode)) {
+            values.put("compatible_mode", compatibleMode);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static Connection openRawConnection(
+            String url,
+            String username,
+            String password) throws SQLException {
+        Properties properties = new Properties();
+        if (hasText(username)) {
+            properties.setProperty("user", username);
+        }
+        if (password != null) {
+            properties.setProperty("password", password);
+        }
+        return DriverManager.getConnection(url, properties);
+    }
+
+    private static void bestEffortDrop(
+            String url,
+            String username,
+            String password,
+            String schema,
+            String tableName) {
+        if (!hasText(schema) || !hasText(tableName)) {
+            return;
+        }
+        try (Connection connection = openRawConnection(url, username, password);
+             Statement statement = connection.createStatement()) {
+            statement.execute("DROP TABLE " + qualified(schema, tableName));
+        } catch (Exception ignored) {
+            // Cleanup is best effort so the original integration assertion stays visible.
+        }
+    }
+
+    private static String qualified(String schema, String table) {
+        return quote(schema) + "." + quote(table);
+    }
+
+    private static String quote(String identifier) {
+        return "\"" + identifier.replace("\"", "\"\"") + "\"";
+    }
+
+    private static String environment(String key) {
+        return System.getenv(key);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/xugu/XuguTypeMapperTest.java
@@ -1,0 +1,195 @@
+package com.link.up.connector.jdbc.core.dialect.xugu;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import org.junit.Test;
+
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+
+public class XuguTypeMapperTest {
+
+    private final XuguTypeMapper mapper = new XuguTypeMapper();
+
+    @Test
+    public void supportsNumericPrecisionUpToThirtyEight() {
+        Column column = Column.builder("AMOUNT", new DecimalType(38, 18)).build();
+        assertEquals("NUMERIC(38,18)", mapper.toDatabaseType(column));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTargetNumericPrecisionAboveXuguLimit() {
+        mapper.toDatabaseType(
+                Column.builder("AMOUNT", new DecimalType(39, 18)).build());
+    }
+
+    @Test
+    public void unspecifiedNumericUsesXuguDefaultTwelveZero() {
+        assertEquals(
+                new DecimalType(12, 0),
+                mapper.mapType(Types.NUMERIC, "NUMERIC", 0, 0));
+    }
+
+    @Test
+    public void invalidSourceNumericShapesStayExactText() {
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.NUMERIC, "NUMERIC", 39, 2));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.NUMERIC, "NUMBER", 20, -2));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.NUMERIC, "DECIMAL", 10, 12));
+    }
+
+    @Test
+    public void bitFamiliesStayExactBitStrings() {
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.BIT, "BIT(8)", 8, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.OTHER, "VARBIT(60000)", 60000, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.OTHER, "BIT VARYING(64)", 64, 0));
+    }
+
+    @Test
+    public void mapsScalarAndCompatibilityAliases() {
+        assertEquals(
+                BasicType.BYTE_TYPE,
+                mapper.mapType(Types.TINYINT, "TINYINT", 3, 0));
+        assertEquals(
+                BasicType.SHORT_TYPE,
+                mapper.mapType(Types.SMALLINT, "SHORT", 5, 0));
+        assertEquals(
+                BasicType.INT_TYPE,
+                mapper.mapType(Types.INTEGER, "PLS_INTEGER", 10, 0));
+        assertEquals(
+                BasicType.LONG_TYPE,
+                mapper.mapType(Types.BIGINT, "LONGINT", 19, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.VARCHAR, "VARCHAR2", 255, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.OTHER, "JSON", 0, 0));
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(Types.OTHER, "GUID", 36, 0));
+    }
+
+    @Test
+    public void timezoneTypesNeverLoseOffsets() {
+        assertEquals(
+                BasicType.STRING_TYPE,
+                mapper.mapType(
+                        Types.TIME_WITH_TIMEZONE,
+                        "TIME WITH TIME ZONE",
+                        0,
+                        3));
+        assertEquals(
+                BasicType.TIMESTAMP_TZ_TYPE,
+                mapper.mapType(
+                        Types.TIMESTAMP_WITH_TIMEZONE,
+                        "TIMESTAMP WITH TIME ZONE",
+                        0,
+                        6));
+        assertEquals(
+                "VARCHAR(64)",
+                mapper.toDatabaseType(
+                        Column.builder("EVENT_TIME", BasicType.STRING_TYPE)
+                                .sourceType("TIME(3) WITH TIME ZONE")
+                                .build(),
+                        true));
+        assertEquals(
+                "VARCHAR(64)",
+                mapper.toDatabaseType(
+                        Column.builder("EVENT_AT", BasicType.TIMESTAMP_TZ_TYPE)
+                                .precision(6)
+                                .build()));
+    }
+
+    @Test
+    public void enforcesXuguTemporalPrecisionBounds() {
+        assertEquals(
+                "TIME(3)",
+                mapper.toDatabaseType(
+                        Column.builder("EVENT_TIME", BasicType.TIME_TYPE)
+                                .precision(3)
+                                .build()));
+        assertEquals(
+                "TIMESTAMP(6)",
+                mapper.toDatabaseType(
+                        Column.builder("CREATED_AT", BasicType.TIMESTAMP_TYPE)
+                                .precision(6)
+                                .build()));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTimePrecisionAboveThree() {
+        mapper.toDatabaseType(
+                Column.builder("EVENT_TIME", BasicType.TIME_TYPE)
+                        .precision(4)
+                        .build());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTimestampPrecisionAboveSix() {
+        mapper.toDatabaseType(
+                Column.builder("CREATED_AT", BasicType.TIMESTAMP_TYPE)
+                        .precision(7)
+                        .build());
+    }
+
+    @Test
+    public void usesLobsBeyondBoundedFieldLimits() {
+        assertEquals(
+                "VARCHAR(60000)",
+                mapper.toDatabaseType(
+                        Column.builder("TEXT_VALUE", BasicType.STRING_TYPE)
+                                .length(60000L)
+                                .build()));
+        assertEquals(
+                "CLOB",
+                mapper.toDatabaseType(
+                        Column.builder("TEXT_VALUE", BasicType.STRING_TYPE)
+                                .length(60001L)
+                                .build()));
+        assertEquals(
+                "BINARY(60000)",
+                mapper.toDatabaseType(
+                        Column.builder("BIN_VALUE", BasicType.BYTES_TYPE)
+                                .length(60000L)
+                                .build()));
+        assertEquals(
+                "BLOB",
+                mapper.toDatabaseType(
+                        Column.builder("BIN_VALUE", BasicType.BYTES_TYPE)
+                                .length(60001L)
+                                .build()));
+    }
+
+    @Test
+    public void preservesSafeSameDialectTypesButNotTimezoneOrInvalidNumeric() {
+        Column json = Column.builder("PAYLOAD", BasicType.STRING_TYPE)
+                .sourceType("JSON")
+                .build();
+        assertEquals("JSON", mapper.toDatabaseType(json, true));
+
+        Column badNumeric = Column.builder("AMOUNT", BasicType.STRING_TYPE)
+                .sourceType("NUMERIC(39,2)")
+                .build();
+        assertEquals("CLOB", mapper.toDatabaseType(badNumeric, true));
+
+        Column timestampTz = Column.builder("EVENT_AT", BasicType.TIMESTAMP_TZ_TYPE)
+                .sourceType("TIMESTAMP(6) WITH TIME ZONE")
+                .precision(6)
+                .build();
+        assertEquals("VARCHAR(64)", mapper.toDatabaseType(timestampTz, true));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/JdbcXuguTargetPathTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/JdbcXuguTargetPathTest.java
@@ -1,0 +1,127 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class JdbcXuguTargetPathTest {
+
+    @Test
+    public void sourceDatabaseAndSchemaDoNotLeakIntoXuguTarget() {
+        TablePath target = XuguSinkSupport.resolveTargetPath(
+                config(null, null, baseUrl(), "SYSDBA", null),
+                TablePath.of("source_db", "public", "orders"));
+
+        assertEquals(
+                TablePath.of("SYSTEM", "SYSDBA", "orders"),
+                target);
+    }
+
+    @Test
+    public void explicitTargetSchemaWithoutDatabaseIsPreserved() {
+        TablePath target = XuguSinkSupport.resolveTargetPath(
+                config("App", null, baseUrl(), "SYSDBA", null),
+                TablePath.of("source_db", "public", "orders"));
+
+        assertEquals(
+                TablePath.of("SYSTEM", "App", "orders"),
+                target);
+    }
+
+    @Test
+    public void explicitMappedTargetSchemaIsPreserved() {
+        TablePath target = XuguSinkSupport.resolveTargetPath(
+                config("TARGET", null, baseUrl(), "SYSDBA", null),
+                TablePath.of(null, "APP", "orders"));
+
+        assertEquals(
+                TablePath.of("SYSTEM", "APP", "orders"),
+                target);
+    }
+
+    @Test
+    public void urlCurrentSchemaHasHighestPrecedenceForUnqualifiedTarget() {
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put("current_schema", "FROM_PROPERTIES");
+        TablePath target = XuguSinkSupport.resolveTargetPath(
+                config(
+                        "FROM_CONNECTOR",
+                        null,
+                        baseUrl() + "?current_schema=from_url",
+                        "SYSDBA",
+                        properties),
+                TablePath.of("orders"));
+
+        assertEquals(
+                TablePath.of("SYSTEM", "FROM_URL", "orders"),
+                target);
+    }
+
+    @Test
+    public void postgresModeNormalizesUsernameFallbackToLowercase() {
+        TablePath target = XuguSinkSupport.resolveTargetPath(
+                config(null, "POSTGRESQL", baseUrl(), "AppUser", null),
+                TablePath.of("orders"));
+
+        assertEquals(
+                TablePath.of("SYSTEM", "appuser", "orders"),
+                target);
+    }
+
+    @Test
+    public void mysqlModePreservesUsernameFallbackSpelling() {
+        TablePath target = XuguSinkSupport.resolveTargetPath(
+                config(null, "MYSQL", baseUrl(), "AppUser", null),
+                TablePath.of("orders"));
+
+        assertEquals(
+                TablePath.of("SYSTEM", "AppUser", "orders"),
+                target);
+    }
+
+    @Test
+    public void defaultModeUppercasesUsernameFallback() {
+        TablePath target = XuguSinkSupport.resolveTargetPath(
+                config(null, null, baseUrl(), "appuser", null),
+                TablePath.of("orders"));
+
+        assertEquals(
+                TablePath.of("SYSTEM", "APPUSER", "orders"),
+                target);
+    }
+
+    private static JdbcConnectionConfig config(
+            String schema,
+            String compatibleMode,
+            String url,
+            String username,
+            Map<String, String> properties) {
+
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", "com.xugu.cloudjdbc.Driver");
+        if (username != null) {
+            values.put("username", username);
+        }
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (compatibleMode != null) {
+            values.put("compatible_mode", compatibleMode);
+        }
+        if (properties != null) {
+            values.put("properties", properties);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:xugu://127.0.0.1:5138/SYSTEM";
+    }
+}


### PR DESCRIPTION
## Summary

Completes another hardening pass for the XuguDB offline JDBC connector before merging into `main`.

### Xugu offline connector
- add Xugu JDBC dependency and dialect/catalog/source/sink integration
- support Xugu JDBC URL recognition, catalog discovery, type mapping, DDL and MERGE-based upsert
- keep complex/native types on conservative loss-aware fallback paths where Flux has no equivalent type

### Hardening in this pass
- make Xugu metadata lookup exact even when `useLike=true`
  - escape JDBC metadata wildcard characters (`%`, `_`, search escape)
  - verify returned `TABLE_SCHEM` / `TABLE_NAME` before consuming metadata rows
  - keep table/column listing compatible with explicit `useLike=false`
- reject foreign-database `TablePath` values in `XuguCatalog` instead of silently rewriting them to the URL database
- align Xugu connector-level `schema` with the runtime JDBC `current_schema` for unqualified custom SQL
- make custom-query schema discovery reuse `JdbcConnectionProvider` + dialect-resolved connection properties, matching runtime reader behavior
- execute Xugu DDL with `Statement` instead of `PreparedStatement` because Xugu JDBC documents DDL as unsupported through `PreparedStatement`

### Tests
- extend Xugu dialect tests for `current_schema` precedence/defaults
- add metadata-pattern escaping regression tests
- add an opt-in real-Xugu integration test covering:
  - catalog open/create/discovery
  - wildcard-safe metadata lookup using a deliberately matching decoy table
  - MERGE upsert round trip
  - unqualified query resolution through connector `schema` / session `current_schema`
- add a separate opt-in strict `TIME(3)` round-trip check via `XUGU_IT_CHECK_TIME_PRECISION=true`

## Validation status

- GitHub reports the PR as mergeable with `main`.
- No GitHub Actions workflow run or commit status is currently returned for this head commit, so this PR does **not** claim Maven/CI validation.
- The real database integration tests are skipped unless `XUGU_JDBC_URL` is configured, so this PR does **not** claim real-instance verification yet.

## Real Xugu test environment

Example variables:

```bash
XUGU_JDBC_URL=jdbc:xugu://127.0.0.1:5138/SYSTEM
XUGU_JDBC_USER=SYSDBA
XUGU_JDBC_PASSWORD=...
XUGU_JDBC_SCHEMA=SYSDBA
```

Optional strict TIME precision validation:

```bash
XUGU_IT_CHECK_TIME_PRECISION=true
```

## Remaining non-blocking scope

- `jdbc:xugu:file://...` listener-file URL form is not implemented in this pass
- ARRAY / INTERVAL / spatial/native types without Flux equivalents remain conservative text/LOB fallbacks rather than full native-type round trips
- `TIME(1..3)` remains explicitly gated behind the real-driver precision check before being treated as verified
