### PR TITLE
feat(starrocks): add native source connector

### DIFF
--- a/CONNECTOR_ADAPTATION.md
+++ b/CONNECTOR_ADAPTATION.md
@@ -33,6 +33,21 @@ Yak Link Up 优先复用已有执行模型，再增加数据库差异层。新�
    - CREATE TABLE。
    - 确认已有数据库方言没有回归。
 
+## Native OLAP Connector
+
+当数据库提供的原生批量协议明显不同于 JDBC 执行模型，并且这些协议是 Connector 正确性或性能语义的一部分时，可以使用独立 Connector，而不是把原生协议塞进 `link-up-connector-jdbc`。
+
+StarRocks 使用独立的 `link-up-connector-starrocks`：
+
+- Native Source 通过 FE `/_query_plan` 获取 opaque query plan 和 Tablet 路由。
+- Source Split 绑定 BE 与 Tablet 集合，Reader 通过 StarRocks Thrift Scanner 直接读取 BE。
+- BE 返回 Apache Arrow，Connector 在边界内转换为 `FluxRow`。
+- StarRocks Source 不依赖 JDBC / MySQL Driver，也不复用 JDBC Split Planner。
+- Stage 1 只处理 bounded full read；Schema 由任务显式声明，复杂类型在没有安全映射前明确失败。
+- Stage 2 的 Sink 使用 StarRocks Stream Load，并继续留在同一个独立 Connector 模块中，不回落到 JDBC batch insert。
+
+这种例外是协议边界，不是为数据库复制通用执行框架。Source 仍复用 Link-Up 的 `SourceSplitEnumerator`、动态 Split 分配、`SourceReader`、Channel、Metrics 和 Job 生命周期。
+
 ## 数据库差异不要强行抹平
 
 适配时保留真正影响正确性的差异。例如 PostgreSQL cursor fetch 需要事务；Oracle `DATE` 包含时分秒、UPSERT 使用 `MERGE`；SQL Server 使用 `database.schema.table`，`timestamp` 实际是 `rowversion`，`tinyint` 是 0~255，`datetimeoffset` 需要保留时区偏移。

