### PR TITLE
feat(starrocks): add bounded stream load sink

### DIFF
--- a/CONNECTOR_ADAPTATION.md
+++ b/CONNECTOR_ADAPTATION.md
@@ -44,9 +44,11 @@ StarRocks 使用独立的 `link-up-connector-starrocks`：
 - BE 返回 Apache Arrow，Connector 在边界内转换为 `FluxRow`。
 - StarRocks Source 不依赖 JDBC / MySQL Driver，也不复用 JDBC Split Planner。
 - Stage 1 只处理 bounded full read；Schema 由任务显式声明，复杂类型在没有安全映射前明确失败。
-- Stage 2 的 Sink 使用 StarRocks Stream Load，并继续留在同一个独立 Connector 模块中，不回落到 JDBC batch insert。
+- Stage 2 Sink 通过 Stream Load 写入：按行数/字节数形成批次，网络重试复用 label；`Label Already Exists` 必须先确认 label 最终状态，只有明确 `ABORTED` 才允许换新 label。
+- Stream Load 成功 flush 已经是远端独立提交；没有真正 2PC 时，不把 Link-Up 的 `commit/abort` 生命周期包装成 Job-level exactly once。
+- Stage 2 不使用 JDBC 自动建表，也不声明 CDC / DELETE / runtime schema evolution 能力。
 
-这种例外是协议边界，不是为数据库复制通用执行框架。Source 仍复用 Link-Up 的 `SourceSplitEnumerator`、动态 Split 分配、`SourceReader`、Channel、Metrics 和 Job 生命周期。
+这种例外是协议边界，不是为数据库复制通用执行框架。Source 仍复用 Link-Up 的 `SourceSplitEnumerator`、动态 Split 分配、`SourceReader`、Channel、Metrics 和 Job 生命周期；Sink 仍复用 `SinkPreparer`、`SinkWriter`、Task commit evidence 和统一错误传播。
 
 ## 数据库差异不要强行抹平
 

--- a/link-up-connectors/link-up-connector-starrocks/README.md
+++ b/link-up-connectors/link-up-connector-starrocks/README.md
@@ -49,11 +49,12 @@ Stage 2 支持：
 - `batch_max_rows` / `batch_max_bytes` 双阈值 flush
 - 多 FE 轮转和 307/308 redirect
 - 同一批次失败重试复用同一个 label
-- `Label Already Exists` 后查询最终状态：`VISIBLE/COMMITTED` 视为成功，只有明确 `ABORTED` 才创建新 label
-- `Publish Timeout` 按 StarRocks Stream Load 语义视为已接受成功结果
-- `stream_load.params` 透传高级 Stream Load header 参数
-- JSON 日期/时间/Decimal/Bytes 的稳定序列化
+- `Label Already Exists` 后查询最终状态：`VISIBLE/COMMITTED` 视为成功，只有明确 `ABORTED` 才允许换新 label 再提交
+- `Publish Timeout` 按 StarRocks Stream Load 语义视为已提交成功结果，不重复发送
+- `stream_load.params` 仅透传不改变 Stage 2 写入模型的安全 Stream Load header，例如 `strict_mode`、`timeout`、`max_filter_ratio`
+- JSON 日期/时间/Decimal 的稳定序列化
 - CSV schema 顺序 `columns` header
+- `BINARY/VARBINARY` 仅在 CSV 模式按十六进制文本写入
 
 Stage 2 明确不包含：
 
@@ -61,12 +62,42 @@ Stage 2 明确不包含：
 - 自动建库、自动建表或 JDBC Catalog
 - 2PC / Job-level exactly once
 - CDC / DELETE / RowKind 语义
+- partial update / `merge_condition`
+- Merge Commit / 异步合并提交
 - 运行时 Schema Evolution
 - 多目标表 Sink
 
 Stream Load 每次成功 flush 都已经在 StarRocks 侧形成独立提交，所以 Link-Up `commit()` 不能把它描述成可回滚事务。`abort()` 只能丢弃还没发送的本地 buffer，不能撤销已经成功的 Stream Load。
 
-Connector 在一次 flush 的内部重试会复用相同 label，避免网络超时造成重复导入；但如果整个 Link-Up SinkTask 重新执行，会创建新的 label，因此任务级 Retry 仍应结合目标表主键/去重语义判断。
+Connector 在一次 flush 的内部重试会复用相同 label，避免网络超时造成重复导入；但如果整个 Link-Up SinkTask 重新执行，会创建新的 label，因此任务级 Retry 仍应结合目标表自身的 key/去重语义判断。
+
+### Label boundary
+
+每个 flush 使用：
+
+```text
+<label_prefix><32-char uuid>
+```
+
+因此自定义 `label_prefix` 会在配置阶段按 StarRocks Label 约束校验：
+
+- 只能包含字母、数字和下划线
+- 必须以字母或下划线开头
+- Connector 会自动补尾部 `_`
+- prefix 最长 96 个字符，为 32 位 UUID 预留空间，确保最终 Label 不超过 128 个字符
+
+未配置 `label_prefix` 时，Connector 会从 `database/table` 生成合法且有界的 prefix。
+
+### `stream_load.params` boundary
+
+`stream_load.params` 不是绕过 Connector 语义边界的逃生口。Connector 自己负责的 header（例如 `label`、`format`、`columns`、`strip_outer_array`、`jsonpaths`）会 fail-fast；Stage 2 明确不支持的语义也会 fail-fast，包括：
+
+- `enable_merge_commit` / `merge_commit_*`
+- `partial_update` / `partial_update_mode` / `merge_condition`
+- `two_phase_commit`
+- `compression` / `content-encoding`（当前 payload 未压缩）
+
+这样可以保证 label 幂等重试、payload 编码和 bounded full-row write 的语义不被透传参数悄悄改写。
 
 ## Native Source single table example
 
@@ -173,7 +204,7 @@ sink {
 }
 ```
 
-CSV Stage 2 不会猜测 quoting/enclose 规则。如果字段值包含已配置的列分隔符或行分隔符，Connector 会直接失败并建议改用 JSON，避免生成 StarRocks 解析语义不确定的数据。
+CSV Stage 2 不会猜测 quoting/enclose 规则。如果字段值包含已配置的列分隔符或行分隔符，Connector 会直接失败并建议改用 JSON，避免生成 StarRocks 解析语义不确定的数据。`BINARY/VARBINARY` 是例外：StarRocks Stream Load 对这类字段只支持 CSV，Connector 会把 `byte[]` 编码为十六进制文本。
 
 ## Type boundary
 
@@ -181,4 +212,8 @@ Native Source 的类型边界保持保守。核心标量 StarRocks 类型会映�
 
 `LARGEINT` 在 Source 中以精确文本承载，避免完整 signed 128-bit 范围被错误压缩到 `DECIMAL(38,0)`。
 
-Source 的 `ARRAY` / `MAP` 在没有专门 Arrow 转换验证前仍会配置阶段 fail-fast；Sink JSON 序列化可以保留已有 Flux `ARRAY/MAP/ROW` Java 值的 JSON 结构，但这不等于运行时 Schema Evolution 或复杂类型自动发现。
+Source 的 `ARRAY` / `MAP` 在没有专门 Arrow 转换验证前仍会配置阶段 fail-fast。Sink 对已经存在于 Flux 行中的 `ARRAY/MAP` 可以保留 JSON-compatible 结构；这不等于复杂类型自动发现或 runtime schema evolution。
+
+`ROW/STRUCT` 需要嵌套字段名和目标结构元数据。Stage 2 不从 `FluxRow` 的位置字段猜测 STRUCT 字段，因此会 fail-fast，留给后续专门的复杂类型适配，而不是静默写错。
+
+`BYTES` 对应 StarRocks `BINARY/VARBINARY` 时只支持 CSV 十六进制写入；JSON 模式会在序列化阶段 fail-fast。

--- a/link-up-connectors/link-up-connector-starrocks/README.md
+++ b/link-up-connectors/link-up-connector-starrocks/README.md
@@ -55,6 +55,7 @@ Stage 2 支持：
 - JSON 日期/时间/Decimal 的稳定序列化
 - CSV schema 顺序 `columns` header
 - `BINARY/VARBINARY` 仅在 CSV 模式按十六进制文本写入
+- Stream Load 返回过滤行时接入 Link-Up dirty-data evidence，避免“任务成功但少数据”只存在于日志
 
 Stage 2 明确不包含：
 
@@ -66,8 +67,10 @@ Stage 2 明确不包含：
 - Merge Commit / 异步合并提交
 - 运行时 Schema Evolution
 - 多目标表 Sink
+- `ARRAY` / `MAP` / `ROW` 复杂类型写入
+- `TIMESTAMP_TZ` 到 StarRocks `DATETIME` 的隐式时区丢弃
 
-Stream Load 每次成功 flush 都已经在 StarRocks 侧形成独立提交，所以 Link-Up `commit()` 不能把它描述成可回滚事务。`abort()` 只能丢弃还没发送的本地 buffer，不能撤销已经成功的 Stream Load。
+Stream Load 每次成功 flush 都已经在 StarRocks 侧形成独立提交，所以 Link-Up `commit()` 不能把它描述成可回滚事务。`abort()` 只能丢弃还没发送的本地 buffer，不能撤销已经成功的 Stream Load；`close()` 同样不会偷偷 flush 尚未进入 `prepareCommit()` 的 buffer。
 
 Connector 在一次 flush 的内部重试会复用相同 label，避免网络超时造成重复导入；但如果整个 Link-Up SinkTask 重新执行，会创建新的 label，因此任务级 Retry 仍应结合目标表自身的 key/去重语义判断。
 
@@ -98,6 +101,14 @@ Connector 在一次 flush 的内部重试会复用相同 label，避免网络超
 - `compression` / `content-encoding`（当前 payload 未压缩）
 
 这样可以保证 label 幂等重试、payload 编码和 bounded full-row write 的语义不被透传参数悄悄改写。
+
+### Filtered rows / dirty-data evidence
+
+默认情况下 Stream Load 应通过严格模式尽早暴露非法数据。如果用户显式允许 `max_filter_ratio > 0`，StarRocks 可能返回成功同时带有 `NumberFilteredRows > 0`。
+
+Stage 2 会保留 StarRocks 的成功结果，但同时向 Link-Up `DirtyDataAwareSinkWriter` 写入 `STREAM_LOAD_FILTERED` 证据，包含过滤数量、Message 和 ErrorURL（如有）。这样 Job 结果可以看到数据损失证据，而不是只能翻 Sink 日志。
+
+这不是逐行重放或 CDC dirty-row recovery；Stream Load 响应只提供批次级过滤信息，因此 Stage 2 只记录批次级 evidence。
 
 ## Native Source single table example
 
@@ -204,7 +215,9 @@ sink {
 }
 ```
 
-CSV Stage 2 不会猜测 quoting/enclose 规则。如果字段值包含已配置的列分隔符或行分隔符，Connector 会直接失败并建议改用 JSON，避免生成 StarRocks 解析语义不确定的数据。`BINARY/VARBINARY` 是例外：StarRocks Stream Load 对这类字段只支持 CSV，Connector 会把 `byte[]` 编码为十六进制文本。
+CSV Stage 2 不会猜测 quoting/enclose 规则。如果字段值包含已配置的列分隔符或行分隔符，Connector 会直接失败并建议改用 JSON，避免生成 StarRocks 解析语义不确定的数据。非空字符串如果恰好等于 CSV NULL marker `\N` 也会 fail-fast，避免被目标端静默解释成 NULL。
+
+`BINARY/VARBINARY` 是例外：StarRocks Stream Load 对这类字段只支持 CSV，Connector 会把 `byte[]` 编码为十六进制文本。
 
 ## Type boundary
 
@@ -212,8 +225,8 @@ Native Source 的类型边界保持保守。核心标量 StarRocks 类型会映�
 
 `LARGEINT` 在 Source 中以精确文本承载，避免完整 signed 128-bit 范围被错误压缩到 `DECIMAL(38,0)`。
 
-Source 的 `ARRAY` / `MAP` 在没有专门 Arrow 转换验证前仍会配置阶段 fail-fast。Sink 对已经存在于 Flux 行中的 `ARRAY/MAP` 可以保留 JSON-compatible 结构；这不等于复杂类型自动发现或 runtime schema evolution。
+Stage 2 Sink 同样只承诺已经验证过的离线标量写入。`ARRAY` / `MAP` / `ROW` 需要独立的目标类型、嵌套字段和 Stream Load 兼容性测试，因此当前在 Schema 初始化阶段 fail-fast，不根据 Java Collection 或位置字段猜测目标结构。
 
-`ROW/STRUCT` 需要嵌套字段名和目标结构元数据。Stage 2 不从 `FluxRow` 的位置字段猜测 STRUCT 字段，因此会 fail-fast，留给后续专门的复杂类型适配，而不是静默写错。
+Flux `TIMESTAMP_TZ` 会携带 offset，而 StarRocks `DATETIME` 不应由 Connector 隐式决定如何丢弃该 offset。Stage 2 因此 fail-fast，要求任务在上游显式转换为期望时区的 `TIMESTAMP`。
 
-`BYTES` 对应 StarRocks `BINARY/VARBINARY` 时只支持 CSV 十六进制写入；JSON 模式会在序列化阶段 fail-fast。
+`BYTES` 对应 StarRocks `BINARY/VARBINARY` 时只支持 CSV 十六进制写入；JSON 模式会在 Schema 初始化阶段 fail-fast。

--- a/link-up-connectors/link-up-connector-starrocks/README.md
+++ b/link-up-connectors/link-up-connector-starrocks/README.md
@@ -4,7 +4,7 @@
 
 ## Stage 1: Native Source
 
