### PR TITLE
feat(doris): add bounded native arrow source

### DIFF
--- a/link-up-connectors/link-up-connector-doris/README.md
+++ b/link-up-connectors/link-up-connector-doris/README.md
@@ -1,0 +1,109 @@
+# Link-Up Doris Connector
+
+`link-up-connector-doris` provides Doris Catalog metadata support, Stream Load Sink support, and a bounded native Source.
+
+## Native Source
+
+The Source data path follows the Doris native scanner design used by SeaTunnel:
+
+```text
+DorisSource
+  -> Doris Catalog metadata discovery (MySQL-compatible protocol)
+  -> FE POST /api/{database}/{table}/_query_plan
+  -> opaqued query plan + tablet routings
+  -> deterministic tablet/BE splits
+  -> BE TDorisExternalService openScanner/getNext/closeScanner
+  -> Arrow IPC batch
+  -> FluxRow
+```
+
+The JDBC/MySQL protocol is used only for table metadata discovery. Actual table data is not read through JDBC.
+
+### Supported in this stage
+
+- bounded/offline reads only
+- single-table and multi-table reads
+- Catalog-backed schema discovery
+- `doris.read.field` column projection
+- `doris.filter.query` predicate pushdown into the FE query plan
+- tablet-level split planning and BE parallelism
+- Doris FE failover/retry for `_query_plan`
+- Doris v1 query-plan response and v2 `{code,msg,data}` envelope compatibility
+- direct BE Thrift scanner reads
+- Arrow IPC -> `FluxRow` decoding for scalar fields
+- per-table `doris.request.tablet.size`, `doris.batch.size`, and `doris.exec.mem.limit`
+- `LARGEINT` exposed as `STRING` for the native Source so the full signed 128-bit range is preserved
+
+### Explicitly out of scope
+
+- CDC / streaming reads
+- Arrow Flight SQL mode
+- asynchronous Arrow decode queues
+- ARRAY / MAP / STRUCT native conversion
+- HLL / BITMAP aggregate-type reads
+- runtime schema evolution
+- JDBC data-read fallback
+
+Arrow Flight SQL is intentionally not the default implementation here. Doris documents it as a high-performance option, but it currently has a different execution boundary and does not provide the same tablet-level multi-BE parallel read model. The FE query-plan + BE scanner path maps directly onto Link-Up's `SourceSplitEnumerator` / `SourceReader` architecture.
+
+## Source configuration
+
+Single table:
+
+```hocon
+source {
+  Doris {
+    fenodes = "fe-1:8030,fe-2:8030"
+    username = "root"
+    password = ""
+    database = "analytics"
+    table = "orders"
+
+    doris.read.field = "id,order_no,amount,created_at"
+    doris.filter.query = "id >= 100"
+    doris.request.tablet.size = 8
+    doris.batch.size = 1024
+    doris.request.connect.timeout.ms = 30000
+    doris.request.read.timeout.ms = 30000
+    doris.request.query.timeout.s = 3600
+    doris.request.retries = 3
+    doris.exec.mem.limit = 2147483648
+  }
+}
+```
+
+Multiple tables:
+
+```hocon
+source {
+  Doris {
+    fenodes = "fe-1:8030,fe-2:8030"
+    username = "root"
+    password = ""
+
+    table_list = [
+      {
+        database = "analytics"
+        table = "orders"
+        doris.read.field = "id,amount"
+        doris.filter.query = "status = 'PAID'"
+        doris.request.tablet.size = 4
+      },
+      {
+        database = "crm"
+        table = "customers"
+      }
+    ]
+  }
+}
+```
+
+Compatibility aliases such as `scan_filter`, `request_tablet_size`, `scan_batch_rows`, `scan_connect_timeout_ms`, `scan_read_timeout_ms`, `scan_query_timeout_sec`, `max_retries`, and `scan_mem_limit` are accepted for consistency with other Link-Up native sources.
+
+## Type boundary
+
+The native Arrow decoder supports Link-Up scalar targets: boolean, integer widths, floating point, decimal, string, bytes, date, time, and timestamp.
+
+Doris `LARGEINT` is signed 128-bit and is normalized to Link-Up `STRING` in the native Source. This avoids silently narrowing values into an insufficient decimal precision.
+
+Complex and aggregate types are deliberately conservative in this stage. `ARRAY`, `MAP`, `STRUCT`, `HLL`, and `BITMAP` fail during source schema preparation rather than being converted through `String.valueOf(...)` and producing ambiguous data.

