### PR TITLE
feat(clickhouse): add bounded part-split source

### DIFF
--- a/CONNECTOR_ADAPTATION.md
+++ b/CONNECTOR_ADAPTATION.md
@@ -35,7 +35,7 @@ Yak Link Up 优先复用已有执行模型，再增加数据库差异层。新�
 
 ## Native OLAP Connector
 
-当数据库提供的原生批量协议明显不同于 JDBC 执行模型，并且这些协议是 Connector 正确性或性能语义的一部分时，可以使用独立 Connector，而不是把原生协议塞进 `link-up-connector-jdbc`。
+当数据库提供的原生批量协议或物理分片模型明显不同于 JDBC 执行模型，并且这些能力是 Connector 正确性或性能语义的一部分时，可以使用独立 Connector，而不是把数据库特有规划逻辑塞进 `link-up-connector-jdbc`。
 
 StarRocks 使用独立的 `link-up-connector-starrocks`：
 
@@ -48,7 +48,25 @@ StarRocks 使用独立的 `link-up-connector-starrocks`：
 - Stream Load 成功 flush 已经是远端独立提交；没有真正 2PC 时，不把 Link-Up 的 `commit/abort` 生命周期包装成 Job-level exactly once。
 - Stage 2 不使用 JDBC 自动建表，也不声明 CDC / DELETE / runtime schema evolution 能力。
 
-这种例外是协议边界，不是为数据库复制通用执行框架。Source 仍复用 Link-Up 的 `SourceSplitEnumerator`、动态 Split 分配、`SourceReader`、Channel、Metrics 和 Job 生命周期；Sink 仍复用 `SinkPreparer`、`SinkWriter`、Task commit evidence 和统一错误传播。
+Doris 的 bounded Native Source 同样属于独立 OLAP 数据面：
+
+- Catalog 元数据继续使用 Doris 的 MySQL-compatible protocol，避免重复实现稳定的 schema discovery。
+- 数据读取使用 FE `/_query_plan` + BE `TDorisExternalService` Scanner，BE 返回 Arrow IPC 后转换为 `FluxRow`。
+- Tablet/BE 路由由 `SourceSplitEnumerator` 转成确定性的 bounded splits。
+- 该 Source 不把 Doris Binlog/CDC 或 Arrow Flight SQL 混入当前离线读取阶段。
+
+ClickHouse 使用独立的 `link-up-connector-clickhouse`，但不重复实现网络协议：
+
+- 元数据与数据传输复用 ClickHouse 官方 Java/JDBC HTTP client。
+- MergeTree-family table mode 从 `system.parts` 读取 `active = 1` 的当前 parts，并按 `split.size` 形成 `_part` bounded splits。
+- `partition_list` 只约束 part discovery；`filter_query` 继续由 ClickHouse 服务端过滤。
+- local table 配置多个 host 时，每个 host 被视为一个 shard 节点；不要把同一 shard 的多个 replica 当成独立 host，以免重复读取相同 parts。
+- `Distributed` table 在第一阶段由一个 bounded query 交给 ClickHouse 自己做集群分发，不枚举每个 replica。
+- 自定义 SQL 第一阶段是单 bounded split，不自动改写 JOIN/GROUP BY/subquery 到多个 shard；复杂 SQL 并行重写留给独立阶段。
+- 高位无符号/128-bit/256-bit 数值不做有损缩窄；复杂 ARRAY/MAP/TUPLE/NESTED/AggregateFunction 在没有明确 Flux 语义前 fail-fast。
+- Stage 1 不包含 CDC、连续轮询、mutation/Keeper change capture、runtime schema evolution 或 Sink。
+
+这种例外是协议/物理分片边界，不是为数据库复制通用执行框架。Source 仍复用 Link-Up 的 `SourceSplitEnumerator`、动态 Split 分配、`SourceReader`、Channel、Metrics 和 Job 生命周期；Sink 仍复用 `SinkPreparer`、`SinkWriter`、Task commit evidence 和统一错误传播。
 
 ## 数据库差异不要强行抹平
 

--- a/link-up-connectors/link-up-connector-clickhouse/README.md
+++ b/link-up-connectors/link-up-connector-clickhouse/README.md
@@ -1,0 +1,167 @@
+# Link-Up ClickHouse Connector
+
+`link-up-connector-clickhouse` provides a standalone bounded/offline ClickHouse Source.
+
+The connector follows the mature read model used by Apache SeaTunnel while keeping the first Link-Up stage deliberately small:
+
+```text
+ClickHouseSource
+  -> schema discovery through the official ClickHouse JDBC/HTTP driver
+  -> table mode: system.tables + system.parts(active = 1)
+  -> deterministic active-part splits
+  -> split-bound ClickHouse HTTP/JDBC query
+  -> ResultSet
+  -> FluxRow
+```
+
+The transport is not reimplemented by Link-Up. Connections and query decoding use ClickHouse's official Java/JDBC client over HTTP. The ClickHouse-specific part of this connector is the bounded planning model: table mode understands MergeTree active parts and turns them into Link-Up `SourceSplit`s instead of treating ClickHouse as a generic unsplittable JDBC table.
+
+## Stage 1 boundary
+
+Supported:
+
+- bounded/offline reads only
+- single-table and `table_list` multi-table configuration
+- schema discovery from `system.columns`
+- primary-key metadata from `system.columns.is_in_primary_key`
+- MergeTree-family table reads split by active parts from `system.parts`
+- `partition_list` filtering during part discovery
+- `split.size` / `split_size` part grouping
+- `filter_query` ClickHouse-side filtering
+- `batch_size` reader batching
+- SQL mode for bounded custom queries
+- Distributed table mode through one ClickHouse distributed query
+- multiple HTTP nodes for local MergeTree shard reads
+- `clickhouse.config` passthrough to the official JDBC client
+- explicit `server_time_zone`
+- conservative scalar type mapping with exact unsigned/high-width ranges
+
+Explicitly out of scope:
+
+- CDC / streaming / continuous polling
+- mutation-log or Keeper-based change capture
+- exactly-once streaming checkpoint semantics
+- automatic SQL rewrite for JOIN/GROUP BY/subquery parallelization
+- automatic Distributed-table-to-local-table SQL rewriting
+- ARRAY / MAP / TUPLE / NESTED native conversion
+- AggregateFunction state decoding
+- runtime schema evolution
+- ClickHouse Sink
+
+## Why part-level splits
+
+For a MergeTree-family table, ClickHouse stores current data in active data parts. `system.parts` exposes those parts and the `active` flag. SeaTunnel's ClickHouse Source uses the same model for table-mode parallel reads: parts are discovered per shard, grouped into source splits, and each split reads only its assigned `_part` values.
+
+Link-Up keeps that model because it maps directly to `SourceSplitEnumerator` / `SourceReader` and avoids OFFSET-based partitioning.
+
+For a local MergeTree table with multiple `host` entries, **configure one reachable node per shard**. Do not list multiple replicas containing the same local data as independent hosts, otherwise each replica would legitimately expose the same active parts and the job could read duplicate rows.
+
+For a ClickHouse `Distributed` table this stage intentionally does not enumerate every replica. It creates one bounded table-query split and lets ClickHouse execute the distributed query itself.
+
+## Single-table example
+
+```hocon
+source {
+  ClickHouse {
+    host = "ch-shard-1:8123,ch-shard-2:8123"
+    username = "default"
+    password = ""
+
+    table_path = "analytics.orders"
+    partition_list = ["20260905", "20260906"]
+    filter_query = "status = 'PAID'"
+    split.size = 2
+    batch_size = 1024
+    server_time_zone = "UTC"
+
+    clickhouse.config = {
+      socket_timeout = "300000"
+    }
+  }
+}
+```
+
+`split.size` means the maximum number of active ClickHouse parts grouped into one Link-Up split. Its default is `Integer.MAX_VALUE`, matching SeaTunnel's bounded ClickHouse Source default. `batch_size` defaults to `1024`.
+
+## Multi-table example
+
+```hocon
+source {
+  ClickHouse {
+    host = "ch-1:8123"
+    username = "default"
+    password = ""
+
+    table_list = [
+      {
+        table_path = "analytics.orders"
+        filter_query = "id >= 100"
+        split_size = 1
+        batch_size = 2048
+      },
+      {
+        table_path = "crm.customers"
+        partition_list = ["202609"]
+      }
+    ]
+  }
+}
+```
+
+Inside `table_list`, use `split_size`; the flattened single-table form also accepts the SeaTunnel-style `split.size`. Link-Up compatibility aliases such as `scan_filter`, `request_part_size`, and `scan_batch_rows` are accepted.
+
+## SQL mode
+
+```hocon
+source {
+  ClickHouse {
+    host = "ch-1:8123"
+    username = "default"
+    password = ""
+
+    table_path = "analytics.orders"
+    sql = "SELECT id, amount FROM analytics.orders WHERE created_at >= today() - 1"
+    filter_query = "amount > 0"
+    batch_size = 1024
+  }
+}
+```
+
+When `sql` is present, Link-Up treats it as a bounded query and wraps it as a subquery before applying an optional additional `filter_query`. `table_path` is optional in SQL mode; when omitted, the connector creates a synthetic dataset identity for the query result.
+
+Unlike SeaTunnel's later-stage SQL splitter, Stage 1 does **not** rewrite simple SQL onto individual cluster shards and does not try to classify JOIN/GROUP BY/subquery semantics. A custom SQL query is one Link-Up split. This is a deliberate correctness boundary, not a missing streaming feature.
+
+`partition_list` is table-mode-only. In SQL mode, write the partition predicate explicitly in SQL.
+
+## Type boundary
+
+The bounded Source maps scalar ClickHouse types conservatively:
+
+- `Bool` -> `BOOLEAN`
+- `Int8` -> `TINYINT`
+- `UInt8` / `Int16` -> `SMALLINT`
+- `UInt16` / `Int32` -> `INT`
+- `UInt32` / `Int64` -> `BIGINT`
+- `UInt64` -> `DECIMAL(20,0)`
+- `Int128` / `UInt128` / `Int256` / `UInt256` -> exact `STRING`
+- `Float32` -> `FLOAT`
+- `Float64` -> `DOUBLE`
+- `Decimal*` -> `DECIMAL`
+- `Date` / `Date32` -> `DATE`
+- `DateTime` / `DateTime64` -> `TIMESTAMP`
+- `String`, `FixedString`, UUID/IP/Enum/JSON/Dynamic/Variant/geometric scalar-like values -> `STRING`
+- `Interval*` -> `BIGINT`
+
+`Nullable`, `LowCardinality`, and scalar `SimpleAggregateFunction` wrappers are unwrapped while preserving nullability/source type metadata.
+
+`UInt64` is not narrowed into Java signed `long`, and 128/256-bit integers are not narrowed into an insufficient decimal precision. This follows the same data-correctness rule used by the Link-Up StarRocks/Doris native sources.
+
+`ARRAY`, `MAP`, `TUPLE`, `NESTED`, and `AggregateFunction` fail during schema preparation in Stage 1 rather than being silently converted through `String.valueOf(...)`.
+
+## Operational notes
+
+- Table mode requires a MergeTree-family or `Distributed` table. For other engines, configure an explicit bounded `sql` query.
+- Empty MergeTree tables simply enumerate zero splits and finish successfully.
+- Part names and filters are pushed to ClickHouse; Link-Up does not read entire parts and discard rows locally.
+- Reader connections are split-scoped and are closed on split completion/failure.
+- `batch_size` controls the Link-Up read batch/fetch hint; it does not change ClickHouse table semantics.