-当前实现只包含 bounded Native Source：
+Native Source 数据链路：
 
 ```text
 StarRocksSource
@@ -27,16 +27,48 @@ Stage 1 支持：
 - BE Scanner batch / timeout / keep-alive / memory 参数
 - 标量类型 Arrow -> FluxRow 转换
 
-Stage 1 不包含：
+## Stage 2: Stream Load Sink
 
-- JDBC fallback
-- Stream Load Sink（Stage 2）
-- CDC / streaming
-- 运行时 schema evolution
-- Native Catalog 自动 Schema 发现
-- ARRAY / MAP 的 Arrow 转换
+Stage 2 新增 bounded Stream Load Sink：
 
-## Single table example
+```text
+RecordBatch<FluxRow>
+  -> schema-aware JSON / CSV serialization
+  -> row / byte threshold buffering
+  -> FE PUT /api/{database}/{table}/_stream_load
+  -> 307/308 redirect to BE
+  -> label-based idempotent retry
+  -> Label Already Exists -> GET /api/{database}/get_load_state
+```
+
+Stage 2 支持：
+
+- 单目标表 bounded write
+- JSON Stream Load（默认）
+- CSV Stream Load
+- `batch_max_rows` / `batch_max_bytes` 双阈值 flush
+- 多 FE 轮转和 307/308 redirect
+- 同一批次失败重试复用同一个 label
+- `Label Already Exists` 后查询最终状态：`VISIBLE/COMMITTED` 视为成功，只有明确 `ABORTED` 才创建新 label
+- `Publish Timeout` 按 StarRocks Stream Load 语义视为已接受成功结果
+- `stream_load.params` 透传高级 Stream Load header 参数
+- JSON 日期/时间/Decimal/Bytes 的稳定序列化
+- CSV schema 顺序 `columns` header
+
+Stage 2 明确不包含：
+
+- JDBC fallback / MySQL Driver
+- 自动建库、自动建表或 JDBC Catalog
+- 2PC / Job-level exactly once
+- CDC / DELETE / RowKind 语义
+- 运行时 Schema Evolution
+- 多目标表 Sink
+
+Stream Load 每次成功 flush 都已经在 StarRocks 侧形成独立提交，所以 Link-Up `commit()` 不能把它描述成可回滚事务。`abort()` 只能丢弃还没发送的本地 buffer，不能撤销已经成功的 Stream Load。
+
+Connector 在一次 flush 的内部重试会复用相同 label，避免网络超时造成重复导入；但如果整个 Link-Up SinkTask 重新执行，会创建新的 label，因此任务级 Retry 仍应结合目标表主键/去重语义判断。
+
+## Native Source single table example
 
 ```hocon
 source {
@@ -63,7 +95,7 @@ source {
 }
 ```
 
-## Multiple tables example
+## Native Source multiple tables example
 
 ```hocon
 source {
@@ -98,8 +130,55 @@ source {
 }
 ```
 
+## Stream Load Sink example
+
+```hocon
+sink {
+  StarRocks {
+    node_urls = ["fe-1:8030", "fe-2:8030"]
+    username = "root"
+    password = ""
+    database = "warehouse"
+    table = "orders"
+
+    load_format = JSON
+    batch_max_rows = 5000
+    batch_max_bytes = 5242880
+    max_retries = 3
+    retry_backoff_ms = 1000
+    max_retry_backoff_ms = 5000
+
+    stream_load.params = {
+      strict_mode = "true"
+      timeout = "600"
+    }
+  }
+}
+```
+
+CSV 示例：
+
+```hocon
+sink {
+  StarRocks {
+    node_urls = ["127.0.0.1:8030"]
+    username = "root"
+    database = "warehouse"
+    table = "orders"
+
+    load_format = CSV
+    column_separator = "|"
+    row_delimiter = "\n"
+  }
+}
+```
+
+CSV Stage 2 不会猜测 quoting/enclose 规则。如果字段值包含已配置的列分隔符或行分隔符，Connector 会直接失败并建议改用 JSON，避免生成 StarRocks 解析语义不确定的数据。
+
 ## Type boundary
 
-Stage 1 intentionally keeps the Native Source type boundary conservative. Core scalar StarRocks types are mapped to Flux types, including `BOOLEAN`, integer types, `LARGEINT`, `FLOAT`, `DOUBLE`, `DECIMAL`, string types, `JSON`, `DATE` and `DATETIME`.
+Native Source 的类型边界保持保守。核心标量 StarRocks 类型会映射为 Flux 类型，包括 `BOOLEAN`、整数、`LARGEINT`、`FLOAT`、`DOUBLE`、`DECIMAL`、字符串、`JSON`、`DATE` 和 `DATETIME`。
 
-`ARRAY` and `MAP` fail during configuration instead of being silently converted to an unsafe representation. They can be added later with dedicated Arrow conversion tests.
+`LARGEINT` 在 Source 中以精确文本承载，避免完整 signed 128-bit 范围被错误压缩到 `DECIMAL(38,0)`。
+
+Source 的 `ARRAY` / `MAP` 在没有专门 Arrow 转换验证前仍会配置阶段 fail-fast；Sink JSON 序列化可以保留已有 Flux `ARRAY/MAP/ROW` Java 值的 JSON 结构，但这不等于运行时 Schema Evolution 或复杂类型自动发现。

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/sink/StarRocksStreamLoadClient.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/sink/StarRocksStreamLoadClient.java
@@ -1,0 +1,386 @@
+package com.link.up.connector.starrocks.client.sink;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.starrocks.config.StarRocksLoadFormat;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+import okhttp3.HttpUrl;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** Task-local HTTP client for StarRocks Stream Load. */
+public final class StarRocksStreamLoadClient implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StarRocksStreamLoadClient.class);
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final MediaType JSON_MEDIA_TYPE =
+            MediaType.parse("application/json; charset=utf-8");
+    private static final MediaType TEXT_MEDIA_TYPE =
+            MediaType.parse("text/plain; charset=utf-8");
+    private static final int MAX_REDIRECTS = 5;
+
+    private final StarRocksSinkConfig config;
+    private final OkHttpClient httpClient;
+    private final AtomicInteger nextNode = new AtomicInteger();
+
+    public StarRocksStreamLoadClient(StarRocksSinkConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(config.getConnectTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .readTimeout(config.getSocketTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .writeTimeout(config.getSocketTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .followRedirects(false)
+                        .build();
+    }
+
+    public StarRocksStreamLoadResponse load(
+            byte[] payload,
+            TableSchema schema)
+            throws IOException {
+        Objects.requireNonNull(payload, "payload must not be null");
+        Objects.requireNonNull(schema, "schema must not be null");
+        if (payload.length == 0) {
+            throw new IllegalArgumentException("StarRocks Stream Load payload must not be empty");
+        }
+
+        String label = createLabel();
+        IOException lastFailure = null;
+        int maxAttempts = Math.max(1, config.getMaxRetries() + 1);
+
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                StarRocksStreamLoadResponse response =
+                        executeStreamLoad(payload, label, schema);
+
+                if (response.isSuccess()) {
+                    return response;
+                }
+
+                if (response.isLabelAlreadyExists()) {
+                    LabelResolution resolution = waitForLabelResolution(label);
+                    if (resolution == LabelResolution.COMMITTED) {
+                        return StarRocksStreamLoadResponse.resolvedCommitted(
+                                label,
+                                response.getBody());
+                    }
+                    if (resolution == LabelResolution.ABORTED) {
+                        String oldLabel = label;
+                        label = createLabel();
+                        LOG.warn(
+                                "StarRocks Stream Load label {} is ABORTED; retrying with new label {}",
+                                oldLabel,
+                                label);
+                        continue;
+                    }
+                }
+
+                throw new NonRetryableStreamLoadException(
+                        "StarRocks Stream Load failed: status="
+                                + response.getStatus()
+                                + ", label="
+                                + label
+                                + ", message="
+                                + response.getMessage()
+                                + ", errorUrl="
+                                + response.getErrorUrl());
+
+            } catch (NonRetryableStreamLoadException failure) {
+                throw failure;
+            } catch (IOException failure) {
+                lastFailure = failure;
+                if (attempt >= maxAttempts) {
+                    break;
+                }
+                LOG.warn(
+                        "StarRocks Stream Load attempt {}/{} failed for label={}, retrying same label: {}",
+                        attempt,
+                        maxAttempts,
+                        label,
+                        failure.getMessage());
+                sleepBeforeRetry(attempt);
+            }
+        }
+
+        throw new IOException(
+                "StarRocks Stream Load exceeded retry limit for label=" + label,
+                lastFailure);
+    }
+
+    private StarRocksStreamLoadResponse executeStreamLoad(
+            byte[] payload,
+            String label,
+            TableSchema schema)
+            throws IOException {
+        String node = selectNode();
+        HttpUrl url = buildStreamLoadUrl(node);
+        Map<String, String> headers = buildHeaders(label, schema);
+        MediaType mediaType = config.getLoadFormat() == StarRocksLoadFormat.JSON
+                ? JSON_MEDIA_TYPE
+                : TEXT_MEDIA_TYPE;
+
+        Request.Builder builder =
+                new Request.Builder()
+                        .url(url)
+                        .put(RequestBody.create(payload, mediaType));
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            builder.header(entry.getKey(), entry.getValue());
+        }
+        return executeWithRedirect(builder.build(), 0);
+    }
+
+    private StarRocksStreamLoadResponse executeWithRedirect(
+            Request request,
+            int redirectCount)
+            throws IOException {
+        if (redirectCount > MAX_REDIRECTS) {
+            throw new IOException(
+                    "StarRocks Stream Load redirect count exceeded " + MAX_REDIRECTS);
+        }
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            if (response.code() == 307 || response.code() == 308) {
+                String location = response.header("Location");
+                if (location == null || location.trim().isEmpty()) {
+                    throw new IOException(
+                            "StarRocks Stream Load redirect response has no Location header");
+                }
+                Request redirected = request.newBuilder().url(location).build();
+                return executeWithRedirect(redirected, redirectCount + 1);
+            }
+
+            String body = response.body() == null ? "" : response.body().string();
+            if (!response.isSuccessful()) {
+                if (response.code() >= 400
+                        && response.code() < 500
+                        && response.code() != 408
+                        && response.code() != 429) {
+                    throw new NonRetryableStreamLoadException(
+                            "StarRocks Stream Load HTTP client error: status="
+                                    + response.code()
+                                    + ", body="
+                                    + body);
+                }
+                throw new IOException(
+                        "StarRocks Stream Load HTTP error: status="
+                                + response.code()
+                                + ", body="
+                                + body);
+            }
+
+            StarRocksStreamLoadResponse loadResponse =
+                    StarRocksStreamLoadResponse.parse(body);
+            LOG.debug(
+                    "StarRocks Stream Load response: status={}, label={}, loaded={}, filtered={}",
+                    loadResponse.getStatus(),
+                    loadResponse.getLabel(),
+                    loadResponse.getNumberLoadedRows(),
+                    loadResponse.getNumberFilteredRows());
+            return loadResponse;
+        }
+    }
+
+    Map<String, String> buildHeaders(
+            String label,
+            TableSchema schema) {
+        Map<String, String> headers = new LinkedHashMap<String, String>();
+        headers.putAll(config.getStreamLoadParams());
+        headers.put("Authorization", basicAuth());
+        headers.put("label", label);
+        headers.put("Expect", "100-continue");
+
+        if (config.getLoadFormat() == StarRocksLoadFormat.JSON) {
+            headers.put("format", "json");
+            headers.put("strip_outer_array", "true");
+        } else {
+            headers.put("format", "csv");
+            headers.put("column_separator", config.getColumnSeparator());
+            headers.put("row_delimiter", config.getRowDelimiter());
+            headers.put("columns", columnsHeader(schema));
+        }
+        return headers;
+    }
+
+    private LabelResolution waitForLabelResolution(String label) throws IOException {
+        long deadlineNanos =
+                System.nanoTime()
+                        + TimeUnit.MILLISECONDS.toNanos(config.getLabelStateTimeoutMs());
+
+        while (System.nanoTime() < deadlineNanos) {
+            String state = queryLabelState(label);
+            if ("VISIBLE".equalsIgnoreCase(state)
+                    || "COMMITTED".equalsIgnoreCase(state)) {
+                return LabelResolution.COMMITTED;
+            }
+            if ("ABORTED".equalsIgnoreCase(state)) {
+                return LabelResolution.ABORTED;
+            }
+            if (!"PREPARE".equalsIgnoreCase(state)) {
+                throw new IOException(
+                        "StarRocks Stream Load label has unknown final state: label="
+                                + label
+                                + ", state="
+                                + state);
+            }
+            sleepForLabelPoll(deadlineNanos);
+        }
+
+        throw new IOException(
+                "Timed out waiting for StarRocks Stream Load label state: label=" + label);
+    }
+
+    private String queryLabelState(String label) throws IOException {
+        HttpUrl url = buildLabelStateUrl(selectNode(), label);
+        Request request =
+                new Request.Builder()
+                        .url(url)
+                        .get()
+                        .header("Authorization", basicAuth())
+                        .build();
+
+        try (Response response = httpClient.newCall(request).execute()) {
+            String body = response.body() == null ? "" : response.body().string();
+            if (!response.isSuccessful()) {
+                throw new IOException(
+                        "Failed to query StarRocks Stream Load label state: status="
+                                + response.code()
+                                + ", body="
+                                + body);
+            }
+            JsonNode root = JSON_MAPPER.readTree(body);
+            JsonNode state = root == null ? null : root.get("state");
+            if (state == null || state.isNull() || state.asText().trim().isEmpty()) {
+                throw new IOException(
+                        "StarRocks label state response has no state: " + body);
+            }
+            return state.asText().trim();
+        }
+    }
+
+    private HttpUrl buildStreamLoadUrl(String node) {
+        return baseUrl(node)
+                .newBuilder()
+                .encodedPath("/")
+                .query(null)
+                .addPathSegment("api")
+                .addPathSegment(config.getDatabase())
+                .addPathSegment(config.getTable())
+                .addPathSegment("_stream_load")
+                .build();
+    }
+
+    private HttpUrl buildLabelStateUrl(String node, String label) {
+        return baseUrl(node)
+                .newBuilder()
+                .encodedPath("/")
+                .query(null)
+                .addPathSegment("api")
+                .addPathSegment(config.getDatabase())
+                .addPathSegment("get_load_state")
+                .addQueryParameter("label", label)
+                .build();
+    }
+
+    private static HttpUrl baseUrl(String node) {
+        String value = node;
+        if (!value.startsWith("http://") && !value.startsWith("https://")) {
+            value = "http://" + value;
+        }
+        HttpUrl url = HttpUrl.parse(value);
+        if (url == null) {
+            throw new IllegalArgumentException("Invalid StarRocks node URL: " + node);
+        }
+        return url;
+    }
+
+    private String selectNode() {
+        int size = config.getNodeUrls().size();
+        int index = Math.floorMod(nextNode.getAndIncrement(), size);
+        return config.getNodeUrls().get(index);
+    }
+
+    private String createLabel() {
+        return config.getLabelPrefix()
+                + UUID.randomUUID().toString().replace("-", "");
+    }
+
+    private String basicAuth() {
+        String auth = config.getUsername() + ":" + config.getPassword();
+        return "Basic "
+                + Base64.getEncoder().encodeToString(
+                        auth.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String columnsHeader(TableSchema schema) {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            String name = schema.getColumn(i).getName();
+            builder.append('`').append(name.replace("`", "``")).append('`');
+        }
+        return builder.toString();
+    }
+
+    private void sleepBeforeRetry(int attempt) throws IOException {
+        long delay = Math.min(
+                (long) config.getRetryBackoffMs() * Math.max(1, attempt),
+                (long) config.getMaxRetryBackoffMs());
+        sleep(delay, "retrying StarRocks Stream Load");
+    }
+
+    private void sleepForLabelPoll(long deadlineNanos) throws IOException {
+        long remainingNanos = Math.max(0L, deadlineNanos - System.nanoTime());
+        long remainingMs = TimeUnit.NANOSECONDS.toMillis(remainingNanos);
+        long delay = Math.min(config.getLabelStatePollMs(), Math.max(1L, remainingMs));
+        sleep(delay, "waiting for StarRocks label state");
+    }
+
+    private static void sleep(long millis, String operation) throws IOException {
+        if (millis <= 0L) {
+            return;
+        }
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException failure) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Interrupted while " + operation, failure);
+        }
+    }
+
+    @Override
+    public void close() {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+    }
+
+    private enum LabelResolution {
+        COMMITTED,
+        ABORTED
+    }
+
+    private static final class NonRetryableStreamLoadException extends IOException {
+        private static final long serialVersionUID = 1L;
+
+        private NonRetryableStreamLoadException(String message) {
+            super(message);
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/sink/StarRocksStreamLoadResponse.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/client/sink/StarRocksStreamLoadResponse.java
@@ -1,0 +1,136 @@
+package com.link.up.connector.starrocks.client.sink;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/** Parsed StarRocks Stream Load response. */
+public final class StarRocksStreamLoadResponse {
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    private final String status;
+    private final String label;
+    private final String message;
+    private final String errorUrl;
+    private final long numberTotalRows;
+    private final long numberLoadedRows;
+    private final long numberFilteredRows;
+    private final String txnId;
+    private final String body;
+
+    private StarRocksStreamLoadResponse(
+            String status,
+            String label,
+            String message,
+            String errorUrl,
+            long numberTotalRows,
+            long numberLoadedRows,
+            long numberFilteredRows,
+            String txnId,
+            String body) {
+        this.status = status;
+        this.label = label;
+        this.message = message;
+        this.errorUrl = errorUrl;
+        this.numberTotalRows = numberTotalRows;
+        this.numberLoadedRows = numberLoadedRows;
+        this.numberFilteredRows = numberFilteredRows;
+        this.txnId = txnId;
+        this.body = body;
+    }
+
+    public static StarRocksStreamLoadResponse parse(String body) throws IOException {
+        if (body == null || body.trim().isEmpty()) {
+            throw new IOException("StarRocks Stream Load returned an empty response body");
+        }
+        JsonNode root = JSON_MAPPER.readTree(body);
+        if (root == null || !root.isObject()) {
+            throw new IOException("StarRocks Stream Load response is not a JSON object: " + body);
+        }
+        String status = firstText(root, "Status", "status");
+        if (status == null || status.trim().isEmpty()) {
+            throw new IOException("StarRocks Stream Load response has no Status: " + body);
+        }
+        return new StarRocksStreamLoadResponse(
+                status,
+                firstText(root, "Label", "label"),
+                firstText(root, "Message", "message"),
+                firstText(root, "ErrorURL", "errorURL", "errorUrl"),
+                firstLong(root, "NumberTotalRows", "numberTotalRows"),
+                firstLong(root, "NumberLoadedRows", "numberLoadedRows"),
+                firstLong(root, "NumberFilteredRows", "numberFilteredRows"),
+                firstText(root, "TxnId", "txnId", "TransactionId"),
+                body);
+    }
+
+    public static StarRocksStreamLoadResponse resolvedCommitted(
+            String label,
+            String originalBody) {
+        return new StarRocksStreamLoadResponse(
+                "Success",
+                label,
+                "Existing Stream Load label is already COMMITTED/VISIBLE",
+                null,
+                0L,
+                0L,
+                0L,
+                null,
+                originalBody);
+    }
+
+    public boolean isSuccess() {
+        return equalsStatus("Success") || equalsStatus("Publish Timeout");
+    }
+
+    public boolean isLabelAlreadyExists() {
+        if (equalsStatus("Label Already Exists")) {
+            return true;
+        }
+        return message != null
+                && message.contains("Label [")
+                && message.contains("has already been used");
+    }
+
+    private boolean equalsStatus(String expected) {
+        return status != null && expected.equalsIgnoreCase(status.trim());
+    }
+
+    private static String firstText(JsonNode root, String... names) {
+        for (String name : names) {
+            JsonNode value = root.get(name);
+            if (value != null && !value.isNull()) {
+                return value.asText();
+            }
+        }
+        return null;
+    }
+
+    private static long firstLong(JsonNode root, String... names) {
+        for (String name : names) {
+            JsonNode value = root.get(name);
+            if (value != null && !value.isNull()) {
+                if (value.isNumber()) {
+                    return value.asLong();
+                }
+                try {
+                    return Long.parseLong(value.asText());
+                } catch (NumberFormatException ignored) {
+                    return 0L;
+                }
+            }
+        }
+        return 0L;
+    }
+
+    public String getStatus() { return status; }
+    public String getLabel() { return label; }
+    public String getMessage() { return message; }
+    public String getErrorUrl() { return errorUrl; }
+    public long getNumberTotalRows() { return numberTotalRows; }
+    public long getNumberLoadedRows() { return numberLoadedRows; }
+    public long getNumberFilteredRows() { return numberFilteredRows; }
+    public String getTxnId() { return txnId; }
+    public String getBody() { return body; }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksLoadFormat.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksLoadFormat.java
@@ -1,0 +1,7 @@
+package com.link.up.connector.starrocks.config;
+
+/** Supported StarRocks Stream Load payload formats. */
+public enum StarRocksLoadFormat {
+    JSON,
+    CSV
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSinkConfig.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSinkConfig.java
@@ -1,0 +1,301 @@
+package com.link.up.connector.starrocks.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/** Parsed immutable configuration for the StarRocks bounded Stream Load Sink. */
+public final class StarRocksSinkConfig {
+
+    private static final long MAX_IN_MEMORY_PAYLOAD_BYTES = Integer.MAX_VALUE - 4096L;
+    private static final Pattern LABEL_PREFIX_PATTERN = Pattern.compile("[A-Za-z0-9_-]+_");
+    private static final Set<String> RESERVED_STREAM_LOAD_HEADERS;
+
+    static {
+        Set<String> reserved = new LinkedHashSet<String>();
+        reserved.add("authorization");
+        reserved.add("label");
+        reserved.add("format");
+        reserved.add("expect");
+        reserved.add("content-type");
+        reserved.add("strip_outer_array");
+        reserved.add("read_json_by_line");
+        reserved.add("column_separator");
+        reserved.add("row_delimiter");
+        reserved.add("columns");
+        RESERVED_STREAM_LOAD_HEADERS = Collections.unmodifiableSet(reserved);
+    }
+
+    private final List<String> nodeUrls;
+    private final String username;
+    private final String password;
+    private final String database;
+    private final String table;
+    private final String labelPrefix;
+    private final StarRocksLoadFormat loadFormat;
+    private final int batchMaxRows;
+    private final long batchMaxBytes;
+    private final int maxRetries;
+    private final int retryBackoffMs;
+    private final int maxRetryBackoffMs;
+    private final int connectTimeoutMs;
+    private final int socketTimeoutMs;
+    private final int labelStateTimeoutMs;
+    private final int labelStatePollMs;
+    private final String columnSeparator;
+    private final String rowDelimiter;
+    private final Map<String, String> streamLoadParams;
+
+    private StarRocksSinkConfig(
+            List<String> nodeUrls,
+            String username,
+            String password,
+            String database,
+            String table,
+            String labelPrefix,
+            StarRocksLoadFormat loadFormat,
+            int batchMaxRows,
+            long batchMaxBytes,
+            int maxRetries,
+            int retryBackoffMs,
+            int maxRetryBackoffMs,
+            int connectTimeoutMs,
+            int socketTimeoutMs,
+            int labelStateTimeoutMs,
+            int labelStatePollMs,
+            String columnSeparator,
+            String rowDelimiter,
+            Map<String, String> streamLoadParams) {
+        this.nodeUrls = nodeUrls;
+        this.username = username;
+        this.password = password;
+        this.database = database;
+        this.table = table;
+        this.labelPrefix = labelPrefix;
+        this.loadFormat = loadFormat;
+        this.batchMaxRows = batchMaxRows;
+        this.batchMaxBytes = batchMaxBytes;
+        this.maxRetries = maxRetries;
+        this.retryBackoffMs = retryBackoffMs;
+        this.maxRetryBackoffMs = maxRetryBackoffMs;
+        this.connectTimeoutMs = connectTimeoutMs;
+        this.socketTimeoutMs = socketTimeoutMs;
+        this.labelStateTimeoutMs = labelStateTimeoutMs;
+        this.labelStatePollMs = labelStatePollMs;
+        this.columnSeparator = columnSeparator;
+        this.rowDelimiter = rowDelimiter;
+        this.streamLoadParams = streamLoadParams;
+    }
+
+    public static StarRocksSinkConfig of(ReadonlyConfig options) {
+        Objects.requireNonNull(options, "options must not be null");
+
+        List<String> nodeUrls = normalizeNodes(options.get(StarRocksSinkOptions.NODE_URLS));
+        String username = requireText(options.get(StarRocksSinkOptions.USERNAME), "username");
+        String password = options.get(StarRocksSinkOptions.PASSWORD);
+        String database = requireText(options.get(StarRocksSinkOptions.DATABASE), "database");
+        String table = requireText(options.get(StarRocksSinkOptions.TABLE), "table");
+
+        StarRocksLoadFormat loadFormat = options.get(StarRocksSinkOptions.LOAD_FORMAT);
+        if (loadFormat == null) {
+            loadFormat = StarRocksLoadFormat.JSON;
+        }
+
+        int batchMaxRows = positive(options.get(StarRocksSinkOptions.BATCH_MAX_ROWS), "batch_max_rows");
+        long batchMaxBytes = positive(options.get(StarRocksSinkOptions.BATCH_MAX_BYTES), "batch_max_bytes");
+        if (batchMaxBytes > MAX_IN_MEMORY_PAYLOAD_BYTES) {
+            throw new IllegalArgumentException(
+                    "StarRocks Sink batch_max_bytes must be <= " + MAX_IN_MEMORY_PAYLOAD_BYTES);
+        }
+
+        int maxRetries = nonNegative(options.get(StarRocksSinkOptions.MAX_RETRIES), "max_retries");
+        int retryBackoffMs = nonNegative(options.get(StarRocksSinkOptions.RETRY_BACKOFF_MS), "retry_backoff_ms");
+        int maxRetryBackoffMs = nonNegative(
+                options.get(StarRocksSinkOptions.MAX_RETRY_BACKOFF_MS),
+                "max_retry_backoff_ms");
+        if (maxRetryBackoffMs < retryBackoffMs) {
+            throw new IllegalArgumentException(
+                    "StarRocks Sink max_retry_backoff_ms must be >= retry_backoff_ms");
+        }
+
+        int connectTimeoutMs = positive(
+                options.get(StarRocksSinkOptions.CONNECT_TIMEOUT_MS),
+                "connect_timeout_ms");
+        int socketTimeoutMs = positive(
+                options.get(StarRocksSinkOptions.SOCKET_TIMEOUT_MS),
+                "socket_timeout_ms");
+        int labelStateTimeoutMs = positive(
+                options.get(StarRocksSinkOptions.LABEL_STATE_TIMEOUT_MS),
+                "label_state_timeout_ms");
+        int labelStatePollMs = positive(
+                options.get(StarRocksSinkOptions.LABEL_STATE_POLL_MS),
+                "label_state_poll_ms");
+        if (labelStatePollMs > labelStateTimeoutMs) {
+            throw new IllegalArgumentException(
+                    "StarRocks Sink label_state_poll_ms must be <= label_state_timeout_ms");
+        }
+
+        String columnSeparator = requireDelimiter(
+                options.get(StarRocksSinkOptions.COLUMN_SEPARATOR),
+                "column_separator");
+        String rowDelimiter = requireDelimiter(
+                options.get(StarRocksSinkOptions.ROW_DELIMITER),
+                "row_delimiter");
+
+        Map<String, String> streamLoadParams = immutableParams(
+                options.get(StarRocksSinkOptions.STREAM_LOAD_PARAMS));
+        validateStreamLoadParams(streamLoadParams);
+
+        String configuredPrefix = options.getOptional(StarRocksSinkOptions.LABEL_PREFIX).orElse(null);
+        String labelPrefix = configuredPrefix == null || configuredPrefix.trim().isEmpty()
+                ? defaultLabelPrefix(database, table)
+                : normalizeLabelPrefix(configuredPrefix.trim());
+
+        return new StarRocksSinkConfig(
+                nodeUrls,
+                username,
+                password == null ? "" : password,
+                database,
+                table,
+                labelPrefix,
+                loadFormat,
+                batchMaxRows,
+                batchMaxBytes,
+                maxRetries,
+                retryBackoffMs,
+                maxRetryBackoffMs,
+                connectTimeoutMs,
+                socketTimeoutMs,
+                labelStateTimeoutMs,
+                labelStatePollMs,
+                columnSeparator,
+                rowDelimiter,
+                streamLoadParams);
+    }
+
+    private static List<String> normalizeNodes(List<String> nodes) {
+        if (nodes == null || nodes.isEmpty()) {
+            throw new IllegalArgumentException("StarRocks Sink node_urls must not be empty");
+        }
+        LinkedHashSet<String> normalized = new LinkedHashSet<String>();
+        for (String node : nodes) {
+            String value = requireText(node, "node_urls item");
+            while (value.endsWith("/")) {
+                value = value.substring(0, value.length() - 1);
+            }
+            normalized.add(value);
+        }
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException("StarRocks Sink node_urls must not be empty");
+        }
+        return Collections.unmodifiableList(new ArrayList<String>(normalized));
+    }
+
+    private static Map<String, String> immutableParams(Map<String, String> params) {
+        if (params == null || params.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> copy = new LinkedHashMap<String, String>();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            String key = requireText(entry.getKey(), "stream_load.params key");
+            String value = entry.getValue();
+            if (value == null) {
+                throw new IllegalArgumentException(
+                        "StarRocks Sink stream_load.params value must not be null: " + key);
+            }
+            copy.put(key, value);
+        }
+        return Collections.unmodifiableMap(copy);
+    }
+
+    private static void validateStreamLoadParams(Map<String, String> params) {
+        for (String key : params.keySet()) {
+            if (RESERVED_STREAM_LOAD_HEADERS.contains(key.toLowerCase(Locale.ROOT))) {
+                throw new IllegalArgumentException(
+                        "StarRocks Sink stream_load.params must not override connector-owned header: "
+                                + key);
+            }
+        }
+    }
+
+    private static String defaultLabelPrefix(String database, String table) {
+        return normalizeLabelPrefix("link_up_" + sanitizeLabelPart(database) + "_" + sanitizeLabelPart(table) + "_");
+    }
+
+    private static String sanitizeLabelPart(String value) {
+        return value.replaceAll("[^A-Za-z0-9_-]", "_");
+    }
+
+    private static String normalizeLabelPrefix(String value) {
+        String prefix = value.endsWith("_") ? value : value + "_";
+        if (!LABEL_PREFIX_PATTERN.matcher(prefix).matches()) {
+            throw new IllegalArgumentException(
+                    "StarRocks Sink label_prefix may contain only letters, digits, '_' and '-'");
+        }
+        return prefix;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException("StarRocks Sink '" + name + "' must not be blank");
+        }
+        return value.trim();
+    }
+
+    private static String requireDelimiter(String value, String name) {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("StarRocks Sink '" + name + "' must not be empty");
+        }
+        return value;
+    }
+
+    private static int positive(Integer value, String name) {
+        if (value == null || value.intValue() <= 0) {
+            throw new IllegalArgumentException("StarRocks Sink '" + name + "' must be > 0");
+        }
+        return value.intValue();
+    }
+
+    private static long positive(Long value, String name) {
+        if (value == null || value.longValue() <= 0L) {
+            throw new IllegalArgumentException("StarRocks Sink '" + name + "' must be > 0");
+        }
+        return value.longValue();
+    }
+
+    private static int nonNegative(Integer value, String name) {
+        if (value == null || value.intValue() < 0) {
+            throw new IllegalArgumentException("StarRocks Sink '" + name + "' must be >= 0");
+        }
+        return value.intValue();
+    }
+
+    public List<String> getNodeUrls() { return nodeUrls; }
+    public String getUsername() { return username; }
+    public String getPassword() { return password; }
+    public String getDatabase() { return database; }
+    public String getTable() { return table; }
+    public String getLabelPrefix() { return labelPrefix; }
+    public StarRocksLoadFormat getLoadFormat() { return loadFormat; }
+    public int getBatchMaxRows() { return batchMaxRows; }
+    public long getBatchMaxBytes() { return batchMaxBytes; }
+    public int getMaxRetries() { return maxRetries; }
+    public int getRetryBackoffMs() { return retryBackoffMs; }
+    public int getMaxRetryBackoffMs() { return maxRetryBackoffMs; }
+    public int getConnectTimeoutMs() { return connectTimeoutMs; }
+    public int getSocketTimeoutMs() { return socketTimeoutMs; }
+    public int getLabelStateTimeoutMs() { return labelStateTimeoutMs; }
+    public int getLabelStatePollMs() { return labelStatePollMs; }
+    public String getColumnSeparator() { return columnSeparator; }
+    public String getRowDelimiter() { return rowDelimiter; }
+    public Map<String, String> getStreamLoadParams() { return streamLoadParams; }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSinkConfig.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSinkConfig.java
@@ -2,6 +2,7 @@ package com.link.up.connector.starrocks.config;
 
 import com.link.up.api.configuration.ReadonlyConfig;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -17,22 +18,53 @@ import java.util.regex.Pattern;
 public final class StarRocksSinkConfig {
 
     private static final long MAX_IN_MEMORY_PAYLOAD_BYTES = Integer.MAX_VALUE - 4096L;
-    private static final Pattern LABEL_PREFIX_PATTERN = Pattern.compile("[A-Za-z0-9_-]+_");
-    private static final Set<String> RESERVED_STREAM_LOAD_HEADERS;
+    private static final int MAX_LABEL_LENGTH = 128;
+    private static final int GENERATED_LABEL_SUFFIX_LENGTH = 32;
+    private static final int MAX_LABEL_PREFIX_LENGTH =
+            MAX_LABEL_LENGTH - GENERATED_LABEL_SUFFIX_LENGTH;
+    private static final int MAX_DELIMITER_BYTES = 50;
+    private static final Pattern LABEL_PREFIX_PATTERN =
+            Pattern.compile("[A-Za-z_][A-Za-z0-9_]*");
+    private static final Set<String> CONNECTOR_OWNED_STREAM_LOAD_HEADERS;
+    private static final Set<String> UNSUPPORTED_STAGE2_STREAM_LOAD_HEADERS;
 
     static {
-        Set<String> reserved = new LinkedHashSet<String>();
-        reserved.add("authorization");
-        reserved.add("label");
-        reserved.add("format");
-        reserved.add("expect");
-        reserved.add("content-type");
-        reserved.add("strip_outer_array");
-        reserved.add("read_json_by_line");
-        reserved.add("column_separator");
-        reserved.add("row_delimiter");
-        reserved.add("columns");
-        RESERVED_STREAM_LOAD_HEADERS = Collections.unmodifiableSet(reserved);
+        Set<String> owned = new LinkedHashSet<String>();
+        owned.add("authorization");
+        owned.add("label");
+        owned.add("format");
+        owned.add("expect");
+        owned.add("content-type");
+        owned.add("strip_outer_array");
+        owned.add("read_json_by_line");
+        owned.add("column_separator");
+        owned.add("row_delimiter");
+        owned.add("columns");
+        owned.add("jsonpaths");
+        owned.add("json_root");
+        CONNECTOR_OWNED_STREAM_LOAD_HEADERS = Collections.unmodifiableSet(owned);
+
+        Set<String> unsupported = new LinkedHashSet<String>();
+        // Merge Commit makes StarRocks generate/own the label and therefore breaks this
+        // connector's per-flush label idempotency contract. It also introduces asynchronous
+        // merge semantics that are intentionally outside the bounded Stage 2 scope.
+        unsupported.add("enable_merge_commit");
+        unsupported.add("merge_commit_async");
+        unsupported.add("merge_commit_interval_ms");
+        unsupported.add("merge_commit_parallel");
+
+        // Stage 2 is full-row bounded loading. CDC/delete and partial-update semantics are
+        // intentionally deferred instead of being smuggled in through passthrough headers.
+        unsupported.add("partial_update");
+        unsupported.add("partial_update_mode");
+        unsupported.add("merge_condition");
+        unsupported.add("two_phase_commit");
+
+        // The connector currently sends an uncompressed in-memory payload. Advertising a
+        // compression algorithm without compressing the body would make StarRocks misread it.
+        unsupported.add("compression");
+        unsupported.add("content-encoding");
+        UNSUPPORTED_STAGE2_STREAM_LOAD_HEADERS = Collections.unmodifiableSet(unsupported);
     }
 
     private final List<String> nodeUrls;
@@ -219,27 +251,44 @@ public final class StarRocksSinkConfig {
 
     private static void validateStreamLoadParams(Map<String, String> params) {
         for (String key : params.keySet()) {
-            if (RESERVED_STREAM_LOAD_HEADERS.contains(key.toLowerCase(Locale.ROOT))) {
+            String normalized = key.toLowerCase(Locale.ROOT);
+            if (CONNECTOR_OWNED_STREAM_LOAD_HEADERS.contains(normalized)) {
                 throw new IllegalArgumentException(
                         "StarRocks Sink stream_load.params must not override connector-owned header: "
+                                + key);
+            }
+            if (UNSUPPORTED_STAGE2_STREAM_LOAD_HEADERS.contains(normalized)) {
+                throw new IllegalArgumentException(
+                        "StarRocks Sink Stage 2 does not support stream_load.params header: "
                                 + key);
             }
         }
     }
 
     private static String defaultLabelPrefix(String database, String table) {
-        return normalizeLabelPrefix("link_up_" + sanitizeLabelPart(database) + "_" + sanitizeLabelPart(table) + "_");
+        String base = "link_up_" + sanitizeLabelPart(database) + "_" + sanitizeLabelPart(table);
+        int maxBaseLength = MAX_LABEL_PREFIX_LENGTH - 1;
+        if (base.length() > maxBaseLength) {
+            base = base.substring(0, maxBaseLength);
+        }
+        return normalizeLabelPrefix(base);
     }
 
     private static String sanitizeLabelPart(String value) {
-        return value.replaceAll("[^A-Za-z0-9_-]", "_");
+        return value.replaceAll("[^A-Za-z0-9_]", "_");
     }
 
     private static String normalizeLabelPrefix(String value) {
         String prefix = value.endsWith("_") ? value : value + "_";
         if (!LABEL_PREFIX_PATTERN.matcher(prefix).matches()) {
             throw new IllegalArgumentException(
-                    "StarRocks Sink label_prefix may contain only letters, digits, '_' and '-'");
+                    "StarRocks Sink label_prefix must start with a letter or '_' and contain only letters, digits and '_'");
+        }
+        if (prefix.length() > MAX_LABEL_PREFIX_LENGTH) {
+            throw new IllegalArgumentException(
+                    "StarRocks Sink label_prefix is too long: generated Stream Load label must be <= "
+                            + MAX_LABEL_LENGTH
+                            + " characters");
         }
         return prefix;
     }
@@ -254,6 +303,10 @@ public final class StarRocksSinkConfig {
     private static String requireDelimiter(String value, String name) {
         if (value == null || value.isEmpty()) {
             throw new IllegalArgumentException("StarRocks Sink '" + name + "' must not be empty");
+        }
+        if (value.getBytes(StandardCharsets.UTF_8).length > MAX_DELIMITER_BYTES) {
+            throw new IllegalArgumentException(
+                    "StarRocks Sink '" + name + "' must be <= " + MAX_DELIMITER_BYTES + " bytes");
         }
         return value;
     }

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSinkOptions.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/config/StarRocksSinkOptions.java
@@ -1,0 +1,173 @@
+package com.link.up.connector.starrocks.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+import java.util.Map;
+
+/** StarRocks bounded Stream Load Sink options. */
+public final class StarRocksSinkOptions {
+
+    private StarRocksSinkOptions() {
+    }
+
+    public static final Option<List<String>> NODE_URLS =
+            Options.key("node_urls")
+                    .listType()
+                    .noDefaultValue()
+                    .withFallbackKeys("nodeUrls")
+                    .withDescription("StarRocks FE HTTP 地址列表，例如 [\"127.0.0.1:8030\"]")
+                    .withSemanticType("STARROCKS_FE_NODES")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("StarRocks 用户名")
+                    .withSemanticType("USERNAME")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .sensitive()
+                    .withDescription("StarRocks 密码")
+                    .withSemanticType("PASSWORD")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> DATABASE =
+            Options.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("StarRocks 目标数据库名")
+                    .withSemanticType("DATABASE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> TABLE =
+            Options.key("table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("StarRocks 目标表名")
+                    .withSemanticType("TABLE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> LABEL_PREFIX =
+            Options.key("label_prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withFallbackKeys("labelPrefix")
+                    .withDescription("Stream Load label 前缀；未配置时由 database/table 生成")
+                    .withSemanticType("STARROCKS_LABEL_PREFIX")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<StarRocksLoadFormat> LOAD_FORMAT =
+            Options.key("load_format")
+                    .enumType(StarRocksLoadFormat.class)
+                    .defaultValue(StarRocksLoadFormat.JSON)
+                    .withFallbackKeys("starrocks.config.format")
+                    .withDescription("Stream Load payload 格式：JSON 或 CSV")
+                    .withSemanticType("LOAD_FORMAT")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> BATCH_MAX_ROWS =
+            Options.key("batch_max_rows")
+                    .intType()
+                    .defaultValue(1024)
+                    .withDescription("单次 Stream Load 最大行数")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Long> BATCH_MAX_BYTES =
+            Options.key("batch_max_bytes")
+                    .longType()
+                    .defaultValue(5L * 1024L * 1024L)
+                    .withDescription("单次 Stream Load payload 刷新阈值，单位字节")
+                    .withSemanticType("MEMORY_BYTES")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> MAX_RETRIES =
+            Options.key("max_retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("Stream Load 网络/服务端瞬态失败最大重试次数")
+                    .withSemanticType("RETRY_COUNT")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> RETRY_BACKOFF_MS =
+            Options.key("retry_backoff_ms")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("Stream Load 重试基础退避时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> MAX_RETRY_BACKOFF_MS =
+            Options.key("max_retry_backoff_ms")
+                    .intType()
+                    .defaultValue(5000)
+                    .withDescription("Stream Load 最大重试退避时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> CONNECT_TIMEOUT_MS =
+            Options.key("connect_timeout_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription("连接 StarRocks FE/BE 的超时时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SOCKET_TIMEOUT_MS =
+            Options.key("socket_timeout_ms")
+                    .intType()
+                    .defaultValue(180000)
+                    .withDescription("Stream Load 读写超时时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> LABEL_STATE_TIMEOUT_MS =
+            Options.key("label_state_timeout_ms")
+                    .intType()
+                    .defaultValue(180000)
+                    .withDescription("Label Already Exists 时等待最终状态的最长时间")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> LABEL_STATE_POLL_MS =
+            Options.key("label_state_poll_ms")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("查询 Stream Load label 状态的轮询间隔")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<String> COLUMN_SEPARATOR =
+            Options.key("column_separator")
+                    .stringType()
+                    .defaultValue("\t")
+                    .withFallbackKeys("starrocks.config.column_separator")
+                    .withDescription("CSV Stream Load 列分隔符")
+                    .withSemanticType("DELIMITER")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<String> ROW_DELIMITER =
+            Options.key("row_delimiter")
+                    .stringType()
+                    .defaultValue("\n")
+                    .withFallbackKeys("starrocks.config.row_delimiter")
+                    .withDescription("CSV Stream Load 行分隔符")
+                    .withSemanticType("DELIMITER")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Map<String, String>> STREAM_LOAD_PARAMS =
+            Options.key("stream_load.params")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("透传给 StarRocks Stream Load 的附加 header 参数")
+                    .withSemanticType("STARROCKS_STREAM_LOAD_PARAMS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializer.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializer.java
@@ -10,14 +10,11 @@ import com.link.up.connector.starrocks.config.StarRocksLoadFormat;
 import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
 
 import java.io.ByteArrayOutputStream;
-import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -27,6 +24,7 @@ public final class StarRocksRowSerializer {
 
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     private static final char[] HEX = "0123456789ABCDEF".toCharArray();
+    private static final String CSV_NULL_MARKER = "\\N";
 
     private final StarRocksSinkConfig config;
     private final TableSchema schema;
@@ -43,6 +41,7 @@ public final class StarRocksRowSerializer {
         }
         this.config = config;
         this.schema = schema;
+        validateSchema();
         this.rowDelimiterBytes = config.getRowDelimiter().getBytes(StandardCharsets.UTF_8);
     }
 
@@ -134,11 +133,16 @@ public final class StarRocksRowSerializer {
             }
             Object value = row.getField(i);
             if (value == null) {
-                builder.append("\\N");
+                builder.append(CSV_NULL_MARKER);
                 continue;
             }
             SqlType sqlType = schema.getColumn(i).getDataType().getSqlType();
             String text = csvText(value, sqlType);
+            if (CSV_NULL_MARKER.equals(text)) {
+                throw new IllegalArgumentException(
+                        "Non-null CSV value equals StarRocks null marker \\N; "
+                                + "use JSON load_format or normalize the value upstream");
+            }
             if (text.contains(separator)
                     || text.contains(config.getRowDelimiter())
                     || text.indexOf('\n') >= 0
@@ -187,66 +191,20 @@ public final class StarRocksRowSerializer {
             case TIMESTAMP:
                 return timestampText(value);
             case BYTES:
-                throw new IllegalArgumentException(
-                        "StarRocks BINARY/VARBINARY Stream Load is not supported with JSON; "
-                                + "use load_format=CSV so bytes can be encoded as hexadecimal text");
-            case STRING:
+                throw unsupportedBinaryJson();
             case TIMESTAMP_TZ:
-                return String.valueOf(value);
+                throw unsupportedTimezoneTimestamp();
             case ARRAY:
             case MAP:
-                return normalizeAny(value);
             case ROW:
-                throw new IllegalArgumentException(
-                        "StarRocks ROW/STRUCT Sink values require explicit nested field metadata; "
-                                + "Stage 2 intentionally does not infer STRUCT fields from FluxRow values");
+                throw unsupportedComplexType(sqlType);
+            case STRING:
+                return String.valueOf(value);
             case NULL:
                 return null;
             default:
-                return normalizeAny(value);
+                return String.valueOf(value);
         }
-    }
-
-    private static Object normalizeAny(Object value) {
-        if (value == null) {
-            return null;
-        }
-        if (value instanceof LocalDate
-                || value instanceof LocalTime) {
-            return value.toString();
-        }
-        if (value instanceof LocalDateTime) {
-            return timestampText(value);
-        }
-        if (value instanceof byte[]) {
-            throw new IllegalArgumentException(
-                    "Nested binary values are not supported by the bounded StarRocks Stage 2 serializer");
-        }
-        if (value instanceof Map) {
-            Map<?, ?> source = (Map<?, ?>) value;
-            Map<String, Object> result = new LinkedHashMap<String, Object>();
-            for (Map.Entry<?, ?> entry : source.entrySet()) {
-                result.put(String.valueOf(entry.getKey()), normalizeAny(entry.getValue()));
-            }
-            return result;
-        }
-        if (value instanceof Collection) {
-            List<Object> result = new ArrayList<Object>();
-            for (Object item : (Collection<?>) value) {
-                result.add(normalizeAny(item));
-            }
-            return result;
-        }
-        Class<?> type = value.getClass();
-        if (type.isArray()) {
-            int length = Array.getLength(value);
-            List<Object> result = new ArrayList<Object>(length);
-            for (int i = 0; i < length; i++) {
-                result.add(normalizeAny(Array.get(value, i)));
-            }
-            return result;
-        }
-        return value;
     }
 
     private static String csvText(Object value, SqlType sqlType) {
@@ -257,10 +215,11 @@ public final class StarRocksRowSerializer {
             }
             return toHex((byte[]) value);
         }
-        if (sqlType == SqlType.ROW) {
-            throw new IllegalArgumentException(
-                    "StarRocks ROW/STRUCT Sink values require explicit nested field metadata; "
-                            + "Stage 2 intentionally does not infer STRUCT fields from FluxRow values");
+        if (sqlType == SqlType.TIMESTAMP_TZ) {
+            throw unsupportedTimezoneTimestamp();
+        }
+        if (sqlType == SqlType.ARRAY || sqlType == SqlType.MAP || sqlType == SqlType.ROW) {
+            throw unsupportedComplexType(sqlType);
         }
         if (value instanceof LocalDateTime) {
             return timestampText(value);
@@ -268,14 +227,53 @@ public final class StarRocksRowSerializer {
         if (value instanceof LocalDate || value instanceof LocalTime) {
             return value.toString();
         }
-        if (value instanceof Map || value instanceof Collection || value.getClass().isArray()) {
-            try {
-                return JSON_MAPPER.writeValueAsString(normalizeAny(value));
-            } catch (JsonProcessingException failure) {
-                throw new IllegalArgumentException("Failed to serialize complex CSV value", failure);
+        return String.valueOf(value);
+    }
+
+    private void validateSchema() {
+        for (Column column : schema.getColumns()) {
+            SqlType sqlType = column.getDataType().getSqlType();
+            if (sqlType == SqlType.BYTES && config.getLoadFormat() == StarRocksLoadFormat.JSON) {
+                throw new IllegalArgumentException(
+                        "StarRocks Sink column '"
+                                + column.getName()
+                                + "' is BYTES: BINARY/VARBINARY Stream Load requires load_format=CSV");
+            }
+            if (sqlType == SqlType.TIMESTAMP_TZ) {
+                throw new IllegalArgumentException(
+                        "StarRocks Sink column '"
+                                + column.getName()
+                                + "' is TIMESTAMP_TZ: Stage 2 does not implicitly discard timezone offsets; "
+                                + "convert it explicitly upstream before loading into DATETIME");
+            }
+            if (sqlType == SqlType.ARRAY || sqlType == SqlType.MAP || sqlType == SqlType.ROW) {
+                throw new IllegalArgumentException(
+                        "StarRocks Sink column '"
+                                + column.getName()
+                                + "' uses unsupported Stage 2 complex type "
+                                + sqlType
+                                + "; map it to a validated scalar representation explicitly");
             }
         }
-        return String.valueOf(value);
+    }
+
+    private static IllegalArgumentException unsupportedBinaryJson() {
+        return new IllegalArgumentException(
+                "StarRocks BINARY/VARBINARY Stream Load is not supported with JSON; "
+                        + "use load_format=CSV so bytes can be encoded as hexadecimal text");
+    }
+
+    private static IllegalArgumentException unsupportedTimezoneTimestamp() {
+        return new IllegalArgumentException(
+                "StarRocks Stage 2 does not implicitly discard TIMESTAMP_TZ offsets; "
+                        + "convert the value explicitly upstream before loading into DATETIME");
+    }
+
+    private static IllegalArgumentException unsupportedComplexType(SqlType sqlType) {
+        return new IllegalArgumentException(
+                "StarRocks Stage 2 does not support complex Sink type "
+                        + sqlType
+                        + " yet; map it to a validated scalar representation explicitly");
     }
 
     private static String toHex(byte[] value) {

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializer.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializer.java
@@ -17,7 +17,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -27,6 +26,7 @@ import java.util.Map;
 public final class StarRocksRowSerializer {
 
     private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final char[] HEX = "0123456789ABCDEF".toCharArray();
 
     private final StarRocksSinkConfig config;
     private final TableSchema schema;
@@ -137,7 +137,8 @@ public final class StarRocksRowSerializer {
                 builder.append("\\N");
                 continue;
             }
-            String text = csvText(value);
+            SqlType sqlType = schema.getColumn(i).getDataType().getSqlType();
+            String text = csvText(value, sqlType);
             if (text.contains(separator)
                     || text.contains(config.getRowDelimiter())
                     || text.indexOf('\n') >= 0
@@ -186,16 +187,19 @@ public final class StarRocksRowSerializer {
             case TIMESTAMP:
                 return timestampText(value);
             case BYTES:
-                return value instanceof byte[]
-                        ? Base64.getEncoder().encodeToString((byte[]) value)
-                        : String.valueOf(value);
+                throw new IllegalArgumentException(
+                        "StarRocks BINARY/VARBINARY Stream Load is not supported with JSON; "
+                                + "use load_format=CSV so bytes can be encoded as hexadecimal text");
             case STRING:
             case TIMESTAMP_TZ:
                 return String.valueOf(value);
             case ARRAY:
             case MAP:
-            case ROW:
                 return normalizeAny(value);
+            case ROW:
+                throw new IllegalArgumentException(
+                        "StarRocks ROW/STRUCT Sink values require explicit nested field metadata; "
+                                + "Stage 2 intentionally does not infer STRUCT fields from FluxRow values");
             case NULL:
                 return null;
             default:
@@ -215,7 +219,8 @@ public final class StarRocksRowSerializer {
             return timestampText(value);
         }
         if (value instanceof byte[]) {
-            return Base64.getEncoder().encodeToString((byte[]) value);
+            throw new IllegalArgumentException(
+                    "Nested binary values are not supported by the bounded StarRocks Stage 2 serializer");
         }
         if (value instanceof Map) {
             Map<?, ?> source = (Map<?, ?>) value;
@@ -244,9 +249,18 @@ public final class StarRocksRowSerializer {
         return value;
     }
 
-    private static String csvText(Object value) {
-        if (value instanceof byte[]) {
-            return Base64.getEncoder().encodeToString((byte[]) value);
+    private static String csvText(Object value, SqlType sqlType) {
+        if (sqlType == SqlType.BYTES) {
+            if (!(value instanceof byte[])) {
+                throw new IllegalArgumentException(
+                        "StarRocks BYTES Sink field must contain byte[] values");
+            }
+            return toHex((byte[]) value);
+        }
+        if (sqlType == SqlType.ROW) {
+            throw new IllegalArgumentException(
+                    "StarRocks ROW/STRUCT Sink values require explicit nested field metadata; "
+                            + "Stage 2 intentionally does not infer STRUCT fields from FluxRow values");
         }
         if (value instanceof LocalDateTime) {
             return timestampText(value);
@@ -262,6 +276,16 @@ public final class StarRocksRowSerializer {
             }
         }
         return String.valueOf(value);
+    }
+
+    private static String toHex(byte[] value) {
+        char[] chars = new char[value.length * 2];
+        for (int i = 0; i < value.length; i++) {
+            int unsigned = value[i] & 0xFF;
+            chars[i * 2] = HEX[unsigned >>> 4];
+            chars[i * 2 + 1] = HEX[unsigned & 0x0F];
+        }
+        return new String(chars);
     }
 
     private static String timestampText(Object value) {

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializer.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializer.java
@@ -1,0 +1,288 @@
+package com.link.up.connector.starrocks.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.starrocks.config.StarRocksLoadFormat;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Serializes Flux rows into deterministic StarRocks Stream Load payloads. */
+public final class StarRocksRowSerializer {
+
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+    private final StarRocksSinkConfig config;
+    private final TableSchema schema;
+    private final byte[] rowDelimiterBytes;
+
+    public StarRocksRowSerializer(
+            StarRocksSinkConfig config,
+            TableSchema schema) {
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        if (schema == null) {
+            throw new IllegalArgumentException("schema must not be null");
+        }
+        this.config = config;
+        this.schema = schema;
+        this.rowDelimiterBytes = config.getRowDelimiter().getBytes(StandardCharsets.UTF_8);
+    }
+
+    public byte[] serializeRow(FluxRow row) {
+        validateArity(row);
+        if (config.getLoadFormat() == StarRocksLoadFormat.CSV) {
+            return serializeCsvRow(row).getBytes(StandardCharsets.UTF_8);
+        }
+        return serializeJsonRow(row).getBytes(StandardCharsets.UTF_8);
+    }
+
+    public byte[] joinRecords(List<byte[]> records, long rawRecordBytes) {
+        if (records == null || records.isEmpty()) {
+            return new byte[0];
+        }
+        long payloadSize = payloadSizeBytes(records.size(), rawRecordBytes);
+        if (payloadSize > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("StarRocks Stream Load payload is too large");
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream((int) payloadSize);
+        if (config.getLoadFormat() == StarRocksLoadFormat.JSON) {
+            output.write('[');
+            for (int i = 0; i < records.size(); i++) {
+                if (i > 0) {
+                    output.write(',');
+                }
+                write(output, records.get(i));
+            }
+            output.write(']');
+            return output.toByteArray();
+        }
+
+        for (int i = 0; i < records.size(); i++) {
+            if (i > 0) {
+                write(output, rowDelimiterBytes);
+            }
+            write(output, records.get(i));
+        }
+        return output.toByteArray();
+    }
+
+    public long payloadSizeBytes(int recordCount, long rawRecordBytes) {
+        if (recordCount <= 0) {
+            return 0L;
+        }
+        if (config.getLoadFormat() == StarRocksLoadFormat.JSON) {
+            return rawRecordBytes + 2L + Math.max(0, recordCount - 1);
+        }
+        return rawRecordBytes
+                + ((long) Math.max(0, recordCount - 1) * rowDelimiterBytes.length);
+    }
+
+    public String csvColumnsHeader() {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            String name = schema.getColumn(i).getName();
+            builder.append('`').append(name.replace("`", "``")).append('`');
+        }
+        return builder.toString();
+    }
+
+    private String serializeJsonRow(FluxRow row) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            Column column = schema.getColumn(i);
+            values.put(
+                    column.getName(),
+                    normalizeForJson(row.getField(i), column.getDataType().getSqlType()));
+        }
+        try {
+            return JSON_MAPPER.writeValueAsString(values);
+        } catch (JsonProcessingException failure) {
+            throw new IllegalArgumentException(
+                    "Failed to serialize FluxRow as StarRocks JSON",
+                    failure);
+        }
+    }
+
+    private String serializeCsvRow(FluxRow row) {
+        String separator = config.getColumnSeparator();
+        StringBuilder builder = new StringBuilder(schema.getColumnCount() * 24);
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            if (i > 0) {
+                builder.append(separator);
+            }
+            Object value = row.getField(i);
+            if (value == null) {
+                builder.append("\\N");
+                continue;
+            }
+            String text = csvText(value);
+            if (text.contains(separator)
+                    || text.contains(config.getRowDelimiter())
+                    || text.indexOf('\n') >= 0
+                    || text.indexOf('\r') >= 0) {
+                throw new IllegalArgumentException(
+                        "CSV value contains the configured column/row delimiter; "
+                                + "use JSON load_format or choose safe delimiters");
+            }
+            builder.append(text);
+        }
+        return builder.toString();
+    }
+
+    private Object normalizeForJson(Object value, SqlType sqlType) {
+        if (value == null) {
+            return null;
+        }
+        switch (sqlType) {
+            case BOOLEAN:
+                return value instanceof Boolean
+                        ? value
+                        : Boolean.valueOf(String.valueOf(value));
+            case TINYINT:
+            case SMALLINT:
+            case INT:
+            case BIGINT:
+                if (value instanceof Number) {
+                    return value;
+                }
+                return Long.valueOf(String.valueOf(value));
+            case FLOAT:
+            case DOUBLE:
+                if (value instanceof Number) {
+                    return value;
+                }
+                return Double.valueOf(String.valueOf(value));
+            case DECIMAL:
+                if (value instanceof BigDecimal) {
+                    return value;
+                }
+                return new BigDecimal(String.valueOf(value));
+            case DATE:
+                return value instanceof LocalDate ? value.toString() : String.valueOf(value);
+            case TIME:
+                return value instanceof LocalTime ? value.toString() : String.valueOf(value);
+            case TIMESTAMP:
+                return timestampText(value);
+            case BYTES:
+                return value instanceof byte[]
+                        ? Base64.getEncoder().encodeToString((byte[]) value)
+                        : String.valueOf(value);
+            case STRING:
+            case TIMESTAMP_TZ:
+                return String.valueOf(value);
+            case ARRAY:
+            case MAP:
+            case ROW:
+                return normalizeAny(value);
+            case NULL:
+                return null;
+            default:
+                return normalizeAny(value);
+        }
+    }
+
+    private static Object normalizeAny(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDate
+                || value instanceof LocalTime) {
+            return value.toString();
+        }
+        if (value instanceof LocalDateTime) {
+            return timestampText(value);
+        }
+        if (value instanceof byte[]) {
+            return Base64.getEncoder().encodeToString((byte[]) value);
+        }
+        if (value instanceof Map) {
+            Map<?, ?> source = (Map<?, ?>) value;
+            Map<String, Object> result = new LinkedHashMap<String, Object>();
+            for (Map.Entry<?, ?> entry : source.entrySet()) {
+                result.put(String.valueOf(entry.getKey()), normalizeAny(entry.getValue()));
+            }
+            return result;
+        }
+        if (value instanceof Collection) {
+            List<Object> result = new ArrayList<Object>();
+            for (Object item : (Collection<?>) value) {
+                result.add(normalizeAny(item));
+            }
+            return result;
+        }
+        Class<?> type = value.getClass();
+        if (type.isArray()) {
+            int length = Array.getLength(value);
+            List<Object> result = new ArrayList<Object>(length);
+            for (int i = 0; i < length; i++) {
+                result.add(normalizeAny(Array.get(value, i)));
+            }
+            return result;
+        }
+        return value;
+    }
+
+    private static String csvText(Object value) {
+        if (value instanceof byte[]) {
+            return Base64.getEncoder().encodeToString((byte[]) value);
+        }
+        if (value instanceof LocalDateTime) {
+            return timestampText(value);
+        }
+        if (value instanceof LocalDate || value instanceof LocalTime) {
+            return value.toString();
+        }
+        if (value instanceof Map || value instanceof Collection || value.getClass().isArray()) {
+            try {
+                return JSON_MAPPER.writeValueAsString(normalizeAny(value));
+            } catch (JsonProcessingException failure) {
+                throw new IllegalArgumentException("Failed to serialize complex CSV value", failure);
+            }
+        }
+        return String.valueOf(value);
+    }
+
+    private static String timestampText(Object value) {
+        String text = String.valueOf(value);
+        return value instanceof LocalDateTime ? text.replace('T', ' ') : text;
+    }
+
+    private void validateArity(FluxRow row) {
+        if (row == null) {
+            throw new IllegalArgumentException("row must not be null");
+        }
+        if (row.getArity() != schema.getColumnCount()) {
+            throw new IllegalArgumentException(
+                    "StarRocks Sink row arity does not match table schema: row="
+                            + row.getArity()
+                            + ", schema="
+                            + schema.getColumnCount());
+        }
+    }
+
+    private static void write(ByteArrayOutputStream output, byte[] bytes) {
+        output.write(bytes, 0, bytes.length);
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/sink/StarRocksSinkFactory.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/sink/StarRocksSinkFactory.java
@@ -1,0 +1,72 @@
+package com.link.up.connector.starrocks.sink;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+import com.link.up.connector.starrocks.config.StarRocksSinkOptions;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** SPI factory for the bounded StarRocks Stream Load Sink. */
+@AutoService(SinkFactory.class)
+public final class StarRocksSinkFactory implements SinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return "starrocks";
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        StarRocksSinkOptions.NODE_URLS,
+                        StarRocksSinkOptions.USERNAME,
+                        StarRocksSinkOptions.DATABASE,
+                        StarRocksSinkOptions.TABLE)
+                .optional(
+                        StarRocksSinkOptions.PASSWORD,
+                        StarRocksSinkOptions.LABEL_PREFIX,
+                        StarRocksSinkOptions.LOAD_FORMAT,
+                        StarRocksSinkOptions.BATCH_MAX_ROWS,
+                        StarRocksSinkOptions.BATCH_MAX_BYTES,
+                        StarRocksSinkOptions.MAX_RETRIES,
+                        StarRocksSinkOptions.RETRY_BACKOFF_MS,
+                        StarRocksSinkOptions.MAX_RETRY_BACKOFF_MS,
+                        StarRocksSinkOptions.CONNECT_TIMEOUT_MS,
+                        StarRocksSinkOptions.SOCKET_TIMEOUT_MS,
+                        StarRocksSinkOptions.LABEL_STATE_TIMEOUT_MS,
+                        StarRocksSinkOptions.LABEL_STATE_POLL_MS,
+                        StarRocksSinkOptions.COLUMN_SEPARATOR,
+                        StarRocksSinkOptions.ROW_DELIMITER,
+                        StarRocksSinkOptions.STREAM_LOAD_PARAMS)
+                .build();
+    }
+
+    @Override
+    public SinkPreparer createPreparer(ReadonlyConfig config) {
+        return new StarRocksSinkPreparer(StarRocksSinkConfig.of(config));
+    }
+
+    @Override
+    public SinkWriter<FluxRow> createSink(
+            ReadonlyConfig config,
+            PreparedSinkMetadata metadata) {
+        return new StarRocksSinkWriter(
+                StarRocksSinkConfig.of(config),
+                metadata);
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/sink/StarRocksSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/sink/StarRocksSinkPreparer.java
@@ -1,0 +1,52 @@
+package com.link.up.connector.starrocks.sink;
+
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPrepareContext;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Prepares the target table metadata for the bounded StarRocks Stream Load Sink. */
+final class StarRocksSinkPreparer implements SinkPreparer {
+
+    private final StarRocksSinkConfig config;
+
+    StarRocksSinkPreparer(StarRocksSinkConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public PreparedSinkMetadata prepare(SinkPrepareContext context) {
+        if (context == null) {
+            throw new IllegalArgumentException("context must not be null");
+        }
+        if (context.getSourceTables().size() != 1) {
+            throw new IllegalArgumentException(
+                    "StarRocks Stream Load Sink Stage 2 supports exactly one source table");
+        }
+
+        Map<TablePath, CatalogTable> targets =
+                new LinkedHashMap<TablePath, CatalogTable>();
+
+        for (Map.Entry<TablePath, CatalogTable> entry : context.getSourceTables().entrySet()) {
+            CatalogTable sourceTable = entry.getValue();
+            if (sourceTable == null || sourceTable.getTableSchema() == null) {
+                throw new IllegalArgumentException(
+                        "StarRocks Stream Load Sink requires source table schema");
+            }
+
+            TablePath targetPath = TablePath.of(config.getDatabase(), config.getTable());
+            CatalogTable targetTable =
+                    CatalogTable.builder(targetPath, sourceTable.getTableSchema())
+                            .options(sourceTable.getOptions())
+                            .build();
+            targets.put(entry.getKey(), targetTable);
+        }
+
+        return new PreparedSinkMetadata(targets);
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/sink/StarRocksSinkWriter.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/sink/StarRocksSinkWriter.java
@@ -1,6 +1,12 @@
 package com.link.up.connector.starrocks.sink;
 
+import com.link.up.api.dirtydata.BoundedMemoryDirtyDataCollector;
+import com.link.up.api.dirtydata.DirtyDataCollector;
+import com.link.up.api.dirtydata.DirtyDataContext;
+import com.link.up.api.dirtydata.DirtyDataSummary;
+import com.link.up.api.dirtydata.DirtyRecord;
 import com.link.up.api.sink.CommitScope;
+import com.link.up.api.sink.DirtyDataAwareSinkWriter;
 import com.link.up.api.sink.PreparedSinkMetadata;
 import com.link.up.api.sink.SinkWriter;
 import com.link.up.api.source.RecordBatch;
@@ -19,12 +25,13 @@ import java.util.List;
 import java.util.Objects;
 
 /** Writes bounded FluxRow batches through StarRocks Stream Load. */
-public final class StarRocksSinkWriter implements SinkWriter<FluxRow> {
+public final class StarRocksSinkWriter
+        implements SinkWriter<FluxRow>, DirtyDataAwareSinkWriter {
 
     private static final Logger LOG = LoggerFactory.getLogger(StarRocksSinkWriter.class);
 
     private final StarRocksSinkConfig config;
-    private final StarRocksStreamLoadClient client;
+    private final StreamLoadExecutor streamLoadExecutor;
     private final List<byte[]> bufferedRecords = new ArrayList<byte[]>();
 
     private TableSchema schema;
@@ -35,28 +42,37 @@ public final class StarRocksSinkWriter implements SinkWriter<FluxRow> {
     private long totalFilteredRows;
     private boolean opened;
 
+    private DirtyDataCollector dirtyDataCollector;
+    private DirtyDataContext dirtyDataContext;
+
     public StarRocksSinkWriter(
             StarRocksSinkConfig config,
             PreparedSinkMetadata metadata) {
         this(
                 config,
                 metadata,
-                new StarRocksStreamLoadClient(
-                        Objects.requireNonNull(config, "config must not be null")));
+                new HttpStreamLoadExecutor(
+                        new StarRocksStreamLoadClient(
+                                Objects.requireNonNull(config, "config must not be null"))));
     }
 
     StarRocksSinkWriter(
             StarRocksSinkConfig config,
             PreparedSinkMetadata metadata,
-            StarRocksStreamLoadClient client) {
+            StreamLoadExecutor streamLoadExecutor) {
         this.config = Objects.requireNonNull(config, "config must not be null");
         Objects.requireNonNull(metadata, "metadata must not be null");
-        this.client = Objects.requireNonNull(client, "client must not be null");
+        this.streamLoadExecutor = Objects.requireNonNull(
+                streamLoadExecutor,
+                "streamLoadExecutor must not be null");
     }
 
     @Override
-    public void open() {
+    public void open() throws Exception {
         opened = true;
+        if (dirtyDataCollector != null) {
+            dirtyDataCollector.open();
+        }
         LOG.info(
                 "StarRocks SinkWriter opened: database={}, table={}, format={}, maxRows={}, maxBytes={}",
                 config.getDatabase(),
@@ -150,13 +166,35 @@ public final class StarRocksSinkWriter implements SinkWriter<FluxRow> {
     }
 
     @Override
-    public void close() {
+    public void configureDirtyData(DirtyDataContext context) throws Exception {
+        dirtyDataContext = Objects.requireNonNull(context, "context must not be null");
+        dirtyDataCollector =
+                new BoundedMemoryDirtyDataCollector(
+                        context.getTaskId(),
+                        100,
+                        1000,
+                        0.1);
+        if (opened) {
+            dirtyDataCollector.open();
+        }
+    }
+
+    @Override
+    public DirtyDataSummary getDirtyDataSummary() {
+        return dirtyDataCollector == null
+                ? DirtyDataSummary.empty()
+                : dirtyDataCollector.summary();
+    }
+
+    @Override
+    public void close() throws Exception {
         try {
             bufferedRecords.clear();
             bufferedRecordBytes = 0L;
-            client.close();
+            streamLoadExecutor.close();
         } finally {
             opened = false;
+            closeDirtyDataCollector();
         }
         LOG.info(
                 "StarRocks SinkWriter closed: totalWrittenRows={}, totalLoadRequests={}, totalFilteredRows={}",
@@ -193,39 +231,107 @@ public final class StarRocksSinkWriter implements SinkWriter<FluxRow> {
                     "Cannot flush StarRocks Sink before source schema is initialized");
         }
 
+        int flushRows = bufferedRecords.size();
         byte[] payload = serializer.joinRecords(bufferedRecords, bufferedRecordBytes);
         LOG.debug(
                 "Flushing StarRocks Stream Load batch: rows={}, payloadBytes={}",
-                bufferedRecords.size(),
+                flushRows,
                 payload.length);
 
-        StarRocksStreamLoadResponse response = client.load(payload, schema);
+        StarRocksStreamLoadResponse response = streamLoadExecutor.load(payload, schema);
         if (!response.isSuccess()) {
             throw new IllegalStateException(
                     "StarRocks Stream Load client returned non-success response: "
                             + response.getStatus());
         }
 
-        totalWrittenRows += bufferedRecords.size();
+        totalWrittenRows += flushRows;
         totalLoadRequests++;
         totalFilteredRows += response.getNumberFilteredRows();
-
-        if (response.getNumberFilteredRows() > 0L) {
-            LOG.warn(
-                    "StarRocks Stream Load filtered {} rows: label={}, message={}, errorUrl={}",
-                    response.getNumberFilteredRows(),
-                    response.getLabel(),
-                    response.getMessage(),
-                    response.getErrorUrl());
-        }
+        recordFilteredRows(response, flushRows);
 
         bufferedRecords.clear();
         bufferedRecordBytes = 0L;
     }
 
+    private void recordFilteredRows(
+            StarRocksStreamLoadResponse response,
+            int flushRows) {
+        if (response.getNumberFilteredRows() <= 0L) {
+            return;
+        }
+
+        LOG.warn(
+                "StarRocks Stream Load filtered {} rows: label={}, message={}, errorUrl={}",
+                response.getNumberFilteredRows(),
+                response.getLabel(),
+                response.getMessage(),
+                response.getErrorUrl());
+
+        if (dirtyDataCollector == null) {
+            return;
+        }
+
+        try {
+            dirtyDataCollector.recordAttempt(flushRows);
+            String message =
+                    "StarRocks Stream Load filtered "
+                            + response.getNumberFilteredRows()
+                            + " rows: "
+                            + response.getMessage();
+            if (response.getErrorUrl() != null && !response.getErrorUrl().trim().isEmpty()) {
+                message += ", ErrorURL=" + response.getErrorUrl();
+            }
+            dirtyDataCollector.collect(
+                    new DirtyRecord(
+                            "STREAM_LOAD_FILTERED",
+                            message,
+                            dirtyDataContext,
+                            System.currentTimeMillis()));
+        } catch (Exception failure) {
+            LOG.error("Failed to record StarRocks dirty-data evidence", failure);
+        }
+    }
+
+    private void closeDirtyDataCollector() {
+        if (dirtyDataCollector == null) {
+            return;
+        }
+        try {
+            dirtyDataCollector.close(true);
+        } catch (Exception failure) {
+            LOG.warn("Failed to close StarRocks dirty data collector", failure);
+        }
+    }
+
     private void checkOpened() {
         if (!opened) {
             throw new IllegalStateException("StarRocks SinkWriter has not been opened");
+        }
+    }
+
+    interface StreamLoadExecutor extends AutoCloseable {
+        StarRocksStreamLoadResponse load(byte[] payload, TableSchema schema) throws Exception;
+
+        @Override
+        void close() throws Exception;
+    }
+
+    private static final class HttpStreamLoadExecutor implements StreamLoadExecutor {
+        private final StarRocksStreamLoadClient client;
+
+        private HttpStreamLoadExecutor(StarRocksStreamLoadClient client) {
+            this.client = client;
+        }
+
+        @Override
+        public StarRocksStreamLoadResponse load(byte[] payload, TableSchema schema) throws Exception {
+            return client.load(payload, schema);
+        }
+
+        @Override
+        public void close() {
+            client.close();
         }
     }
 }

--- a/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/sink/StarRocksSinkWriter.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/main/java/com/link/up/connector/starrocks/sink/StarRocksSinkWriter.java
@@ -1,0 +1,231 @@
+package com.link.up.connector.starrocks.sink;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.starrocks.client.sink.StarRocksStreamLoadClient;
+import com.link.up.connector.starrocks.client.sink.StarRocksStreamLoadResponse;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+import com.link.up.connector.starrocks.converter.StarRocksRowSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Writes bounded FluxRow batches through StarRocks Stream Load. */
+public final class StarRocksSinkWriter implements SinkWriter<FluxRow> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(StarRocksSinkWriter.class);
+
+    private final StarRocksSinkConfig config;
+    private final StarRocksStreamLoadClient client;
+    private final List<byte[]> bufferedRecords = new ArrayList<byte[]>();
+
+    private TableSchema schema;
+    private StarRocksRowSerializer serializer;
+    private long bufferedRecordBytes;
+    private long totalWrittenRows;
+    private long totalLoadRequests;
+    private long totalFilteredRows;
+    private boolean opened;
+
+    public StarRocksSinkWriter(
+            StarRocksSinkConfig config,
+            PreparedSinkMetadata metadata) {
+        this(
+                config,
+                metadata,
+                new StarRocksStreamLoadClient(
+                        Objects.requireNonNull(config, "config must not be null")));
+    }
+
+    StarRocksSinkWriter(
+            StarRocksSinkConfig config,
+            PreparedSinkMetadata metadata,
+            StarRocksStreamLoadClient client) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(metadata, "metadata must not be null");
+        this.client = Objects.requireNonNull(client, "client must not be null");
+    }
+
+    @Override
+    public void open() {
+        opened = true;
+        LOG.info(
+                "StarRocks SinkWriter opened: database={}, table={}, format={}, maxRows={}, maxBytes={}",
+                config.getDatabase(),
+                config.getTable(),
+                config.getLoadFormat(),
+                config.getBatchMaxRows(),
+                config.getBatchMaxBytes());
+    }
+
+    @Override
+    public void write(
+            RecordBatch<FluxRow> batch,
+            CatalogTable sourceTable)
+            throws Exception {
+        checkOpened();
+        if (batch == null || batch.isEndOfInput() || batch.getRecords().isEmpty()) {
+            return;
+        }
+
+        initializeSchema(sourceTable);
+
+        for (FluxRow row : batch.getRecords()) {
+            byte[] record = serializer.serializeRow(row);
+            long singlePayloadBytes = serializer.payloadSizeBytes(1, record.length);
+            if (singlePayloadBytes > config.getBatchMaxBytes()) {
+                throw new IllegalArgumentException(
+                        "One serialized StarRocks row exceeds batch_max_bytes: payloadBytes="
+                                + singlePayloadBytes
+                                + ", limit="
+                                + config.getBatchMaxBytes());
+            }
+
+            long nextPayloadBytes =
+                    serializer.payloadSizeBytes(
+                            bufferedRecords.size() + 1,
+                            bufferedRecordBytes + record.length);
+
+            if (!bufferedRecords.isEmpty()
+                    && (bufferedRecords.size() >= config.getBatchMaxRows()
+                    || nextPayloadBytes > config.getBatchMaxBytes())) {
+                flush();
+            }
+
+            bufferedRecords.add(record);
+            bufferedRecordBytes += record.length;
+
+            if (bufferedRecords.size() >= config.getBatchMaxRows()
+                    || serializer.payloadSizeBytes(
+                                    bufferedRecords.size(),
+                                    bufferedRecordBytes)
+                            >= config.getBatchMaxBytes()) {
+                flush();
+            }
+        }
+    }
+
+    @Override
+    public void prepareCommit() throws Exception {
+        checkOpened();
+        flush();
+    }
+
+    @Override
+    public void commit() {
+        checkOpened();
+        LOG.info(
+                "StarRocks SinkWriter commit boundary reached: totalWrittenRows={}, totalLoadRequests={}",
+                totalWrittenRows,
+                totalLoadRequests);
+    }
+
+    @Override
+    public void abort() {
+        bufferedRecords.clear();
+        bufferedRecordBytes = 0L;
+        LOG.warn(
+                "StarRocks SinkWriter aborted unsent buffer; already successful Stream Load batches cannot be rolled back: writtenRows={}",
+                totalWrittenRows);
+    }
+
+    @Override
+    public CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    @Override
+    public String getRetryAdvice() {
+        return "StarRocks Stream Load commits each successful flush independently. "
+                + "The connector reuses labels inside one flush retry, but a whole-task retry creates new labels; "
+                + "verify already loaded target data or rely on target-table key semantics before retrying.";
+    }
+
+    @Override
+    public void close() {
+        try {
+            bufferedRecords.clear();
+            bufferedRecordBytes = 0L;
+            client.close();
+        } finally {
+            opened = false;
+        }
+        LOG.info(
+                "StarRocks SinkWriter closed: totalWrittenRows={}, totalLoadRequests={}, totalFilteredRows={}",
+                totalWrittenRows,
+                totalLoadRequests,
+                totalFilteredRows);
+    }
+
+    private void initializeSchema(CatalogTable sourceTable) {
+        if (sourceTable == null || sourceTable.getTableSchema() == null) {
+            throw new IllegalArgumentException(
+                    "StarRocks Stream Load Sink requires CatalogTable schema on write");
+        }
+
+        TableSchema incoming = sourceTable.getTableSchema();
+        if (schema == null) {
+            schema = incoming;
+            serializer = new StarRocksRowSerializer(config, schema);
+            return;
+        }
+
+        if (!schema.equals(incoming)) {
+            throw new IllegalArgumentException(
+                    "StarRocks Stream Load Sink does not support runtime schema changes in Stage 2");
+        }
+    }
+
+    private void flush() throws Exception {
+        if (bufferedRecords.isEmpty()) {
+            return;
+        }
+        if (serializer == null || schema == null) {
+            throw new IllegalStateException(
+                    "Cannot flush StarRocks Sink before source schema is initialized");
+        }
+
+        byte[] payload = serializer.joinRecords(bufferedRecords, bufferedRecordBytes);
+        LOG.debug(
+                "Flushing StarRocks Stream Load batch: rows={}, payloadBytes={}",
+                bufferedRecords.size(),
+                payload.length);
+
+        StarRocksStreamLoadResponse response = client.load(payload, schema);
+        if (!response.isSuccess()) {
+            throw new IllegalStateException(
+                    "StarRocks Stream Load client returned non-success response: "
+                            + response.getStatus());
+        }
+
+        totalWrittenRows += bufferedRecords.size();
+        totalLoadRequests++;
+        totalFilteredRows += response.getNumberFilteredRows();
+
+        if (response.getNumberFilteredRows() > 0L) {
+            LOG.warn(
+                    "StarRocks Stream Load filtered {} rows: label={}, message={}, errorUrl={}",
+                    response.getNumberFilteredRows(),
+                    response.getLabel(),
+                    response.getMessage(),
+                    response.getErrorUrl());
+        }
+
+        bufferedRecords.clear();
+        bufferedRecordBytes = 0L;
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("StarRocks SinkWriter has not been opened");
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/StarRocksConnectorPackageBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/StarRocksConnectorPackageBoundaryTest.java
@@ -1,6 +1,8 @@
 package com.link.up.connector.starrocks;
 
+import com.link.up.connector.starrocks.client.sink.StarRocksStreamLoadClient;
 import com.link.up.connector.starrocks.client.source.StarRocksBeReadClient;
+import com.link.up.connector.starrocks.sink.StarRocksSinkFactory;
 import com.link.up.connector.starrocks.source.StarRocksSourceFactory;
 import org.junit.Test;
 
@@ -13,12 +15,18 @@ import static org.junit.Assert.assertTrue;
 public class StarRocksConnectorPackageBoundaryTest {
 
     @Test
-    public void nativeSourceLivesInStandaloneConnector() {
+    public void nativeSourceAndStreamLoadSinkLiveInStandaloneConnector() {
         assertEquals(
                 "com.link.up.connector.starrocks.source",
                 StarRocksSourceFactory.class.getPackage().getName());
+        assertEquals(
+                "com.link.up.connector.starrocks.sink",
+                StarRocksSinkFactory.class.getPackage().getName());
         assertTrue(
                 StarRocksBeReadClient.class.getName()
+                        .startsWith("com.link.up.connector.starrocks."));
+        assertTrue(
+                StarRocksStreamLoadClient.class.getName()
                         .startsWith("com.link.up.connector.starrocks."));
     }
 

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/client/sink/StarRocksStreamLoadClientTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/client/sink/StarRocksStreamLoadClientTest.java
@@ -1,0 +1,77 @@
+package com.link.up.connector.starrocks.client.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StarRocksStreamLoadClientTest {
+
+    @Test
+    public void jsonHeadersOwnIdempotencyAndPayloadSemantics() {
+        Map<String, Object> values = minimalConfig();
+        Map<String, String> extra = new LinkedHashMap<String, String>();
+        extra.put("strict_mode", "true");
+        values.put("stream_load.params", extra);
+        StarRocksSinkConfig config =
+                StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .build();
+
+        StarRocksStreamLoadClient client = new StarRocksStreamLoadClient(config);
+        try {
+            Map<String, String> headers = client.buildHeaders("batch_1", schema);
+            assertEquals("batch_1", headers.get("label"));
+            assertEquals("json", headers.get("format"));
+            assertEquals("true", headers.get("strip_outer_array"));
+            assertEquals("true", headers.get("strict_mode"));
+            assertEquals("100-continue", headers.get("Expect"));
+            assertTrue(headers.get("Authorization").startsWith("Basic "));
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void csvHeadersCarryExactSchemaOrder() {
+        Map<String, Object> values = minimalConfig();
+        values.put("load_format", "CSV");
+        values.put("column_separator", "|");
+        StarRocksSinkConfig config =
+                StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .build();
+
+        StarRocksStreamLoadClient client = new StarRocksStreamLoadClient(config);
+        try {
+            Map<String, String> headers = client.buildHeaders("batch_2", schema);
+            assertEquals("csv", headers.get("format"));
+            assertEquals("|", headers.get("column_separator"));
+            assertEquals("`id`,`name`", headers.get("columns"));
+        } finally {
+            client.close();
+        }
+    }
+
+    private static Map<String, Object> minimalConfig() {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("node_urls", Arrays.asList("127.0.0.1:8030"));
+        values.put("username", "root");
+        values.put("password", "secret");
+        values.put("database", "demo");
+        values.put("table", "orders");
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/client/sink/StarRocksStreamLoadResponseTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/client/sink/StarRocksStreamLoadResponseTest.java
@@ -1,0 +1,42 @@
+package com.link.up.connector.starrocks.client.sink;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class StarRocksStreamLoadResponseTest {
+
+    @Test
+    public void parsesSuccessResponse() throws Exception {
+        StarRocksStreamLoadResponse response =
+                StarRocksStreamLoadResponse.parse(
+                        "{\"Status\":\"Success\",\"Label\":\"l1\","
+                                + "\"NumberTotalRows\":3,\"NumberLoadedRows\":3,"
+                                + "\"NumberFilteredRows\":0,\"TxnId\":42}");
+
+        assertTrue(response.isSuccess());
+        assertFalse(response.isLabelAlreadyExists());
+        assertEquals("l1", response.getLabel());
+        assertEquals(3L, response.getNumberLoadedRows());
+        assertEquals("42", response.getTxnId());
+    }
+
+    @Test
+    public void publishTimeoutIsSuccessfulStreamLoadOutcome() throws Exception {
+        StarRocksStreamLoadResponse response =
+                StarRocksStreamLoadResponse.parse(
+                        "{\"Status\":\"Publish Timeout\",\"Label\":\"l2\"}");
+        assertTrue(response.isSuccess());
+    }
+
+    @Test
+    public void detectsCurrentLabelReuseFromLegacyFailureMessage() throws Exception {
+        StarRocksStreamLoadResponse response =
+                StarRocksStreamLoadResponse.parse(
+                        "{\"Status\":\"Fail\",\"Label\":\"l3\","
+                                + "\"Message\":\"Label [l3] has already been used\"}");
+        assertTrue(response.isLabelAlreadyExists());
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/config/StarRocksSinkConfigTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/config/StarRocksSinkConfigTest.java
@@ -1,0 +1,73 @@
+package com.link.up.connector.starrocks.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StarRocksSinkConfigTest {
+
+    @Test
+    public void parsesMinimalBoundedSinkConfig() {
+        StarRocksSinkConfig config = StarRocksSinkConfig.of(
+                ReadonlyConfig.fromMap(minimalConfig()));
+
+        assertEquals(Arrays.asList("fe-1:8030", "fe-2:8030"), config.getNodeUrls());
+        assertEquals("root", config.getUsername());
+        assertEquals("demo", config.getDatabase());
+        assertEquals("orders", config.getTable());
+        assertEquals(StarRocksLoadFormat.JSON, config.getLoadFormat());
+        assertEquals(1024, config.getBatchMaxRows());
+        assertEquals(5L * 1024L * 1024L, config.getBatchMaxBytes());
+        assertTrue(config.getLabelPrefix().startsWith("link_up_demo_orders_"));
+    }
+
+    @Test
+    public void parsesCsvAndStreamLoadParams() {
+        Map<String, Object> values = minimalConfig();
+        values.put("load_format", "CSV");
+        values.put("column_separator", "|");
+        Map<String, String> params = new LinkedHashMap<String, String>();
+        params.put("strict_mode", "true");
+        params.put("timeout", "300");
+        values.put("stream_load.params", params);
+
+        StarRocksSinkConfig config =
+                StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+
+        assertEquals(StarRocksLoadFormat.CSV, config.getLoadFormat());
+        assertEquals("|", config.getColumnSeparator());
+        assertEquals("true", config.getStreamLoadParams().get("strict_mode"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsReservedStreamLoadHeaderOverride() {
+        Map<String, Object> values = minimalConfig();
+        Map<String, String> params = new LinkedHashMap<String, String>();
+        params.put("label", "unsafe");
+        values.put("stream_load.params", params);
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsNonPositiveBatchSize() {
+        Map<String, Object> values = minimalConfig();
+        values.put("batch_max_rows", 0);
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static Map<String, Object> minimalConfig() {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("node_urls", Arrays.asList("fe-1:8030", "fe-2:8030"));
+        values.put("username", "root");
+        values.put("password", "");
+        values.put("database", "demo");
+        values.put("table", "orders");
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/config/StarRocksSinkConfigTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/config/StarRocksSinkConfigTest.java
@@ -25,10 +25,11 @@ public class StarRocksSinkConfigTest {
         assertEquals(1024, config.getBatchMaxRows());
         assertEquals(5L * 1024L * 1024L, config.getBatchMaxBytes());
         assertTrue(config.getLabelPrefix().startsWith("link_up_demo_orders_"));
+        assertTrue(config.getLabelPrefix().length() <= 96);
     }
 
     @Test
-    public void parsesCsvAndStreamLoadParams() {
+    public void parsesCsvAndSafeStreamLoadParams() {
         Map<String, Object> values = minimalConfig();
         values.put("load_format", "CSV");
         values.put("column_separator", "|");
@@ -45,12 +46,80 @@ public class StarRocksSinkConfigTest {
         assertEquals("true", config.getStreamLoadParams().get("strict_mode"));
     }
 
+    @Test
+    public void longDefaultLabelPrefixIsTrimmedForGeneratedUuid() {
+        Map<String, Object> values = minimalConfig();
+        values.put("database", repeat('d', 100));
+        values.put("table", repeat('t', 100));
+
+        StarRocksSinkConfig config =
+                StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+
+        assertTrue(config.getLabelPrefix().startsWith("link_up_"));
+        assertEquals(96, config.getLabelPrefix().length());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void rejectsReservedStreamLoadHeaderOverride() {
         Map<String, Object> values = minimalConfig();
         Map<String, String> params = new LinkedHashMap<String, String>();
         params.put("label", "unsafe");
         values.put("stream_load.params", params);
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMergeCommitBecauseItOwnsLabels() {
+        Map<String, Object> values = minimalConfig();
+        Map<String, String> params = new LinkedHashMap<String, String>();
+        params.put("enable_merge_commit", "true");
+        values.put("stream_load.params", params);
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsPartialUpdateSemanticsInBoundedStage2() {
+        Map<String, Object> values = minimalConfig();
+        Map<String, String> params = new LinkedHashMap<String, String>();
+        params.put("partial_update", "true");
+        values.put("stream_load.params", params);
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsCompressionHeaderWithoutCompressedPayload() {
+        Map<String, Object> values = minimalConfig();
+        Map<String, String> params = new LinkedHashMap<String, String>();
+        params.put("compression", "gzip");
+        values.put("stream_load.params", params);
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsLabelPrefixWithHyphen() {
+        Map<String, Object> values = minimalConfig();
+        values.put("label_prefix", "batch-run");
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsLabelPrefixStartingWithDigit() {
+        Map<String, Object> values = minimalConfig();
+        values.put("label_prefix", "1batch");
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsLabelPrefixThatLeavesNoRoomForUuid() {
+        Map<String, Object> values = minimalConfig();
+        values.put("label_prefix", repeat('a', 97));
+        StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsDelimiterBeyondStarRocksLimit() {
+        Map<String, Object> values = minimalConfig();
+        values.put("column_separator", repeat('x', 51));
         StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
     }
 
@@ -69,5 +138,11 @@ public class StarRocksSinkConfigTest {
         values.put("database", "demo");
         values.put("table", "orders");
         return values;
+    }
+
+    private static String repeat(char value, int count) {
+        char[] chars = new char[count];
+        Arrays.fill(chars, value);
+        return new String(chars);
     }
 }

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializerTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializerTest.java
@@ -100,14 +100,23 @@ public class StarRocksRowSerializerTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void jsonRejectsBinaryBecauseStarRocksJsonLoadDoesNotSupportIt() {
+    public void jsonRejectsBinaryAtSchemaInitialization() {
         StarRocksSinkConfig config = config("JSON", "\t");
         TableSchema schema = TableSchema.builder()
                 .column(Column.builder("payload", BasicType.BYTES_TYPE).build())
                 .build();
 
-        new StarRocksRowSerializer(config, schema)
-                .serializeRow(FluxRow.of(new byte[] {0x01, 0x02}));
+        new StarRocksRowSerializer(config, schema);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTimestampWithTimezoneInsteadOfDroppingOffset() {
+        StarRocksSinkConfig config = config("JSON", "\t");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("created_at", BasicType.TIMESTAMP_TZ_TYPE).build())
+                .build();
+
+        new StarRocksRowSerializer(config, schema);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -118,6 +127,16 @@ public class StarRocksRowSerializerTest {
                 .build();
         new StarRocksRowSerializer(config, schema)
                 .serializeRow(FluxRow.of("A|B"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void csvRejectsNonNullValueEqualToNullMarker() {
+        StarRocksSinkConfig config = config("CSV", "|");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .build();
+        new StarRocksRowSerializer(config, schema)
+                .serializeRow(FluxRow.of("\\N"));
     }
 
     private static StarRocksSinkConfig config(String format, String separator) {

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializerTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializerTest.java
@@ -1,0 +1,107 @@
+package com.link.up.connector.starrocks.converter;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StarRocksRowSerializerTest {
+
+    @Test
+    public void serializesJsonArrayWithTemporalAndDecimalValues() {
+        StarRocksSinkConfig config = config("JSON", "\t");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .column(Column.builder("amount", new DecimalType(18, 2)).build())
+                .column(Column.builder("created_on", BasicType.DATE_TYPE).build())
+                .column(Column.builder("created_at", BasicType.TIMESTAMP_TYPE).build())
+                .column(Column.builder("note", BasicType.STRING_TYPE).build())
+                .build();
+        StarRocksRowSerializer serializer = new StarRocksRowSerializer(config, schema);
+
+        byte[] first = serializer.serializeRow(
+                FluxRow.of(
+                        1L,
+                        new BigDecimal("12.30"),
+                        LocalDate.of(2026, 9, 5),
+                        LocalDateTime.of(2026, 9, 5, 12, 34, 56),
+                        null));
+        byte[] second = serializer.serializeRow(
+                FluxRow.of(
+                        2L,
+                        new BigDecimal("9.99"),
+                        LocalDate.of(2026, 9, 6),
+                        LocalDateTime.of(2026, 9, 6, 8, 0, 1),
+                        "ok"));
+
+        List<byte[]> rows = new ArrayList<byte[]>();
+        rows.add(first);
+        rows.add(second);
+        byte[] payload = serializer.joinRecords(rows, first.length + second.length);
+        String json = new String(payload, StandardCharsets.UTF_8);
+
+        assertTrue(json.startsWith("["));
+        assertTrue(json.endsWith("]"));
+        assertTrue(json.contains("\"id\":1"));
+        assertTrue(json.contains("\"amount\":12.30"));
+        assertTrue(json.contains("\"created_on\":\"2026-09-05\""));
+        assertTrue(json.contains("\"created_at\":\"2026-09-05 12:34:56\""));
+        assertTrue(json.contains("\"note\":null"));
+    }
+
+    @Test
+    public void serializesCsvUsingConfiguredDelimiterAndNullMarker() {
+        StarRocksSinkConfig config = config("CSV", "|");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .column(Column.builder("note", BasicType.STRING_TYPE).build())
+                .build();
+        StarRocksRowSerializer serializer = new StarRocksRowSerializer(config, schema);
+
+        String record = new String(
+                serializer.serializeRow(FluxRow.of(7L, "Alice", null)),
+                StandardCharsets.UTF_8);
+
+        assertEquals("7|Alice|\\N", record);
+        assertEquals("`id`,`name`,`note`", serializer.csvColumnsHeader());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void csvFailsFastWhenValueContainsDelimiter() {
+        StarRocksSinkConfig config = config("CSV", "|");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .build();
+        new StarRocksRowSerializer(config, schema)
+                .serializeRow(FluxRow.of("A|B"));
+    }
+
+    private static StarRocksSinkConfig config(String format, String separator) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("node_urls", Arrays.asList("127.0.0.1:8030"));
+        values.put("username", "root");
+        values.put("database", "demo");
+        values.put("table", "orders");
+        values.put("load_format", format);
+        values.put("column_separator", separator);
+        return StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializerTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/converter/StarRocksRowSerializerTest.java
@@ -84,6 +84,32 @@ public class StarRocksRowSerializerTest {
         assertEquals("`id`,`name`,`note`", serializer.csvColumnsHeader());
     }
 
+    @Test
+    public void serializesBinaryAsHexForCsvStreamLoad() {
+        StarRocksSinkConfig config = config("CSV", "|");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("payload", BasicType.BYTES_TYPE).build())
+                .build();
+        StarRocksRowSerializer serializer = new StarRocksRowSerializer(config, schema);
+
+        String record = new String(
+                serializer.serializeRow(FluxRow.of(new byte[] {0x00, 0x0F, (byte) 0xFF})),
+                StandardCharsets.UTF_8);
+
+        assertEquals("000FFF", record);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void jsonRejectsBinaryBecauseStarRocksJsonLoadDoesNotSupportIt() {
+        StarRocksSinkConfig config = config("JSON", "\t");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("payload", BasicType.BYTES_TYPE).build())
+                .build();
+
+        new StarRocksRowSerializer(config, schema)
+                .serializeRow(FluxRow.of(new byte[] {0x01, 0x02}));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void csvFailsFastWhenValueContainsDelimiter() {
         StarRocksSinkConfig config = config("CSV", "|");

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/sink/StarRocksSinkPreparerTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/sink/StarRocksSinkPreparerTest.java
@@ -1,0 +1,80 @@
+package com.link.up.connector.starrocks.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPrepareContext;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class StarRocksSinkPreparerTest {
+
+    @Test
+    public void mapsSingleSourceSchemaToConfiguredTarget() throws Exception {
+        Map<String, Object> configValues = new LinkedHashMap<String, Object>();
+        configValues.put("node_urls", Arrays.asList("127.0.0.1:8030"));
+        configValues.put("username", "root");
+        configValues.put("database", "warehouse");
+        configValues.put("table", "orders_sink");
+        StarRocksSinkConfig config =
+                StarRocksSinkConfig.of(ReadonlyConfig.fromMap(configValues));
+
+        TablePath sourcePath = TablePath.of("source_db", "orders");
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .build();
+        CatalogTable sourceTable = CatalogTable.builder(sourcePath, schema).build();
+        Map<TablePath, CatalogTable> sourceTables =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        sourceTables.put(sourcePath, sourceTable);
+
+        PreparedSinkMetadata metadata =
+                new StarRocksSinkPreparer(config)
+                        .prepare(
+                                new SinkPrepareContext(
+                                        ReadonlyConfig.fromMap(configValues),
+                                        sourceTables));
+
+        CatalogTable target = metadata.getTargetTable(sourcePath);
+        assertEquals(TablePath.of("warehouse", "orders_sink"), target.getTablePath());
+        assertEquals(schema, target.getTableSchema());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMultiSourceTopologyInStageTwo() throws Exception {
+        Map<String, Object> configValues = new LinkedHashMap<String, Object>();
+        configValues.put("node_urls", Arrays.asList("127.0.0.1:8030"));
+        configValues.put("username", "root");
+        configValues.put("database", "warehouse");
+        configValues.put("table", "orders_sink");
+        StarRocksSinkConfig config =
+                StarRocksSinkConfig.of(ReadonlyConfig.fromMap(configValues));
+
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .build();
+        Map<TablePath, CatalogTable> sourceTables =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        TablePath first = TablePath.of("source_db", "a");
+        TablePath second = TablePath.of("source_db", "b");
+        sourceTables.put(first, CatalogTable.builder(first, schema).build());
+        sourceTables.put(second, CatalogTable.builder(second, schema).build());
+
+        new StarRocksSinkPreparer(config)
+                .prepare(
+                        new SinkPrepareContext(
+                                ReadonlyConfig.fromMap(configValues),
+                                sourceTables));
+    }
+}

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/sink/StarRocksSinkWriterTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/sink/StarRocksSinkWriterTest.java
@@ -1,0 +1,190 @@
+package com.link.up.connector.starrocks.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.dirtydata.DirtyDataContext;
+import com.link.up.api.dirtydata.DirtyDataSummary;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.starrocks.client.sink.StarRocksStreamLoadResponse;
+import com.link.up.connector.starrocks.config.StarRocksSinkConfig;
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class StarRocksSinkWriterTest {
+
+    @Test
+    public void flushesAtRowThresholdAndPrepareCommitFlushesRemainder() throws Exception {
+        StarRocksSinkConfig config = config(2);
+        TableSchema schema = schema();
+        CatalogTable sourceTable = sourceTable(schema);
+        RecordingExecutor executor = new RecordingExecutor();
+        StarRocksSinkWriter writer = writer(config, executor);
+
+        writer.open();
+        writer.write(
+                RecordBatch.data(
+                        Arrays.asList(
+                                FluxRow.of(1L, "a"),
+                                FluxRow.of(2L, "b"),
+                                FluxRow.of(3L, "c"))),
+                sourceTable);
+
+        assertEquals(1, executor.payloads.size());
+        assertTrue(executor.payloads.get(0).contains("\"id\":1"));
+        assertTrue(executor.payloads.get(0).contains("\"id\":2"));
+
+        writer.prepareCommit();
+        assertEquals(2, executor.payloads.size());
+        assertTrue(executor.payloads.get(1).contains("\"id\":3"));
+
+        writer.commit();
+        writer.close();
+        assertTrue(executor.closed);
+    }
+
+    @Test
+    public void abortDiscardsUnsentBufferAndCloseDoesNotFlush() throws Exception {
+        StarRocksSinkConfig config = config(10);
+        RecordingExecutor executor = new RecordingExecutor();
+        StarRocksSinkWriter writer = writer(config, executor);
+
+        writer.open();
+        writer.write(
+                RecordBatch.data(Collections.singletonList(FluxRow.of(1L, "a"))),
+                sourceTable(schema()));
+        assertEquals(0, executor.payloads.size());
+
+        writer.abort();
+        writer.close();
+
+        assertEquals(0, executor.payloads.size());
+        assertTrue(executor.closed);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsRuntimeSchemaChanges() throws Exception {
+        StarRocksSinkConfig config = config(10);
+        RecordingExecutor executor = new RecordingExecutor();
+        StarRocksSinkWriter writer = writer(config, executor);
+        TableSchema first = schema();
+        TableSchema second = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .column(Column.builder("extra", BasicType.STRING_TYPE).build())
+                .build();
+
+        writer.open();
+        try {
+            writer.write(
+                    RecordBatch.data(Collections.singletonList(FluxRow.of(1L, "a"))),
+                    sourceTable(first));
+            writer.write(
+                    RecordBatch.data(Collections.singletonList(FluxRow.of(2L, "b", "x"))),
+                    sourceTable(second));
+        } finally {
+            writer.close();
+        }
+    }
+
+    @Test
+    public void recordsFilteredRowsAsDirtyDataEvidence() throws Exception {
+        StarRocksSinkConfig config = config(2);
+        RecordingExecutor executor = new RecordingExecutor();
+        executor.responseBody =
+                "{\"Status\":\"Success\",\"Label\":\"batch_1\","
+                        + "\"NumberLoadedRows\":1,\"NumberFilteredRows\":1,"
+                        + "\"Message\":\"one row filtered\","
+                        + "\"ErrorURL\":\"http://fe/error\"}";
+        StarRocksSinkWriter writer = writer(config, executor);
+        writer.configureDirtyData(
+                new DirtyDataContext(
+                        "job-1",
+                        "task-1",
+                        "starrocks",
+                        "orders",
+                        null));
+
+        writer.open();
+        writer.write(
+                RecordBatch.data(
+                        Arrays.asList(
+                                FluxRow.of(1L, "a"),
+                                FluxRow.of(2L, "b"))),
+                sourceTable(schema()));
+
+        DirtyDataSummary summary = writer.getDirtyDataSummary();
+        assertEquals(1L, summary.getDirtyCount());
+        assertEquals(2L, summary.getAttemptedCount());
+        assertEquals(Long.valueOf(1L), summary.getTaskCounts().get("task-1"));
+        assertEquals(1, summary.getSampleCount());
+
+        writer.close();
+    }
+
+    private static StarRocksSinkWriter writer(
+            StarRocksSinkConfig config,
+            RecordingExecutor executor) {
+        return new StarRocksSinkWriter(
+                config,
+                new PreparedSinkMetadata(Collections.<TablePath, CatalogTable>emptyMap()),
+                executor);
+    }
+
+    private static StarRocksSinkConfig config(int batchRows) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("node_urls", Arrays.asList("127.0.0.1:8030"));
+        values.put("username", "root");
+        values.put("database", "demo");
+        values.put("table", "orders");
+        values.put("batch_max_rows", batchRows);
+        values.put("batch_max_bytes", 1024L * 1024L);
+        return StarRocksSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static TableSchema schema() {
+        return TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .build();
+    }
+
+    private static CatalogTable sourceTable(TableSchema schema) {
+        return CatalogTable.builder(TablePath.of("source", "orders"), schema).build();
+    }
+
+    private static final class RecordingExecutor
+            implements StarRocksSinkWriter.StreamLoadExecutor {
+        private final List<String> payloads = new ArrayList<String>();
+        private String responseBody =
+                "{\"Status\":\"Success\",\"Label\":\"batch_1\","
+                        + "\"NumberLoadedRows\":2,\"NumberFilteredRows\":0}";
+        private boolean closed;
+
+        @Override
+        public StarRocksStreamLoadResponse load(byte[] payload, TableSchema schema) throws Exception {
+            payloads.add(new String(payload, StandardCharsets.UTF_8));
+            return StarRocksStreamLoadResponse.parse(responseBody);
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Complete Stage 2 of the standalone StarRocks connector by adding a bounded Stream Load Sink on top of the Sink SPI introduced by Link-Up.

The write path is:

`RecordBatch<FluxRow> -> schema-aware JSON/CSV serialization -> row/byte bounded buffer -> FE Stream Load -> BE redirect -> StarRocks commit`

This stays inside `link-up-connector-starrocks` and does not fall back to JDBC.

## What changed

- add `StarRocksSinkFactory` / `StarRocksSinkPreparer` / `StarRocksSinkWriter`
- add HTTP Stream Load client and response model
- support JSON and CSV payloads
- flush by both `batch_max_rows` and `batch_max_bytes`
- round-robin FE nodes and follow 307/308 redirects
- reuse the same label when retrying one flush
- resolve `Label Already Exists` through `/api/{database}/get_load_state`
- treat `VISIBLE` / `COMMITTED` as already committed and only retry with a new label after explicit `ABORTED`
- treat `Publish Timeout` as an accepted successful Stream Load result and do not resend the batch
- validate StarRocks label characters and maximum length before execution
- bound retry/backoff, socket/connect timeouts and label-state polling
- allow safe `stream_load.params` passthrough while rejecting connector-owned or Stage-2-breaking headers
- serialize scalar Flux values deterministically
- support `BINARY/VARBINARY` only through CSV hexadecimal encoding
- surface `NumberFilteredRows > 0` through Link-Up dirty-data evidence instead of hiding data loss only in logs
- add Sink writer lifecycle tests for threshold flush, `prepareCommit`, abort/close behavior, runtime schema rejection and filtered-row evidence
- document the Stage 2 protocol and capability boundary

## Stage 2 boundaries

This PR intentionally remains a bounded/offline Sink.

It does **not** add:

- CDC / streaming semantics
- DELETE / RowKind handling
- partial update or `merge_condition`
- Merge Commit / asynchronous merge loading
- 2PC or Job-level exactly once
- runtime schema evolution
- automatic database/table creation or JDBC Catalog fallback
- multi-target-table Sink routing
- ARRAY / MAP / ROW complex-type writing

`TIMESTAMP_TZ` is also rejected instead of silently dropping the offset while writing StarRocks `DATETIME`; callers must make the timezone conversion explicit upstream.

Stream Load commits each successful flush independently. Link-Up `commit()` therefore remains a task lifecycle boundary rather than pretending that already successful Stream Load requests can still be rolled back. `abort()` and `close()` only discard unsent local buffers.

## Idempotency boundary

Retries for the same flush reuse the same StarRocks label. If a retry sees an existing label, the connector checks the final load state before deciding whether the batch may be resent.

A whole SinkTask retry is intentionally not advertised as exactly-once: it creates new labels and must rely on the target table's own key/deduplication semantics or explicit operator verification.

Merge Commit parameters are rejected because Merge Commit changes label ownership/commit behavior and would invalidate this per-flush idempotency contract.

## Validation

Added coverage for:

- minimal/CSV Sink configuration and option validation
- label syntax/length and default prefix bounding
- blocking Merge Commit, partial-update and connector-owned Stream Load headers
- Stream Load request headers and response parsing
- JSON temporal/decimal serialization
- CSV delimiter/null-marker behavior
- BINARY CSV hexadecimal encoding and JSON fail-fast behavior
- TIMESTAMP_TZ fail-fast behavior
- single-target Sink preparation
- row-threshold flush + `prepareCommit` remainder flush
- abort/close not implicitly flushing unsent data
- runtime schema change rejection
- filtered-row dirty-data evidence
- standalone StarRocks package boundary

A repository-side Maven/test run is still required before merge. This execution environment cannot resolve `github.com` for a local clone/dependency run, and this commit currently has no GitHub Actions workflow run. The implementation and tests were statically reviewed against the current Link-Up APIs and the current StarRocks/SeaTunnel Stream Load behavior.

## Relationship to Stage 1

PR #103 delivered the standalone Native Source. This PR completes the explicitly deferred Stage 2 Stream Load Sink while preserving the same native-connector boundary and keeping CDC/realtime work out of scope.