--- a/link-up-connectors/link-up-connector-doris/pom.xml
+++ b/link-up-connectors/link-up-connector-doris/pom.xml
@@ -39,13 +39,33 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.12.0</version>
+            <version>${okhttp.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.4</version>
+            <version>${jackson.version}</version>
         </dependency>
+
+        <!-- Doris native Source: generated TDorisExternalService thrift API. -->
+        <dependency>
+            <groupId>org.apache.doris</groupId>
+            <artifactId>thrift-service</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <!-- Doris BE scanner returns Arrow IPC batches. Keep Arrow aligned with Link-Up. -->
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-vector</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.arrow</groupId>
+            <artifactId>arrow-memory-netty</artifactId>
+            <version>${arrow.version}</version>
+        </dependency>
+
+        <!-- Catalog metadata discovery still uses Doris' MySQL-compatible protocol. -->
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/DorisBeReadClient.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/DorisBeReadClient.java
@@ -1,0 +1,261 @@
+package com.link.up.connector.doris.client.source;
+
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.FluxRowType;
+import com.link.up.connector.doris.client.source.model.DorisQueryPartition;
+import com.link.up.connector.doris.config.DorisSourceConfig;
+import com.link.up.connector.doris.config.DorisSourceTableConfig;
+import com.link.up.connector.doris.converter.DorisArrowRowReader;
+import org.apache.doris.sdk.thrift.TDorisExternalService;
+import org.apache.doris.sdk.thrift.TScanBatchResult;
+import org.apache.doris.sdk.thrift.TScanCloseParams;
+import org.apache.doris.sdk.thrift.TScanCloseResult;
+import org.apache.doris.sdk.thrift.TScanNextBatchParams;
+import org.apache.doris.sdk.thrift.TScanOpenParams;
+import org.apache.doris.sdk.thrift.TScanOpenResult;
+import org.apache.doris.sdk.thrift.TStatus;
+import org.apache.doris.sdk.thrift.TStatusCode;
+import org.apache.thrift.TConfiguration;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.transport.TSocket;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Task-local Thrift client for the Doris BE external scanner service. */
+public final class DorisBeReadClient implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DorisBeReadClient.class);
+    private static final String DEFAULT_CLUSTER_NAME = "default_cluster";
+
+    private final DorisSourceConfig config;
+    private final DorisSourceTableConfig tableConfig;
+    private final DorisQueryPartition partition;
+    private final FluxRowType rowType;
+
+    private TSocket socket;
+    private TDorisExternalService.Client client;
+    private String contextId;
+    private int readerOffset;
+    private boolean eos;
+    private List<FluxRow> currentRows = Collections.emptyList();
+    private int currentRowIndex;
+
+    public DorisBeReadClient(
+            DorisSourceConfig config,
+            DorisSourceTableConfig tableConfig,
+            DorisQueryPartition partition,
+            FluxRowType rowType) {
+        this.config = config;
+        this.tableConfig = tableConfig;
+        this.partition = partition;
+        this.rowType = rowType;
+    }
+
+    public void open() throws Exception {
+        Exception lastFailure = null;
+        int attempts = Math.max(1, config.getRequestRetries() + 1);
+        for (int attempt = 0; attempt < attempts; attempt++) {
+            try {
+                openConnection();
+                TScanOpenResult result = client.openScanner(openParams());
+                ensureOk("openScanner", result == null ? null : result.getStatus());
+                if (result == null
+                        || result.getContextId() == null
+                        || result.getContextId().trim().isEmpty()) {
+                    throw new IOException("Doris BE openScanner returned an empty context id");
+                }
+                contextId = result.getContextId();
+                readerOffset = 0;
+                eos = false;
+                currentRows = Collections.emptyList();
+                currentRowIndex = 0;
+                LOG.info(
+                        "Opened Doris native scanner: table={}.{}, be={}, tablets={}, contextId={}",
+                        partition.getDatabase(),
+                        partition.getTable(),
+                        partition.getBeAddress(),
+                        partition.getTabletIds().size(),
+                        contextId);
+                return;
+            } catch (Exception failure) {
+                lastFailure = failure;
+                closeTransport();
+                LOG.warn(
+                        "Doris BE scanner open failed: be={}, attempt={}/{}, error={}",
+                        partition.getBeAddress(),
+                        attempt + 1,
+                        attempts,
+                        failure.getMessage());
+            }
+        }
+        throw new IOException(
+                "Unable to open Doris BE scanner for " + partition.getBeAddress(), lastFailure);
+    }
+
+    public boolean hasNext() throws Exception {
+        while (currentRowIndex >= currentRows.size() && !eos) {
+            fetchNextBatch();
+        }
+        return currentRowIndex < currentRows.size();
+    }
+
+    public FluxRow next() throws Exception {
+        if (!hasNext()) {
+            throw new IllegalStateException("No more Doris rows in current split");
+        }
+        return currentRows.get(currentRowIndex++);
+    }
+
+    private void openConnection() throws Exception {
+        String[] hostPort = parseBeAddress(partition.getBeAddress());
+        String host = hostPort[0];
+        int port = Integer.parseInt(hostPort[1]);
+        socket =
+                new TSocket(
+                        new TConfiguration(),
+                        host,
+                        port,
+                        config.getReadTimeoutMs(),
+                        config.getConnectTimeoutMs());
+        socket.open();
+        TProtocol protocol = new TBinaryProtocol.Factory().getProtocol(socket);
+        client = new TDorisExternalService.Client(protocol);
+    }
+
+    private TScanOpenParams openParams() {
+        TScanOpenParams params = new TScanOpenParams();
+        params.setCluster(DEFAULT_CLUSTER_NAME);
+        params.setDatabase(partition.getDatabase());
+        params.setTable(partition.getTable());
+        params.setTabletIds(new ArrayList<Long>(partition.getTabletIds()));
+        params.setOpaquedQueryPlan(partition.getOpaquedQueryPlan());
+        params.setBatchSize(tableConfig.getBatchSize());
+        params.setQueryTimeout(config.getQueryTimeoutSec());
+        params.setMemLimit(tableConfig.getExecMemLimit());
+        params.setUser(config.getUsername());
+        params.setPasswd(config.getPassword());
+        return params;
+    }
+
+    private void fetchNextBatch() throws Exception {
+        TScanNextBatchParams params = new TScanNextBatchParams();
+        params.setContextId(contextId);
+        params.setOffset(readerOffset);
+
+        Exception lastFailure = null;
+        int attempts = Math.max(1, config.getRequestRetries() + 1);
+        for (int attempt = 0; attempt < attempts; attempt++) {
+            try {
+                TScanBatchResult result = client.getNext(params);
+                ensureOk("getNext", result == null ? null : result.getStatus());
+                if (result == null) {
+                    throw new IOException("Doris BE getNext returned null result");
+                }
+                eos = result.isEos();
+                byte[] payload = result.getRows();
+                currentRows =
+                        payload == null || payload.length == 0
+                                ? Collections.<FluxRow>emptyList()
+                                : DorisArrowRowReader.read(payload, rowType);
+                currentRowIndex = 0;
+                readerOffset += currentRows.size();
+                return;
+            } catch (TException failure) {
+                lastFailure = failure;
+                LOG.warn(
+                        "Doris BE getNext failed: be={}, contextId={}, offset={}, attempt={}/{}, error={}",
+                        partition.getBeAddress(),
+                        contextId,
+                        readerOffset,
+                        attempt + 1,
+                        attempts,
+                        failure.getMessage());
+            }
+        }
+        throw new IOException(
+                "Doris BE getNext failed after retries: be="
+                        + partition.getBeAddress()
+                        + ", contextId="
+                        + contextId
+                        + ", offset="
+                        + readerOffset,
+                lastFailure);
+    }
+
+    private static void ensureOk(String operation, TStatus status) throws IOException {
+        if (status == null || status.getStatusCode() != TStatusCode.OK) {
+            throw new IOException(
+                    "Doris BE "
+                            + operation
+                            + " failed: status="
+                            + (status == null ? "null" : status.getStatusCode())
+                            + ", errors="
+                            + (status == null ? "[]" : status.getErrorMsgs()));
+        }
+    }
+
+    static String[] parseBeAddress(String address) {
+        if (address == null) {
+            throw new IllegalArgumentException("BE address must not be null");
+        }
+        String value = address.trim();
+        int separator = value.lastIndexOf(':');
+        if (separator <= 0 || separator == value.length() - 1) {
+            throw new IllegalArgumentException(
+                    "Illegal Doris BE address, expected host:port: " + address);
+        }
+        String port = value.substring(separator + 1);
+        int parsedPort;
+        try {
+            parsedPort = Integer.parseInt(port);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Illegal Doris BE port: " + address, e);
+        }
+        if (parsedPort <= 0 || parsedPort > 65535) {
+            throw new IllegalArgumentException("Doris BE port must be between 1 and 65535: " + address);
+        }
+        return new String[] {value.substring(0, separator), port};
+    }
+
+    private void closeTransport() {
+        if (socket != null) {
+            socket.close();
+        }
+        client = null;
+        socket = null;
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        if (client != null && contextId != null) {
+            TScanCloseParams params = new TScanCloseParams();
+            params.setContextId(contextId);
+            try {
+                TScanCloseResult result = client.closeScanner(params);
+                ensureOk("closeScanner", result == null ? null : result.getStatus());
+            } catch (Exception e) {
+                failure = e;
+                LOG.warn(
+                        "Failed to close Doris scanner: be={}, contextId={}",
+                        partition.getBeAddress(),
+                        contextId,
+                        e);
+            }
+        }
+        closeTransport();
+        contextId = null;
+        currentRows = Collections.emptyList();
+        currentRowIndex = 0;
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/DorisBeReadClient.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/DorisBeReadClient.java
@@ -160,6 +160,15 @@ public final class DorisBeReadClient implements AutoCloseable {
                 }
                 eos = result.isEos();
                 byte[] payload = result.getRows();
+                if (!eos && (payload == null || payload.length == 0)) {
+                    throw new IOException(
+                            "Doris BE getNext returned an empty Arrow payload before EOS: be="
+                                    + partition.getBeAddress()
+                                    + ", contextId="
+                                    + contextId
+                                    + ", offset="
+                                    + readerOffset);
+                }
                 currentRows =
                         payload == null || payload.length == 0
                                 ? Collections.<FluxRow>emptyList()

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/DorisQueryPlanClient.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/DorisQueryPlanClient.java
@@ -1,0 +1,217 @@
+package com.link.up.connector.doris.client.source;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.connector.doris.client.source.model.DorisQueryPlan;
+import com.link.up.connector.doris.config.DorisSourceConfig;
+import com.link.up.connector.doris.config.DorisSourceTableConfig;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/** Obtains opaque native scan plans from Doris FE over HTTP. */
+public final class DorisQueryPlanClient implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DorisQueryPlanClient.class);
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+
+    private final DorisSourceConfig config;
+    private final ObjectMapper objectMapper;
+    private final OkHttpClient httpClient;
+
+    public DorisQueryPlanClient(DorisSourceConfig config) {
+        this.config = config;
+        this.objectMapper = new ObjectMapper();
+        this.httpClient =
+                new OkHttpClient.Builder()
+                        .connectTimeout(config.getConnectTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .writeTimeout(config.getConnectTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .readTimeout(config.getReadTimeoutMs(), TimeUnit.MILLISECONDS)
+                        .build();
+    }
+
+    public DorisQueryPlan fetchQueryPlan(
+            DorisSourceTableConfig tableConfig,
+            CatalogTable table) throws IOException {
+        String sql = buildQuerySql(tableConfig, table);
+        String requestBody =
+                objectMapper.writeValueAsString(java.util.Collections.singletonMap("sql", sql));
+
+        IOException lastFailure = null;
+        int attempts = Math.max(1, config.getRequestRetries() + 1);
+        List<String> nodes = config.getFeNodes();
+        for (int attempt = 0; attempt < attempts; attempt++) {
+            String node = nodes.get(attempt % nodes.size());
+            String url =
+                    normalizeHttpNode(node)
+                            + "/api/"
+                            + tableConfig.getDatabase()
+                            + "/"
+                            + tableConfig.getTable()
+                            + "/_query_plan";
+            Request request =
+                    new Request.Builder()
+                            .url(url)
+                            .header("Authorization", basicAuth())
+                            .header("Accept", "application/json")
+                            .post(RequestBody.create(requestBody.getBytes(StandardCharsets.UTF_8), JSON))
+                            .build();
+            try (Response response = httpClient.newCall(request).execute()) {
+                ResponseBody body = response.body();
+                String text = body == null ? "" : body.string();
+                if (!response.isSuccessful()) {
+                    throw new IOException(
+                            "Doris FE query-plan request failed: httpStatus="
+                                    + response.code()
+                                    + ", node="
+                                    + node
+                                    + ", body="
+                                    + abbreviate(text, 1000));
+                }
+                DorisQueryPlan plan = parsePlanResponse(text, objectMapper);
+                validatePlan(plan, tableConfig, node);
+                return plan;
+            } catch (IOException failure) {
+                lastFailure = failure;
+                LOG.warn(
+                        "Doris FE query-plan request failed: table={}.{}, node={}, attempt={}/{}, error={}",
+                        tableConfig.getDatabase(),
+                        tableConfig.getTable(),
+                        node,
+                        attempt + 1,
+                        attempts,
+                        failure.getMessage());
+            }
+        }
+        throw new IOException(
+                "Unable to obtain Doris query plan for "
+                        + tableConfig.getDatabase()
+                        + "."
+                        + tableConfig.getTable()
+                        + " after "
+                        + attempts
+                        + " attempts",
+                lastFailure);
+    }
+
+    static String buildQuerySql(DorisSourceTableConfig tableConfig, CatalogTable table) {
+        if (table == null || table.getTableSchema() == null) {
+            throw new IllegalArgumentException("Doris native Source requires discovered table schema");
+        }
+        List<String> fields = new ArrayList<String>();
+        for (Column column : table.getTableSchema().getColumns()) {
+            fields.add(quoteIdentifier(column.getName()));
+        }
+        if (fields.isEmpty()) {
+            throw new IllegalArgumentException("Doris native Source requires at least one projected field");
+        }
+        StringBuilder sql = new StringBuilder();
+        sql.append("SELECT ")
+                .append(String.join(", ", fields))
+                .append(" FROM ")
+                .append(quoteIdentifier(tableConfig.getDatabase()))
+                .append('.')
+                .append(quoteIdentifier(tableConfig.getTable()));
+        if (hasText(tableConfig.getFilterQuery())) {
+            sql.append(" WHERE ").append(tableConfig.getFilterQuery().trim());
+        }
+        return sql.toString();
+    }
+
+    static DorisQueryPlan parsePlanResponse(String responseText, ObjectMapper mapper)
+            throws IOException {
+        if (!hasText(responseText)) {
+            throw new IOException("Doris FE returned an empty query-plan response");
+        }
+        JsonNode root = mapper.readTree(responseText);
+        JsonNode planNode = root;
+        if (root.has("code") && root.has("msg")) {
+            int code = root.path("code").asInt(-1);
+            if (code != 0) {
+                throw new IOException(
+                        "Doris FE query-plan response failed: code="
+                                + code
+                                + ", msg="
+                                + root.path("msg").asText(""));
+            }
+            planNode = root.get("data");
+        }
+        if (planNode == null || planNode.isNull()) {
+            throw new IOException("Doris FE query-plan response does not contain data");
+        }
+        return mapper.treeToValue(planNode, DorisQueryPlan.class);
+    }
+
+    private static void validatePlan(
+            DorisQueryPlan plan,
+            DorisSourceTableConfig table,
+            String node) throws IOException {
+        if (plan == null || plan.getStatus() != 200 || !hasText(plan.getOpaquedQueryPlan())) {
+            throw new IOException(
+                    "Doris FE returned an invalid query plan: table="
+                            + table.getDatabase()
+                            + "."
+                            + table.getTable()
+                            + ", node="
+                            + node
+                            + ", status="
+                            + (plan == null ? "null" : plan.getStatus()));
+        }
+        if (plan.getPartitions() == null) {
+            throw new IOException("Doris FE query plan does not contain partitions");
+        }
+    }
+
+    private String basicAuth() {
+        String credentials = config.getUsername() + ":" + config.getPassword();
+        return "Basic "
+                + Base64.getEncoder()
+                        .encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+    }
+
+    static String normalizeHttpNode(String node) {
+        String value = node.trim();
+        if (!value.startsWith("http://") && !value.startsWith("https://")) {
+            value = "http://" + value;
+        }
+        while (value.endsWith("/")) {
+            value = value.substring(0, value.length() - 1);
+        }
+        return value;
+    }
+
+    private static String quoteIdentifier(String value) {
+        return "`" + value.replace("`", "``") + "`";
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private static String abbreviate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength) + "...";
+    }
+
+    @Override
+    public void close() {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/DorisSplitPlanner.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/DorisSplitPlanner.java
@@ -1,0 +1,138 @@
+package com.link.up.connector.doris.client.source;
+
+import com.link.up.connector.doris.client.source.model.DorisQueryPartition;
+import com.link.up.connector.doris.client.source.model.DorisQueryPlan;
+import com.link.up.connector.doris.client.source.model.DorisTablet;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/** Converts Doris FE tablet routing into deterministic BE-bound Source partitions. */
+public final class DorisSplitPlanner {
+
+    private DorisSplitPlanner() {
+    }
+
+    public static List<DorisQueryPartition> plan(
+            String database,
+            String table,
+            DorisQueryPlan queryPlan,
+            int requestTabletSize) {
+        if (queryPlan == null) {
+            throw new IllegalArgumentException("queryPlan must not be null");
+        }
+        if (requestTabletSize <= 0) {
+            throw new IllegalArgumentException("requestTabletSize must be greater than 0");
+        }
+        if (!hasText(queryPlan.getOpaquedQueryPlan())) {
+            throw new IllegalArgumentException("Doris query plan does not contain opaqued_query_plan");
+        }
+
+        Map<String, DorisTablet> tablets = queryPlan.getPartitions();
+        if (tablets == null || tablets.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Map.Entry<String, DorisTablet>> ordered =
+                new ArrayList<Map.Entry<String, DorisTablet>>(tablets.entrySet());
+        Collections.sort(
+                ordered,
+                new Comparator<Map.Entry<String, DorisTablet>>() {
+                    @Override
+                    public int compare(
+                            Map.Entry<String, DorisTablet> left,
+                            Map.Entry<String, DorisTablet> right) {
+                        return compareTabletId(left.getKey(), right.getKey());
+                    }
+                });
+
+        Map<String, List<Long>> beToTablets = new LinkedHashMap<String, List<Long>>();
+        for (Map.Entry<String, DorisTablet> entry : ordered) {
+            long tabletId = parseTabletId(entry.getKey());
+            String be = selectBackend(entry.getValue(), beToTablets);
+            List<Long> assigned = beToTablets.get(be);
+            if (assigned == null) {
+                assigned = new ArrayList<Long>();
+                beToTablets.put(be, assigned);
+            }
+            assigned.add(tabletId);
+        }
+
+        List<String> backends = new ArrayList<String>(beToTablets.keySet());
+        Collections.sort(backends);
+        List<DorisQueryPartition> result = new ArrayList<DorisQueryPartition>();
+        for (String backend : backends) {
+            List<Long> tabletIds =
+                    new ArrayList<Long>(new LinkedHashSet<Long>(beToTablets.get(backend)));
+            Collections.sort(tabletIds);
+            int offset = 0;
+            while (offset < tabletIds.size()) {
+                int end = Math.min(tabletIds.size(), offset + requestTabletSize);
+                result.add(
+                        new DorisQueryPartition(
+                                database,
+                                table,
+                                backend,
+                                tabletIds.subList(offset, end),
+                                queryPlan.getOpaquedQueryPlan()));
+                offset = end;
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    private static String selectBackend(
+            DorisTablet tablet,
+            Map<String, List<Long>> assigned) {
+        if (tablet == null || tablet.getRoutings().isEmpty()) {
+            throw new IllegalArgumentException("Doris tablet has no BE routing");
+        }
+        List<String> candidates = new ArrayList<String>();
+        for (String routing : tablet.getRoutings()) {
+            if (hasText(routing)) {
+                candidates.add(routing.trim());
+            }
+        }
+        if (candidates.isEmpty()) {
+            throw new IllegalArgumentException("Doris tablet has no valid BE routing");
+        }
+        Collections.sort(candidates);
+
+        String selected = null;
+        int selectedLoad = Integer.MAX_VALUE;
+        for (String candidate : candidates) {
+            List<Long> current = assigned.get(candidate);
+            int load = current == null ? 0 : current.size();
+            if (selected == null || load < selectedLoad) {
+                selected = candidate;
+                selectedLoad = load;
+            }
+        }
+        return selected;
+    }
+
+    private static int compareTabletId(String left, String right) {
+        try {
+            return Long.compare(Long.parseLong(left), Long.parseLong(right));
+        } catch (NumberFormatException ignored) {
+            return String.valueOf(left).compareTo(String.valueOf(right));
+        }
+    }
+
+    private static long parseTabletId(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid Doris tablet id: " + value, e);
+        }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisQueryPartition.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisQueryPartition.java
@@ -1,0 +1,42 @@
+package com.link.up.connector.doris.client.source.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** One Doris native scan partition bound to one BE and a bounded tablet group. */
+public final class DorisQueryPartition implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String database;
+    private final String table;
+    private final String beAddress;
+    private final List<Long> tabletIds;
+    private final String opaquedQueryPlan;
+
+    public DorisQueryPartition(
+            String database,
+            String table,
+            String beAddress,
+            List<Long> tabletIds,
+            String opaquedQueryPlan) {
+        this.database = Objects.requireNonNull(database, "database must not be null");
+        this.table = Objects.requireNonNull(table, "table must not be null");
+        this.beAddress = Objects.requireNonNull(beAddress, "beAddress must not be null");
+        if (tabletIds == null || tabletIds.isEmpty()) {
+            throw new IllegalArgumentException("tabletIds must not be empty");
+        }
+        this.tabletIds = Collections.unmodifiableList(new ArrayList<Long>(tabletIds));
+        this.opaquedQueryPlan =
+                Objects.requireNonNull(opaquedQueryPlan, "opaquedQueryPlan must not be null");
+    }
+
+    public String getDatabase() { return database; }
+    public String getTable() { return table; }
+    public String getBeAddress() { return beAddress; }
+    public List<Long> getTabletIds() { return tabletIds; }
+    public String getOpaquedQueryPlan() { return opaquedQueryPlan; }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisQueryPlan.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisQueryPlan.java
@@ -1,0 +1,27 @@
+package com.link.up.connector.doris.client.source.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Query plan returned by the Doris FE native scan endpoint. */
+public final class DorisQueryPlan implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private int status;
+
+    @JsonProperty("opaqued_query_plan")
+    private String opaquedQueryPlan;
+
+    private Map<String, DorisTablet> partitions = new LinkedHashMap<String, DorisTablet>();
+
+    public int getStatus() { return status; }
+    public void setStatus(int status) { this.status = status; }
+    public String getOpaquedQueryPlan() { return opaquedQueryPlan; }
+    public void setOpaquedQueryPlan(String opaquedQueryPlan) { this.opaquedQueryPlan = opaquedQueryPlan; }
+    public Map<String, DorisTablet> getPartitions() { return partitions; }
+    public void setPartitions(Map<String, DorisTablet> partitions) { this.partitions = partitions; }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisQueryPlan.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisQueryPlan.java
@@ -1,5 +1,6 @@
 package com.link.up.connector.doris.client.source.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.io.Serializable;
@@ -7,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Query plan returned by the Doris FE native scan endpoint. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class DorisQueryPlan implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisTablet.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisTablet.java
@@ -1,0 +1,28 @@
+package com.link.up.connector.doris.client.source.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Tablet routing returned by the Doris FE Query Plan endpoint. */
+public final class DorisTablet implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private List<String> routings = new ArrayList<String>();
+    private long version;
+    private long versionHash;
+    private long schemaHash;
+
+    public List<String> getRoutings() {
+        return routings == null ? Collections.<String>emptyList() : routings;
+    }
+    public void setRoutings(List<String> routings) { this.routings = routings; }
+    public long getVersion() { return version; }
+    public void setVersion(long version) { this.version = version; }
+    public long getVersionHash() { return versionHash; }
+    public void setVersionHash(long versionHash) { this.versionHash = versionHash; }
+    public long getSchemaHash() { return schemaHash; }
+    public void setSchemaHash(long schemaHash) { this.schemaHash = schemaHash; }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisTablet.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/client/source/model/DorisTablet.java
@@ -1,11 +1,14 @@
 package com.link.up.connector.doris.client.source.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 /** Tablet routing returned by the Doris FE Query Plan endpoint. */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public final class DorisTablet implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/config/DorisSourceConfig.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/config/DorisSourceConfig.java
@@ -1,0 +1,275 @@
+package com.link.up.connector.doris.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable runtime configuration for the Doris bounded native Source. */
+public final class DorisSourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> feNodes;
+    private final int queryPort;
+    private final String username;
+    private final String password;
+    private final List<DorisSourceTableConfig> tableConfigs;
+    private final int connectTimeoutMs;
+    private final int readTimeoutMs;
+    private final int queryTimeoutSec;
+    private final int requestRetries;
+
+    private DorisSourceConfig(
+            List<String> feNodes,
+            int queryPort,
+            String username,
+            String password,
+            List<DorisSourceTableConfig> tableConfigs,
+            int connectTimeoutMs,
+            int readTimeoutMs,
+            int queryTimeoutSec,
+            int requestRetries) {
+        this.feNodes = Collections.unmodifiableList(new ArrayList<String>(feNodes));
+        this.queryPort = queryPort;
+        this.username = username;
+        this.password = password;
+        this.tableConfigs =
+                Collections.unmodifiableList(new ArrayList<DorisSourceTableConfig>(tableConfigs));
+        this.connectTimeoutMs = connectTimeoutMs;
+        this.readTimeoutMs = readTimeoutMs;
+        this.queryTimeoutSec = queryTimeoutSec;
+        this.requestRetries = requestRetries;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static DorisSourceConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        List<String> feNodes = parseFeNodes(config.get(DorisSourceOptions.FENODES));
+        int queryPort = config.get(DorisSourceOptions.QUERY_PORT);
+        String username = requireText(config.get(DorisSourceOptions.USERNAME), "username");
+        String password = config.getOptional(DorisSourceOptions.PASSWORD).orElse("");
+        String commonDatabase = config.getOptional(DorisSourceOptions.DATABASE).orElse(null);
+        String commonFilter = config.get(DorisSourceOptions.FILTER_QUERY);
+        List<String> commonFields =
+                parseFields(config.getOptional(DorisSourceOptions.READ_FIELDS).orElse(null));
+        int commonTabletSize = config.get(DorisSourceOptions.REQUEST_TABLET_SIZE);
+        int commonBatchSize = config.get(DorisSourceOptions.BATCH_SIZE);
+        long commonMemLimit = config.get(DorisSourceOptions.EXEC_MEM_LIMIT);
+
+        String singleTable = config.getOptional(DorisSourceOptions.TABLE).orElse(null);
+        List<Map> tableList =
+                config.getOptional(DorisSourceOptions.TABLE_LIST)
+                        .orElse(Collections.<Map>emptyList());
+        if (hasText(singleTable) == !tableList.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Exactly one of Doris source table or table_list must be configured");
+        }
+
+        List<DorisSourceTableConfig> tables = new ArrayList<DorisSourceTableConfig>();
+        if (hasText(singleTable)) {
+            String database = requireText(commonDatabase, "database");
+            tables.add(
+                    new DorisSourceTableConfig(
+                            database,
+                            singleTable,
+                            commonFilter,
+                            commonFields,
+                            commonTabletSize,
+                            commonBatchSize,
+                            commonMemLimit));
+        } else {
+            for (Map item : tableList) {
+                String database = firstText(item, "database");
+                if (!hasText(database)) {
+                    database = commonDatabase;
+                }
+                database = requireText(database, "table_list[].database");
+                String table = requireText(stringValue(item.get("table")), "table_list[].table");
+                String filter = firstText(item, "doris.filter.query", "filter_query", "scan_filter");
+                if (!hasText(filter)) {
+                    filter = commonFilter;
+                }
+                Object fieldsValue = firstValue(item, "doris.read.field", "read_fields");
+                List<String> fields =
+                        fieldsValue == null ? commonFields : parseFieldsValue(fieldsValue);
+                int tabletSize =
+                        intValue(
+                                firstValue(item, "doris.request.tablet.size", "request_tablet_size"),
+                                commonTabletSize,
+                                "table_list[].doris.request.tablet.size");
+                int batchSize =
+                        intValue(
+                                firstValue(item, "doris.batch.size", "scan_batch_rows"),
+                                commonBatchSize,
+                                "table_list[].doris.batch.size");
+                long memLimit =
+                        longValue(
+                                firstValue(item, "doris.exec.mem.limit", "scan_mem_limit"),
+                                commonMemLimit,
+                                "table_list[].doris.exec.mem.limit");
+                tables.add(
+                        new DorisSourceTableConfig(
+                                database, table, filter, fields, tabletSize, batchSize, memLimit));
+            }
+        }
+
+        int connectTimeoutMs = config.get(DorisSourceOptions.REQUEST_CONNECT_TIMEOUT_MS);
+        int readTimeoutMs = config.get(DorisSourceOptions.REQUEST_READ_TIMEOUT_MS);
+        int queryTimeoutSec = config.get(DorisSourceOptions.REQUEST_QUERY_TIMEOUT_SEC);
+        int retries = config.get(DorisSourceOptions.REQUEST_RETRIES);
+
+        if (queryPort <= 0 || queryPort > 65535) {
+            throw new IllegalArgumentException("query-port must be between 1 and 65535");
+        }
+        validatePositive(commonTabletSize, "doris.request.tablet.size");
+        validatePositive(commonBatchSize, "doris.batch.size");
+        if (commonMemLimit <= 0L) {
+            throw new IllegalArgumentException("doris.exec.mem.limit must be greater than 0");
+        }
+        if (connectTimeoutMs <= 0) {
+            throw new IllegalArgumentException("doris.request.connect.timeout.ms must be greater than 0");
+        }
+        if (readTimeoutMs <= 0) {
+            throw new IllegalArgumentException("doris.request.read.timeout.ms must be greater than 0");
+        }
+        if (queryTimeoutSec == 0 || queryTimeoutSec < -1) {
+            throw new IllegalArgumentException(
+                    "doris.request.query.timeout.s must be -1 or greater than 0");
+        }
+        if (retries < 0) {
+            throw new IllegalArgumentException("doris.request.retries must not be negative");
+        }
+
+        return new DorisSourceConfig(
+                feNodes,
+                queryPort,
+                username,
+                password == null ? "" : password,
+                tables,
+                connectTimeoutMs,
+                readTimeoutMs,
+                queryTimeoutSec,
+                retries);
+    }
+
+    private static void validatePositive(int value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be greater than 0");
+        }
+    }
+
+    private static int intValue(Object value, int defaultValue, String name) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            int result = value instanceof Number
+                    ? ((Number) value).intValue()
+                    : Integer.parseInt(String.valueOf(value));
+            validatePositive(result, name);
+            return result;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(name + " must be an integer", e);
+        }
+    }
+
+    private static long longValue(Object value, long defaultValue, String name) {
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            long result = value instanceof Number
+                    ? ((Number) value).longValue()
+                    : Long.parseLong(String.valueOf(value));
+            if (result <= 0L) {
+                throw new IllegalArgumentException(name + " must be greater than 0");
+            }
+            return result;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(name + " must be a long", e);
+        }
+    }
+
+    private static List<String> parseFeNodes(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("fenodes must contain at least one FE HTTP address");
+        }
+        List<String> result = new ArrayList<String>();
+        for (String part : value.split(",")) {
+            String node = requireText(part, "fenodes item");
+            while (node.endsWith("/")) {
+                node = node.substring(0, node.length() - 1);
+            }
+            result.add(node);
+        }
+        return result;
+    }
+
+    private static List<String> parseFields(String value) {
+        if (!hasText(value)) {
+            return Collections.emptyList();
+        }
+        List<String> fields = new ArrayList<String>();
+        for (String field : value.split(",")) {
+            fields.add(requireText(field, "doris.read.field item"));
+        }
+        return fields;
+    }
+
+    private static List<String> parseFieldsValue(Object value) {
+        if (value instanceof List) {
+            List<String> result = new ArrayList<String>();
+            for (Object item : (List<?>) value) {
+                result.add(requireText(stringValue(item), "read_fields item"));
+            }
+            return result;
+        }
+        return parseFields(stringValue(value));
+    }
+
+    private static Object firstValue(Map<?, ?> values, String... keys) {
+        for (String key : keys) {
+            Object value = values.get(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private static String firstText(Map<?, ?> values, String... keys) {
+        return stringValue(firstValue(values, keys));
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+
+    private static String requireText(String value, String name) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value.trim();
+    }
+
+    public List<String> getFeNodes() { return feNodes; }
+    public String getFenodes() { return String.join(",", feNodes); }
+    public int getQueryPort() { return queryPort; }
+    public String getUsername() { return username; }
+    public String getPassword() { return password; }
+    public List<DorisSourceTableConfig> getTableConfigs() { return tableConfigs; }
+    public int getConnectTimeoutMs() { return connectTimeoutMs; }
+    public int getReadTimeoutMs() { return readTimeoutMs; }
+    public int getQueryTimeoutSec() { return queryTimeoutSec; }
+    public int getRequestRetries() { return requestRetries; }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/config/DorisSourceOptions.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/config/DorisSourceOptions.java
@@ -1,0 +1,113 @@
+package com.link.up.connector.doris.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+import java.util.Map;
+
+/** Doris bounded native Source options. */
+public final class DorisSourceOptions {
+
+    private DorisSourceOptions() {
+    }
+
+    // Reuse the existing Doris datasource vocabulary shared with Sink/Catalog.
+    public static final Option<String> FENODES = DorisSinkOptions.FENODES;
+    public static final Option<Integer> QUERY_PORT = DorisSinkOptions.QUERY_PORT;
+    public static final Option<String> USERNAME = DorisSinkOptions.USERNAME;
+    public static final Option<String> PASSWORD = DorisSinkOptions.PASSWORD;
+    public static final Option<String> DATABASE = DorisSinkOptions.DATABASE;
+    public static final Option<String> TABLE = DorisSinkOptions.TABLE;
+
+    @SuppressWarnings("rawtypes")
+    public static final Option<List<Map>> TABLE_LIST =
+            Options.key("table_list")
+                    .listType(Map.class)
+                    .noDefaultValue()
+                    .withDescription("Doris 多表 bounded read 配置；每项至少包含 table")
+                    .withSemanticType("TABLE_LIST")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> READ_FIELDS =
+            Options.key("doris.read.field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withFallbackKeys("read_fields")
+                    .withDescription("读取字段列表，逗号分隔；未配置时读取发现到的全部字段")
+                    .withSemanticType("PROJECTION_FIELDS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> FILTER_QUERY =
+            Options.key("doris.filter.query")
+                    .stringType()
+                    .defaultValue("")
+                    .withFallbackKeys("scan_filter")
+                    .withDescription("下推到 Doris FE Query Plan 的过滤表达式，不包含 WHERE")
+                    .withSemanticType("SQL_FILTER")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> REQUEST_TABLET_SIZE =
+            Options.key("doris.request.tablet.size")
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withFallbackKeys("request_tablet_size")
+                    .withDescription("单个 Source Split 最多包含的 Doris Tablet 数量")
+                    .withSemanticType("SPLIT_SIZE")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> REQUEST_CONNECT_TIMEOUT_MS =
+            Options.key("doris.request.connect.timeout.ms")
+                    .intType()
+                    .defaultValue(30_000)
+                    .withFallbackKeys("scan_connect_timeout_ms")
+                    .withDescription("连接 Doris FE/BE 的超时时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> REQUEST_READ_TIMEOUT_MS =
+            Options.key("doris.request.read.timeout.ms")
+                    .intType()
+                    .defaultValue(30_000)
+                    .withFallbackKeys("scan_read_timeout_ms")
+                    .withDescription("读取 Doris FE/BE 响应的超时时间，单位毫秒")
+                    .withSemanticType("TIMEOUT_MILLIS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> REQUEST_QUERY_TIMEOUT_SEC =
+            Options.key("doris.request.query.timeout.s")
+                    .intType()
+                    .defaultValue(3600)
+                    .withFallbackKeys("scan_query_timeout_sec")
+                    .withDescription("Doris BE Scanner 查询超时，单位秒；-1 表示不限制")
+                    .withSemanticType("TIMEOUT_SECONDS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> REQUEST_RETRIES =
+            Options.key("doris.request.retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withFallbackKeys("max_retries")
+                    .withDescription("FE Query Plan / BE Scanner 请求最大重试次数")
+                    .withSemanticType("RETRY_COUNT")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> BATCH_SIZE =
+            Options.key("doris.batch.size")
+                    .intType()
+                    .defaultValue(1024)
+                    .withFallbackKeys("scan_batch_rows")
+                    .withDescription("Doris BE Scanner 每批最大行数")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Long> EXEC_MEM_LIMIT =
+            Options.key("doris.exec.mem.limit")
+                    .longType()
+                    .defaultValue(2_147_483_648L)
+                    .withFallbackKeys("scan_mem_limit")
+                    .withDescription("单个 Doris BE Scanner 查询内存上限，单位字节")
+                    .withSemanticType("MEMORY_BYTES")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/config/DorisSourceTableConfig.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/config/DorisSourceTableConfig.java
@@ -1,0 +1,94 @@
+package com.link.up.connector.doris.config;
+
+import com.link.up.api.table.catalog.TablePath;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Per-table configuration for Doris bounded native Source. */
+public final class DorisSourceTableConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String database;
+    private final String table;
+    private final String filterQuery;
+    private final List<String> readFields;
+    private final int requestTabletSize;
+    private final int batchSize;
+    private final long execMemLimit;
+
+    public DorisSourceTableConfig(
+            String database,
+            String table,
+            String filterQuery,
+            List<String> readFields,
+            int requestTabletSize,
+            int batchSize,
+            long execMemLimit) {
+        this.database = requireText(database, "database");
+        this.table = requireText(table, "table");
+        this.filterQuery = filterQuery == null ? "" : filterQuery.trim();
+        this.readFields = Collections.unmodifiableList(normalizeFields(readFields));
+        if (requestTabletSize <= 0) {
+            throw new IllegalArgumentException("requestTabletSize must be greater than 0");
+        }
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+        if (execMemLimit <= 0L) {
+            throw new IllegalArgumentException("execMemLimit must be greater than 0");
+        }
+        this.requestTabletSize = requestTabletSize;
+        this.batchSize = batchSize;
+        this.execMemLimit = execMemLimit;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public String getFilterQuery() {
+        return filterQuery;
+    }
+
+    public List<String> getReadFields() {
+        return readFields;
+    }
+
+    public int getRequestTabletSize() { return requestTabletSize; }
+    public int getBatchSize() { return batchSize; }
+    public long getExecMemLimit() { return execMemLimit; }
+
+    public TablePath getTablePath() {
+        return TablePath.of(database, table);
+    }
+
+    private static List<String> normalizeFields(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> result = new ArrayList<String>();
+        for (String value : values) {
+            String field = requireText(value, "read field");
+            if (result.contains(field)) {
+                throw new IllegalArgumentException("Duplicate Doris read field: " + field);
+            }
+            result.add(field);
+        }
+        return result;
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value.trim();
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/converter/DorisArrowRowReader.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/converter/DorisArrowRowReader.java
@@ -1,0 +1,225 @@
+package com.link.up.connector.doris.converter;
+
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.FluxRowType;
+import com.link.up.api.table.type.SqlType;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamReader;
+import org.apache.arrow.vector.types.Types;
+import org.apache.arrow.vector.util.Text;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Decodes one Doris BE Arrow IPC payload into Link-Up Flux rows. */
+public final class DorisArrowRowReader {
+
+    private DorisArrowRowReader() {
+    }
+
+    public static List<FluxRow> read(byte[] payload, FluxRowType rowType) throws IOException {
+        if (payload == null || payload.length == 0) {
+            return java.util.Collections.emptyList();
+        }
+        if (rowType == null) {
+            throw new IllegalArgumentException("rowType must not be null");
+        }
+
+        List<FluxRow> rows = new ArrayList<FluxRow>();
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
+             ArrowStreamReader reader =
+                     new ArrowStreamReader(new ByteArrayInputStream(payload), allocator)) {
+            VectorSchemaRoot root = reader.getVectorSchemaRoot();
+            while (reader.loadNextBatch()) {
+                Map<String, FieldVector> vectors = indexVectors(root.getFieldVectors());
+                for (int rowIndex = 0; rowIndex < root.getRowCount(); rowIndex++) {
+                    FluxRow row = new FluxRow(rowType.getFieldCount());
+                    for (int fieldIndex = 0; fieldIndex < rowType.getFieldCount(); fieldIndex++) {
+                        String fieldName = rowType.getFieldName(fieldIndex);
+                        FieldVector vector = findVector(vectors, fieldName);
+                        if (vector == null) {
+                            throw new IOException(
+                                    "Doris Arrow payload does not contain projected field: " + fieldName);
+                        }
+                        Object raw = vector.isNull(rowIndex) ? null : vector.getObject(rowIndex);
+                        row.setField(
+                                fieldIndex,
+                                convertValue(
+                                        raw,
+                                        rowType.getFieldType(fieldIndex),
+                                        vector.getMinorType()));
+                    }
+                    rows.add(row);
+                }
+            }
+        }
+        return rows;
+    }
+
+    private static Map<String, FieldVector> indexVectors(List<FieldVector> vectors) {
+        Map<String, FieldVector> result = new HashMap<String, FieldVector>();
+        for (FieldVector vector : vectors) {
+            String name = vector.getField().getName();
+            result.put(name, vector);
+            result.put(name.toLowerCase(Locale.ROOT), vector);
+        }
+        return result;
+    }
+
+    private static FieldVector findVector(Map<String, FieldVector> vectors, String fieldName) {
+        FieldVector exact = vectors.get(fieldName);
+        return exact != null ? exact : vectors.get(fieldName.toLowerCase(Locale.ROOT));
+    }
+
+    private static Object convertValue(
+            Object value,
+            FluxDataType<?> targetType,
+            Types.MinorType minorType) {
+        if (value == null) {
+            return null;
+        }
+        SqlType sqlType = targetType.getSqlType();
+        switch (sqlType) {
+            case STRING:
+                if (value instanceof Text) {
+                    return value.toString();
+                }
+                if (value instanceof byte[]) {
+                    return new String((byte[]) value, StandardCharsets.UTF_8);
+                }
+                return String.valueOf(value);
+            case BOOLEAN:
+                if (value instanceof Boolean) {
+                    return value;
+                }
+                if (value instanceof Number) {
+                    return ((Number) value).longValue() != 0L;
+                }
+                return Boolean.parseBoolean(value.toString());
+            case TINYINT:
+                return number(value).byteValue();
+            case SMALLINT:
+                return number(value).shortValue();
+            case INT:
+                return number(value).intValue();
+            case BIGINT:
+                return number(value).longValue();
+            case FLOAT:
+                return number(value).floatValue();
+            case DOUBLE:
+                return number(value).doubleValue();
+            case DECIMAL:
+                if (value instanceof BigDecimal) {
+                    return value;
+                }
+                return new BigDecimal(value instanceof Text ? value.toString() : String.valueOf(value));
+            case DATE:
+                return dateValue(value);
+            case TIME:
+                return timeValue(value);
+            case TIMESTAMP:
+                return timestampValue(value, minorType);
+            case BYTES:
+                if (value instanceof byte[]) {
+                    return value;
+                }
+                if (value instanceof ByteBuffer) {
+                    ByteBuffer source = ((ByteBuffer) value).duplicate();
+                    byte[] bytes = new byte[source.remaining()];
+                    source.get(bytes);
+                    return bytes;
+                }
+                if (value instanceof Text) {
+                    return value.toString().getBytes(StandardCharsets.UTF_8);
+                }
+                return String.valueOf(value).getBytes(StandardCharsets.UTF_8);
+            case NULL:
+                return null;
+            case ARRAY:
+            case MAP:
+            case ROW:
+            case TIMESTAMP_TZ:
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported Doris Arrow conversion target: " + sqlType);
+        }
+    }
+
+    private static Number number(Object value) {
+        if (value instanceof Number) {
+            return (Number) value;
+        }
+        return new BigDecimal(value instanceof Text ? value.toString() : String.valueOf(value));
+    }
+
+    private static LocalDate dateValue(Object value) {
+        if (value instanceof LocalDate) {
+            return (LocalDate) value;
+        }
+        if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).toLocalDate();
+        }
+        if (value instanceof Number) {
+            return LocalDate.ofEpochDay(((Number) value).longValue());
+        }
+        return LocalDate.parse(value.toString());
+    }
+
+    private static LocalTime timeValue(Object value) {
+        if (value instanceof LocalTime) {
+            return (LocalTime) value;
+        }
+        if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).toLocalTime();
+        }
+        if (value instanceof Number) {
+            long raw = ((Number) value).longValue();
+            if (raw >= 0 && raw < 86_400L) {
+                return LocalTime.ofSecondOfDay(raw);
+            }
+        }
+        return LocalTime.parse(value.toString());
+    }
+
+    private static LocalDateTime timestampValue(Object value, Types.MinorType minorType) {
+        if (value instanceof LocalDateTime) {
+            return (LocalDateTime) value;
+        }
+        if (value instanceof Number) {
+            long raw = ((Number) value).longValue();
+            String minorName = minorType == null ? "" : minorType.name();
+            Instant instant;
+            if (minorName.contains("NANO")) {
+                instant = Instant.ofEpochSecond(raw / 1_000_000_000L, raw % 1_000_000_000L);
+            } else if (minorName.contains("MICRO")) {
+                instant = Instant.ofEpochSecond(raw / 1_000_000L, (raw % 1_000_000L) * 1_000L);
+            } else if (minorName.contains("MILLI")) {
+                instant = Instant.ofEpochMilli(raw);
+            } else if (minorName.contains("SEC")) {
+                instant = Instant.ofEpochSecond(raw);
+            } else {
+                instant = Instant.ofEpochMilli(raw);
+            }
+            // Doris DATETIME is timezone-less. Using UTC here keeps numeric Arrow conversion deterministic.
+            return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+        }
+        String text = value.toString();
+        return LocalDateTime.parse(text.indexOf('T') >= 0 ? text : text.replace(' ', 'T'));
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisNativeSourceSchema.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisNativeSourceSchema.java
@@ -1,0 +1,83 @@
+package com.link.up.connector.doris.source;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.doris.config.DorisSourceTableConfig;
+
+import java.util.List;
+import java.util.Locale;
+
+/** Applies projection and conservative native-scan type boundaries to discovered Doris metadata. */
+final class DorisNativeSourceSchema {
+
+    private DorisNativeSourceSchema() {
+    }
+
+    static CatalogTable prepare(CatalogTable discovered, DorisSourceTableConfig tableConfig) {
+        if (discovered == null || discovered.getTableSchema() == null) {
+            throw new IllegalArgumentException("Doris Catalog returned empty table metadata");
+        }
+        TableSchema schema = discovered.getTableSchema();
+        List<String> projected = tableConfig.getReadFields();
+        if (!projected.isEmpty()) {
+            schema = schema.project(projected);
+        }
+        schema = normalizeScalarTypes(schema);
+        validateNativeTypes(schema);
+        return discovered.withSchema(schema)
+                .toBuilder()
+                .option("connector", "doris")
+                .option("read_mode", "native-thrift-arrow")
+                .build();
+    }
+
+    private static TableSchema normalizeScalarTypes(TableSchema schema) {
+        TableSchema.Builder builder = TableSchema.builder();
+        for (Column column : schema.getColumns()) {
+            String sourceType = column.getSourceType();
+            String normalized =
+                    sourceType == null ? "" : sourceType.toLowerCase(Locale.ROOT).trim();
+            if (normalized.startsWith("largeint")) {
+                // Doris LARGEINT is signed 128-bit; STRING preserves the complete range.
+                builder.column(column.toBuilder()
+                        .dataType(BasicType.STRING_TYPE)
+                        .precision(null)
+                        .scale(null)
+                        .build());
+            } else if (normalized.startsWith("tinyint")) {
+                builder.column(column.toBuilder().dataType(BasicType.BYTE_TYPE).build());
+            } else if (normalized.startsWith("smallint")) {
+                builder.column(column.toBuilder().dataType(BasicType.SHORT_TYPE).build());
+            } else {
+                builder.column(column);
+            }
+        }
+        if (schema.getPrimaryKey() != null) {
+            builder.primaryKey(schema.getPrimaryKey());
+        }
+        return builder.build();
+    }
+
+    static void validateNativeTypes(TableSchema schema) {
+        for (Column column : schema.getColumns()) {
+            String sourceType = column.getSourceType();
+            if (sourceType == null) {
+                continue;
+            }
+            String normalized = sourceType.toLowerCase(Locale.ROOT).trim();
+            if (normalized.startsWith("array")
+                    || normalized.startsWith("map")
+                    || normalized.startsWith("struct")
+                    || normalized.startsWith("hll")
+                    || normalized.startsWith("bitmap")) {
+                throw new IllegalArgumentException(
+                        "Doris native Source does not support complex/aggregate type in this stage: column="
+                                + column.getName()
+                                + ", type="
+                                + sourceType);
+            }
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSource.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSource.java
@@ -1,0 +1,54 @@
+package com.link.up.connector.doris.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.doris.config.DorisSourceConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Doris bounded Source using FE query plans and direct BE Thrift/Arrow scans. */
+public final class DorisSource implements Source<DorisSourceSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final DorisSourceConfig config;
+
+    public DorisSource(DorisSourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public SourceSplitEnumerator<DorisSourceSplit> createEnumerator(
+            Map<TablePath, CatalogTable> tables,
+            SourceEnumeratorContext context) {
+        Objects.requireNonNull(tables, "tables must not be null");
+        Objects.requireNonNull(context, "context must not be null");
+        return new DorisSourceSplitEnumerator(config, tables);
+    }
+
+    @Override
+    @Deprecated
+    public List<DorisSourceSplit> createSplits(
+            Map<TablePath, CatalogTable> tables) throws Exception {
+        try (DorisSourceSplitEnumerator enumerator =
+                     new DorisSourceSplitEnumerator(config, tables)) {
+            return enumerator.enumerateSplits();
+        }
+    }
+
+    @Override
+    public SourceReader<FluxRow, DorisSourceSplit> createReader(
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        return new DorisSourceReader(config, tables, batchSize);
+    }
+
+    public DorisSourceConfig getConfig() { return config; }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSourceFactory.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSourceFactory.java
@@ -1,0 +1,101 @@
+package com.link.up.connector.doris.source;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.connector.doris.catalog.DorisCatalog;
+import com.link.up.connector.doris.catalog.DorisCatalogConfig;
+import com.link.up.connector.doris.config.DorisSourceConfig;
+import com.link.up.connector.doris.config.DorisSourceOptions;
+import com.link.up.connector.doris.config.DorisSourceTableConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** SPI factory for the Doris bounded native Source connector. */
+@AutoService(TableSourceFactory.class)
+public final class DorisSourceFactory implements TableSourceFactory<DorisSourceSplit> {
+
+    private static final String IDENTIFIER = "doris";
+
+    @Override
+    public String factoryIdentifier() { return IDENTIFIER; }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY,
+                        ConnectorCapability.MULTI_TABLE,
+                        ConnectorCapability.PARTITION_SPLIT));
+    }
+
+    @Override
+    public Source<DorisSourceSplit> createSource(SourceFactoryContext context) {
+        return new DorisSource(createConfig(context));
+    }
+
+    @Override
+    public List<CatalogTable> discoverTableSchemas(SourceFactoryContext context) throws Exception {
+        DorisSourceConfig config = createConfig(context);
+        DorisCatalogConfig catalogConfig =
+                new DorisCatalogConfig(
+                        config.getFenodes(),
+                        config.getQueryPort(),
+                        config.getUsername(),
+                        config.getPassword(),
+                        null);
+        DorisCatalog catalog = new DorisCatalog("doris-native-source", catalogConfig);
+        try {
+            catalog.open();
+            List<CatalogTable> result = new ArrayList<CatalogTable>();
+            for (DorisSourceTableConfig tableConfig : config.getTableConfigs()) {
+                CatalogTable discovered = catalog.getTable(tableConfig.getTablePath());
+                result.add(DorisNativeSourceSchema.prepare(discovered, tableConfig));
+            }
+            return Collections.unmodifiableList(result);
+        } finally {
+            catalog.close();
+        }
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        DorisSourceOptions.FENODES,
+                        DorisSourceOptions.USERNAME)
+                .optional(
+                        DorisSourceOptions.PASSWORD,
+                        DorisSourceOptions.QUERY_PORT,
+                        DorisSourceOptions.DATABASE,
+                        DorisSourceOptions.TABLE,
+                        DorisSourceOptions.TABLE_LIST,
+                        DorisSourceOptions.READ_FIELDS,
+                        DorisSourceOptions.FILTER_QUERY,
+                        DorisSourceOptions.REQUEST_TABLET_SIZE,
+                        DorisSourceOptions.REQUEST_CONNECT_TIMEOUT_MS,
+                        DorisSourceOptions.REQUEST_READ_TIMEOUT_MS,
+                        DorisSourceOptions.REQUEST_QUERY_TIMEOUT_SEC,
+                        DorisSourceOptions.REQUEST_RETRIES,
+                        DorisSourceOptions.BATCH_SIZE,
+                        DorisSourceOptions.EXEC_MEM_LIMIT)
+                .build();
+    }
+
+    private DorisSourceConfig createConfig(SourceFactoryContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        ReadonlyConfig options =
+                Objects.requireNonNull(context.getOptions(), "source options must not be null");
+        return DorisSourceConfig.of(options);
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSourceReader.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSourceReader.java
@@ -1,0 +1,185 @@
+package com.link.up.connector.doris.source;
+
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.doris.client.source.DorisBeReadClient;
+import com.link.up.connector.doris.config.DorisSourceConfig;
+import com.link.up.connector.doris.config.DorisSourceTableConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Reads assigned Doris native splits through task-local BE scanner clients. */
+public final class DorisSourceReader
+        implements SourceReader<FluxRow, DorisSourceSplit> {
+
+    private final DorisSourceConfig config;
+    private final Map<TablePath, CatalogTable> tables;
+    private final int frameworkBatchSize;
+
+    private List<DorisSourceSplit> splits = Collections.emptyList();
+    private int splitIndex;
+    private DorisSourceSplit currentSplit;
+    private DorisBeReadClient currentClient;
+    private boolean opened;
+    private boolean finished;
+
+    public DorisSourceReader(
+            DorisSourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.tables = Objects.requireNonNull(tables, "tables must not be null");
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+        this.frameworkBatchSize = batchSize;
+    }
+
+    @Override
+    public void open(List<DorisSourceSplit> splits) throws Exception {
+        if (opened) {
+            throw new IllegalStateException("DorisSourceReader has already been opened");
+        }
+        if (splits == null) {
+            throw new IllegalArgumentException("splits must not be null");
+        }
+        this.splits = Collections.unmodifiableList(new ArrayList<DorisSourceSplit>(splits));
+        splitIndex = 0;
+        currentSplit = null;
+        currentClient = null;
+        finished = false;
+        opened = true;
+    }
+
+    @Override
+    public void open() throws Exception {
+        open(Collections.<DorisSourceSplit>emptyList());
+    }
+
+    @Override
+    public void openSplit(DorisSourceSplit split) throws Exception {
+        checkOpened();
+        if (currentSplit != null) {
+            throw new IllegalStateException("A Doris source split is already open");
+        }
+        finished = false;
+        openCurrentSplit(Objects.requireNonNull(split, "split must not be null"));
+    }
+
+    @Override
+    public void closeSplit() throws Exception {
+        closeCurrentSplit();
+    }
+
+    @Override
+    public RecordBatch<FluxRow> readBatch() throws Exception {
+        checkOpened();
+        if (finished) {
+            return RecordBatch.endOfInput();
+        }
+        while (true) {
+            if (currentSplit == null) {
+                if (!openNextSplit()) {
+                    finished = true;
+                    return RecordBatch.endOfInput();
+                }
+            }
+            DorisSourceSplit batchSplit = currentSplit;
+            List<FluxRow> rows = new ArrayList<FluxRow>(frameworkBatchSize);
+            boolean exhausted = false;
+            while (rows.size() < frameworkBatchSize) {
+                if (!currentClient.hasNext()) {
+                    exhausted = true;
+                    break;
+                }
+                rows.add(currentClient.next());
+            }
+            if (exhausted) {
+                closeCurrentSplit();
+            }
+            if (!rows.isEmpty()) {
+                return RecordBatch.of(batchSplit, rows);
+            }
+        }
+    }
+
+    private boolean openNextSplit() throws Exception {
+        if (splitIndex >= splits.size()) {
+            return false;
+        }
+        openCurrentSplit(splits.get(splitIndex++));
+        return true;
+    }
+
+    private void openCurrentSplit(DorisSourceSplit split) throws Exception {
+        CatalogTable table = tables.get(split.getTablePath());
+        if (table == null) {
+            throw new IllegalArgumentException(
+                    "Cannot find schema for Doris split table: " + split.getTablePath());
+        }
+        DorisSourceTableConfig tableConfig = findTableConfig(split.getTablePath());
+        DorisBeReadClient client =
+                new DorisBeReadClient(config, tableConfig, split.getPartition(), table.getRowType());
+        try {
+            client.open();
+        } catch (Exception failure) {
+            try {
+                client.close();
+            } catch (Exception closeFailure) {
+                failure.addSuppressed(closeFailure);
+            }
+            throw failure;
+        }
+        currentSplit = split;
+        currentClient = client;
+    }
+
+    private DorisSourceTableConfig findTableConfig(TablePath tablePath) {
+        for (DorisSourceTableConfig tableConfig : config.getTableConfigs()) {
+            if (tableConfig.getTablePath().equals(tablePath)) {
+                return tableConfig;
+            }
+        }
+        throw new IllegalArgumentException("Cannot find Doris table config for: " + tablePath);
+    }
+
+    private void closeCurrentSplit() throws Exception {
+        if (currentClient == null) {
+            currentSplit = null;
+            return;
+        }
+        try {
+            currentClient.close();
+        } finally {
+            currentClient = null;
+            currentSplit = null;
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("DorisSourceReader has not been opened");
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!opened) {
+            return;
+        }
+        try {
+            closeCurrentSplit();
+        } finally {
+            opened = false;
+            finished = true;
+            splits = Collections.emptyList();
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSourceSplit.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSourceSplit.java
@@ -1,0 +1,45 @@
+package com.link.up.connector.doris.source;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.doris.client.source.model.DorisQueryPartition;
+
+import java.util.Objects;
+
+/** A deterministic Link-Up split for one Doris BE native scan partition. */
+public final class DorisSourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String splitId;
+    private final TablePath tablePath;
+    private final DorisQueryPartition partition;
+
+    public DorisSourceSplit(
+            String splitId,
+            TablePath tablePath,
+            DorisQueryPartition partition) {
+        this.splitId = Objects.requireNonNull(splitId, "splitId must not be null");
+        this.tablePath = Objects.requireNonNull(tablePath, "tablePath must not be null");
+        this.partition = Objects.requireNonNull(partition, "partition must not be null");
+    }
+
+    @Override
+    public String splitId() { return splitId; }
+
+    @Override
+    public String dataSetId() { return tablePath.toString(); }
+
+    public TablePath getTablePath() { return tablePath; }
+    public DorisQueryPartition getPartition() { return partition; }
+
+    @Override
+    public String toString() {
+        return "DorisSourceSplit{"
+                + "splitId='" + splitId + '\''
+                + ", tablePath=" + tablePath
+                + ", be=" + partition.getBeAddress()
+                + ", tablets=" + partition.getTabletIds()
+                + '}';
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSourceSplitEnumerator.java
+++ b/link-up-connectors/link-up-connector-doris/src/main/java/com/link/up/connector/doris/source/DorisSourceSplitEnumerator.java
@@ -1,0 +1,82 @@
+package com.link.up.connector.doris.source;
+
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.doris.client.source.DorisQueryPlanClient;
+import com.link.up.connector.doris.client.source.DorisSplitPlanner;
+import com.link.up.connector.doris.client.source.model.DorisQueryPartition;
+import com.link.up.connector.doris.client.source.model.DorisQueryPlan;
+import com.link.up.connector.doris.config.DorisSourceConfig;
+import com.link.up.connector.doris.config.DorisSourceTableConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/** Bounded native split enumerator backed by Doris FE query plans. */
+public final class DorisSourceSplitEnumerator
+        implements SourceSplitEnumerator<DorisSourceSplit> {
+
+    private final DorisSourceConfig config;
+    private final Map<TablePath, CatalogTable> tables;
+    private final DorisQueryPlanClient queryPlanClient;
+
+    public DorisSourceSplitEnumerator(
+            DorisSourceConfig config,
+            Map<TablePath, CatalogTable> tables) {
+        this(config, tables, new DorisQueryPlanClient(config));
+    }
+
+    DorisSourceSplitEnumerator(
+            DorisSourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            DorisQueryPlanClient queryPlanClient) {
+        this.config = config;
+        this.tables = tables;
+        this.queryPlanClient = queryPlanClient;
+    }
+
+    @Override
+    public List<DorisSourceSplit> enumerateSplits() throws Exception {
+        List<DorisSourceSplit> result = new ArrayList<DorisSourceSplit>();
+        for (DorisSourceTableConfig tableConfig : config.getTableConfigs()) {
+            CatalogTable table = tables.get(tableConfig.getTablePath());
+            if (table == null) {
+                throw new IllegalArgumentException(
+                        "Cannot find discovered schema for Doris source table: "
+                                + tableConfig.getTablePath());
+            }
+            DorisQueryPlan queryPlan = queryPlanClient.fetchQueryPlan(tableConfig, table);
+            List<DorisQueryPartition> partitions =
+                    DorisSplitPlanner.plan(
+                            tableConfig.getDatabase(),
+                            tableConfig.getTable(),
+                            queryPlan,
+                            tableConfig.getRequestTabletSize());
+            int partitionIndex = 0;
+            for (DorisQueryPartition partition : partitions) {
+                String splitId =
+                        tableConfig.getDatabase()
+                                + "."
+                                + tableConfig.getTable()
+                                + "@"
+                                + partition.getBeAddress()
+                                + "#"
+                                + partitionIndex++;
+                result.add(
+                        new DorisSourceSplit(
+                                splitId,
+                                tableConfig.getTablePath(),
+                                partition));
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public void close() {
+        queryPlanClient.close();
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/DorisConnectorPackageBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/DorisConnectorPackageBoundaryTest.java
@@ -1,7 +1,9 @@
 package com.link.up.connector.doris;
 
+import com.link.up.connector.doris.converter.DorisArrowRowReader;
 import com.link.up.connector.doris.converter.DorisRowSerializer;
 import com.link.up.connector.doris.sink.DorisSinkWriter;
+import com.link.up.connector.doris.source.DorisSourceFactory;
 import org.junit.Test;
 
 import java.io.File;
@@ -21,6 +23,16 @@ public class DorisConnectorPackageBoundaryTest {
     }
 
     @Test
+    public void nativeArrowDecodingBelongsToConverterRole() {
+        assertEquals(
+                "com.link.up.connector.doris.converter",
+                DorisArrowRowReader.class.getPackage().getName());
+        assertEquals(
+                "com.link.up.connector.doris.source",
+                DorisSourceFactory.class.getPackage().getName());
+    }
+
+    @Test
     public void sinkWriterDelegatesTwoPhaseCommitState() {
         boolean found = false;
 
@@ -37,10 +49,20 @@ public class DorisConnectorPackageBoundaryTest {
     }
 
     @Test
+    public void nativeSourceDoesNotIntroduceJdbcDataReaderRole() {
+        File sourceRoot = new File("src/main/java/com/link/up/connector/doris/source");
+        File[] files = sourceRoot.listFiles();
+        assertTrue("Doris source package should exist", files != null && files.length > 0);
+        for (File file : files) {
+            assertFalse(
+                    "Doris native Source must not add JDBC data readers: " + file.getName(),
+                    file.getName().toLowerCase().contains("jdbc"));
+        }
+    }
+
+    @Test
     public void forbiddenGenericRootPackagesMustNotExist() {
-        File root =
-                new File(
-                        "src/main/java/com/link/up/connector/doris");
+        File root = new File("src/main/java/com/link/up/connector/doris");
 
         String[] forbidden = {
                 "common",
@@ -54,8 +76,7 @@ public class DorisConnectorPackageBoundaryTest {
 
         for (String name : forbidden) {
             assertFalse(
-                    "Forbidden Doris connector root package exists: "
-                            + name,
+                    "Forbidden Doris connector root package exists: " + name,
                     new File(root, name).exists());
         }
     }

--- a/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/client/source/DorisQueryPlanClientTest.java
+++ b/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/client/source/DorisQueryPlanClientTest.java
@@ -1,0 +1,74 @@
+package com.link.up.connector.doris.client.source;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.doris.client.source.model.DorisQueryPlan;
+import com.link.up.connector.doris.config.DorisSourceTableConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DorisQueryPlanClientTest {
+
+    @Test
+    public void buildsProjectedBoundedQuerySql() {
+        DorisSourceTableConfig config =
+                new DorisSourceTableConfig(
+                        "analytics",
+                        "orders",
+                        "id >= 100",
+                        Arrays.asList("id", "amount"),
+                        Integer.MAX_VALUE,
+                        1024,
+                        2_147_483_648L);
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                        .column(Column.builder("amount", BasicType.DOUBLE_TYPE).build())
+                        .build();
+        CatalogTable table = CatalogTable.builder(TablePath.of("analytics", "orders"), schema).build();
+
+        assertEquals(
+                "SELECT `id`, `amount` FROM `analytics`.`orders` WHERE id >= 100",
+                DorisQueryPlanClient.buildQuerySql(config, table));
+    }
+
+    @Test
+    public void parsesLegacyQueryPlanResponse() throws Exception {
+        String json =
+                "{\"status\":200,\"opaqued_query_plan\":\"opaque\","
+                        + "\"partitions\":{\"10\":{\"routings\":[\"be-1:9060\"]}}}";
+        DorisQueryPlan plan =
+                DorisQueryPlanClient.parsePlanResponse(json, new ObjectMapper());
+        assertEquals(200, plan.getStatus());
+        assertEquals("opaque", plan.getOpaquedQueryPlan());
+        assertTrue(plan.getPartitions().containsKey("10"));
+    }
+
+    @Test
+    public void unwrapsDorisV2ResponseEnvelope() throws Exception {
+        String json =
+                "{\"msg\":\"success\",\"code\":0,\"count\":0,\"data\":{"
+                        + "\"status\":200,\"opaqued_query_plan\":\"opaque-v2\","
+                        + "\"partitions\":{\"11\":{\"routings\":[\"be-2:9060\"]}}}}";
+        DorisQueryPlan plan =
+                DorisQueryPlanClient.parsePlanResponse(json, new ObjectMapper());
+        assertEquals(200, plan.getStatus());
+        assertEquals("opaque-v2", plan.getOpaquedQueryPlan());
+        assertEquals("be-2:9060", plan.getPartitions().get("11").getRoutings().get(0));
+    }
+
+    @Test(expected = java.io.IOException.class)
+    public void rejectsFailedV2Envelope() throws Exception {
+        DorisQueryPlanClient.parsePlanResponse(
+                "{\"msg\":\"denied\",\"code\":1,\"data\":null}",
+                new ObjectMapper());
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/client/source/DorisSplitPlannerTest.java
+++ b/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/client/source/DorisSplitPlannerTest.java
@@ -1,0 +1,46 @@
+package com.link.up.connector.doris.client.source;
+
+import com.link.up.connector.doris.client.source.model.DorisQueryPartition;
+import com.link.up.connector.doris.client.source.model.DorisQueryPlan;
+import com.link.up.connector.doris.client.source.model.DorisTablet;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class DorisSplitPlannerTest {
+
+    @Test
+    public void balancesTabletRoutingAndChunksDeterministically() {
+        DorisQueryPlan plan = new DorisQueryPlan();
+        plan.setStatus(200);
+        plan.setOpaquedQueryPlan("opaque");
+        Map<String, DorisTablet> tablets = new LinkedHashMap<String, DorisTablet>();
+        tablets.put("3", tablet("be-b:9060", "be-a:9060"));
+        tablets.put("1", tablet("be-a:9060", "be-b:9060"));
+        tablets.put("2", tablet("be-a:9060", "be-b:9060"));
+        tablets.put("4", tablet("be-a:9060", "be-b:9060"));
+        plan.setPartitions(tablets);
+
+        List<DorisQueryPartition> partitions =
+                DorisSplitPlanner.plan("db", "orders", plan, 1);
+
+        assertEquals(4, partitions.size());
+        assertEquals("be-a:9060", partitions.get(0).getBeAddress());
+        assertEquals(Arrays.asList(1L), partitions.get(0).getTabletIds());
+        assertEquals(Arrays.asList(3L), partitions.get(1).getTabletIds());
+        assertEquals("be-b:9060", partitions.get(2).getBeAddress());
+        assertEquals(Arrays.asList(2L), partitions.get(2).getTabletIds());
+        assertEquals(Arrays.asList(4L), partitions.get(3).getTabletIds());
+    }
+
+    private static DorisTablet tablet(String... routings) {
+        DorisTablet tablet = new DorisTablet();
+        tablet.setRoutings(Arrays.asList(routings));
+        return tablet;
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/config/DorisSourceConfigTest.java
+++ b/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/config/DorisSourceConfigTest.java
@@ -1,0 +1,109 @@
+package com.link.up.connector.doris.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class DorisSourceConfigTest {
+
+    @Test
+    public void parsesSingleTableWithSeaTunnelCompatibleDefaults() {
+        Map<String, Object> values = base();
+        values.put("database", "analytics");
+        values.put("table", "orders");
+        values.put("doris.read.field", "id, amount");
+        values.put("doris.filter.query", "id >= 10");
+
+        DorisSourceConfig config = DorisSourceConfig.of(ReadonlyConfig.fromMap(values));
+
+        assertEquals(Arrays.asList("fe-1:8030", "fe-2:8030"), config.getFeNodes());
+        assertEquals(9030, config.getQueryPort());
+        assertEquals(30_000, config.getConnectTimeoutMs());
+        assertEquals(30_000, config.getReadTimeoutMs());
+        assertEquals(3600, config.getQueryTimeoutSec());
+        assertEquals(3, config.getRequestRetries());
+
+        DorisSourceTableConfig table = config.getTableConfigs().get(0);
+        assertEquals("analytics", table.getDatabase());
+        assertEquals("orders", table.getTable());
+        assertEquals(Arrays.asList("id", "amount"), table.getReadFields());
+        assertEquals("id >= 10", table.getFilterQuery());
+        assertEquals(Integer.MAX_VALUE, table.getRequestTabletSize());
+        assertEquals(1024, table.getBatchSize());
+        assertEquals(2_147_483_648L, table.getExecMemLimit());
+    }
+
+    @Test
+    public void tableListSupportsPerTableDatabaseAndScanOverrides() {
+        Map<String, Object> values = base();
+
+        Map<String, Object> first = new LinkedHashMap<String, Object>();
+        first.put("database", "db_a");
+        first.put("table", "orders");
+        first.put("doris.read.field", "id,total");
+        first.put("doris.request.tablet.size", 2);
+        first.put("doris.batch.size", 256);
+        first.put("doris.exec.mem.limit", 1024L * 1024L);
+
+        Map<String, Object> second = new LinkedHashMap<String, Object>();
+        second.put("database", "db_b");
+        second.put("table", "customers");
+        second.put("doris.filter.query", "active = 1");
+
+        values.put("table_list", Arrays.asList(first, second));
+        DorisSourceConfig config = DorisSourceConfig.of(ReadonlyConfig.fromMap(values));
+
+        assertEquals(2, config.getTableConfigs().size());
+        assertEquals("db_a", config.getTableConfigs().get(0).getDatabase());
+        assertEquals(2, config.getTableConfigs().get(0).getRequestTabletSize());
+        assertEquals(256, config.getTableConfigs().get(0).getBatchSize());
+        assertEquals("db_b", config.getTableConfigs().get(1).getDatabase());
+        assertEquals("active = 1", config.getTableConfigs().get(1).getFilterQuery());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMissingDatabaseForSingleTable() {
+        Map<String, Object> values = base();
+        values.put("table", "orders");
+        DorisSourceConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTableAndTableListTogether() {
+        Map<String, Object> values = base();
+        values.put("database", "db");
+        values.put("table", "orders");
+        Map<String, Object> item = new LinkedHashMap<String, Object>();
+        item.put("database", "db");
+        item.put("table", "customers");
+        values.put("table_list", Arrays.asList(item));
+        DorisSourceConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test
+    public void acceptsCompatibilityFallbackKeys() {
+        Map<String, Object> values = base();
+        values.put("database", "db");
+        values.put("table", "t");
+        values.put("request_tablet_size", 3);
+        values.put("scan_batch_rows", 128);
+        DorisSourceConfig config = DorisSourceConfig.of(ReadonlyConfig.fromMap(values));
+        assertEquals(3, config.getTableConfigs().get(0).getRequestTabletSize());
+        assertEquals(128, config.getTableConfigs().get(0).getBatchSize());
+        assertTrue(config.getTableConfigs().get(0).getReadFields().isEmpty());
+    }
+
+    private static Map<String, Object> base() {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("fenodes", "fe-1:8030,fe-2:8030");
+        values.put("username", "root");
+        values.put("password", "");
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/converter/DorisArrowRowReaderTest.java
+++ b/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/converter/DorisArrowRowReaderTest.java
@@ -1,0 +1,60 @@
+package com.link.up.connector.doris.converter;
+
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.FluxRowType;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class DorisArrowRowReaderTest {
+
+    @Test
+    public void decodesArrowIpcBatchByProjectedFieldName() throws Exception {
+        byte[] payload;
+        try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
+            BigIntVector id = new BigIntVector("id", allocator);
+            VarCharVector name = new VarCharVector("name", allocator);
+            id.allocateNew(2);
+            name.allocateNew();
+            id.setSafe(0, 7L);
+            id.setSafe(1, 8L);
+            name.setSafe(0, "alice".getBytes(StandardCharsets.UTF_8));
+            name.setNull(1);
+            id.setValueCount(2);
+            name.setValueCount(2);
+
+            try (VectorSchemaRoot root = VectorSchemaRoot.of(name, id);
+                 ByteArrayOutputStream output = new ByteArrayOutputStream();
+                 ArrowStreamWriter writer = new ArrowStreamWriter(root, null, output)) {
+                root.setRowCount(2);
+                writer.start();
+                writer.writeBatch();
+                writer.end();
+                payload = output.toByteArray();
+            }
+        }
+
+        FluxRowType rowType =
+                new FluxRowType(
+                        new String[] {"id", "name"},
+                        new FluxDataType<?>[] {BasicType.LONG_TYPE, BasicType.STRING_TYPE});
+        List<FluxRow> rows = DorisArrowRowReader.read(payload, rowType);
+
+        assertEquals(2, rows.size());
+        assertEquals(7L, rows.get(0).getField(0));
+        assertEquals("alice", rows.get(0).getField(1));
+        assertEquals(8L, rows.get(1).getField(0));
+        assertEquals(null, rows.get(1).getField(1));
+    }
+}

--- a/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/source/DorisNativeSourceSchemaTest.java
+++ b/link-up-connectors/link-up-connector-doris/src/test/java/com/link/up/connector/doris/source/DorisNativeSourceSchemaTest.java
@@ -1,0 +1,54 @@
+package com.link.up.connector.doris.source;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.doris.config.DorisSourceTableConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+public class DorisNativeSourceSchemaTest {
+
+    @Test
+    public void projectsColumnsAndNormalizesLargeIntToString() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(
+                                Column.builder("id", new DecimalType(20, 0))
+                                        .sourceType("LARGEINT")
+                                        .build())
+                        .column(Column.builder("name", BasicType.STRING_TYPE).sourceType("VARCHAR(32)").build())
+                        .build();
+        CatalogTable discovered = CatalogTable.builder(TablePath.of("db", "t"), schema).build();
+        DorisSourceTableConfig config =
+                new DorisSourceTableConfig(
+                        "db", "t", "", Arrays.asList("id"), Integer.MAX_VALUE, 1024, 1024L);
+
+        CatalogTable prepared = DorisNativeSourceSchema.prepare(discovered, config);
+
+        assertEquals(1, prepared.getTableSchema().getColumnCount());
+        assertEquals(SqlType.STRING, prepared.getTableSchema().getColumn(0).getDataType().getSqlType());
+        assertEquals("native-thrift-arrow", prepared.getOptions().get("read_mode"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsArrayUntilDedicatedArrowComplexConversionExists() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("tags", BasicType.STRING_TYPE).sourceType("ARRAY<VARCHAR(20)>").build())
+                        .build();
+        CatalogTable discovered = CatalogTable.builder(TablePath.of("db", "t"), schema).build();
+        DorisSourceTableConfig config =
+                new DorisSourceTableConfig(
+                        "db", "t", "", Collections.<String>emptyList(), Integer.MAX_VALUE, 1024, 1024L);
+        DorisNativeSourceSchema.prepare(discovered, config);
+    }
+}


### PR DESCRIPTION
## Summary

Add a bounded/offline native Doris Source to the existing `link-up-connector-doris` module, following the native scan architecture used by Apache SeaTunnel's Doris Source and Doris' official Query Plan / Thrift scanner APIs.

The data path is:

`Doris Catalog metadata -> FE _query_plan -> tablet/BE splits -> TDorisExternalService Thrift scanner -> Arrow IPC -> FluxRow`

The existing MySQL-compatible Doris Catalog is reused only for schema discovery. Actual table data is read directly from Doris BE scanners and does not fall back to JDBC.

## Why this path

SeaTunnel's Doris Source opens a BE scanner with `TScanOpenParams`, reads `TScanBatchResult#getRows()` through `getNext`, decodes the returned Arrow IPC stream, advances the scanner offset, and closes the scanner explicitly.

Doris currently supports both Thrift and ArrowFlightSQL read protocols. This PR deliberately chooses the Thrift scanner + Arrow IPC path because it maps cleanly to Link-Up's bounded `SourceSplitEnumerator` / `SourceReader` model and preserves Tablet-level multi-BE parallel reads. Arrow Flight SQL is kept out of this stage rather than introducing a second read protocol and a different execution boundary.

## What changed

- add `DorisSourceFactory`, `DorisSource`, `DorisSourceSplitEnumerator`, `DorisSourceSplit`, and `DorisSourceReader`
- add Doris Source configuration with SeaTunnel-compatible option names and Link-Up compatibility aliases
- support single-table and `table_list` multi-table bounded reads
- reuse the existing `DorisCatalog` for table/schema discovery
- support `doris.read.field` projection before native planning
- support `doris.filter.query` predicate pushdown through the FE Query Plan SQL
- add FE `_query_plan` client with FE failover/retry
- support both legacy flat Query Plan responses and Doris v2 `{code,msg,data}` envelopes
- tolerate additive Query Plan response fields for forward compatibility
- convert FE tablet routings into deterministic, balanced BE-bound splits
- support per-table `doris.request.tablet.size`, `doris.batch.size`, and `doris.exec.mem.limit`
- add task-local `TDorisExternalService` BE scanner client using `openScanner/getNext/closeScanner`
- decode BE Arrow IPC batches into Link-Up `FluxRow` values
- match Arrow vectors by projected field name rather than assuming physical vector order
- fail fast on malformed scanner responses, including an empty non-EOS Arrow batch that could otherwise loop at the same offset
- preserve full Doris `LARGEINT` range by exposing it as `STRING` in the native Source
- normalize `TINYINT` / `SMALLINT` to Link-Up byte/short scalar types for the native reader
- keep ARRAY / MAP / STRUCT / HLL / BITMAP outside this stage instead of silently stringifying ambiguous values
- add source architecture/configuration/type-boundary documentation

## Source options

The implementation accepts the Doris/SeaTunnel-style options:

- `fenodes`
- `query-port`
- `username` / `password`
- `database` / `table`
- `table_list`
- `doris.read.field`
- `doris.filter.query`
- `doris.request.tablet.size`
- `doris.request.connect.timeout.ms`
- `doris.request.read.timeout.ms`
- `doris.request.query.timeout.s`
- `doris.request.retries`
- `doris.batch.size`
- `doris.exec.mem.limit`

Link-Up aliases such as `scan_filter`, `request_tablet_size`, `scan_batch_rows`, `scan_connect_timeout_ms`, `scan_read_timeout_ms`, `scan_query_timeout_sec`, `max_retries`, and `scan_mem_limit` are also accepted.

Defaults intentionally follow SeaTunnel's mature Doris Source where applicable: 30s connect/read timeout, 3600s query timeout, 3 retries, 1024 BE batch rows, `Integer.MAX_VALUE` tablets per split, and 2 GiB scanner memory limit.

## Type boundary

This stage supports scalar Arrow -> Flux conversions for:

- BOOLEAN
- TINYINT / SMALLINT / INT / BIGINT
- LARGEINT as exact STRING
- FLOAT / DOUBLE
- DECIMAL
- CHAR / VARCHAR / STRING / TEXT / JSON as STRING
- BINARY / VARBINARY as bytes
- DATE / TIME / DATETIME/TIMESTAMP

Complex and aggregate types remain fail-fast for the native Source until dedicated Arrow conversion semantics are implemented:

- ARRAY
- MAP
- STRUCT
- HLL
- BITMAP

This is intentionally more conservative than silently routing complex values through `String.valueOf(...)`.

## Scope / non-goals

This PR remains an offline bounded Source. It intentionally does **not** add:

- CDC or continuous streaming semantics
- Doris Binlog incremental scan
- Arrow Flight SQL read mode
- asynchronous Arrow deserialization queues
- runtime schema evolution
- JDBC data-read fallback
- complex Arrow ARRAY/MAP/STRUCT conversion

Doris' newer connector documentation includes incremental/binlog capabilities, but those semantics are intentionally not mixed into this adaptation.

## Tests added

- single-table config and SeaTunnel-compatible defaults
- per-table multi-table overrides
- invalid single/table-list combinations
- compatibility fallback option keys
- legacy Query Plan response parsing
- Doris v2 Query Plan envelope parsing
- failed v2 Query Plan response handling
- projected/filter Query Plan SQL generation
- deterministic tablet/BE split balancing and chunking
- native Source schema projection
- LARGEINT exact-string normalization
- complex-type fail-fast boundary
- Arrow IPC decoding by field name
- package boundary check ensuring the native Source does not introduce a JDBC data-reader role

## Validation note

The implementation was statically reviewed against:

- Apache SeaTunnel Doris Source (`DorisValueReader`, `BackendClient`, source options/docs)
- Apache Doris official Table Query Plan API
- Apache Doris official Thrift/Arrow Source connector behavior
- `org.apache.doris:thrift-service:1.0.1` / libthrift 0.16.0 API
- the current Link-Up Source/Split/Reader SPI

A repository-side Maven test run and a real Doris integration smoke test are still required before merge. This repository currently has no GitHub Actions workflow available for the branch, and this execution environment cannot perform a reliable local Maven dependency/test run. The PR is therefore intentionally left as Draft.