--- a/link-up-connectors/link-up-connector-starrocks/README.md
+++ b/link-up-connectors/link-up-connector-starrocks/README.md
@@ -1,0 +1,105 @@
+# Link-Up StarRocks Connector
+
+`link-up-connector-starrocks` 是独立的 StarRocks Connector，不依赖 `link-up-connector-jdbc`。
+
+## Stage 1: Native Source
+
+当前实现只包含 bounded Native Source：
+
+```text
+StarRocksSource
+  -> FE POST /api/{database}/{table}/_query_plan
+  -> opaqued query plan + tablet routings
+  -> deterministic tablet/BE splits
+  -> BE Thrift open_scanner/get_next/close_scanner
+  -> Apache Arrow
+  -> FluxRow
+```
+
+Stage 1 支持：
+
+- 单表和多表 bounded read
+- 显式 `schema.fields`
+- 列投影
+- `scan_filter` 下推
+- Tablet Split 和 BE 并行读取
+- FE Query Plan failover/retry
+- BE Scanner batch / timeout / keep-alive / memory 参数
+- 标量类型 Arrow -> FluxRow 转换
+
+Stage 1 不包含：
+
+- JDBC fallback
+- Stream Load Sink（Stage 2）
+- CDC / streaming
+- 运行时 schema evolution
+- Native Catalog 自动 Schema 发现
+- ARRAY / MAP 的 Arrow 转换
+
+## Single table example
+
+```hocon
+source {
+  StarRocks {
+    node_urls = ["127.0.0.1:8030"]
+    username = "root"
+    password = ""
+    database = "demo"
+    table = "orders"
+
+    scan_filter = "id >= 100"
+    request_tablet_size = 8
+    scan_batch_rows = 4096
+
+    schema {
+      fields {
+        id = BIGINT
+        order_no = STRING
+        amount = "DECIMAL(18,2)"
+        created_at = DATETIME
+      }
+    }
+  }
+}
+```
+
+## Multiple tables example
+
+```hocon
+source {
+  StarRocks {
+    node_urls = ["fe-1:8030", "fe-2:8030"]
+    username = "root"
+    password = ""
+    database = "demo"
+
+    table_list = [
+      {
+        table = "orders"
+        scan_filter = "status = 'PAID'"
+        schema = {
+          fields = {
+            id = BIGINT
+            amount = "DECIMAL(18,2)"
+          }
+        }
+      },
+      {
+        table = "customers"
+        schema = {
+          fields = {
+            id = BIGINT
+            name = STRING
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+## Type boundary
+
+Stage 1 intentionally keeps the Native Source type boundary conservative. Core scalar StarRocks types are mapped to Flux types, including `BOOLEAN`, integer types, `LARGEINT`, `FLOAT`, `DOUBLE`, `DECIMAL`, string types, `JSON`, `DATE` and `DATETIME`.
+
+`ARRAY` and `MAP` fail during configuration instead of being silently converted to an unsafe representation. They can be added later with dedicated Arrow conversion tests.

--- a/link-up-connectors/link-up-connector-starrocks/pom.xml
+++ b/link-up-connectors/link-up-connector-starrocks/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.link.up</groupId>
+        <artifactId>link-up-connectors</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>link-up-connector-starrocks</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto-service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>starrocks-thrift-sdk</artifactId>
+            <version>${starrocks.thrift.sdk.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/StarRocksBeReadClient.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/StarRocksBeReadClient.java
@@ -1,0 +1,196 @@
+package com.link.up.connector.starrocks.client.source;
+
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.FluxRowType;
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPartition;
+import com.link.up.connector.starrocks.config.StarRocksSourceConfig;
+import com.link.up.connector.starrocks.converter.StarRocksArrowRowReader;
+import com.starrocks.shade.org.apache.thrift.TException;
+import com.starrocks.shade.org.apache.thrift.protocol.TBinaryProtocol;
+import com.starrocks.shade.org.apache.thrift.protocol.TProtocol;
+import com.starrocks.shade.org.apache.thrift.transport.TSocket;
+import com.starrocks.thrift.TScanBatchResult;
+import com.starrocks.thrift.TScanCloseParams;
+import com.starrocks.thrift.TScanNextBatchParams;
+import com.starrocks.thrift.TScanOpenParams;
+import com.starrocks.thrift.TScanOpenResult;
+import com.starrocks.thrift.TStarrocksExternalService;
+import com.starrocks.thrift.TStatusCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Task-local Thrift client for StarRocks BE native scanner. */
+public final class StarRocksBeReadClient implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StarRocksBeReadClient.class);
+    private static final String DEFAULT_CLUSTER_NAME = "default_cluster";
+
+    private final StarRocksSourceConfig config;
+    private final StarRocksQueryPartition partition;
+    private final FluxRowType rowType;
+
+    private TSocket socket;
+    private TStarrocksExternalService.Client client;
+    private String contextId;
+    private int readerOffset;
+    private boolean eos;
+    private List<FluxRow> currentRows = Collections.emptyList();
+    private int currentRowIndex;
+
+    public StarRocksBeReadClient(
+            StarRocksSourceConfig config,
+            StarRocksQueryPartition partition,
+            FluxRowType rowType) {
+        this.config = config;
+        this.partition = partition;
+        this.rowType = rowType;
+    }
+
+    public void open() throws Exception {
+        String[] hostPort = parseBeAddress(partition.getBeAddress());
+        String host = hostPort[0];
+        int port = Integer.parseInt(hostPort[1]);
+
+        socket =
+                new TSocket(
+                        host,
+                        port,
+                        config.getConnectTimeoutMs(),
+                        config.getConnectTimeoutMs());
+        socket.open();
+        TProtocol protocol = new TBinaryProtocol.Factory().getProtocol(socket);
+        client = new TStarrocksExternalService.Client(protocol);
+
+        TScanOpenParams params = new TScanOpenParams();
+        params.setTablet_ids(new ArrayList<Long>(partition.getTabletIds()));
+        params.setOpaqued_query_plan(partition.getOpaquedQueryPlan());
+        params.setCluster(DEFAULT_CLUSTER_NAME);
+        params.setDatabase(partition.getDatabase());
+        params.setTable(partition.getTable());
+        params.setUser(config.getUsername());
+        params.setPasswd(config.getPassword());
+        params.setBatch_size(config.getBatchRows());
+        params.setKeep_alive_min((short) Math.min(Short.MAX_VALUE, config.getKeepAliveMin()));
+        params.setQuery_timeout(config.getQueryTimeoutSec());
+        params.setMem_limit(config.getMemLimit());
+        if (!config.getScanParams().isEmpty()) {
+            params.setProperties(config.getScanParams());
+        }
+
+        TScanOpenResult result = client.open_scanner(params);
+        ensureOk("open_scanner", result == null ? null : result.getStatus());
+        if (result == null || result.getContext_id() == null || result.getContext_id().trim().isEmpty()) {
+            throw new IOException("StarRocks BE open_scanner returned an empty context id");
+        }
+
+        contextId = result.getContext_id();
+        readerOffset = 0;
+        eos = false;
+        currentRows = Collections.emptyList();
+        currentRowIndex = 0;
+
+        LOG.info(
+                "Opened StarRocks native scanner: table={}.{}, be={}, tablets={}, contextId={}",
+                partition.getDatabase(),
+                partition.getTable(),
+                partition.getBeAddress(),
+                partition.getTabletIds().size(),
+                contextId);
+    }
+
+    public boolean hasNext() throws Exception {
+        while (currentRowIndex >= currentRows.size() && !eos) {
+            fetchNextBatch();
+        }
+        return currentRowIndex < currentRows.size();
+    }
+
+    public FluxRow next() throws Exception {
+        if (!hasNext()) {
+            throw new IllegalStateException("No more StarRocks rows in current split");
+        }
+        return currentRows.get(currentRowIndex++);
+    }
+
+    private void fetchNextBatch() throws Exception {
+        TScanNextBatchParams params = new TScanNextBatchParams();
+        params.setContext_id(contextId);
+        params.setOffset(readerOffset);
+
+        TScanBatchResult result = client.get_next(params);
+        ensureOk("get_next", result == null ? null : result.getStatus());
+        if (result == null) {
+            throw new IOException("StarRocks BE get_next returned null result");
+        }
+
+        eos = result.isEos();
+        byte[] payload = result.getRows();
+        currentRows =
+                payload == null || payload.length == 0
+                        ? Collections.<FluxRow>emptyList()
+                        : StarRocksArrowRowReader.read(payload, rowType);
+        currentRowIndex = 0;
+        readerOffset += currentRows.size();
+    }
+
+    private static void ensureOk(String operation, com.starrocks.thrift.TStatus status)
+            throws IOException {
+        if (status == null || status.getStatus_code() != TStatusCode.OK) {
+            throw new IOException(
+                    "StarRocks BE "
+                            + operation
+                            + " failed: status="
+                            + (status == null ? "null" : status.getStatus_code())
+                            + ", errors="
+                            + (status == null ? "[]" : status.getError_msgs()));
+        }
+    }
+
+    private static String[] parseBeAddress(String address) {
+        if (address == null) {
+            throw new IllegalArgumentException("BE address must not be null");
+        }
+        String value = address.trim();
+        int separator = value.lastIndexOf(':');
+        if (separator <= 0 || separator == value.length() - 1) {
+            throw new IllegalArgumentException(
+                    "Illegal StarRocks BE address, expected host:port: " + address);
+        }
+        return new String[]{value.substring(0, separator), value.substring(separator + 1)};
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        if (client != null && contextId != null) {
+            TScanCloseParams params = new TScanCloseParams();
+            params.setContext_id(contextId);
+            try {
+                client.close_scanner(params);
+            } catch (TException e) {
+                failure = e;
+                LOG.warn(
+                        "Failed to close StarRocks scanner: be={}, contextId={}",
+                        partition.getBeAddress(),
+                        contextId,
+                        e);
+            }
+        }
+        if (socket != null) {
+            socket.close();
+        }
+        client = null;
+        socket = null;
+        contextId = null;
+        currentRows = Collections.emptyList();
+        currentRowIndex = 0;
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/StarRocksQueryPlanClient.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/StarRocksQueryPlanClient.java
@@ -1,0 +1,212 @@
+package com.link.up.connector.starrocks.client.source;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPlan;
+import com.link.up.connector.starrocks.config.StarRocksSourceConfig;
+import com.link.up.connector.starrocks.config.StarRocksSourceTableConfig;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/** Obtains opaque native scan plans from StarRocks FE over HTTP. */
+public final class StarRocksQueryPlanClient implements AutoCloseable {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(StarRocksQueryPlanClient.class);
+
+    private static final MediaType JSON =
+            MediaType.parse("application/json; charset=utf-8");
+
+    private final StarRocksSourceConfig config;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final OkHttpClient httpClient;
+
+    public StarRocksQueryPlanClient(StarRocksSourceConfig config) {
+        this.config = config;
+        long readTimeoutMs =
+                config.getQueryTimeoutSec() < 0
+                        ? 0L
+                        : Math.max(1000L, config.getQueryTimeoutSec() * 1000L);
+        OkHttpClient.Builder builder =
+                new OkHttpClient.Builder()
+                        .connectTimeout(config.getConnectTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .writeTimeout(config.getConnectTimeoutMs(), TimeUnit.MILLISECONDS);
+        if (readTimeoutMs == 0L) {
+            builder.readTimeout(0L, TimeUnit.MILLISECONDS);
+        } else {
+            builder.readTimeout(readTimeoutMs, TimeUnit.MILLISECONDS);
+        }
+        this.httpClient = builder.build();
+    }
+
+    public StarRocksQueryPlan fetchQueryPlan(
+            StarRocksSourceTableConfig tableConfig) throws IOException {
+
+        String sql = buildQuerySql(tableConfig);
+        String requestBody =
+                objectMapper.writeValueAsString(
+                        java.util.Collections.singletonMap("sql", sql));
+
+        IOException lastFailure = null;
+        int attempts = Math.max(1, config.getMaxRetries() + 1);
+        List<String> nodes = config.getNodeUrls();
+
+        for (int attempt = 0; attempt < attempts; attempt++) {
+            String node = nodes.get(attempt % nodes.size());
+            String url =
+                    normalizeHttpNode(node)
+                            + "/api/"
+                            + tableConfig.getDatabase()
+                            + "/"
+                            + tableConfig.getTable()
+                            + "/_query_plan";
+
+            Request request =
+                    new Request.Builder()
+                            .url(url)
+                            .header("Authorization", basicAuth())
+                            .header("Accept", "application/json")
+                            .post(
+                                    RequestBody.create(
+                                            requestBody.getBytes(StandardCharsets.UTF_8),
+                                            JSON))
+                            .build();
+
+            try (Response response = httpClient.newCall(request).execute()) {
+                ResponseBody body = response.body();
+                String responseText = body == null ? "" : body.string();
+                if (!response.isSuccessful()) {
+                    throw new IOException(
+                            "StarRocks FE query-plan request failed: httpStatus="
+                                    + response.code()
+                                    + ", node="
+                                    + node
+                                    + ", body="
+                                    + abbreviate(responseText, 1000));
+                }
+
+                StarRocksQueryPlan plan =
+                        objectMapper.readValue(responseText, StarRocksQueryPlan.class);
+                validatePlan(plan, tableConfig, node);
+                return plan;
+            } catch (IOException failure) {
+                lastFailure = failure;
+                LOG.warn(
+                        "StarRocks FE query-plan request failed: table={}.{}, node={}, attempt={}/{}, error={}",
+                        tableConfig.getDatabase(),
+                        tableConfig.getTable(),
+                        node,
+                        attempt + 1,
+                        attempts,
+                        failure.getMessage());
+            }
+        }
+
+        throw new IOException(
+                "Unable to obtain StarRocks query plan for "
+                        + tableConfig.getDatabase()
+                        + "."
+                        + tableConfig.getTable()
+                        + " after "
+                        + attempts
+                        + " attempts",
+                lastFailure);
+    }
+
+    static String buildQuerySql(StarRocksSourceTableConfig tableConfig) {
+        List<String> fields = new ArrayList<String>();
+        for (Column column : tableConfig.getCatalogTable().getTableSchema().getColumns()) {
+            fields.add(quoteIdentifier(column.getName()));
+        }
+        if (fields.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "StarRocks Native Source requires at least one projected field");
+        }
+
+        StringBuilder sql = new StringBuilder();
+        sql.append("SELECT ")
+                .append(String.join(", ", fields))
+                .append(" FROM ")
+                .append(quoteIdentifier(tableConfig.getDatabase()))
+                .append('.')
+                .append(quoteIdentifier(tableConfig.getTable()));
+        if (hasText(tableConfig.getScanFilter())) {
+            sql.append(" WHERE ").append(tableConfig.getScanFilter().trim());
+        }
+        return sql.toString();
+    }
+
+    private void validatePlan(
+            StarRocksQueryPlan plan,
+            StarRocksSourceTableConfig table,
+            String node) throws IOException {
+        if (plan == null || !hasText(plan.getOpaquedQueryPlan())) {
+            throw new IOException(
+                    "StarRocks FE returned an invalid query plan: table="
+                            + table.getDatabase()
+                            + "."
+                            + table.getTable()
+                            + ", node="
+                            + node);
+        }
+        if (plan.getPartitions() == null) {
+            throw new IOException(
+                    "StarRocks FE query plan does not contain partitions: table="
+                            + table.getDatabase()
+                            + "."
+                            + table.getTable());
+        }
+    }
+
+    private String basicAuth() {
+        String credentials = config.getUsername() + ":" + config.getPassword();
+        return "Basic "
+                + Base64.getEncoder()
+                        .encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String normalizeHttpNode(String node) {
+        String value = node.trim();
+        if (!value.startsWith("http://") && !value.startsWith("https://")) {
+            value = "http://" + value;
+        }
+        while (value.endsWith("/")) {
+            value = value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+
+    private static String quoteIdentifier(String value) {
+        return "`" + value.replace("`", "``") + "`";
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private static String abbreviate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength) + "...";
+    }
+
+    @Override
+    public void close() {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/StarRocksSplitPlanner.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/StarRocksSplitPlanner.java
@@ -1,0 +1,141 @@
+package com.link.up.connector.starrocks.client.source;
+
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPartition;
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPlan;
+import com.link.up.connector.starrocks.client.source.model.StarRocksTablet;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/** Converts FE tablet routing into deterministic BE-bound native scan partitions. */
+public final class StarRocksSplitPlanner {
+
+    private StarRocksSplitPlanner() {
+    }
+
+    public static List<StarRocksQueryPartition> plan(
+            String database,
+            String table,
+            StarRocksQueryPlan queryPlan,
+            int requestTabletSize) {
+
+        if (queryPlan == null) {
+            throw new IllegalArgumentException("queryPlan must not be null");
+        }
+        if (requestTabletSize <= 0) {
+            throw new IllegalArgumentException("requestTabletSize must be greater than 0");
+        }
+        if (!hasText(queryPlan.getOpaquedQueryPlan())) {
+            throw new IllegalArgumentException("StarRocks query plan does not contain opaqued_query_plan");
+        }
+
+        Map<String, StarRocksTablet> tablets = queryPlan.getPartitions();
+        if (tablets == null || tablets.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Map.Entry<String, StarRocksTablet>> orderedTablets =
+                new ArrayList<Map.Entry<String, StarRocksTablet>>(tablets.entrySet());
+        Collections.sort(
+                orderedTablets,
+                new Comparator<Map.Entry<String, StarRocksTablet>>() {
+                    @Override
+                    public int compare(
+                            Map.Entry<String, StarRocksTablet> left,
+                            Map.Entry<String, StarRocksTablet> right) {
+                        return compareTabletId(left.getKey(), right.getKey());
+                    }
+                });
+
+        Map<String, List<Long>> beToTablets = new LinkedHashMap<String, List<Long>>();
+        for (Map.Entry<String, StarRocksTablet> entry : orderedTablets) {
+            long tabletId = parseTabletId(entry.getKey());
+            String be = selectBackend(entry.getValue(), beToTablets);
+            List<Long> assigned = beToTablets.get(be);
+            if (assigned == null) {
+                assigned = new ArrayList<Long>();
+                beToTablets.put(be, assigned);
+            }
+            assigned.add(tabletId);
+        }
+
+        List<String> backends = new ArrayList<String>(beToTablets.keySet());
+        Collections.sort(backends);
+
+        List<StarRocksQueryPartition> result = new ArrayList<StarRocksQueryPartition>();
+        for (String backend : backends) {
+            List<Long> tabletIds =
+                    new ArrayList<Long>(new LinkedHashSet<Long>(beToTablets.get(backend)));
+            Collections.sort(tabletIds);
+            int offset = 0;
+            while (offset < tabletIds.size()) {
+                int end = Math.min(tabletIds.size(), offset + requestTabletSize);
+                result.add(
+                        new StarRocksQueryPartition(
+                                database,
+                                table,
+                                backend,
+                                tabletIds.subList(offset, end),
+                                queryPlan.getOpaquedQueryPlan()));
+                offset = end;
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private static String selectBackend(
+            StarRocksTablet tablet,
+            Map<String, List<Long>> assigned) {
+        if (tablet == null || tablet.getRoutings() == null || tablet.getRoutings().isEmpty()) {
+            throw new IllegalArgumentException("StarRocks tablet has no BE routing");
+        }
+
+        List<String> candidates = new ArrayList<String>();
+        for (String routing : tablet.getRoutings()) {
+            if (hasText(routing)) {
+                candidates.add(routing.trim());
+            }
+        }
+        if (candidates.isEmpty()) {
+            throw new IllegalArgumentException("StarRocks tablet has no valid BE routing");
+        }
+        Collections.sort(candidates);
+
+        String selected = null;
+        int selectedLoad = Integer.MAX_VALUE;
+        for (String candidate : candidates) {
+            List<Long> current = assigned.get(candidate);
+            int load = current == null ? 0 : current.size();
+            if (selected == null || load < selectedLoad) {
+                selected = candidate;
+                selectedLoad = load;
+            }
+        }
+        return selected;
+    }
+
+    private static int compareTabletId(String left, String right) {
+        try {
+            return Long.compare(Long.parseLong(left), Long.parseLong(right));
+        } catch (NumberFormatException ignored) {
+            return String.valueOf(left).compareTo(String.valueOf(right));
+        }
+    }
+
+    private static long parseTabletId(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid StarRocks tablet id: " + value, e);
+        }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/model/StarRocksQueryPartition.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/model/StarRocksQueryPartition.java
@@ -1,0 +1,57 @@
+package com.link.up.connector.starrocks.client.source.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** One native scan partition bound to a StarRocks BE and a group of tablets. */
+public final class StarRocksQueryPartition implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String database;
+    private final String table;
+    private final String beAddress;
+    private final List<Long> tabletIds;
+    private final String opaquedQueryPlan;
+
+    public StarRocksQueryPartition(
+            String database,
+            String table,
+            String beAddress,
+            List<Long> tabletIds,
+            String opaquedQueryPlan) {
+        this.database = Objects.requireNonNull(database, "database must not be null");
+        this.table = Objects.requireNonNull(table, "table must not be null");
+        this.beAddress = Objects.requireNonNull(beAddress, "beAddress must not be null");
+        if (tabletIds == null || tabletIds.isEmpty()) {
+            throw new IllegalArgumentException("tabletIds must not be empty");
+        }
+        this.tabletIds =
+                Collections.unmodifiableList(new ArrayList<Long>(tabletIds));
+        this.opaquedQueryPlan =
+                Objects.requireNonNull(opaquedQueryPlan, "opaquedQueryPlan must not be null");
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public String getBeAddress() {
+        return beAddress;
+    }
+
+    public List<Long> getTabletIds() {
+        return tabletIds;
+    }
+
+    public String getOpaquedQueryPlan() {
+        return opaquedQueryPlan;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/model/StarRocksQueryPlan.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/model/StarRocksQueryPlan.java
@@ -1,0 +1,45 @@
+package com.link.up.connector.starrocks.client.source.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Query plan returned by the StarRocks FE native scan endpoint. */
+public final class StarRocksQueryPlan implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int status;
+
+    @JsonProperty("opaqued_query_plan")
+    private String opaquedQueryPlan;
+
+    private Map<String, StarRocksTablet> partitions =
+            new LinkedHashMap<String, StarRocksTablet>();
+
+    public int getStatus() {
+        return status;
+    }
+
+    public void setStatus(int status) {
+        this.status = status;
+    }
+
+    public String getOpaquedQueryPlan() {
+        return opaquedQueryPlan;
+    }
+
+    public void setOpaquedQueryPlan(String opaquedQueryPlan) {
+        this.opaquedQueryPlan = opaquedQueryPlan;
+    }
+
+    public Map<String, StarRocksTablet> getPartitions() {
+        return partitions;
+    }
+
+    public void setPartitions(Map<String, StarRocksTablet> partitions) {
+        this.partitions = partitions;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/model/StarRocksTablet.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/source/model/StarRocksTablet.java
@@ -1,0 +1,51 @@
+package com.link.up.connector.starrocks.client.source.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Tablet routing returned by the StarRocks FE query-plan endpoint. */
+public final class StarRocksTablet implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<String> routings = new ArrayList<String>();
+    private int version;
+    private long versionHash;
+    private long schemaHash;
+
+    public List<String> getRoutings() {
+        return routings == null
+                ? Collections.<String>emptyList()
+                : routings;
+    }
+
+    public void setRoutings(List<String> routings) {
+        this.routings = routings;
+    }
+
+    public int getVersion() {
+        return version;
+    }
+
+    public void setVersion(int version) {
+        this.version = version;
+    }
+
+    public long getVersionHash() {
+        return versionHash;
+    }
+
+    public void setVersionHash(long versionHash) {
+        this.versionHash = versionHash;
+    }
+
+    public long getSchemaHash() {
+        return schemaHash;
+    }
+
+    public void setSchemaHash(long schemaHash) {
+        this.schemaHash = schemaHash;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSourceConfig.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSourceConfig.java
@@ -1,0 +1,272 @@
+package com.link.up.connector.starrocks.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.connector.starrocks.schema.StarRocksSchemaParser;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable runtime configuration for StarRocks Native Source. */
+public final class StarRocksSourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> nodeUrls;
+    private final String username;
+    private final String password;
+    private final String database;
+    private final List<StarRocksSourceTableConfig> tableConfigs;
+    private final int requestTabletSize;
+    private final int connectTimeoutMs;
+    private final int queryTimeoutSec;
+    private final int keepAliveMin;
+    private final int batchRows;
+    private final long memLimit;
+    private final int maxRetries;
+    private final Map<String, String> scanParams;
+
+    private StarRocksSourceConfig(
+            List<String> nodeUrls,
+            String username,
+            String password,
+            String database,
+            List<StarRocksSourceTableConfig> tableConfigs,
+            int requestTabletSize,
+            int connectTimeoutMs,
+            int queryTimeoutSec,
+            int keepAliveMin,
+            int batchRows,
+            long memLimit,
+            int maxRetries,
+            Map<String, String> scanParams) {
+        this.nodeUrls = Collections.unmodifiableList(new ArrayList<String>(nodeUrls));
+        this.username = username;
+        this.password = password;
+        this.database = database;
+        this.tableConfigs =
+                Collections.unmodifiableList(new ArrayList<StarRocksSourceTableConfig>(tableConfigs));
+        this.requestTabletSize = requestTabletSize;
+        this.connectTimeoutMs = connectTimeoutMs;
+        this.queryTimeoutSec = queryTimeoutSec;
+        this.keepAliveMin = keepAliveMin;
+        this.batchRows = batchRows;
+        this.memLimit = memLimit;
+        this.maxRetries = maxRetries;
+        this.scanParams =
+                Collections.unmodifiableMap(new LinkedHashMap<String, String>(scanParams));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static StarRocksSourceConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        List<String> nodeUrls = normalizeNodes(config.get(StarRocksSourceOptions.NODE_URLS));
+        String username = requireText(config.get(StarRocksSourceOptions.USERNAME), "username");
+        String password = config.get(StarRocksSourceOptions.PASSWORD);
+        String database = requireText(config.get(StarRocksSourceOptions.DATABASE), "database");
+        String commonFilter = config.get(StarRocksSourceOptions.SCAN_FILTER);
+
+        String singleTable = config.getOptional(StarRocksSourceOptions.TABLE).orElse(null);
+        List<Map> tableList =
+                config.getOptional(StarRocksSourceOptions.TABLE_LIST)
+                        .orElse(Collections.<Map>emptyList());
+
+        if (hasText(singleTable) == !tableList.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Exactly one of StarRocks source table or table_list must be configured");
+        }
+
+        List<StarRocksSourceTableConfig> tables = new ArrayList<StarRocksSourceTableConfig>();
+        if (hasText(singleTable)) {
+            Map<String, Object> schemaFields =
+                    config.getOptional(StarRocksSourceOptions.SCHEMA_FIELDS)
+                            .orElseThrow(
+                                    () ->
+                                            new IllegalArgumentException(
+                                                    "schema.fields is required for StarRocks Native Source"));
+            tables.add(
+                    new StarRocksSourceTableConfig(
+                            database,
+                            singleTable,
+                            commonFilter,
+                            StarRocksSchemaParser.parse(schemaFields)));
+        } else {
+            for (Map item : tableList) {
+                String table = requireText(stringValue(item.get("table")), "table_list[].table");
+                Map<String, Object> schemaFields = extractSchemaFields(item);
+                String filter = stringValue(item.get("scan_filter"));
+                if (!hasText(filter)) {
+                    filter = commonFilter;
+                }
+                tables.add(
+                        new StarRocksSourceTableConfig(
+                                database,
+                                table,
+                                filter,
+                                StarRocksSchemaParser.parse(schemaFields)));
+            }
+        }
+
+        int requestTabletSize = config.get(StarRocksSourceOptions.REQUEST_TABLET_SIZE);
+        int connectTimeoutMs = config.get(StarRocksSourceOptions.SCAN_CONNECT_TIMEOUT_MS);
+        int queryTimeoutSec = config.get(StarRocksSourceOptions.SCAN_QUERY_TIMEOUT_SEC);
+        int keepAliveMin = config.get(StarRocksSourceOptions.SCAN_KEEP_ALIVE_MIN);
+        int batchRows = config.get(StarRocksSourceOptions.SCAN_BATCH_ROWS);
+        long memLimit = config.get(StarRocksSourceOptions.SCAN_MEM_LIMIT);
+        int maxRetries = config.get(StarRocksSourceOptions.MAX_RETRIES);
+
+        if (requestTabletSize <= 0) {
+            throw new IllegalArgumentException("request_tablet_size must be greater than 0");
+        }
+        if (connectTimeoutMs <= 0) {
+            throw new IllegalArgumentException("scan_connect_timeout_ms must be greater than 0");
+        }
+        if (queryTimeoutSec == 0 || queryTimeoutSec < -1) {
+            throw new IllegalArgumentException("scan_query_timeout_sec must be -1 or greater than 0");
+        }
+        if (keepAliveMin <= 0) {
+            throw new IllegalArgumentException("scan_keep_alive_min must be greater than 0");
+        }
+        if (batchRows <= 0) {
+            throw new IllegalArgumentException("scan_batch_rows must be greater than 0");
+        }
+        if (memLimit <= 0) {
+            throw new IllegalArgumentException("scan_mem_limit must be greater than 0");
+        }
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("max_retries must not be negative");
+        }
+
+        Map<String, String> scanParams =
+                config.getOptional(StarRocksSourceOptions.SCAN_PARAMS)
+                        .orElse(Collections.<String, String>emptyMap());
+
+        return new StarRocksSourceConfig(
+                nodeUrls,
+                username,
+                password == null ? "" : password,
+                database,
+                tables,
+                requestTabletSize,
+                connectTimeoutMs,
+                queryTimeoutSec,
+                keepAliveMin,
+                batchRows,
+                memLimit,
+                maxRetries,
+                scanParams);
+    }
+
+    private static List<String> normalizeNodes(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("node_urls must contain at least one FE address");
+        }
+        List<String> result = new ArrayList<String>();
+        for (String value : values) {
+            String node = requireText(value, "node_urls item");
+            while (node.endsWith("/")) {
+                node = node.substring(0, node.length() - 1);
+            }
+            result.add(node);
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> extractSchemaFields(Map<?, ?> item) {
+        Object direct = item.get("schema.fields");
+        if (direct instanceof Map) {
+            return (Map<String, Object>) direct;
+        }
+        Object schema = item.get("schema");
+        if (schema instanceof Map) {
+            Object fields = ((Map<?, ?>) schema).get("fields");
+            if (fields instanceof Map) {
+                return (Map<String, Object>) fields;
+            }
+        }
+        throw new IllegalArgumentException(
+                "table_list[].schema.fields is required for StarRocks Native Source");
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private static String requireText(String value, String name) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value.trim();
+    }
+
+    public List<String> getNodeUrls() {
+        return nodeUrls;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public List<StarRocksSourceTableConfig> getTableConfigs() {
+        return tableConfigs;
+    }
+
+    public List<CatalogTable> getCatalogTables() {
+        List<CatalogTable> result = new ArrayList<CatalogTable>(tableConfigs.size());
+        for (StarRocksSourceTableConfig tableConfig : tableConfigs) {
+            result.add(tableConfig.getCatalogTable());
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    public int getRequestTabletSize() {
+        return requestTabletSize;
+    }
+
+    public int getConnectTimeoutMs() {
+        return connectTimeoutMs;
+    }
+
+    public int getQueryTimeoutSec() {
+        return queryTimeoutSec;
+    }
+
+    public int getKeepAliveMin() {
+        return keepAliveMin;
+    }
+
+    public int getBatchRows() {
+        return batchRows;
+    }
+
+    public long getMemLimit() {
+        return memLimit;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public Map<String, String> getScanParams() {
+        return scanParams;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSourceOptions.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSourceOptions.java
@@ -1,0 +1,146 @@
+package com.link.up.connector.starrocks.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+import java.util.Map;
+
+/** StarRocks Native Source options. */
+public final class StarRocksSourceOptions {
+
+    private StarRocksSourceOptions() {
+    }
+
+    public static final Option<List<String>> NODE_URLS =
+            Options.key("node_urls")
+                    .listType()
+                    .noDefaultValue()
+                    .withFallbackKeys("nodeUrls")
+                    .withDescription("StarRocks FE HTTP 地址列表，例如 [\"127.0.0.1:8030\"]")
+                    .withSemanticType("STARROCKS_FE_NODES")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("StarRocks 用户名")
+                    .withSemanticType("USERNAME")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .sensitive()
+                    .withDescription("StarRocks 密码")
+                    .withSemanticType("PASSWORD")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> DATABASE =
+            Options.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("StarRocks 数据库名")
+                    .withSemanticType("DATABASE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> TABLE =
+            Options.key("table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("StarRocks 表名；与 table_list 二选一")
+                    .withSemanticType("TABLE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    @SuppressWarnings("rawtypes")
+    public static final Option<List<Map>> TABLE_LIST =
+            Options.key("table_list")
+                    .listType(Map.class)
+                    .noDefaultValue()
+                    .withDescription("多表读取配置，每项包含 table、schema.fields，可选 scan_filter")
+                    .withSemanticType("TABLE_LIST")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Map<String, Object>> SCHEMA_FIELDS =
+            Options.key("schema.fields")
+                    .mapObjectType()
+                    .noDefaultValue()
+                    .withDescription("Native Scan 输出 Schema；key 为字段名，value 为 StarRocks 类型")
+                    .withSemanticType("SCHEMA_FIELDS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> SCAN_FILTER =
+            Options.key("scan_filter")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("下推到 StarRocks Query Plan 的 WHERE 条件，不包含 WHERE 关键字")
+                    .withSemanticType("SQL_FILTER")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> REQUEST_TABLET_SIZE =
+            Options.key("request_tablet_size")
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withDescription("单个 Source Split 最多包含的 Tablet 数量")
+                    .withSemanticType("SPLIT_SIZE")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SCAN_CONNECT_TIMEOUT_MS =
+            Options.key("scan_connect_timeout_ms")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("连接 StarRocks BE Scanner 的超时时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SCAN_QUERY_TIMEOUT_SEC =
+            Options.key("scan_query_timeout_sec")
+                    .intType()
+                    .defaultValue(3600)
+                    .withDescription("BE Scanner 查询超时，单位秒；-1 表示不限制")
+                    .withSemanticType("TIMEOUT_SECONDS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SCAN_KEEP_ALIVE_MIN =
+            Options.key("scan_keep_alive_min")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription("BE Scanner Keep Alive 时间，单位分钟")
+                    .withSemanticType("DURATION_MINUTES")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SCAN_BATCH_ROWS =
+            Options.key("scan_batch_rows")
+                    .intType()
+                    .defaultValue(1024)
+                    .withDescription("每次从 BE 获取的最大行数")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Long> SCAN_MEM_LIMIT =
+            Options.key("scan_mem_limit")
+                    .longType()
+                    .defaultValue(1024L * 1024L * 1024L)
+                    .withDescription("单个 BE Scanner 查询可使用的最大内存字节数")
+                    .withSemanticType("MEMORY_BYTES")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> MAX_RETRIES =
+            Options.key("max_retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("获取 FE Query Plan 的最大重试次数")
+                    .withSemanticType("RETRY_COUNT")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Map<String, String>> SCAN_PARAMS =
+            Options.key("scan.params")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("透传给 StarRocks BE Scanner 的附加参数")
+                    .withSemanticType("STARROCKS_SCAN_PARAMS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSourceTableConfig.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSourceTableConfig.java
@@ -1,0 +1,62 @@
+package com.link.up.connector.starrocks.config;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Per-table configuration for StarRocks Native Source. */
+public final class StarRocksSourceTableConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String database;
+    private final String table;
+    private final String scanFilter;
+    private final CatalogTable catalogTable;
+
+    public StarRocksSourceTableConfig(
+            String database,
+            String table,
+            String scanFilter,
+            TableSchema schema) {
+        this.database = requireText(database, "database");
+        this.table = requireText(table, "table");
+        this.scanFilter = scanFilter == null ? "" : scanFilter.trim();
+        Objects.requireNonNull(schema, "schema must not be null");
+        this.catalogTable =
+                CatalogTable.builder(TablePath.of(this.database, this.table), schema)
+                        .option("connector", "starrocks")
+                        .option("read_mode", "native")
+                        .build();
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public String getScanFilter() {
+        return scanFilter;
+    }
+
+    public CatalogTable getCatalogTable() {
+        return catalogTable;
+    }
+
+    public TablePath getTablePath() {
+        return catalogTable.getTablePath();
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value.trim();
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/converter/StarRocksArrowRowReader.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/converter/StarRocksArrowRowReader.java
@@ -1,0 +1,232 @@
+package com.link.up.connector.starrocks.converter;
+
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.FluxRowType;
+import com.link.up.api.table.type.SqlType;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.util.Text;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Decodes one StarRocks BE Arrow payload into Link-Up Flux rows. */
+public final class StarRocksArrowRowReader {
+
+    private StarRocksArrowRowReader() {
+    }
+
+    public static List<FluxRow> read(byte[] payload, FluxRowType rowType) throws IOException {
+        if (payload == null || payload.length == 0) {
+            return java.util.Collections.emptyList();
+        }
+        if (rowType == null) {
+            throw new IllegalArgumentException("rowType must not be null");
+        }
+
+        List<FluxRow> rows = new ArrayList<FluxRow>();
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+             ArrowStreamReader reader =
+                     new ArrowStreamReader(new ByteArrayInputStream(payload), allocator)) {
+
+            VectorSchemaRoot root = reader.getVectorSchemaRoot();
+            while (reader.loadNextBatch()) {
+                Map<String, FieldVector> vectors = indexVectors(root.getFieldVectors());
+                for (int rowIndex = 0; rowIndex < root.getRowCount(); rowIndex++) {
+                    FluxRow row = new FluxRow(rowType.getFieldCount());
+                    for (int fieldIndex = 0; fieldIndex < rowType.getFieldCount(); fieldIndex++) {
+                        String fieldName = rowType.getFieldName(fieldIndex);
+                        FieldVector vector = findVector(vectors, fieldName);
+                        if (vector == null) {
+                            throw new IOException(
+                                    "Arrow payload does not contain projected field: " + fieldName);
+                        }
+                        Object raw = vector.isNull(rowIndex) ? null : vector.getObject(rowIndex);
+                        row.setField(
+                                fieldIndex,
+                                convertValue(
+                                        raw,
+                                        rowType.getFieldType(fieldIndex),
+                                        vector.getMinorType()));
+                    }
+                    rows.add(row);
+                }
+            }
+        }
+        return rows;
+    }
+
+    private static Map<String, FieldVector> indexVectors(List<FieldVector> vectors) {
+        Map<String, FieldVector> result = new HashMap<String, FieldVector>();
+        for (FieldVector vector : vectors) {
+            String name = vector.getField().getName();
+            result.put(name, vector);
+            result.put(name.toLowerCase(Locale.ROOT), vector);
+        }
+        return result;
+    }
+
+    private static FieldVector findVector(Map<String, FieldVector> vectors, String fieldName) {
+        FieldVector exact = vectors.get(fieldName);
+        return exact != null ? exact : vectors.get(fieldName.toLowerCase(Locale.ROOT));
+    }
+
+    private static Object convertValue(
+            Object value,
+            FluxDataType<?> targetType,
+            Types.MinorType minorType) {
+        if (value == null) {
+            return null;
+        }
+
+        SqlType sqlType = targetType.getSqlType();
+        switch (sqlType) {
+            case STRING:
+                if (value instanceof Text) {
+                    return value.toString();
+                }
+                if (value instanceof byte[]) {
+                    return new String((byte[]) value, StandardCharsets.UTF_8);
+                }
+                return String.valueOf(value);
+            case BOOLEAN:
+                if (value instanceof Boolean) {
+                    return value;
+                }
+                if (value instanceof Number) {
+                    return ((Number) value).longValue() != 0L;
+                }
+                return Boolean.parseBoolean(value.toString());
+            case TINYINT:
+                return number(value).byteValue();
+            case SMALLINT:
+                return number(value).shortValue();
+            case INT:
+                return number(value).intValue();
+            case BIGINT:
+                return number(value).longValue();
+            case FLOAT:
+                return number(value).floatValue();
+            case DOUBLE:
+                return number(value).doubleValue();
+            case DECIMAL:
+                if (value instanceof BigDecimal) {
+                    return value;
+                }
+                if (value instanceof Number) {
+                    return new BigDecimal(value.toString());
+                }
+                return new BigDecimal(value instanceof Text ? value.toString() : String.valueOf(value));
+            case DATE:
+                return dateValue(value);
+            case TIME:
+                return timeValue(value);
+            case TIMESTAMP:
+                return timestampValue(value, minorType);
+            case BYTES:
+                if (value instanceof byte[]) {
+                    return value;
+                }
+                if (value instanceof Text) {
+                    return value.toString().getBytes(StandardCharsets.UTF_8);
+                }
+                return String.valueOf(value).getBytes(StandardCharsets.UTF_8);
+            case NULL:
+                return null;
+            case ARRAY:
+            case MAP:
+            case ROW:
+            case TIMESTAMP_TZ:
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported StarRocks Arrow conversion target: " + sqlType);
+        }
+    }
+
+    private static Number number(Object value) {
+        if (value instanceof Number) {
+            return (Number) value;
+        }
+        return new BigDecimal(value instanceof Text ? value.toString() : String.valueOf(value));
+    }
+
+    private static LocalDate dateValue(Object value) {
+        if (value instanceof LocalDate) {
+            return (LocalDate) value;
+        }
+        if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).toLocalDate();
+        }
+        if (value instanceof Number) {
+            return LocalDate.ofEpochDay(((Number) value).longValue());
+        }
+        return LocalDate.parse(value.toString());
+    }
+
+    private static LocalTime timeValue(Object value) {
+        if (value instanceof LocalTime) {
+            return (LocalTime) value;
+        }
+        if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).toLocalTime();
+        }
+        if (value instanceof Integer) {
+            return LocalTime.ofSecondOfDay(((Integer) value).longValue());
+        }
+        if (value instanceof Long) {
+            return Instant.ofEpochMilli((Long) value)
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDateTime()
+                    .toLocalTime();
+        }
+        return LocalTime.parse(value.toString());
+    }
+
+    private static LocalDateTime timestampValue(Object value, Types.MinorType minorType) {
+        if (value instanceof LocalDateTime) {
+            return (LocalDateTime) value;
+        }
+        if (value instanceof Number) {
+            long raw = ((Number) value).longValue();
+            String minorName = minorType == null ? "" : minorType.name();
+            Instant instant;
+            if (minorName.contains("NANO")) {
+                instant = Instant.ofEpochSecond(
+                        raw / 1_000_000_000L,
+                        raw % 1_000_000_000L);
+            } else if (minorName.contains("MICRO")) {
+                instant = Instant.ofEpochSecond(
+                        raw / 1_000_000L,
+                        (raw % 1_000_000L) * 1_000L);
+            } else if (minorName.contains("MILLI")) {
+                instant = Instant.ofEpochMilli(raw);
+            } else if (minorName.contains("SEC")) {
+                instant = Instant.ofEpochSecond(raw);
+            } else {
+                instant = Instant.ofEpochMilli(raw);
+            }
+            return instant.atZone(ZoneId.systemDefault()).toLocalDateTime();
+        }
+        String text = value.toString();
+        if (text.indexOf('T') >= 0) {
+            return LocalDateTime.parse(text);
+        }
+        return LocalDateTime.parse(text.replace(' ', 'T'));
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/schema/StarRocksSchemaParser.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/schema/StarRocksSchemaParser.java
@@ -1,0 +1,127 @@
+package com.link.up.connector.starrocks.schema;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Parses the explicit schema required by the StarRocks native scanner. */
+public final class StarRocksSchemaParser {
+
+    private static final Pattern DECIMAL_PATTERN =
+            Pattern.compile(
+                    "decimal(?:v2|v3|32|64|128)?\\s*\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)",
+                    Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern CHAR_PATTERN =
+            Pattern.compile("(?:char|varchar)\\s*\\(\\s*\\d+\\s*\\)", Pattern.CASE_INSENSITIVE);
+
+    private StarRocksSchemaParser() {
+    }
+
+    public static TableSchema parse(Map<String, Object> schemaFields) {
+        Objects.requireNonNull(schemaFields, "schemaFields must not be null");
+        if (schemaFields.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "StarRocks Native Source schema.fields must define at least one field");
+        }
+
+        TableSchema.Builder builder = TableSchema.builder();
+        for (Map.Entry<String, Object> entry : schemaFields.entrySet()) {
+            String fieldName = requireText(entry.getKey(), "field name");
+            String sourceType = requireText(String.valueOf(entry.getValue()), "field type");
+            builder.column(
+                    Column.builder(fieldName, resolveType(sourceType))
+                            .nullable(true)
+                            .sourceType(sourceType)
+                            .build());
+        }
+        return builder.build();
+    }
+
+    static FluxDataType<?> resolveType(String sourceType) {
+        String normalized = requireText(sourceType, "sourceType")
+                .trim()
+                .toLowerCase(Locale.ROOT);
+
+        Matcher decimal = DECIMAL_PATTERN.matcher(normalized);
+        if (decimal.matches()) {
+            int precision = Integer.parseInt(decimal.group(1));
+            int scale = Integer.parseInt(decimal.group(2));
+            if (precision < 1 || precision > 38) {
+                throw new IllegalArgumentException(
+                        "StarRocks DECIMAL precision must be between 1 and 38: " + sourceType);
+            }
+            if (scale < 0 || scale > precision) {
+                throw new IllegalArgumentException(
+                        "StarRocks DECIMAL scale must be between 0 and precision: " + sourceType);
+            }
+            return new DecimalType(precision, scale);
+        }
+
+        if (CHAR_PATTERN.matcher(normalized).matches()) {
+            return BasicType.STRING_TYPE;
+        }
+
+        if (normalized.startsWith("array<") || normalized.startsWith("map<")) {
+            throw new IllegalArgumentException(
+                    "StarRocks Native Source Stage 1 does not support ARRAY/MAP yet; "
+                            + "map the column to a supported scalar representation explicitly: "
+                            + sourceType);
+        }
+
+        switch (normalized) {
+            case "boolean":
+            case "bool":
+                return BasicType.BOOLEAN_TYPE;
+            case "tinyint":
+                return BasicType.BYTE_TYPE;
+            case "smallint":
+                return BasicType.SHORT_TYPE;
+            case "int":
+            case "integer":
+                return BasicType.INT_TYPE;
+            case "bigint":
+                return BasicType.LONG_TYPE;
+            case "largeint":
+                // StarRocks LARGEINT is signed 128-bit. Flux DECIMAL(38, 0)
+                // cannot represent its entire domain safely, so keep exact text.
+                return BasicType.STRING_TYPE;
+            case "float":
+                return BasicType.FLOAT_TYPE;
+            case "double":
+                return BasicType.DOUBLE_TYPE;
+            case "char":
+            case "varchar":
+            case "string":
+            case "json":
+                return BasicType.STRING_TYPE;
+            case "date":
+                return BasicType.DATE_TYPE;
+            case "time":
+                return BasicType.TIME_TYPE;
+            case "datetime":
+            case "timestamp":
+                return BasicType.TIMESTAMP_TYPE;
+            case "null":
+                return BasicType.NULL_TYPE;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported StarRocks Native Source type: " + sourceType);
+        }
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value.trim();
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSource.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSource.java
@@ -1,0 +1,56 @@
+package com.link.up.connector.starrocks.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.starrocks.config.StarRocksSourceConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** StarRocks bounded source using FE query plans and direct BE native scans. */
+public final class StarRocksSource implements Source<StarRocksSourceSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final StarRocksSourceConfig config;
+
+    public StarRocksSource(StarRocksSourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public SourceSplitEnumerator<StarRocksSourceSplit> createEnumerator(
+            Map<TablePath, CatalogTable> tables,
+            SourceEnumeratorContext context) {
+        Objects.requireNonNull(tables, "tables must not be null");
+        Objects.requireNonNull(context, "context must not be null");
+        return new StarRocksSourceSplitEnumerator(config);
+    }
+
+    @Override
+    @Deprecated
+    public List<StarRocksSourceSplit> createSplits(
+            Map<TablePath, CatalogTable> tables) throws Exception {
+        try (StarRocksSourceSplitEnumerator enumerator =
+                     new StarRocksSourceSplitEnumerator(config)) {
+            return enumerator.enumerateSplits();
+        }
+    }
+
+    @Override
+    public SourceReader<FluxRow, StarRocksSourceSplit> createReader(
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        return new StarRocksSourceReader(config, tables, batchSize);
+    }
+
+    public StarRocksSourceConfig getConfig() {
+        return config;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSourceFactory.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSourceFactory.java
@@ -1,0 +1,85 @@
+package com.link.up.connector.starrocks.source;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.connector.starrocks.config.StarRocksSourceConfig;
+import com.link.up.connector.starrocks.config.StarRocksSourceOptions;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** SPI factory for the standalone StarRocks Native Source connector. */
+@AutoService(TableSourceFactory.class)
+public final class StarRocksSourceFactory
+        implements TableSourceFactory<StarRocksSourceSplit> {
+
+    private static final String IDENTIFIER = "starrocks";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY,
+                        ConnectorCapability.MULTI_TABLE,
+                        ConnectorCapability.PARTITION_SPLIT));
+    }
+
+    @Override
+    public Source<StarRocksSourceSplit> createSource(
+            SourceFactoryContext context) {
+        return new StarRocksSource(createConfig(context));
+    }
+
+    @Override
+    public List<CatalogTable> discoverTableSchemas(
+            SourceFactoryContext context) {
+        return createConfig(context).getCatalogTables();
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        StarRocksSourceOptions.NODE_URLS,
+                        StarRocksSourceOptions.USERNAME,
+                        StarRocksSourceOptions.DATABASE)
+                .optional(
+                        StarRocksSourceOptions.PASSWORD,
+                        StarRocksSourceOptions.TABLE,
+                        StarRocksSourceOptions.TABLE_LIST,
+                        StarRocksSourceOptions.SCHEMA_FIELDS,
+                        StarRocksSourceOptions.SCAN_FILTER,
+                        StarRocksSourceOptions.REQUEST_TABLET_SIZE,
+                        StarRocksSourceOptions.SCAN_CONNECT_TIMEOUT_MS,
+                        StarRocksSourceOptions.SCAN_QUERY_TIMEOUT_SEC,
+                        StarRocksSourceOptions.SCAN_KEEP_ALIVE_MIN,
+                        StarRocksSourceOptions.SCAN_BATCH_ROWS,
+                        StarRocksSourceOptions.SCAN_MEM_LIMIT,
+                        StarRocksSourceOptions.MAX_RETRIES,
+                        StarRocksSourceOptions.SCAN_PARAMS)
+                .build();
+    }
+
+    private StarRocksSourceConfig createConfig(SourceFactoryContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        ReadonlyConfig options =
+                Objects.requireNonNull(
+                        context.getOptions(),
+                        "source options must not be null");
+        return StarRocksSourceConfig.of(options);
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSourceReader.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSourceReader.java
@@ -1,0 +1,187 @@
+package com.link.up.connector.starrocks.source;
+
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.starrocks.client.source.StarRocksBeReadClient;
+import com.link.up.connector.starrocks.config.StarRocksSourceConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Reads assigned StarRocks native splits through task-local BE scanner clients. */
+public final class StarRocksSourceReader
+        implements SourceReader<FluxRow, StarRocksSourceSplit> {
+
+    private final StarRocksSourceConfig config;
+    private final Map<TablePath, CatalogTable> tables;
+    private final int batchSize;
+
+    private List<StarRocksSourceSplit> splits = Collections.emptyList();
+    private int splitIndex;
+    private StarRocksSourceSplit currentSplit;
+    private StarRocksBeReadClient currentClient;
+    private boolean opened;
+    private boolean finished;
+
+    public StarRocksSourceReader(
+            StarRocksSourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.tables = Objects.requireNonNull(tables, "tables must not be null");
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public void open(List<StarRocksSourceSplit> splits) throws Exception {
+        if (opened) {
+            throw new IllegalStateException("StarRocksSourceReader has already been opened");
+        }
+        if (splits == null) {
+            throw new IllegalArgumentException("splits must not be null");
+        }
+        this.splits =
+                Collections.unmodifiableList(new ArrayList<StarRocksSourceSplit>(splits));
+        splitIndex = 0;
+        currentSplit = null;
+        currentClient = null;
+        finished = false;
+        opened = true;
+    }
+
+    @Override
+    public void open() throws Exception {
+        open(Collections.<StarRocksSourceSplit>emptyList());
+    }
+
+    @Override
+    public void openSplit(StarRocksSourceSplit split) throws Exception {
+        checkOpened();
+        if (currentSplit != null) {
+            throw new IllegalStateException("A StarRocks split is already open");
+        }
+        // Dynamic split assignment reuses one reader for multiple splits. A
+        // previous split may already have driven readBatch() to END_OF_INPUT.
+        finished = false;
+        openCurrentSplit(Objects.requireNonNull(split, "split must not be null"));
+    }
+
+    @Override
+    public void closeSplit() throws Exception {
+        closeCurrentSplit();
+    }
+
+    @Override
+    public RecordBatch<FluxRow> readBatch() throws Exception {
+        checkOpened();
+        if (finished) {
+            return RecordBatch.endOfInput();
+        }
+
+        while (true) {
+            if (currentSplit == null) {
+                if (!openNextSplit()) {
+                    finished = true;
+                    return RecordBatch.endOfInput();
+                }
+            }
+
+            StarRocksSourceSplit batchSplit = currentSplit;
+            List<FluxRow> rows = new ArrayList<FluxRow>(batchSize);
+            boolean exhausted = false;
+
+            while (rows.size() < batchSize) {
+                if (!currentClient.hasNext()) {
+                    exhausted = true;
+                    break;
+                }
+                rows.add(currentClient.next());
+            }
+
+            if (exhausted) {
+                closeCurrentSplit();
+            }
+
+            if (!rows.isEmpty()) {
+                return RecordBatch.of(batchSplit, rows);
+            }
+        }
+    }
+
+    private boolean openNextSplit() throws Exception {
+        if (splitIndex >= splits.size()) {
+            return false;
+        }
+        openCurrentSplit(splits.get(splitIndex++));
+        return true;
+    }
+
+    private void openCurrentSplit(StarRocksSourceSplit split) throws Exception {
+        CatalogTable table = tables.get(split.getTablePath());
+        if (table == null) {
+            throw new IllegalArgumentException(
+                    "Cannot find schema for StarRocks split table: " + split.getTablePath());
+        }
+
+        StarRocksBeReadClient client =
+                new StarRocksBeReadClient(
+                        config,
+                        split.getPartition(),
+                        table.getRowType());
+        try {
+            client.open();
+        } catch (Exception failure) {
+            try {
+                client.close();
+            } catch (Exception closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
+            throw failure;
+        }
+
+        currentSplit = split;
+        currentClient = client;
+    }
+
+    private void closeCurrentSplit() throws Exception {
+        if (currentClient == null) {
+            currentSplit = null;
+            return;
+        }
+        try {
+            currentClient.close();
+        } finally {
+            currentClient = null;
+            currentSplit = null;
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("StarRocksSourceReader has not been opened");
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!opened) {
+            return;
+        }
+        try {
+            closeCurrentSplit();
+        } finally {
+            opened = false;
+            finished = true;
+            splits = Collections.emptyList();
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSourceSplit.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSourceSplit.java
@@ -1,0 +1,59 @@
+package com.link.up.connector.starrocks.source;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPartition;
+
+import java.util.Objects;
+
+/** A deterministic Link-Up split for one StarRocks BE native scan partition. */
+public final class StarRocksSourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String splitId;
+    private final TablePath tablePath;
+    private final StarRocksQueryPartition partition;
+
+    public StarRocksSourceSplit(
+            String splitId,
+            TablePath tablePath,
+            StarRocksQueryPartition partition) {
+        this.splitId = Objects.requireNonNull(splitId, "splitId must not be null");
+        this.tablePath = Objects.requireNonNull(tablePath, "tablePath must not be null");
+        this.partition = Objects.requireNonNull(partition, "partition must not be null");
+    }
+
+    @Override
+    public String splitId() {
+        return splitId;
+    }
+
+    @Override
+    public String dataSetId() {
+        return tablePath.toString();
+    }
+
+    public TablePath getTablePath() {
+        return tablePath;
+    }
+
+    public StarRocksQueryPartition getPartition() {
+        return partition;
+    }
+
+    @Override
+    public String toString() {
+        return "StarRocksSourceSplit{"
+                + "splitId='"
+                + splitId
+                + '\''
+                + ", tablePath="
+                + tablePath
+                + ", be="
+                + partition.getBeAddress()
+                + ", tablets="
+                + partition.getTabletIds()
+                + '}';
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSourceSplitEnumerator.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/source/StarRocksSourceSplitEnumerator.java
@@ -1,0 +1,68 @@
+package com.link.up.connector.starrocks.source;
+
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.connector.starrocks.client.source.StarRocksQueryPlanClient;
+import com.link.up.connector.starrocks.client.source.StarRocksSplitPlanner;
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPartition;
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPlan;
+import com.link.up.connector.starrocks.config.StarRocksSourceConfig;
+import com.link.up.connector.starrocks.config.StarRocksSourceTableConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Bounded native split enumerator backed by StarRocks FE query plans. */
+public final class StarRocksSourceSplitEnumerator
+        implements SourceSplitEnumerator<StarRocksSourceSplit> {
+
+    private final StarRocksSourceConfig config;
+    private final StarRocksQueryPlanClient queryPlanClient;
+
+    public StarRocksSourceSplitEnumerator(StarRocksSourceConfig config) {
+        this(config, new StarRocksQueryPlanClient(config));
+    }
+
+    StarRocksSourceSplitEnumerator(
+            StarRocksSourceConfig config,
+            StarRocksQueryPlanClient queryPlanClient) {
+        this.config = config;
+        this.queryPlanClient = queryPlanClient;
+    }
+
+    @Override
+    public List<StarRocksSourceSplit> enumerateSplits() throws Exception {
+        List<StarRocksSourceSplit> result = new ArrayList<StarRocksSourceSplit>();
+        for (StarRocksSourceTableConfig table : config.getTableConfigs()) {
+            StarRocksQueryPlan queryPlan = queryPlanClient.fetchQueryPlan(table);
+            List<StarRocksQueryPartition> partitions =
+                    StarRocksSplitPlanner.plan(
+                            table.getDatabase(),
+                            table.getTable(),
+                            queryPlan,
+                            config.getRequestTabletSize());
+            int partitionIndex = 0;
+            for (StarRocksQueryPartition partition : partitions) {
+                String splitId =
+                        table.getDatabase()
+                                + "."
+                                + table.getTable()
+                                + "@"
+                                + partition.getBeAddress()
+                                + "#"
+                                + partitionIndex++;
+                result.add(
+                        new StarRocksSourceSplit(
+                                splitId,
+                                table.getTablePath(),
+                                partition));
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public void close() {
+        queryPlanClient.close();
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/StarRocksConnectorPackageBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/StarRocksConnectorPackageBoundaryTest.java
@@ -1,0 +1,41 @@
+package com.link.up.connector.starrocks;
+
+import com.link.up.connector.starrocks.client.source.StarRocksBeReadClient;
+import com.link.up.connector.starrocks.source.StarRocksSourceFactory;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StarRocksConnectorPackageBoundaryTest {
+
+    @Test
+    public void nativeSourceLivesInStandaloneConnector() {
+        assertEquals(
+                "com.link.up.connector.starrocks.source",
+                StarRocksSourceFactory.class.getPackage().getName());
+        assertTrue(
+                StarRocksBeReadClient.class.getName()
+                        .startsWith("com.link.up.connector.starrocks."));
+    }
+
+    @Test
+    public void connectorDoesNotCreateJdbcPackageBoundary() {
+        File root = new File("src/main/java/com/link/up/connector/starrocks");
+        assertFalse(new File(root, "jdbc").exists());
+    }
+
+    @Test
+    public void forbiddenGenericRootPackagesMustNotExist() {
+        File root = new File("src/main/java/com/link/up/connector/starrocks");
+        String[] forbidden = {"common", "core", "helper", "misc", "utils"};
+        for (String name : forbidden) {
+            assertFalse(
+                    "Forbidden StarRocks connector root package exists: " + name,
+                    new File(root, name).exists());
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/client/source/StarRocksQueryPlanClientTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/client/source/StarRocksQueryPlanClientTest.java
@@ -1,0 +1,31 @@
+package com.link.up.connector.starrocks.client.source;
+
+import com.link.up.connector.starrocks.config.StarRocksSourceTableConfig;
+import com.link.up.connector.starrocks.schema.StarRocksSchemaParser;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class StarRocksQueryPlanClientTest {
+
+    @Test
+    public void buildsProjectedNativeQueryWithFilter() {
+        Map<String, Object> fields = new LinkedHashMap<String, Object>();
+        fields.put("id", "BIGINT");
+        fields.put("order`name", "STRING");
+
+        StarRocksSourceTableConfig table =
+                new StarRocksSourceTableConfig(
+                        "analytics",
+                        "orders",
+                        "id >= 100",
+                        StarRocksSchemaParser.parse(fields));
+
+        assertEquals(
+                "SELECT `id`, `order``name` FROM `analytics`.`orders` WHERE id >= 100",
+                StarRocksQueryPlanClient.buildQuerySql(table));
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/client/source/StarRocksSplitPlannerTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/client/source/StarRocksSplitPlannerTest.java
@@ -1,0 +1,69 @@
+package com.link.up.connector.starrocks.client.source;
+
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPartition;
+import com.link.up.connector.starrocks.client.source.model.StarRocksQueryPlan;
+import com.link.up.connector.starrocks.client.source.model.StarRocksTablet;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class StarRocksSplitPlannerTest {
+
+    @Test
+    public void plansTabletsAcrossCandidateBackendsDeterministically() {
+        StarRocksQueryPlan plan = new StarRocksQueryPlan();
+        plan.setOpaquedQueryPlan("opaque-plan");
+
+        Map<String, StarRocksTablet> tablets =
+                new LinkedHashMap<String, StarRocksTablet>();
+        tablets.put("3", tablet("be-b:9060", "be-a:9060"));
+        tablets.put("1", tablet("be-a:9060", "be-b:9060"));
+        tablets.put("2", tablet("be-a:9060", "be-b:9060"));
+        tablets.put("4", tablet("be-a:9060", "be-b:9060"));
+        plan.setPartitions(tablets);
+
+        List<StarRocksQueryPartition> partitions =
+                StarRocksSplitPlanner.plan("demo", "orders", plan, 1);
+
+        assertEquals(4, partitions.size());
+        assertEquals("be-a:9060", partitions.get(0).getBeAddress());
+        assertEquals(Arrays.asList(1L), partitions.get(0).getTabletIds());
+        assertEquals("be-a:9060", partitions.get(1).getBeAddress());
+        assertEquals(Arrays.asList(3L), partitions.get(1).getTabletIds());
+        assertEquals("be-b:9060", partitions.get(2).getBeAddress());
+        assertEquals(Arrays.asList(2L), partitions.get(2).getTabletIds());
+        assertEquals("be-b:9060", partitions.get(3).getBeAddress());
+        assertEquals(Arrays.asList(4L), partitions.get(3).getTabletIds());
+    }
+
+    @Test
+    public void chunksTabletGroupsByRequestSize() {
+        StarRocksQueryPlan plan = new StarRocksQueryPlan();
+        plan.setOpaquedQueryPlan("opaque-plan");
+        Map<String, StarRocksTablet> tablets =
+                new LinkedHashMap<String, StarRocksTablet>();
+        for (int i = 1; i <= 5; i++) {
+            tablets.put(String.valueOf(i), tablet("be-a:9060"));
+        }
+        plan.setPartitions(tablets);
+
+        List<StarRocksQueryPartition> partitions =
+                StarRocksSplitPlanner.plan("demo", "orders", plan, 2);
+
+        assertEquals(3, partitions.size());
+        assertEquals(Arrays.asList(1L, 2L), partitions.get(0).getTabletIds());
+        assertEquals(Arrays.asList(3L, 4L), partitions.get(1).getTabletIds());
+        assertEquals(Arrays.asList(5L), partitions.get(2).getTabletIds());
+    }
+
+    private static StarRocksTablet tablet(String... routings) {
+        StarRocksTablet tablet = new StarRocksTablet();
+        tablet.setRoutings(Arrays.asList(routings));
+        return tablet;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/config/StarRocksSourceConfigTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/config/StarRocksSourceConfigTest.java
@@ -1,0 +1,108 @@
+package com.link.up.connector.starrocks.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.type.SqlType;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StarRocksSourceConfigTest {
+
+    @Test
+    public void parsesSingleTableNativeSource() {
+        Map<String, Object> root = baseConfig();
+        root.put("table", "orders");
+        root.put("scan_filter", "id > 100");
+        root.put("schema", Collections.<String, Object>singletonMap(
+                "fields", fields("id", "BIGINT", "name", "VARCHAR(64)")));
+
+        StarRocksSourceConfig config =
+                StarRocksSourceConfig.of(ReadonlyConfig.fromMap(root));
+
+        assertEquals(Arrays.asList("fe-1:8030", "fe-2:8030"), config.getNodeUrls());
+        assertEquals("demo", config.getDatabase());
+        assertEquals(1, config.getTableConfigs().size());
+        StarRocksSourceTableConfig table = config.getTableConfigs().get(0);
+        assertEquals("orders", table.getTable());
+        assertEquals("id > 100", table.getScanFilter());
+        assertEquals(SqlType.BIGINT,
+                table.getCatalogTable().getTableSchema().getColumn(0).getDataType().getSqlType());
+        assertEquals(2, config.getCatalogTables().get(0).getTableSchema().getColumns().size());
+    }
+
+    @Test
+    public void parsesMultiTableSchemaAndPerTableFilter() {
+        Map<String, Object> root = baseConfig();
+        root.put("scan_filter", "tenant_id = 7");
+
+        Map<String, Object> orders = new LinkedHashMap<String, Object>();
+        orders.put("table", "orders");
+        orders.put("scan_filter", "status = 'PAID'");
+        orders.put("schema", Collections.<String, Object>singletonMap(
+                "fields", fields("id", "BIGINT", "amount", "DECIMAL(18,2)")));
+
+        Map<String, Object> customers = new LinkedHashMap<String, Object>();
+        customers.put("table", "customers");
+        customers.put("schema", Collections.<String, Object>singletonMap(
+                "fields", fields("id", "BIGINT", "name", "STRING")));
+
+        root.put("table_list", Arrays.<Map<String, Object>>asList(orders, customers));
+
+        StarRocksSourceConfig config =
+                StarRocksSourceConfig.of(ReadonlyConfig.fromMap(root));
+
+        assertEquals(2, config.getTableConfigs().size());
+        assertEquals("status = 'PAID'", config.getTableConfigs().get(0).getScanFilter());
+        assertEquals("tenant_id = 7", config.getTableConfigs().get(1).getScanFilter());
+    }
+
+    @Test
+    public void rejectsTableAndTableListTogether() {
+        Map<String, Object> root = baseConfig();
+        root.put("table", "orders");
+        root.put("schema", Collections.<String, Object>singletonMap(
+                "fields", fields("id", "BIGINT")));
+
+        Map<String, Object> item = new LinkedHashMap<String, Object>();
+        item.put("table", "customers");
+        item.put("schema", Collections.<String, Object>singletonMap(
+                "fields", fields("id", "BIGINT")));
+        root.put("table_list", Collections.<Map<String, Object>>singletonList(item));
+
+        boolean failed = false;
+        try {
+            StarRocksSourceConfig.of(ReadonlyConfig.fromMap(root));
+        } catch (IllegalArgumentException expected) {
+            failed = true;
+            assertTrue(expected.getMessage().contains("Exactly one"));
+        }
+        assertTrue(failed);
+    }
+
+    private static Map<String, Object> baseConfig() {
+        Map<String, Object> root = new LinkedHashMap<String, Object>();
+        root.put("node_urls", Arrays.asList("fe-1:8030", "fe-2:8030"));
+        root.put("username", "root");
+        root.put("password", "secret");
+        root.put("database", "demo");
+        return root;
+    }
+
+    private static Map<String, Object> fields(String... values) {
+        if (values.length % 2 != 0) {
+            throw new IllegalArgumentException("fields must contain name/type pairs");
+        }
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        for (int i = 0; i < values.length; i += 2) {
+            result.put(values[i], values[i + 1]);
+        }
+        return result;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/schema/StarRocksSchemaParserTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/schema/StarRocksSchemaParserTest.java
@@ -1,0 +1,62 @@
+package com.link.up.connector.starrocks.schema;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.SqlType;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StarRocksSchemaParserTest {
+
+    @Test
+    public void mapsCoreStarRocksScalarTypes() {
+        Map<String, Object> fields = new LinkedHashMap<String, Object>();
+        fields.put("flag", "BOOLEAN");
+        fields.put("id", "BIGINT");
+        fields.put("huge", "LARGEINT");
+        fields.put("amount", "DECIMAL(20, 4)");
+        fields.put("name", "VARCHAR(128)");
+        fields.put("payload", "JSON");
+        fields.put("created_on", "DATE");
+        fields.put("created_at", "DATETIME");
+
+        TableSchema schema = StarRocksSchemaParser.parse(fields);
+
+        assertEquals(8, schema.getColumns().size());
+        assertEquals(SqlType.BOOLEAN, schema.getColumn(0).getDataType().getSqlType());
+        assertEquals(SqlType.BIGINT, schema.getColumn(1).getDataType().getSqlType());
+        assertEquals(SqlType.STRING, schema.getColumn(2).getDataType().getSqlType());
+        assertEquals("LARGEINT", schema.getColumn(2).getSourceType());
+        assertEquals(new DecimalType(20, 4), schema.getColumn(3).getDataType());
+        assertEquals(SqlType.STRING, schema.getColumn(4).getDataType().getSqlType());
+        assertEquals(SqlType.STRING, schema.getColumn(5).getDataType().getSqlType());
+        assertEquals(SqlType.DATE, schema.getColumn(6).getDataType().getSqlType());
+        assertEquals(SqlType.TIMESTAMP, schema.getColumn(7).getDataType().getSqlType());
+
+        Column amount = schema.getColumn(3);
+        assertEquals("DECIMAL(20, 4)", amount.getSourceType());
+    }
+
+    @Test
+    public void rejectsComplexTypesDuringStageOne() {
+        boolean failed = false;
+        try {
+            StarRocksSchemaParser.resolveType("ARRAY<INT>");
+        } catch (IllegalArgumentException expected) {
+            failed = true;
+            assertTrue(expected.getMessage().contains("ARRAY/MAP"));
+        }
+        assertTrue(failed);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsDecimalBeyondStarRocksPrecision() {
+        StarRocksSchemaParser.resolveType("DECIMAL(39, 2)");
+    }
+}

--- a/link-up-connectors/pom.xml
+++ b/link-up-connectors/pom.xml
@@ -18,6 +18,7 @@
         <module>link-up-connector-jdbc</module>
         <module>link-up-connector-doris</module>
         <module>link-up-connector-http</module>
+        <module>link-up-connector-starrocks</module>
     </modules>
 
 </project>

--- a/link-up-launcher/pom.xml
+++ b/link-up-launcher/pom.xml
@@ -40,6 +40,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-connector-starrocks</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j2.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
         <log4j2.version>2.23.1</log4j2.version>
         <slf4j.version>2.0.13</slf4j.version>
         <jsqlparser.version>4.9</jsqlparser.version>
+        <okhttp.version>4.12.0</okhttp.version>
+        <jackson.version>2.15.4</jackson.version>
+        <starrocks.thrift.sdk.version>1.0.1</starrocks.thrift.sdk.version>
+        <arrow.version>5.0.0</arrow.version>
 
 
     </properties>


### PR DESCRIPTION
## Summary

Add Stage 1 of the standalone StarRocks connector without depending on `link-up-connector-jdbc`.

The native source path is:

`StarRocks FE query plan -> deterministic Tablet/BE splits -> BE Thrift scanner -> Apache Arrow -> FluxRow`

## What changed

- add standalone `link-up-connector-starrocks` module
- add `StarRocksSourceFactory` / `StarRocksSource` / split enumerator / reader
- obtain native query plans from FE `/_query_plan`
- deterministically balance tablet candidates across BE nodes and chunk by `request_tablet_size`
- read BE data through StarRocks Thrift `open_scanner` / `get_next` / `close_scanner`
- decode Arrow batches into `FluxRow`
- support single-table and multi-table bounded reads
- support explicit `schema.fields`, column projection and `scan_filter`
- support scanner batch size, timeout, keep-alive, memory limit, FE retry/failover, and extra scan parameters
- wire the connector into the Maven reactor and launcher ServiceLoader classpath
- document the Native OLAP connector boundary in `CONNECTOR_ADAPTATION.md`

## Stage 1 boundaries

- no JDBC fallback and no MySQL driver dependency
- no Stream Load Sink yet (Stage 2)
- no CDC / streaming / runtime schema evolution
- schema is explicitly configured in Stage 1; Native Catalog auto-discovery is intentionally deferred
- core scalar StarRocks types are supported
- `LARGEINT` is preserved as exact text because its full signed 128-bit domain cannot safely fit Flux `DECIMAL(38,0)`
- `ARRAY` / `MAP` fail early instead of silently using an unsafe conversion

## Validation

Added tests for:

- deterministic Tablet/BE split planning and split chunking
- StarRocks scalar type mapping and precision boundaries
- single-table / multi-table source config parsing
- projected FE query SQL generation and identifier quoting
- standalone connector package boundaries

I also checked the implementation against the current SeaTunnel StarRocks native source APIs and Link-Up's dynamic split lifecycle. In particular, the reader supports repeated `openSplit -> endOfInput -> openSplit` reuse.

A Maven build could not be executed from the current tool environment because it does not have repository/dependency network access, and this repository currently has no GitHub Actions workflow to execute the build remotely. Keeping this PR as Draft for a repository-side Maven/integration run before merge.