--- a/link-up-connectors/link-up-connector-clickhouse/pom.xml
+++ b/link-up-connectors/link-up-connector-clickhouse/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.link.up</groupId>
+        <artifactId>link-up-connectors</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>link-up-connector-clickhouse</artifactId>
+    <version>1.0.0</version>
+
+    <properties>
+        <!-- Matches the mature SeaTunnel ClickHouse connector and ClickHouse Java 8 documentation. -->
+        <clickhouse.version>0.3.2-patch11</clickhouse.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto-service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>clickhouse-jdbc</artifactId>
+            <version>${clickhouse.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.clickhouse</groupId>
+            <artifactId>clickhouse-http-client</artifactId>
+            <version>${clickhouse.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseJdbcClient.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseJdbcClient.java
@@ -1,0 +1,261 @@
+package com.link.up.connector.clickhouse.client;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceConfig;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceTableConfig;
+import com.link.up.connector.clickhouse.schema.ClickHouseTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+/** Metadata and planning client backed by the official ClickHouse JDBC/HTTP driver. */
+public final class ClickHouseJdbcClient implements AutoCloseable {
+
+    private static final String DRIVER_CLASS = "com.clickhouse.jdbc.ClickHouseDriver";
+
+    private final ClickHouseSourceConfig config;
+
+    public ClickHouseJdbcClient(ClickHouseSourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        ensureDriver();
+    }
+
+    public List<CatalogTable> discoverTables() throws SQLException {
+        List<CatalogTable> result = new ArrayList<CatalogTable>();
+        for (ClickHouseSourceTableConfig tableConfig : config.getTableConfigs()) {
+            result.add(discoverTable(tableConfig));
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    public CatalogTable discoverTable(ClickHouseSourceTableConfig tableConfig)
+            throws SQLException {
+        Objects.requireNonNull(tableConfig, "tableConfig must not be null");
+        TableSchema schema =
+                tableConfig.isSqlMode()
+                        ? discoverSqlSchema(tableConfig)
+                        : discoverPhysicalTableSchema(tableConfig);
+        return CatalogTable.builder(tableConfig.getTablePath(), schema)
+                .option("connector", "clickhouse")
+                .option("read_mode", tableConfig.isSqlMode() ? "sql" : "part")
+                .build();
+    }
+
+    private TableSchema discoverPhysicalTableSchema(ClickHouseSourceTableConfig tableConfig)
+            throws SQLException {
+        String database = requireText(tableConfig.getDatabase(), "database");
+        String table = requireText(tableConfig.getTable(), "table");
+        String sql =
+                "SELECT name, type, is_in_primary_key "
+                        + "FROM system.columns "
+                        + "WHERE database = ? AND table = ? "
+                        + "ORDER BY position";
+
+        TableSchema.Builder builder = TableSchema.builder();
+        List<String> primaryKeys = new ArrayList<String>();
+        int columnCount = 0;
+        try (Connection connection = openConnection(config.getHosts().get(0), database);
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, database);
+            statement.setString(2, table);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String name = resultSet.getString(1);
+                    String sourceType = resultSet.getString(2);
+                    builder.column(ClickHouseTypeMapper.toColumn(name, sourceType));
+                    if (resultSet.getInt(3) != 0) {
+                        primaryKeys.add(name);
+                    }
+                    columnCount++;
+                }
+            }
+        }
+        if (columnCount == 0) {
+            throw new SQLException(
+                    "ClickHouse table has no discoverable columns or does not exist: "
+                            + tableConfig.getTablePath());
+        }
+        if (!primaryKeys.isEmpty()) {
+            builder.primaryKey(PrimaryKey.of("pk_" + String.join("_", primaryKeys), primaryKeys));
+        }
+        return builder.build();
+    }
+
+    private TableSchema discoverSqlSchema(ClickHouseSourceTableConfig tableConfig)
+            throws SQLException {
+        String query =
+                "SELECT * FROM ("
+                        + stripTrailingSemicolon(tableConfig.getSql())
+                        + ") AS _link_up_schema LIMIT 0";
+        String database =
+                tableConfig.getDatabase() == null || tableConfig.isSyntheticTablePath()
+                        ? "default"
+                        : tableConfig.getDatabase();
+
+        TableSchema.Builder builder = TableSchema.builder();
+        try (Connection connection = openConnection(config.getHosts().get(0), database);
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(query)) {
+            ResultSetMetaData metadata = resultSet.getMetaData();
+            if (metadata == null || metadata.getColumnCount() == 0) {
+                throw new SQLException("ClickHouse sql query returned no column metadata");
+            }
+            for (int index = 1; index <= metadata.getColumnCount(); index++) {
+                String name = metadata.getColumnLabel(index);
+                if (name == null || name.trim().isEmpty()) {
+                    name = metadata.getColumnName(index);
+                }
+                String sourceType = metadata.getColumnTypeName(index);
+                Column column = ClickHouseTypeMapper.toColumn(name, sourceType);
+                if (metadata.isNullable(index) != ResultSetMetaData.columnNoNulls
+                        && !column.isNullable()) {
+                    column = column.toBuilder().nullable(true).build();
+                }
+                builder.column(column);
+            }
+        }
+        return builder.build();
+    }
+
+    public String getTableEngine(String endpoint, ClickHouseSourceTableConfig tableConfig)
+            throws SQLException {
+        String sql =
+                "SELECT engine FROM system.tables WHERE database = ? AND name = ? LIMIT 1";
+        try (Connection connection = openConnection(endpoint, tableConfig.getDatabase());
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, tableConfig.getDatabase());
+            statement.setString(2, tableConfig.getTable());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                if (!resultSet.next()) {
+                    throw new SQLException(
+                            "ClickHouse table does not exist on node "
+                                    + endpoint
+                                    + ": "
+                                    + tableConfig.getTablePath());
+                }
+                return resultSet.getString(1);
+            }
+        }
+    }
+
+    public List<String> listActiveParts(
+            String endpoint,
+            ClickHouseSourceTableConfig tableConfig)
+            throws SQLException {
+        StringBuilder sql =
+                new StringBuilder(
+                        "SELECT name FROM system.parts "
+                                + "WHERE database = ? AND table = ? AND active = 1");
+        List<String> partitions = tableConfig.getPartitionList();
+        if (!partitions.isEmpty()) {
+            sql.append(" AND partition IN (");
+            for (int i = 0; i < partitions.size(); i++) {
+                if (i > 0) {
+                    sql.append(',');
+                }
+                sql.append('?');
+            }
+            sql.append(')');
+        }
+        sql.append(" ORDER BY name");
+
+        List<String> result = new ArrayList<String>();
+        try (Connection connection = openConnection(endpoint, tableConfig.getDatabase());
+             PreparedStatement statement = connection.prepareStatement(sql.toString())) {
+            int parameter = 1;
+            statement.setString(parameter++, tableConfig.getDatabase());
+            statement.setString(parameter++, tableConfig.getTable());
+            for (String partition : partitions) {
+                statement.setString(parameter++, partition);
+            }
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String part = resultSet.getString(1);
+                    if (part != null && !part.trim().isEmpty()) {
+                        result.add(part.trim());
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    public Connection openConnection(String endpoint, String database) throws SQLException {
+        Properties properties = new Properties();
+        for (Map.Entry<String, String> entry : config.getClientConfig().entrySet()) {
+            if (entry.getKey() != null && entry.getValue() != null) {
+                properties.setProperty(entry.getKey(), entry.getValue());
+            }
+        }
+        properties.setProperty("user", config.getUsername());
+        properties.setProperty("username", config.getUsername());
+        properties.setProperty("password", config.getPassword());
+        if (config.getServerTimeZone() != null) {
+            properties.setProperty("server_time_zone", config.getServerTimeZone());
+            properties.setProperty("use_server_time_zone", "true");
+        }
+        return DriverManager.getConnection(buildJdbcUrl(endpoint, database), properties);
+    }
+
+    public static String buildJdbcUrl(String endpoint, String database) {
+        String node = requireText(endpoint, "endpoint");
+        if (node.startsWith("jdbc:")) {
+            throw new IllegalArgumentException(
+                    "ClickHouse host must be an HTTP endpoint, not a JDBC URL: " + endpoint);
+        }
+        if (!node.startsWith("http://") && !node.startsWith("https://")) {
+            node = "http://" + node;
+        }
+        while (node.endsWith("/")) {
+            node = node.substring(0, node.length() - 1);
+        }
+        String targetDatabase =
+                database == null || database.trim().isEmpty() ? "default" : database.trim();
+        return "jdbc:clickhouse:" + node + "/" + targetDatabase;
+    }
+
+    public static String stripTrailingSemicolon(String sql) {
+        String value = requireText(sql, "sql");
+        while (value.endsWith(";")) {
+            value = value.substring(0, value.length() - 1).trim();
+        }
+        return value;
+    }
+
+    private static void ensureDriver() {
+        try {
+            Class.forName(DRIVER_CLASS);
+        } catch (ClassNotFoundException failure) {
+            throw new IllegalStateException(
+                    "ClickHouse JDBC driver is not available: " + DRIVER_CLASS,
+                    failure);
+        }
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value.trim();
+    }
+
+    @Override
+    public void close() {
+        // Connections are task/planning scoped and closed at each call site.
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSourceConfig.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSourceConfig.java
@@ -1,0 +1,325 @@
+package com.link.up.connector.clickhouse.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable runtime configuration for the bounded ClickHouse Source. */
+public final class ClickHouseSourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> hosts;
+    private final String username;
+    private final String password;
+    private final String serverTimeZone;
+    private final Map<String, String> clientConfig;
+    private final List<ClickHouseSourceTableConfig> tableConfigs;
+    private final Map<TablePath, ClickHouseSourceTableConfig> tableConfigIndex;
+
+    private ClickHouseSourceConfig(
+            List<String> hosts,
+            String username,
+            String password,
+            String serverTimeZone,
+            Map<String, String> clientConfig,
+            List<ClickHouseSourceTableConfig> tableConfigs) {
+        this.hosts = Collections.unmodifiableList(new ArrayList<String>(hosts));
+        this.username = username;
+        this.password = password;
+        this.serverTimeZone = serverTimeZone;
+        this.clientConfig =
+                Collections.unmodifiableMap(new LinkedHashMap<String, String>(clientConfig));
+        this.tableConfigs =
+                Collections.unmodifiableList(
+                        new ArrayList<ClickHouseSourceTableConfig>(tableConfigs));
+        Map<TablePath, ClickHouseSourceTableConfig> index =
+                new LinkedHashMap<TablePath, ClickHouseSourceTableConfig>();
+        for (ClickHouseSourceTableConfig tableConfig : tableConfigs) {
+            if (index.put(tableConfig.getTablePath(), tableConfig) != null) {
+                throw new IllegalArgumentException(
+                        "Duplicate ClickHouse source dataset path: " + tableConfig.getTablePath());
+            }
+        }
+        this.tableConfigIndex = Collections.unmodifiableMap(index);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public static ClickHouseSourceConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        List<String> hosts = parseHosts(requireText(config.get(ClickHouseSourceOptions.HOST), "host"));
+        String username = requireText(config.get(ClickHouseSourceOptions.USERNAME), "username");
+        String password = config.get(ClickHouseSourceOptions.PASSWORD);
+        String serverTimeZone =
+                normalize(config.getOptional(ClickHouseSourceOptions.SERVER_TIME_ZONE).orElse(null));
+        Map<String, String> clientConfig =
+                config.getOptional(ClickHouseSourceOptions.CLICKHOUSE_CONFIG)
+                        .orElse(Collections.<String, String>emptyMap());
+
+        String commonTablePath =
+                normalize(config.getOptional(ClickHouseSourceOptions.TABLE_PATH).orElse(null));
+        String commonSql = normalize(config.getOptional(ClickHouseSourceOptions.SQL).orElse(null));
+        String commonFilter = normalize(config.get(ClickHouseSourceOptions.FILTER_QUERY));
+        List<String> commonPartitions =
+                config.getOptional(ClickHouseSourceOptions.PARTITION_LIST)
+                        .orElse(Collections.<String>emptyList());
+        int commonSplitSize = config.get(ClickHouseSourceOptions.SPLIT_SIZE);
+        int commonBatchSize = config.get(ClickHouseSourceOptions.BATCH_SIZE);
+        validatePositive(commonSplitSize, "split.size");
+        validatePositive(commonBatchSize, "batch_size");
+
+        List<Map> tableList =
+                config.getOptional(ClickHouseSourceOptions.TABLE_LIST)
+                        .orElse(Collections.<Map>emptyList());
+        if (!tableList.isEmpty() && (commonTablePath != null || commonSql != null)) {
+            throw new IllegalArgumentException(
+                    "ClickHouse source table_list cannot be combined with top-level table_path or sql");
+        }
+
+        List<ClickHouseSourceTableConfig> tables =
+                new ArrayList<ClickHouseSourceTableConfig>();
+        if (tableList.isEmpty()) {
+            if (commonTablePath == null && commonSql == null) {
+                throw new IllegalArgumentException(
+                        "ClickHouse source requires table_path, sql, or table_list");
+            }
+            tables.add(
+                    buildTableConfig(
+                            0,
+                            commonTablePath,
+                            commonSql,
+                            commonFilter,
+                            commonPartitions,
+                            commonSplitSize,
+                            commonBatchSize));
+        } else {
+            int index = 0;
+            for (Map item : tableList) {
+                if (item == null) {
+                    throw new IllegalArgumentException("table_list item must not be null");
+                }
+                String tablePath = normalize(stringValue(item.get("table_path")));
+                String sql = normalize(stringValue(item.get("sql")));
+                if (tablePath == null && sql == null) {
+                    throw new IllegalArgumentException(
+                            "table_list[] requires table_path or sql");
+                }
+                String filter = normalize(stringValue(item.get("filter_query")));
+                if (filter == null) {
+                    filter = commonFilter;
+                }
+                List<String> partitions = listOfStrings(item.get("partition_list"));
+                if (partitions.isEmpty()) {
+                    partitions = commonPartitions;
+                }
+                int splitSize =
+                        intValue(
+                                firstNonNull(item.get("split_size"), item.get("split.size")),
+                                commonSplitSize,
+                                "table_list[].split_size");
+                int batchSize =
+                        intValue(item.get("batch_size"), commonBatchSize, "table_list[].batch_size");
+                tables.add(
+                        buildTableConfig(
+                                index++,
+                                tablePath,
+                                sql,
+                                filter,
+                                partitions,
+                                splitSize,
+                                batchSize));
+            }
+        }
+
+        return new ClickHouseSourceConfig(
+                hosts,
+                username,
+                password == null ? "" : password,
+                serverTimeZone,
+                clientConfig,
+                tables);
+    }
+
+    private static ClickHouseSourceTableConfig buildTableConfig(
+            int index,
+            String tablePathText,
+            String sql,
+            String filter,
+            List<String> partitions,
+            int splitSize,
+            int batchSize) {
+        validatePositive(splitSize, "split size");
+        validatePositive(batchSize, "batch size");
+
+        boolean synthetic = tablePathText == null;
+        TablePath tablePath =
+                synthetic
+                        ? TablePath.of("__query__", "clickhouse_query_" + index)
+                        : parseTablePath(tablePathText);
+
+        if (!synthetic && tablePath.getSchemaName() != null) {
+            throw new IllegalArgumentException(
+                    "ClickHouse table_path must use database.table form: " + tablePathText);
+        }
+        if (sql == null && tablePath.getDatabaseName() == null) {
+            throw new IllegalArgumentException(
+                    "ClickHouse table mode requires database.table: " + tablePathText);
+        }
+
+        return new ClickHouseSourceTableConfig(
+                tablePath,
+                synthetic,
+                sql,
+                filter,
+                normalizePartitions(partitions),
+                splitSize,
+                batchSize);
+    }
+
+    private static TablePath parseTablePath(String value) {
+        try {
+            return TablePath.parse(value);
+        } catch (IllegalArgumentException failure) {
+            throw new IllegalArgumentException(
+                    "Invalid ClickHouse table_path, expected database.table: " + value,
+                    failure);
+        }
+    }
+
+    private static List<String> parseHosts(String value) {
+        List<String> result = new ArrayList<String>();
+        for (String item : value.split(",")) {
+            String host = normalize(item);
+            if (host == null) {
+                continue;
+            }
+            while (host.endsWith("/")) {
+                host = host.substring(0, host.length() - 1);
+            }
+            result.add(host);
+        }
+        if (result.isEmpty()) {
+            throw new IllegalArgumentException("host must contain at least one ClickHouse node");
+        }
+        return result;
+    }
+
+    private static List<String> normalizePartitions(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> result = new ArrayList<String>();
+        for (String value : values) {
+            String normalized = normalize(value);
+            if (normalized == null) {
+                throw new IllegalArgumentException("partition_list values must not be blank");
+            }
+            result.add(normalized);
+        }
+        return result;
+    }
+
+    private static List<String> listOfStrings(Object value) {
+        if (value == null) {
+            return Collections.emptyList();
+        }
+        if (!(value instanceof List)) {
+            throw new IllegalArgumentException("partition_list must be a list");
+        }
+        List<?> source = (List<?>) value;
+        List<String> result = new ArrayList<String>(source.size());
+        for (Object item : source) {
+            result.add(item == null ? null : String.valueOf(item));
+        }
+        return result;
+    }
+
+    private static Object firstNonNull(Object first, Object second) {
+        return first != null ? first : second;
+    }
+
+    private static int intValue(Object value, int defaultValue, String name) {
+        if (value == null) {
+            return defaultValue;
+        }
+        final int result;
+        if (value instanceof Number) {
+            result = ((Number) value).intValue();
+        } else {
+            try {
+                result = Integer.parseInt(String.valueOf(value));
+            } catch (NumberFormatException failure) {
+                throw new IllegalArgumentException(name + " must be an integer", failure);
+            }
+        }
+        validatePositive(result, name);
+        return result;
+    }
+
+    private static void validatePositive(int value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be greater than 0");
+        }
+    }
+
+    private static String stringValue(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static String requireText(String value, String name) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return normalized;
+    }
+
+    public List<String> getHosts() {
+        return hosts;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getServerTimeZone() {
+        return serverTimeZone;
+    }
+
+    public Map<String, String> getClientConfig() {
+        return clientConfig;
+    }
+
+    public List<ClickHouseSourceTableConfig> getTableConfigs() {
+        return tableConfigs;
+    }
+
+    public ClickHouseSourceTableConfig getTableConfig(TablePath tablePath) {
+        ClickHouseSourceTableConfig result = tableConfigIndex.get(tablePath);
+        if (result == null) {
+            throw new IllegalArgumentException(
+                    "Unknown ClickHouse source dataset: " + tablePath);
+        }
+        return result;
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSourceOptions.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSourceOptions.java
@@ -1,0 +1,116 @@
+package com.link.up.connector.clickhouse.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+import java.util.Map;
+
+/** ClickHouse bounded Source options, aligned with SeaTunnel where practical. */
+public final class ClickHouseSourceOptions {
+
+    private ClickHouseSourceOptions() {
+    }
+
+    public static final Option<String> HOST =
+            Options.key("host")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("ClickHouse HTTP nodes, comma separated, for example host1:8123,host2:8123")
+                    .withSemanticType("CLICKHOUSE_HOSTS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("ClickHouse username")
+                    .withSemanticType("USERNAME")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .sensitive()
+                    .withDescription("ClickHouse password")
+                    .withSemanticType("PASSWORD")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> TABLE_PATH =
+            Options.key("table_path")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("ClickHouse table path in database.table form; may be combined with sql for dataset identity")
+                    .withSemanticType("TABLE_PATH")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    @SuppressWarnings("rawtypes")
+    public static final Option<List<Map>> TABLE_LIST =
+            Options.key("table_list")
+                    .listType(Map.class)
+                    .noDefaultValue()
+                    .withDescription("Multi-table bounded read configuration; each item contains table_path or sql")
+                    .withSemanticType("TABLE_LIST")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> SQL =
+            Options.key("sql")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Bounded ClickHouse query; sql mode uses a single Link-Up split in this stage")
+                    .withSemanticType("SQL")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> FILTER_QUERY =
+            Options.key("filter_query")
+                    .stringType()
+                    .defaultValue("")
+                    .withFallbackKeys("scan_filter")
+                    .withDescription("ClickHouse-side filter expression without WHERE")
+                    .withSemanticType("SQL_FILTER")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<List<String>> PARTITION_LIST =
+            Options.key("partition_list")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("ClickHouse partition values used to filter system.parts during table-mode planning")
+                    .withSemanticType("PARTITION_LIST")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> SPLIT_SIZE =
+            Options.key("split.size")
+                    .intType()
+                    .defaultValue(Integer.MAX_VALUE)
+                    .withFallbackKeys("split_size", "request_part_size")
+                    .withDescription("Maximum active ClickHouse parts grouped into one Link-Up split")
+                    .withSemanticType("SPLIT_SIZE")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> BATCH_SIZE =
+            Options.key("batch_size")
+                    .intType()
+                    .defaultValue(1024)
+                    .withFallbackKeys("scan_batch_rows")
+                    .withDescription("Maximum rows emitted from one ClickHouse reader batch")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<String> SERVER_TIME_ZONE =
+            Options.key("server_time_zone")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Explicit ClickHouse server/session time zone used by the JDBC client")
+                    .withSemanticType("TIME_ZONE")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<Map<String, String>> CLICKHOUSE_CONFIG =
+            Options.key("clickhouse.config")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("Additional ClickHouse Java/JDBC client properties")
+                    .withSemanticType("CLICKHOUSE_CLIENT_CONFIG")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSourceTableConfig.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSourceTableConfig.java
@@ -1,0 +1,102 @@
+package com.link.up.connector.clickhouse.config;
+
+import com.link.up.api.table.catalog.TablePath;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Per-dataset bounded ClickHouse Source configuration. */
+public final class ClickHouseSourceTableConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TablePath tablePath;
+    private final boolean syntheticTablePath;
+    private final String sql;
+    private final String filterQuery;
+    private final List<String> partitionList;
+    private final int splitSize;
+    private final int batchSize;
+
+    public ClickHouseSourceTableConfig(
+            TablePath tablePath,
+            boolean syntheticTablePath,
+            String sql,
+            String filterQuery,
+            List<String> partitionList,
+            int splitSize,
+            int batchSize) {
+        this.tablePath = Objects.requireNonNull(tablePath, "tablePath must not be null");
+        this.syntheticTablePath = syntheticTablePath;
+        this.sql = normalize(sql);
+        this.filterQuery = normalize(filterQuery);
+        this.partitionList =
+                Collections.unmodifiableList(
+                        partitionList == null
+                                ? Collections.<String>emptyList()
+                                : new ArrayList<String>(partitionList));
+        if (splitSize <= 0) {
+            throw new IllegalArgumentException("split size must be greater than 0");
+        }
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batch size must be greater than 0");
+        }
+        if (isSqlMode() && !this.partitionList.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "partition_list is only supported for ClickHouse table mode; encode partition predicates in sql mode explicitly");
+        }
+        this.splitSize = splitSize;
+        this.batchSize = batchSize;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    public TablePath getTablePath() {
+        return tablePath;
+    }
+
+    public boolean isSyntheticTablePath() {
+        return syntheticTablePath;
+    }
+
+    public String getSql() {
+        return sql;
+    }
+
+    public boolean isSqlMode() {
+        return sql != null;
+    }
+
+    public String getFilterQuery() {
+        return filterQuery;
+    }
+
+    public List<String> getPartitionList() {
+        return partitionList;
+    }
+
+    public int getSplitSize() {
+        return splitSize;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public String getDatabase() {
+        return tablePath.getDatabaseName();
+    }
+
+    public String getTable() {
+        return tablePath.getTableName();
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/converter/ClickHouseResultSetRowConverter.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/converter/ClickHouseResultSetRowConverter.java
@@ -5,11 +5,18 @@ import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.type.FluxRow;
 import com.link.up.api.table.type.SqlType;
 
+import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
 /** Converts one ClickHouse JDBC ResultSet row into a schema-aligned FluxRow. */
 public final class ClickHouseResultSetRowConverter {
@@ -66,24 +73,23 @@ public final class ClickHouseResultSetRowConverter {
                 double value = resultSet.getDouble(index);
                 return resultSet.wasNull() ? null : value;
             }
-            case DECIMAL:
-                return resultSet.getBigDecimal(index);
+            case DECIMAL: {
+                // Reading through text avoids narrowing UInt64/large Decimal values in older JDBC paths.
+                String value = resultSet.getString(index);
+                return value == null ? null : new BigDecimal(value);
+            }
             case STRING:
                 return resultSet.getString(index);
             case BYTES:
                 return resultSet.getBytes(index);
-            case DATE: {
-                Date value = resultSet.getDate(index);
-                return value == null ? null : value.toLocalDate();
-            }
-            case TIME: {
-                Time value = resultSet.getTime(index);
-                return value == null ? null : value.toLocalTime();
-            }
-            case TIMESTAMP: {
-                Timestamp value = resultSet.getTimestamp(index);
-                return value == null ? null : value.toLocalDateTime();
-            }
+            case DATE:
+                return dateValue(resultSet.getObject(index));
+            case TIME:
+                return timeValue(resultSet.getObject(index));
+            case TIMESTAMP:
+                // clickhouse-jdbc 0.3.2-patch11 exposes DateTime64 as LocalDateTime via getObject().
+                // Prefer that JSR-310 value so we do not re-interpret it through java.sql.Timestamp.
+                return timestampValue(resultSet.getObject(index));
             case NULL:
                 return null;
             case TIMESTAMP_TZ:
@@ -93,6 +99,78 @@ public final class ClickHouseResultSetRowConverter {
             default:
                 throw new SQLException(
                         "Unsupported ClickHouse ResultSet conversion target: " + type);
+        }
+    }
+
+    private static LocalDate dateValue(Object value) throws SQLException {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDate) {
+            return (LocalDate) value;
+        }
+        if (value instanceof Date) {
+            return ((Date) value).toLocalDate();
+        }
+        if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).toLocalDate();
+        }
+        try {
+            return LocalDate.parse(String.valueOf(value));
+        } catch (RuntimeException failure) {
+            throw new SQLException("Cannot convert ClickHouse DATE value: " + value, failure);
+        }
+    }
+
+    private static LocalTime timeValue(Object value) throws SQLException {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalTime) {
+            return (LocalTime) value;
+        }
+        if (value instanceof Time) {
+            return ((Time) value).toLocalTime();
+        }
+        if (value instanceof LocalDateTime) {
+            return ((LocalDateTime) value).toLocalTime();
+        }
+        try {
+            return LocalTime.parse(String.valueOf(value));
+        } catch (RuntimeException failure) {
+            throw new SQLException("Cannot convert ClickHouse TIME value: " + value, failure);
+        }
+    }
+
+    private static LocalDateTime timestampValue(Object value) throws SQLException {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof LocalDateTime) {
+            return (LocalDateTime) value;
+        }
+        if (value instanceof Timestamp) {
+            return ((Timestamp) value).toLocalDateTime();
+        }
+        if (value instanceof OffsetDateTime) {
+            return ((OffsetDateTime) value).toLocalDateTime();
+        }
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toLocalDateTime();
+        }
+
+        String text = String.valueOf(value).trim().replace(' ', 'T');
+        try {
+            return LocalDateTime.parse(text);
+        } catch (DateTimeParseException localFailure) {
+            try {
+                return OffsetDateTime.parse(text).toLocalDateTime();
+            } catch (DateTimeParseException offsetFailure) {
+                offsetFailure.addSuppressed(localFailure);
+                throw new SQLException(
+                        "Cannot convert ClickHouse TIMESTAMP value: " + value,
+                        offsetFailure);
+            }
         }
     }
 }

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/converter/ClickHouseResultSetRowConverter.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/converter/ClickHouseResultSetRowConverter.java
@@ -1,0 +1,98 @@
+package com.link.up.connector.clickhouse.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.SqlType;
+
+import java.sql.Date;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+
+/** Converts one ClickHouse JDBC ResultSet row into a schema-aligned FluxRow. */
+public final class ClickHouseResultSetRowConverter {
+
+    private final TableSchema schema;
+
+    public ClickHouseResultSetRowConverter(TableSchema schema) {
+        if (schema == null) {
+            throw new IllegalArgumentException("schema must not be null");
+        }
+        this.schema = schema;
+    }
+
+    public FluxRow read(ResultSet resultSet) throws SQLException {
+        if (resultSet == null) {
+            throw new IllegalArgumentException("resultSet must not be null");
+        }
+        FluxRow row = new FluxRow(schema.getColumnCount());
+        for (int index = 0; index < schema.getColumnCount(); index++) {
+            Column column = schema.getColumn(index);
+            row.setField(index, readValue(resultSet, index + 1, column.getDataType().getSqlType()));
+        }
+        return row;
+    }
+
+    private static Object readValue(ResultSet resultSet, int index, SqlType type)
+            throws SQLException {
+        switch (type) {
+            case BOOLEAN: {
+                boolean value = resultSet.getBoolean(index);
+                return resultSet.wasNull() ? null : value;
+            }
+            case TINYINT: {
+                byte value = resultSet.getByte(index);
+                return resultSet.wasNull() ? null : value;
+            }
+            case SMALLINT: {
+                short value = resultSet.getShort(index);
+                return resultSet.wasNull() ? null : value;
+            }
+            case INT: {
+                int value = resultSet.getInt(index);
+                return resultSet.wasNull() ? null : value;
+            }
+            case BIGINT: {
+                long value = resultSet.getLong(index);
+                return resultSet.wasNull() ? null : value;
+            }
+            case FLOAT: {
+                float value = resultSet.getFloat(index);
+                return resultSet.wasNull() ? null : value;
+            }
+            case DOUBLE: {
+                double value = resultSet.getDouble(index);
+                return resultSet.wasNull() ? null : value;
+            }
+            case DECIMAL:
+                return resultSet.getBigDecimal(index);
+            case STRING:
+                return resultSet.getString(index);
+            case BYTES:
+                return resultSet.getBytes(index);
+            case DATE: {
+                Date value = resultSet.getDate(index);
+                return value == null ? null : value.toLocalDate();
+            }
+            case TIME: {
+                Time value = resultSet.getTime(index);
+                return value == null ? null : value.toLocalTime();
+            }
+            case TIMESTAMP: {
+                Timestamp value = resultSet.getTimestamp(index);
+                return value == null ? null : value.toLocalDateTime();
+            }
+            case NULL:
+                return null;
+            case TIMESTAMP_TZ:
+            case ARRAY:
+            case MAP:
+            case ROW:
+            default:
+                throw new SQLException(
+                        "Unsupported ClickHouse ResultSet conversion target: " + type);
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/schema/ClickHouseTypeMapper.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/schema/ClickHouseTypeMapper.java
@@ -1,0 +1,311 @@
+package com.link.up.connector.clickhouse.schema;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/** Conservative ClickHouse type mapping for bounded source reads. */
+public final class ClickHouseTypeMapper {
+
+    private ClickHouseTypeMapper() {
+    }
+
+    public static Column toColumn(String name, String sourceType) {
+        TypeInfo info = parse(sourceType);
+        Column.Builder builder =
+                Column.builder(name, info.dataType)
+                        .nullable(info.nullable)
+                        .sourceType(sourceType);
+        if (info.length != null) {
+            builder.length(info.length);
+        }
+        if (info.precision != null) {
+            builder.precision(info.precision);
+        }
+        if (info.scale != null) {
+            builder.scale(info.scale);
+        }
+        return builder.build();
+    }
+
+    public static TypeInfo parse(String sourceType) {
+        String original = requireText(sourceType, "sourceType");
+        String type = original.trim();
+        boolean nullable = false;
+
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            if (isWrapper(type, "Nullable")) {
+                nullable = true;
+                type = unwrap(type);
+                changed = true;
+            } else if (isWrapper(type, "LowCardinality")) {
+                type = unwrap(type);
+                changed = true;
+            } else if (isWrapper(type, "SimpleAggregateFunction")) {
+                List<String> args = splitTopLevel(unwrap(type));
+                if (args.size() < 2) {
+                    throw unsupported(original, "invalid SimpleAggregateFunction type");
+                }
+                type = args.get(args.size() - 1).trim();
+                changed = true;
+            }
+        }
+
+        String upper = type.toUpperCase(Locale.ROOT);
+        if ("BOOL".equals(upper) || "BOOLEAN".equals(upper)) {
+            return info(BasicType.BOOLEAN_TYPE, nullable);
+        }
+        if ("INT8".equals(upper)) {
+            return info(BasicType.BYTE_TYPE, nullable);
+        }
+        if ("UINT8".equals(upper) || "INT16".equals(upper)) {
+            return info(BasicType.SHORT_TYPE, nullable);
+        }
+        if ("UINT16".equals(upper) || "INT32".equals(upper)) {
+            return info(BasicType.INT_TYPE, nullable);
+        }
+        if ("UINT32".equals(upper) || "INT64".equals(upper)) {
+            return info(BasicType.LONG_TYPE, nullable);
+        }
+        if ("UINT64".equals(upper)) {
+            return decimal(20, 0, nullable);
+        }
+        if ("INT128".equals(upper)
+                || "UINT128".equals(upper)
+                || "INT256".equals(upper)
+                || "UINT256".equals(upper)) {
+            return info(BasicType.STRING_TYPE, nullable);
+        }
+        if ("FLOAT32".equals(upper)) {
+            return info(BasicType.FLOAT_TYPE, nullable);
+        }
+        if ("FLOAT64".equals(upper)) {
+            return info(BasicType.DOUBLE_TYPE, nullable);
+        }
+        if (upper.startsWith("DECIMAL(")) {
+            List<String> args = splitTopLevel(unwrap(type));
+            if (args.size() != 2) {
+                throw unsupported(original, "DECIMAL requires precision and scale");
+            }
+            return decimal(parsePositive(args.get(0), "precision"), parseNonNegative(args.get(1), "scale"), nullable);
+        }
+        if (upper.startsWith("DECIMAL32(")) {
+            return decimal(9, parseNonNegative(unwrap(type), "scale"), nullable);
+        }
+        if (upper.startsWith("DECIMAL64(")) {
+            return decimal(18, parseNonNegative(unwrap(type), "scale"), nullable);
+        }
+        if (upper.startsWith("DECIMAL128(")) {
+            return decimal(38, parseNonNegative(unwrap(type), "scale"), nullable);
+        }
+        if (upper.startsWith("DECIMAL256(")) {
+            return decimal(76, parseNonNegative(unwrap(type), "scale"), nullable);
+        }
+        if ("DATE".equals(upper) || "DATE32".equals(upper)) {
+            return info(BasicType.DATE_TYPE, nullable);
+        }
+        if (upper.equals("DATETIME")
+                || upper.startsWith("DATETIME(")
+                || upper.startsWith("DATETIME64(")) {
+            TypeInfo result = info(BasicType.TIMESTAMP_TYPE, nullable);
+            if (upper.startsWith("DATETIME64(")) {
+                List<String> args = splitTopLevel(unwrap(type));
+                if (!args.isEmpty()) {
+                    int precision = parseNonNegative(args.get(0), "DateTime64 precision");
+                    if (precision > 9) {
+                        throw unsupported(original, "DateTime64 precision greater than 9 is unsupported");
+                    }
+                    result = result.withPrecision(precision);
+                }
+            }
+            return result;
+        }
+        if (upper.startsWith("FIXEDSTRING(")) {
+            int length = parsePositive(unwrap(type), "FixedString length");
+            return info(BasicType.STRING_TYPE, nullable).withLength((long) length);
+        }
+        if ("STRING".equals(upper)
+                || "UUID".equals(upper)
+                || "IPV4".equals(upper)
+                || "IPV6".equals(upper)
+                || upper.startsWith("ENUM8(")
+                || upper.startsWith("ENUM16(")
+                || "JSON".equals(upper)
+                || upper.startsWith("OBJECT(")
+                || upper.startsWith("DYNAMIC")
+                || upper.startsWith("VARIANT(")
+                || "POINT".equals(upper)
+                || "RING".equals(upper)
+                || "POLYGON".equals(upper)
+                || "MULTIPOLYGON".equals(upper)) {
+            return info(BasicType.STRING_TYPE, nullable);
+        }
+        if (upper.startsWith("INTERVAL")) {
+            return info(BasicType.LONG_TYPE, nullable);
+        }
+        if ("NOTHING".equals(upper)) {
+            return info(BasicType.NULL_TYPE, true);
+        }
+
+        if (upper.startsWith("ARRAY(")
+                || upper.startsWith("MAP(")
+                || upper.startsWith("TUPLE(")
+                || upper.startsWith("NESTED(")
+                || upper.startsWith("AGGREGATEFUNCTION(")) {
+            throw unsupported(
+                    original,
+                    "complex/aggregate ClickHouse types are intentionally outside the bounded Source stage");
+        }
+
+        throw unsupported(original, "unknown ClickHouse type");
+    }
+
+    private static TypeInfo decimal(int precision, int scale, boolean nullable) {
+        if (scale > precision) {
+            throw new IllegalArgumentException(
+                    "ClickHouse decimal scale must not exceed precision: " + precision + "," + scale);
+        }
+        return new TypeInfo(new DecimalType(precision, scale), nullable, null, precision, scale);
+    }
+
+    private static TypeInfo info(FluxDataType<?> dataType, boolean nullable) {
+        return new TypeInfo(dataType, nullable, null, null, null);
+    }
+
+    private static boolean isWrapper(String value, String wrapper) {
+        String trimmed = value.trim();
+        return trimmed.regionMatches(true, 0, wrapper + "(", 0, wrapper.length() + 1)
+                && trimmed.endsWith(")");
+    }
+
+    private static String unwrap(String value) {
+        int start = value.indexOf('(');
+        int end = value.lastIndexOf(')');
+        if (start < 0 || end <= start) {
+            throw new IllegalArgumentException("Invalid ClickHouse type expression: " + value);
+        }
+        return value.substring(start + 1, end).trim();
+    }
+
+    private static List<String> splitTopLevel(String value) {
+        List<String> result = new ArrayList<String>();
+        int depth = 0;
+        boolean quoted = false;
+        char quote = 0;
+        int start = 0;
+        for (int i = 0; i < value.length(); i++) {
+            char ch = value.charAt(i);
+            if (quoted) {
+                if (ch == quote && (i == 0 || value.charAt(i - 1) != '\\')) {
+                    quoted = false;
+                }
+                continue;
+            }
+            if (ch == '\'' || ch == '"') {
+                quoted = true;
+                quote = ch;
+            } else if (ch == '(') {
+                depth++;
+            } else if (ch == ')') {
+                depth--;
+            } else if (ch == ',' && depth == 0) {
+                result.add(value.substring(start, i).trim());
+                start = i + 1;
+            }
+        }
+        result.add(value.substring(start).trim());
+        return result;
+    }
+
+    private static int parsePositive(String value, String name) {
+        int parsed = parseInteger(value, name);
+        if (parsed <= 0) {
+            throw new IllegalArgumentException(name + " must be greater than 0");
+        }
+        return parsed;
+    }
+
+    private static int parseNonNegative(String value, String name) {
+        int parsed = parseInteger(value, name);
+        if (parsed < 0) {
+            throw new IllegalArgumentException(name + " must not be negative");
+        }
+        return parsed;
+    }
+
+    private static int parseInteger(String value, String name) {
+        try {
+            return Integer.parseInt(value.trim());
+        } catch (NumberFormatException failure) {
+            throw new IllegalArgumentException(name + " must be an integer: " + value, failure);
+        }
+    }
+
+    private static IllegalArgumentException unsupported(String sourceType, String detail) {
+        return new IllegalArgumentException(
+                "Unsupported ClickHouse Source type '" + sourceType + "': " + detail);
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be blank");
+        }
+        return value.trim();
+    }
+
+    public static final class TypeInfo {
+        private final FluxDataType<?> dataType;
+        private final boolean nullable;
+        private final Long length;
+        private final Integer precision;
+        private final Integer scale;
+
+        private TypeInfo(
+                FluxDataType<?> dataType,
+                boolean nullable,
+                Long length,
+                Integer precision,
+                Integer scale) {
+            this.dataType = dataType;
+            this.nullable = nullable;
+            this.length = length;
+            this.precision = precision;
+            this.scale = scale;
+        }
+
+        private TypeInfo withLength(Long value) {
+            return new TypeInfo(dataType, nullable, value, precision, scale);
+        }
+
+        private TypeInfo withPrecision(Integer value) {
+            return new TypeInfo(dataType, nullable, length, value, scale);
+        }
+
+        public FluxDataType<?> getDataType() {
+            return dataType;
+        }
+
+        public boolean isNullable() {
+            return nullable;
+        }
+
+        public Long getLength() {
+            return length;
+        }
+
+        public Integer getPrecision() {
+            return precision;
+        }
+
+        public Integer getScale() {
+            return scale;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHousePartSplitPlanner.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHousePartSplitPlanner.java
@@ -1,0 +1,67 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.link.up.api.table.catalog.TablePath;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Deterministically chunks ClickHouse active part names into Link-Up splits. */
+public final class ClickHousePartSplitPlanner {
+
+    private ClickHousePartSplitPlanner() {
+    }
+
+    public static List<ClickHouseSourceSplit> plan(
+            TablePath tablePath,
+            String endpoint,
+            List<String> partNames,
+            int splitSize,
+            int splitIndexStart) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (endpoint == null || endpoint.trim().isEmpty()) {
+            throw new IllegalArgumentException("endpoint must not be empty");
+        }
+        if (splitSize <= 0) {
+            throw new IllegalArgumentException("splitSize must be greater than 0");
+        }
+        if (partNames == null || partNames.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<String> ordered = new ArrayList<String>();
+        for (String partName : partNames) {
+            if (partName == null || partName.trim().isEmpty()) {
+                throw new IllegalArgumentException("ClickHouse part name must not be empty");
+            }
+            ordered.add(partName.trim());
+        }
+        Collections.sort(ordered);
+
+        List<ClickHouseSourceSplit> result = new ArrayList<ClickHouseSourceSplit>();
+        int offset = 0;
+        int splitIndex = splitIndexStart;
+        while (offset < ordered.size()) {
+            int end = Math.min(ordered.size(), offset + splitSize);
+            List<String> parts = new ArrayList<String>(ordered.subList(offset, end));
+            String splitId =
+                    tablePath.toString()
+                            + "@"
+                            + endpoint
+                            + "#"
+                            + splitIndex++;
+            result.add(
+                    new ClickHouseSourceSplit(
+                            splitId,
+                            tablePath,
+                            endpoint,
+                            ClickHouseSourceSplit.Mode.PARTS,
+                            parts,
+                            null));
+            offset = end;
+        }
+        return Collections.unmodifiableList(result);
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSource.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSource.java
@@ -1,0 +1,56 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** ClickHouse bounded Source using active-part splits and official JDBC/HTTP reads. */
+public final class ClickHouseSource implements Source<ClickHouseSourceSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final ClickHouseSourceConfig config;
+
+    public ClickHouseSource(ClickHouseSourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public SourceSplitEnumerator<ClickHouseSourceSplit> createEnumerator(
+            Map<TablePath, CatalogTable> tables,
+            SourceEnumeratorContext context) {
+        Objects.requireNonNull(tables, "tables must not be null");
+        Objects.requireNonNull(context, "context must not be null");
+        return new ClickHouseSourceSplitEnumerator(config);
+    }
+
+    @Override
+    @Deprecated
+    public List<ClickHouseSourceSplit> createSplits(
+            Map<TablePath, CatalogTable> tables) throws Exception {
+        try (ClickHouseSourceSplitEnumerator enumerator =
+                     new ClickHouseSourceSplitEnumerator(config)) {
+            return enumerator.enumerateSplits();
+        }
+    }
+
+    @Override
+    public SourceReader<FluxRow, ClickHouseSourceSplit> createReader(
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        return new ClickHouseSourceReader(config, tables, batchSize);
+    }
+
+    public ClickHouseSourceConfig getConfig() {
+        return config;
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceFactory.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceFactory.java
@@ -1,0 +1,82 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.connector.clickhouse.client.ClickHouseJdbcClient;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceConfig;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceOptions;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** SPI factory for the standalone bounded ClickHouse Source. */
+@AutoService(TableSourceFactory.class)
+public final class ClickHouseSourceFactory
+        implements TableSourceFactory<ClickHouseSourceSplit> {
+
+    private static final String IDENTIFIER = "clickhouse";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY,
+                        ConnectorCapability.MULTI_TABLE,
+                        ConnectorCapability.PARTITION_SPLIT));
+    }
+
+    @Override
+    public Source<ClickHouseSourceSplit> createSource(SourceFactoryContext context) {
+        return new ClickHouseSource(createConfig(context));
+    }
+
+    @Override
+    public List<CatalogTable> discoverTableSchemas(SourceFactoryContext context)
+            throws Exception {
+        ClickHouseSourceConfig config = createConfig(context);
+        try (ClickHouseJdbcClient client = new ClickHouseJdbcClient(config)) {
+            return client.discoverTables();
+        }
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        ClickHouseSourceOptions.HOST,
+                        ClickHouseSourceOptions.USERNAME)
+                .optional(
+                        ClickHouseSourceOptions.PASSWORD,
+                        ClickHouseSourceOptions.TABLE_PATH,
+                        ClickHouseSourceOptions.TABLE_LIST,
+                        ClickHouseSourceOptions.SQL,
+                        ClickHouseSourceOptions.FILTER_QUERY,
+                        ClickHouseSourceOptions.PARTITION_LIST,
+                        ClickHouseSourceOptions.SPLIT_SIZE,
+                        ClickHouseSourceOptions.BATCH_SIZE,
+                        ClickHouseSourceOptions.SERVER_TIME_ZONE,
+                        ClickHouseSourceOptions.CLICKHOUSE_CONFIG)
+                .build();
+    }
+
+    private ClickHouseSourceConfig createConfig(SourceFactoryContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        ReadonlyConfig options =
+                Objects.requireNonNull(context.getOptions(), "source options must not be null");
+        return ClickHouseSourceConfig.of(options);
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceReader.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceReader.java
@@ -1,0 +1,266 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.clickhouse.client.ClickHouseJdbcClient;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceConfig;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceTableConfig;
+import com.link.up.connector.clickhouse.converter.ClickHouseResultSetRowConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Task-local bounded ClickHouse reader. */
+public final class ClickHouseSourceReader
+        implements SourceReader<FluxRow, ClickHouseSourceSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClickHouseSourceReader.class);
+
+    private final ClickHouseSourceConfig config;
+    private final Map<TablePath, CatalogTable> tables;
+    private final int frameworkBatchSize;
+    private final ClickHouseJdbcClient client;
+
+    private List<ClickHouseSourceSplit> splits = Collections.emptyList();
+    private int splitIndex;
+    private ClickHouseSourceSplit currentSplit;
+    private ClickHouseSourceTableConfig currentTableConfig;
+    private Connection currentConnection;
+    private Statement currentStatement;
+    private ResultSet currentResultSet;
+    private ClickHouseResultSetRowConverter currentConverter;
+    private boolean opened;
+    private boolean finished;
+
+    public ClickHouseSourceReader(
+            ClickHouseSourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.tables = Objects.requireNonNull(tables, "tables must not be null");
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+        this.frameworkBatchSize = batchSize;
+        this.client = new ClickHouseJdbcClient(config);
+    }
+
+    @Override
+    public void open(List<ClickHouseSourceSplit> splits) throws Exception {
+        if (opened) {
+            throw new IllegalStateException("ClickHouseSourceReader has already been opened");
+        }
+        if (splits == null) {
+            throw new IllegalArgumentException("splits must not be null");
+        }
+        this.splits =
+                Collections.unmodifiableList(new ArrayList<ClickHouseSourceSplit>(splits));
+        this.splitIndex = 0;
+        this.finished = false;
+        this.opened = true;
+    }
+
+    @Override
+    public void open() throws Exception {
+        open(Collections.<ClickHouseSourceSplit>emptyList());
+    }
+
+    @Override
+    public void openSplit(ClickHouseSourceSplit split) throws Exception {
+        checkOpened();
+        if (currentSplit != null) {
+            throw new IllegalStateException("A ClickHouse split is already open");
+        }
+        finished = false;
+        openCurrentSplit(Objects.requireNonNull(split, "split must not be null"));
+    }
+
+    @Override
+    public void closeSplit() throws Exception {
+        closeCurrentSplit();
+    }
+
+    @Override
+    public RecordBatch<FluxRow> readBatch() throws Exception {
+        checkOpened();
+        if (finished) {
+            return RecordBatch.endOfInput();
+        }
+
+        while (true) {
+            if (currentSplit == null) {
+                if (!openNextSplit()) {
+                    finished = true;
+                    return RecordBatch.endOfInput();
+                }
+            }
+
+            ClickHouseSourceSplit batchSplit = currentSplit;
+            int rowLimit = Math.min(frameworkBatchSize, currentTableConfig.getBatchSize());
+            List<FluxRow> rows = new ArrayList<FluxRow>(rowLimit);
+            boolean exhausted = false;
+            while (rows.size() < rowLimit) {
+                if (!currentResultSet.next()) {
+                    exhausted = true;
+                    break;
+                }
+                rows.add(currentConverter.read(currentResultSet));
+            }
+
+            if (exhausted) {
+                closeCurrentSplit();
+            }
+            if (!rows.isEmpty()) {
+                return RecordBatch.of(batchSplit, rows);
+            }
+        }
+    }
+
+    private boolean openNextSplit() throws Exception {
+        if (splitIndex >= splits.size()) {
+            return false;
+        }
+        openCurrentSplit(splits.get(splitIndex++));
+        return true;
+    }
+
+    private void openCurrentSplit(ClickHouseSourceSplit split) throws Exception {
+        CatalogTable table = tables.get(split.getTablePath());
+        if (table == null) {
+            throw new IllegalArgumentException(
+                    "Cannot find schema for ClickHouse split table: " + split.getTablePath());
+        }
+        ClickHouseSourceTableConfig tableConfig = config.getTableConfig(split.getTablePath());
+        String database =
+                tableConfig.isSyntheticTablePath() || tableConfig.getDatabase() == null
+                        ? "default"
+                        : tableConfig.getDatabase();
+
+        Connection connection = null;
+        Statement statement = null;
+        ResultSet resultSet = null;
+        try {
+            connection = client.openConnection(split.getEndpoint(), database);
+            statement = connection.createStatement();
+            try {
+                statement.setFetchSize(tableConfig.getBatchSize());
+            } catch (SQLException unsupported) {
+                LOG.debug(
+                        "ClickHouse JDBC driver ignored fetch size {}: {}",
+                        tableConfig.getBatchSize(),
+                        unsupported.getMessage());
+            }
+            String sql = ClickHouseSourceSqlBuilder.build(split, tableConfig, table);
+            LOG.info(
+                    "Opening ClickHouse bounded split: splitId={}, endpoint={}, mode={}",
+                    split.splitId(),
+                    split.getEndpoint(),
+                    split.getMode());
+            LOG.debug("ClickHouse split SQL: {}", sql);
+            resultSet = statement.executeQuery(sql);
+
+            currentSplit = split;
+            currentTableConfig = tableConfig;
+            currentConnection = connection;
+            currentStatement = statement;
+            currentResultSet = resultSet;
+            currentConverter = new ClickHouseResultSetRowConverter(table.getTableSchema());
+        } catch (Exception failure) {
+            closeQuietly(resultSet);
+            closeQuietly(statement);
+            closeQuietly(connection);
+            throw failure;
+        }
+    }
+
+    private void closeCurrentSplit() throws Exception {
+        Exception failure = null;
+        failure = closeResource(currentResultSet, failure);
+        failure = closeResource(currentStatement, failure);
+        failure = closeResource(currentConnection, failure);
+
+        currentResultSet = null;
+        currentStatement = null;
+        currentConnection = null;
+        currentConverter = null;
+        currentTableConfig = null;
+        currentSplit = null;
+
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private static Exception closeResource(AutoCloseable resource, Exception failure) {
+        if (resource == null) {
+            return failure;
+        }
+        try {
+            resource.close();
+        } catch (Exception closeFailure) {
+            if (failure == null) {
+                return closeFailure;
+            }
+            failure.addSuppressed(closeFailure);
+        }
+        return failure;
+    }
+
+    private static void closeQuietly(AutoCloseable resource) {
+        if (resource == null) {
+            return;
+        }
+        try {
+            resource.close();
+        } catch (Exception ignored) {
+            // Preserve the original open failure.
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("ClickHouseSourceReader has not been opened");
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!opened) {
+            return;
+        }
+        Exception failure = null;
+        try {
+            closeCurrentSplit();
+        } catch (Exception closeFailure) {
+            failure = closeFailure;
+        }
+        try {
+            client.close();
+        } catch (Exception closeFailure) {
+            if (failure == null) {
+                failure = closeFailure;
+            } else {
+                failure.addSuppressed(closeFailure);
+            }
+        } finally {
+            opened = false;
+            finished = true;
+            splits = Collections.emptyList();
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceSplit.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceSplit.java
@@ -1,0 +1,94 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.TablePath;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** One bounded ClickHouse read unit, bound to a concrete HTTP node. */
+public final class ClickHouseSourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    public enum Mode {
+        PARTS,
+        TABLE_QUERY,
+        SQL_QUERY
+    }
+
+    private final String splitId;
+    private final TablePath tablePath;
+    private final String endpoint;
+    private final Mode mode;
+    private final List<String> partNames;
+    private final String querySql;
+
+    public ClickHouseSourceSplit(
+            String splitId,
+            TablePath tablePath,
+            String endpoint,
+            Mode mode,
+            List<String> partNames,
+            String querySql) {
+        this.splitId = Objects.requireNonNull(splitId, "splitId must not be null");
+        this.tablePath = Objects.requireNonNull(tablePath, "tablePath must not be null");
+        this.endpoint = Objects.requireNonNull(endpoint, "endpoint must not be null");
+        this.mode = Objects.requireNonNull(mode, "mode must not be null");
+        this.partNames =
+                Collections.unmodifiableList(
+                        partNames == null
+                                ? Collections.<String>emptyList()
+                                : new ArrayList<String>(partNames));
+        this.querySql = querySql;
+        if (mode == Mode.PARTS && this.partNames.isEmpty()) {
+            throw new IllegalArgumentException("PARTS split requires at least one part name");
+        }
+        if (mode == Mode.SQL_QUERY && (querySql == null || querySql.trim().isEmpty())) {
+            throw new IllegalArgumentException("SQL_QUERY split requires querySql");
+        }
+    }
+
+    @Override
+    public String splitId() {
+        return splitId;
+    }
+
+    @Override
+    public String dataSetId() {
+        return tablePath.toString();
+    }
+
+    public TablePath getTablePath() {
+        return tablePath;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public Mode getMode() {
+        return mode;
+    }
+
+    public List<String> getPartNames() {
+        return partNames;
+    }
+
+    public String getQuerySql() {
+        return querySql;
+    }
+
+    @Override
+    public String toString() {
+        return "ClickHouseSourceSplit{"
+                + "splitId='" + splitId + '\''
+                + ", tablePath=" + tablePath
+                + ", endpoint='" + endpoint + '\''
+                + ", mode=" + mode
+                + ", parts=" + partNames.size()
+                + '}';
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceSplitEnumerator.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceSplitEnumerator.java
@@ -1,0 +1,108 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.connector.clickhouse.client.ClickHouseJdbcClient;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceConfig;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceTableConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+/** Bounded split enumerator using ClickHouse active parts for MergeTree tables. */
+public final class ClickHouseSourceSplitEnumerator
+        implements SourceSplitEnumerator<ClickHouseSourceSplit> {
+
+    private final ClickHouseSourceConfig config;
+    private final ClickHouseJdbcClient client;
+
+    public ClickHouseSourceSplitEnumerator(ClickHouseSourceConfig config) {
+        this(config, new ClickHouseJdbcClient(config));
+    }
+
+    ClickHouseSourceSplitEnumerator(
+            ClickHouseSourceConfig config,
+            ClickHouseJdbcClient client) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.client = Objects.requireNonNull(client, "client must not be null");
+    }
+
+    @Override
+    public List<ClickHouseSourceSplit> enumerateSplits() throws Exception {
+        List<ClickHouseSourceSplit> result = new ArrayList<ClickHouseSourceSplit>();
+        for (ClickHouseSourceTableConfig tableConfig : config.getTableConfigs()) {
+            if (tableConfig.isSqlMode()) {
+                String endpoint = config.getHosts().get(0);
+                result.add(
+                        new ClickHouseSourceSplit(
+                                tableConfig.getTablePath() + "@" + endpoint + "#sql",
+                                tableConfig.getTablePath(),
+                                endpoint,
+                                ClickHouseSourceSplit.Mode.SQL_QUERY,
+                                Collections.<String>emptyList(),
+                                tableConfig.getSql()));
+                continue;
+            }
+
+            int splitIndex = 0;
+            boolean distributed = false;
+            for (String endpoint : config.getHosts()) {
+                String engine = client.getTableEngine(endpoint, tableConfig);
+                String normalized = engine == null ? "" : engine.toLowerCase(Locale.ROOT);
+                if (normalized.contains("mergetree")) {
+                    List<String> parts = client.listActiveParts(endpoint, tableConfig);
+                    List<ClickHouseSourceSplit> planned =
+                            ClickHousePartSplitPlanner.plan(
+                                    tableConfig.getTablePath(),
+                                    endpoint,
+                                    parts,
+                                    tableConfig.getSplitSize(),
+                                    splitIndex);
+                    result.addAll(planned);
+                    splitIndex += planned.size();
+                    continue;
+                }
+
+                if ("distributed".equalsIgnoreCase(engine)) {
+                    if (!tableConfig.getPartitionList().isEmpty()) {
+                        throw new IllegalArgumentException(
+                                "partition_list is not supported for ClickHouse Distributed table mode in this stage; "
+                                        + "use filter_query/sql or read the local MergeTree table explicitly");
+                    }
+                    String firstEndpoint = config.getHosts().get(0);
+                    result.add(
+                            new ClickHouseSourceSplit(
+                                    tableConfig.getTablePath()
+                                            + "@"
+                                            + firstEndpoint
+                                            + "#distributed",
+                                    tableConfig.getTablePath(),
+                                    firstEndpoint,
+                                    ClickHouseSourceSplit.Mode.TABLE_QUERY,
+                                    Collections.<String>emptyList(),
+                                    null));
+                    distributed = true;
+                    break;
+                }
+
+                throw new IllegalArgumentException(
+                        "ClickHouse table mode requires a MergeTree-family or Distributed table, but "
+                                + tableConfig.getTablePath()
+                                + " uses engine="
+                                + engine
+                                + ". Configure sql for this table instead.");
+            }
+            if (distributed) {
+                continue;
+            }
+        }
+        return Collections.unmodifiableList(result);
+    }
+
+    @Override
+    public void close() {
+        client.close();
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceSqlBuilder.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/source/ClickHouseSourceSqlBuilder.java
@@ -1,0 +1,91 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.connector.clickhouse.client.ClickHouseJdbcClient;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceTableConfig;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Builds deterministic bounded SELECT statements for ClickHouse splits. */
+public final class ClickHouseSourceSqlBuilder {
+
+    private ClickHouseSourceSqlBuilder() {
+    }
+
+    public static String build(
+            ClickHouseSourceSplit split,
+            ClickHouseSourceTableConfig tableConfig,
+            CatalogTable catalogTable) {
+        if (split == null || tableConfig == null || catalogTable == null) {
+            throw new IllegalArgumentException("split, tableConfig and catalogTable must not be null");
+        }
+
+        if (split.getMode() == ClickHouseSourceSplit.Mode.SQL_QUERY) {
+            StringBuilder sql =
+                    new StringBuilder()
+                            .append("SELECT * FROM (")
+                            .append(ClickHouseJdbcClient.stripTrailingSemicolon(split.getQuerySql()))
+                            .append(") AS _link_up_source");
+            appendFilter(sql, tableConfig.getFilterQuery(), false);
+            return sql.toString();
+        }
+
+        List<String> fields = new ArrayList<String>();
+        for (Column column : catalogTable.getTableSchema().getColumns()) {
+            fields.add(quoteIdentifier(column.getName()));
+        }
+        if (fields.isEmpty()) {
+            throw new IllegalArgumentException("ClickHouse source schema must contain at least one column");
+        }
+
+        StringBuilder sql =
+                new StringBuilder()
+                        .append("SELECT ")
+                        .append(String.join(", ", fields))
+                        .append(" FROM ")
+                        .append(quoteIdentifier(tableConfig.getDatabase()))
+                        .append('.')
+                        .append(quoteIdentifier(tableConfig.getTable()));
+
+        boolean hasWhere = false;
+        if (split.getMode() == ClickHouseSourceSplit.Mode.PARTS) {
+            sql.append(" WHERE _part IN (");
+            List<String> parts = split.getPartNames();
+            for (int i = 0; i < parts.size(); i++) {
+                if (i > 0) {
+                    sql.append(", ");
+                }
+                sql.append(quoteLiteral(parts.get(i)));
+            }
+            sql.append(')');
+            hasWhere = true;
+        }
+        appendFilter(sql, tableConfig.getFilterQuery(), hasWhere);
+        return sql.toString();
+    }
+
+    private static void appendFilter(StringBuilder sql, String filter, boolean hasWhere) {
+        if (filter == null || filter.trim().isEmpty()) {
+            return;
+        }
+        sql.append(hasWhere ? " AND (" : " WHERE (")
+                .append(filter.trim())
+                .append(')');
+    }
+
+    static String quoteIdentifier(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException("ClickHouse identifier must not be empty");
+        }
+        return "`" + value.replace("`", "``") + "`";
+    }
+
+    static String quoteLiteral(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("ClickHouse string literal must not be null");
+        }
+        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'";
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/ClickHouseConnectorPackageBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/ClickHouseConnectorPackageBoundaryTest.java
@@ -1,0 +1,36 @@
+package com.link.up.connector.clickhouse;
+
+import com.link.up.connector.clickhouse.converter.ClickHouseResultSetRowConverter;
+import com.link.up.connector.clickhouse.source.ClickHouseSourceFactory;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ClickHouseConnectorPackageBoundaryTest {
+
+    @Test
+    public void sourceFactoryUsesStableIdentifier() {
+        assertEquals("clickhouse", new ClickHouseSourceFactory().factoryIdentifier());
+    }
+
+    @Test
+    public void rowConversionBelongsToConverterRole() {
+        assertEquals(
+                "com.link.up.connector.clickhouse.converter",
+                ClickHouseResultSetRowConverter.class.getPackage().getName());
+    }
+
+    @Test
+    public void forbiddenGenericRootPackagesMustNotExist() {
+        File root = new File("src/main/java/com/link/up/connector/clickhouse");
+        String[] forbidden = {"common", "core", "helper", "misc", "utils"};
+        for (String name : forbidden) {
+            assertFalse(
+                    "Forbidden ClickHouse connector root package exists: " + name,
+                    new File(root, name).exists());
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseJdbcClientTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseJdbcClientTest.java
@@ -1,0 +1,38 @@
+package com.link.up.connector.clickhouse.client;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClickHouseJdbcClientTest {
+
+    @Test
+    public void buildsHttpJdbcUrl() {
+        assertEquals(
+                "jdbc:clickhouse:http://localhost:8123/analytics",
+                ClickHouseJdbcClient.buildJdbcUrl("localhost:8123", "analytics"));
+    }
+
+    @Test
+    public void preservesHttpsEndpoint() {
+        assertEquals(
+                "jdbc:clickhouse:https://cluster.example.com:8443/default",
+                ClickHouseJdbcClient.buildJdbcUrl(
+                        "https://cluster.example.com:8443/",
+                        null));
+    }
+
+    @Test
+    public void stripsTrailingSemicolons() {
+        assertEquals(
+                "select 1",
+                ClickHouseJdbcClient.stripTrailingSemicolon(" select 1;;; "));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsJdbcUrlInsideHostOption() {
+        ClickHouseJdbcClient.buildJdbcUrl(
+                "jdbc:clickhouse:http://localhost:8123",
+                "default");
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/config/ClickHouseSourceConfigTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/config/ClickHouseSourceConfigTest.java
@@ -1,0 +1,105 @@
+package com.link.up.connector.clickhouse.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ClickHouseSourceConfigTest {
+
+    @Test
+    public void parsesSingleTableWithSeaTunnelDefaults() {
+        Map<String, Object> values = base();
+        values.put("table_path", "analytics.orders");
+
+        ClickHouseSourceConfig config = ClickHouseSourceConfig.of(ReadonlyConfig.fromMap(values));
+
+        assertEquals(Arrays.asList("fe-1:8123", "https://fe-2:8443"), config.getHosts());
+        assertEquals(1, config.getTableConfigs().size());
+        ClickHouseSourceTableConfig table = config.getTableConfigs().get(0);
+        assertEquals("analytics.orders", table.getTablePath().toString());
+        assertEquals(Integer.MAX_VALUE, table.getSplitSize());
+        assertEquals(1024, table.getBatchSize());
+        assertFalse(table.isSqlMode());
+    }
+
+    @Test
+    public void parsesMultiTableOverrides() {
+        Map<String, Object> values = base();
+        values.put("filter_query", "tenant_id > 0");
+
+        List<Map<String, Object>> tableList = new ArrayList<Map<String, Object>>();
+        Map<String, Object> orders = new LinkedHashMap<String, Object>();
+        orders.put("table_path", "analytics.orders");
+        orders.put("split_size", 2);
+        orders.put("batch_size", 256);
+        orders.put("partition_list", Arrays.asList("20260905", "20260906"));
+        tableList.add(orders);
+
+        Map<String, Object> customers = new LinkedHashMap<String, Object>();
+        customers.put("table_path", "crm.customers");
+        customers.put("filter_query", "active = 1");
+        tableList.add(customers);
+        values.put("table_list", tableList);
+
+        ClickHouseSourceConfig config = ClickHouseSourceConfig.of(ReadonlyConfig.fromMap(values));
+
+        assertEquals(2, config.getTableConfigs().size());
+        ClickHouseSourceTableConfig first = config.getTableConfigs().get(0);
+        assertEquals(2, first.getSplitSize());
+        assertEquals(256, first.getBatchSize());
+        assertEquals(Arrays.asList("20260905", "20260906"), first.getPartitionList());
+        assertEquals("tenant_id > 0", first.getFilterQuery());
+
+        ClickHouseSourceTableConfig second = config.getTableConfigs().get(1);
+        assertEquals("active = 1", second.getFilterQuery());
+        assertEquals(Integer.MAX_VALUE, second.getSplitSize());
+    }
+
+    @Test
+    public void supportsSqlOnlyDatasetWithSyntheticPath() {
+        Map<String, Object> values = base();
+        values.put("sql", "select id, amount from analytics.orders");
+
+        ClickHouseSourceConfig config = ClickHouseSourceConfig.of(ReadonlyConfig.fromMap(values));
+        ClickHouseSourceTableConfig table = config.getTableConfigs().get(0);
+
+        assertTrue(table.isSqlMode());
+        assertTrue(table.isSyntheticTablePath());
+        assertEquals("__query__.clickhouse_query_0", table.getTablePath().toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsTableListCombinedWithTopLevelTable() {
+        Map<String, Object> values = base();
+        values.put("table_path", "analytics.orders");
+        Map<String, Object> item = new LinkedHashMap<String, Object>();
+        item.put("table_path", "crm.customers");
+        values.put("table_list", Arrays.asList(item));
+        ClickHouseSourceConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsPartitionListForSqlMode() {
+        Map<String, Object> values = base();
+        values.put("sql", "select * from analytics.orders");
+        values.put("partition_list", Arrays.asList("20260906"));
+        ClickHouseSourceConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static Map<String, Object> base() {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("host", "fe-1:8123, https://fe-2:8443/");
+        values.put("username", "default");
+        values.put("password", "");
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/converter/ClickHouseResultSetRowConverterTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/converter/ClickHouseResultSetRowConverterTest.java
@@ -1,0 +1,53 @@
+package com.link.up.connector.clickhouse.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxRow;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClickHouseResultSetRowConverterTest {
+
+    @Test
+    public void preservesUInt64TextAndLocalDateTime() throws Exception {
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("u64", new DecimalType(20, 0)).build())
+                        .column(Column.builder("created_at", BasicType.TIMESTAMP_TYPE).build())
+                        .build();
+        final LocalDateTime timestamp = LocalDateTime.of(2026, 9, 6, 8, 42, 12, 123000000);
+
+        ResultSet resultSet =
+                (ResultSet)
+                        Proxy.newProxyInstance(
+                                getClass().getClassLoader(),
+                                new Class<?>[] {ResultSet.class},
+                                (proxy, method, args) -> {
+                                    if ("getString".equals(method.getName())
+                                            && Integer.valueOf(1).equals(args[0])) {
+                                        return "18446744073709551615";
+                                    }
+                                    if ("getObject".equals(method.getName())
+                                            && Integer.valueOf(2).equals(args[0])) {
+                                        return timestamp;
+                                    }
+                                    if ("toString".equals(method.getName())) {
+                                        return "ClickHouseResultSetStub";
+                                    }
+                                    throw new UnsupportedOperationException(method.getName());
+                                });
+
+        FluxRow row = new ClickHouseResultSetRowConverter(schema).read(resultSet);
+
+        assertEquals(new BigDecimal("18446744073709551615"), row.getField(0));
+        assertEquals(timestamp, row.getField(1));
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/schema/ClickHouseTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/schema/ClickHouseTypeMapperTest.java
@@ -1,0 +1,69 @@
+package com.link.up.connector.clickhouse.schema;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ClickHouseTypeMapperTest {
+
+    @Test
+    public void preservesUnsignedIntegerRanges() {
+        assertEquals(
+                BasicType.LONG_TYPE,
+                ClickHouseTypeMapper.parse("UInt32").getDataType());
+        assertEquals(
+                new DecimalType(20, 0),
+                ClickHouseTypeMapper.parse("UInt64").getDataType());
+        assertEquals(
+                BasicType.STRING_TYPE,
+                ClickHouseTypeMapper.parse("UInt128").getDataType());
+        assertEquals(
+                BasicType.STRING_TYPE,
+                ClickHouseTypeMapper.parse("Int256").getDataType());
+    }
+
+    @Test
+    public void unwrapsNullableAndLowCardinality() {
+        ClickHouseTypeMapper.TypeInfo info =
+                ClickHouseTypeMapper.parse("Nullable(LowCardinality(String))");
+
+        assertEquals(BasicType.STRING_TYPE, info.getDataType());
+        assertTrue(info.isNullable());
+    }
+
+    @Test
+    public void parsesDateTime64Precision() {
+        ClickHouseTypeMapper.TypeInfo info =
+                ClickHouseTypeMapper.parse("DateTime64(6, 'UTC')");
+
+        assertEquals(BasicType.TIMESTAMP_TYPE, info.getDataType());
+        assertEquals(Integer.valueOf(6), info.getPrecision());
+        assertFalse(info.isNullable());
+    }
+
+    @Test
+    public void columnRetainsOriginalType() {
+        Column column = ClickHouseTypeMapper.toColumn("amount", "Nullable(Decimal(18, 2))");
+
+        assertEquals(new DecimalType(18, 2), column.getDataType());
+        assertEquals("Nullable(Decimal(18, 2))", column.getSourceType());
+        assertTrue(column.isNullable());
+        assertEquals(Integer.valueOf(18), column.getPrecision());
+        assertEquals(Integer.valueOf(2), column.getScale());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void complexArrayFailsFast() {
+        ClickHouseTypeMapper.parse("Array(UInt64)");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void aggregateFunctionFailsFast() {
+        ClickHouseTypeMapper.parse("AggregateFunction(sum, UInt64)");
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/source/ClickHousePartSplitPlannerTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/source/ClickHousePartSplitPlannerTest.java
@@ -1,0 +1,42 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.link.up.api.table.catalog.TablePath;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClickHousePartSplitPlannerTest {
+
+    @Test
+    public void sortsAndChunksPartsDeterministically() {
+        List<ClickHouseSourceSplit> splits =
+                ClickHousePartSplitPlanner.plan(
+                        TablePath.of("analytics", "orders"),
+                        "node-1:8123",
+                        Arrays.asList("p3", "p1", "p2"),
+                        2,
+                        0);
+
+        assertEquals(2, splits.size());
+        assertEquals(Arrays.asList("p1", "p2"), splits.get(0).getPartNames());
+        assertEquals(Arrays.asList("p3"), splits.get(1).getPartNames());
+        assertEquals("analytics.orders@node-1:8123#0", splits.get(0).splitId());
+        assertEquals(ClickHouseSourceSplit.Mode.PARTS, splits.get(0).getMode());
+    }
+
+    @Test
+    public void respectsSplitIndexOffset() {
+        List<ClickHouseSourceSplit> splits =
+                ClickHousePartSplitPlanner.plan(
+                        TablePath.of("analytics", "orders"),
+                        "node-2:8123",
+                        Arrays.asList("part-a"),
+                        1,
+                        7);
+
+        assertEquals("analytics.orders@node-2:8123#7", splits.get(0).splitId());
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/source/ClickHouseSourceSqlBuilderTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/source/ClickHouseSourceSqlBuilderTest.java
@@ -1,0 +1,91 @@
+package com.link.up.connector.clickhouse.source;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.clickhouse.config.ClickHouseSourceTableConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClickHouseSourceSqlBuilderTest {
+
+    @Test
+    public void buildsPartQueryWithProjectionAndFilter() {
+        TablePath path = TablePath.of("analytics", "orders");
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                        .column(Column.builder("order_no", BasicType.STRING_TYPE).build())
+                        .build();
+        CatalogTable table = CatalogTable.builder(path, schema).build();
+        ClickHouseSourceTableConfig config =
+                new ClickHouseSourceTableConfig(
+                        path,
+                        false,
+                        null,
+                        "id >= 100",
+                        Collections.<String>emptyList(),
+                        10,
+                        1024);
+        ClickHouseSourceSplit split =
+                new ClickHouseSourceSplit(
+                        "split-1",
+                        path,
+                        "node-1:8123",
+                        ClickHouseSourceSplit.Mode.PARTS,
+                        Arrays.asList("202609_1_1_0", "202609_2_2_0"),
+                        null);
+
+        String sql = ClickHouseSourceSqlBuilder.build(split, config, table);
+
+        assertEquals(
+                "SELECT `id`, `order_no` FROM `analytics`.`orders` "
+                        + "WHERE _part IN ('202609_1_1_0', '202609_2_2_0') AND (id >= 100)",
+                sql);
+    }
+
+    @Test
+    public void wrapsSqlAndAppliesAdditionalFilter() {
+        TablePath path = TablePath.of("analytics", "orders");
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                        .build();
+        CatalogTable table = CatalogTable.builder(path, schema).build();
+        ClickHouseSourceTableConfig config =
+                new ClickHouseSourceTableConfig(
+                        path,
+                        false,
+                        "select id from analytics.orders;",
+                        "id < 1000",
+                        Collections.<String>emptyList(),
+                        10,
+                        1024);
+        ClickHouseSourceSplit split =
+                new ClickHouseSourceSplit(
+                        "sql-1",
+                        path,
+                        "node-1:8123",
+                        ClickHouseSourceSplit.Mode.SQL_QUERY,
+                        Collections.<String>emptyList(),
+                        "select id from analytics.orders;");
+
+        String sql = ClickHouseSourceSqlBuilder.build(split, config, table);
+
+        assertEquals(
+                "SELECT * FROM (select id from analytics.orders) AS _link_up_source WHERE (id < 1000)",
+                sql);
+    }
+
+    @Test
+    public void escapesPartLiteral() {
+        assertTrue(ClickHouseSourceSqlBuilder.quoteLiteral("a'b").contains("\\'"));
+    }
+}

--- a/link-up-connectors/pom.xml
+++ b/link-up-connectors/pom.xml
@@ -19,6 +19,7 @@
         <module>link-up-connector-doris</module>
         <module>link-up-connector-http</module>
         <module>link-up-connector-starrocks</module>
+        <module>link-up-connector-clickhouse</module>
     </modules>
 
 </project>

--- a/link-up-launcher/pom.xml
+++ b/link-up-launcher/pom.xml
@@ -45,6 +45,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-connector-clickhouse</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j2.version}</version>


### PR DESCRIPTION
## Summary

Add a standalone bounded/offline ClickHouse Source to Yak Link-Up, based on Apache SeaTunnel's current ClickHouse Source architecture and ClickHouse's official Java/JDBC + `system.parts` behavior.

The table-mode read path is:

`system.columns schema -> system.tables engine -> system.parts(active=1) -> deterministic _part splits -> official ClickHouse JDBC/HTTP query -> ResultSet -> FluxRow`

This is an independent `link-up-connector-clickhouse` module because ClickHouse part/shard planning is database-specific, while transport itself deliberately reuses ClickHouse's official Java/JDBC HTTP client instead of reimplementing a wire protocol.

## Design references

SeaTunnel's ClickHouse Source uses two important bounded strategies:

- table mode discovers ClickHouse parts and groups them into source splits;
- custom SQL mode executes bounded queries, with later SeaTunnel stages adding increasingly complex SQL/shard rewriting.

ClickHouse officially exposes current MergeTree data parts through `system.parts`, where `active = 1` identifies live parts. The official Java integration also documents the JDBC/HTTP driver and standard `ResultSet` reads.

For Link-Up Stage 1, this PR keeps the proven part-split model but intentionally does not port SeaTunnel's complex SQL rewrite/shard-localization layer yet.

## What changed

- add new `link-up-connector-clickhouse` Maven module
- register it in `link-up-connectors` and `link-up-launcher` so `ServiceLoader` can discover `SOURCE/clickhouse`
- add `ClickHouseSourceFactory`, `ClickHouseSource`, `ClickHouseSourceSplitEnumerator`, `ClickHouseSourceSplit`, and `ClickHouseSourceReader`
- use the official ClickHouse JDBC/HTTP client (`0.3.2-patch11`, matching SeaTunnel's mature connector line and ClickHouse's Java integration example)
- discover physical table schema from `system.columns`
- retain primary-key column metadata from `is_in_primary_key`
- support single-table and `table_list` multi-table reads
- support SeaTunnel-style `host`, `table_path`, `sql`, `filter_query`, `partition_list`, `split.size`/`split_size`, `batch_size`, `server_time_zone`, and `clickhouse.config`
- support Link-Up aliases such as `scan_filter`, `request_part_size`, and `scan_batch_rows`
- inspect table engine through `system.tables`
- for MergeTree-family tables, discover `system.parts WHERE active = 1`
- filter part discovery with `partition_list`
- deterministically sort and chunk active part names by `split.size`
- bind each part split to a concrete configured ClickHouse HTTP node
- generate `_part IN (...)` queries so filtering stays in ClickHouse
- apply `filter_query` as an additional server-side predicate
- for `Distributed` tables, use one bounded distributed query instead of enumerating replicas and risking duplicate data
- support custom SQL as one bounded Link-Up split in this stage
- support SQL-only datasets with a stable synthetic dataset identity when `table_path` is omitted
- close ResultSet/Statement/Connection resources at split boundaries and on failure

## Type correctness

The Source keeps integer ranges instead of collapsing everything into Java signed primitive widths:

- `Int8` -> `TINYINT`
- `UInt8` / `Int16` -> `SMALLINT`
- `UInt16` / `Int32` -> `INT`
- `UInt32` / `Int64` -> `BIGINT`
- `UInt64` -> `DECIMAL(20,0)`
- `Int128` / `UInt128` / `Int256` / `UInt256` -> exact `STRING`
- `Float32` -> `FLOAT`
- `Float64` -> `DOUBLE`
- `Decimal*` -> `DECIMAL`
- `Date` / `Date32` -> `DATE`
- `DateTime` / `DateTime64` -> `TIMESTAMP`
- common string/UUID/IP/Enum/JSON-like scalar values -> `STRING`

`Nullable`, `LowCardinality`, and scalar `SimpleAggregateFunction` wrappers are safely unwrapped while original `sourceType` metadata is retained.

`UInt64`/large decimal values are read from exact textual representation before constructing `BigDecimal`, avoiding signed-long narrowing in older JDBC paths.

For `DateTime64`, the converter prefers the `LocalDateTime` returned by `clickhouse-jdbc 0.3.2-patch11` via `ResultSet#getObject()` instead of forcing it back through `java.sql.Timestamp`, which can introduce a second timezone interpretation.

Complex types remain deliberately fail-fast in Stage 1:

- ARRAY
- MAP
- TUPLE / NESTED
- AggregateFunction state

They should get dedicated Flux conversion semantics rather than an implicit `String.valueOf(...)` fallback.

## Parallel-read boundary

For local MergeTree tables with multiple `host` entries, each configured host is treated as one shard read node, matching the part-based SeaTunnel model. Operators should configure one node per shard rather than multiple replicas of the same local shard, otherwise duplicate physical data can legitimately be exposed by multiple hosts.

For `Distributed` tables, Stage 1 creates a single distributed table query and lets ClickHouse fan the request out internally.

For custom `sql`, Stage 1 intentionally uses one bounded split. It does not yet rewrite simple SQL onto every shard or try to classify JOIN/GROUP BY/subquery safety. That keeps the first adaptation correct and reviewable.

## Scope / non-goals

This PR is Source-only and bounded/offline. It intentionally does **not** add:

- CDC / streaming / continuous polling
- mutation/Keeper-based change capture
- exactly-once streaming checkpoint semantics
- ClickHouse Sink
- runtime schema evolution
- automatic Distributed-to-local-table SQL rewriting
- automatic JOIN/GROUP BY/subquery shard parallelization
- complex ARRAY/MAP/TUPLE/NESTED conversion

## Tests added

Coverage includes:

- SeaTunnel-compatible single-table defaults
- multi-table per-table overrides
- invalid table/table-list combinations
- SQL-only synthetic dataset identity
- SQL-mode partition boundary
- unsigned/high-width integer type mapping
- Nullable/LowCardinality wrapper handling
- DateTime64 precision metadata
- complex-type fail-fast behavior
- deterministic active-part sorting/chunking
- stable split IDs
- `_part` SQL generation and filter pushdown
- custom SQL wrapping and trailing-semicolon handling
- JDBC URL construction for HTTP/HTTPS
- exact max-`UInt64` conversion (`18446744073709551615`)
- `LocalDateTime` preservation for DateTime64
- package/factory boundary checks

## Validation note

The implementation and tests were statically reviewed against:

- Apache SeaTunnel ClickHouse Source (`ClickhouseSourceFactory`, `ClickhouseSourceReader`, `ClickhouseValueReader`, `PartStrategySplitter`, current source docs)
- ClickHouse official Java/JDBC documentation
- ClickHouse official `system.parts` active-part semantics
- current Link-Up `SourceSplitEnumerator` / dynamic `SourceReader` lifecycle

A repository-side Maven run and a real ClickHouse smoke test are still required before merge. This execution environment cannot resolve `github.com` from the local container, so it cannot clone the repository or perform a reliable Maven dependency run. Suggested merge gate:

`mvn -pl link-up-connectors/link-up-connector-clickhouse -am test`

followed by one real ClickHouse test covering a MergeTree table with multiple parts and a `UInt64` + `DateTime64` column.

The PR is intentionally left as Draft until those checks are completed.