### PR TITLE
feat(clickhouse): add bounded jdbc batch sink

### DIFF
--- a/link-up-connectors/link-up-connector-clickhouse/README.md
+++ b/link-up-connectors/link-up-connector-clickhouse/README.md
@@ -1,8 +1,12 @@
 # Link-Up ClickHouse Connector
 
-`link-up-connector-clickhouse` provides a standalone bounded/offline ClickHouse Source.
+`link-up-connector-clickhouse` provides standalone bounded/offline ClickHouse Source and Sink implementations.
 
-The connector follows the mature read model used by Apache SeaTunnel while keeping the first Link-Up stage deliberately small:
+The connector keeps ClickHouse-specific planning and write semantics inside the module while reusing the official ClickHouse Java/JDBC client over HTTP.
+
+## Source — Stage 1
+
+The bounded Source follows the mature SeaTunnel read model:
 
 ```text
 ClickHouseSource
@@ -13,10 +17,6 @@ ClickHouseSource
   -> ResultSet
   -> FluxRow
 ```
-
-The transport is not reimplemented by Link-Up. Connections and query decoding use ClickHouse's official Java/JDBC client over HTTP. The ClickHouse-specific part of this connector is the bounded planning model: table mode understands MergeTree active parts and turns them into Link-Up `SourceSplit`s instead of treating ClickHouse as a generic unsplittable JDBC table.
-
-## Stage 1 boundary
 
 Supported:
 
@@ -36,29 +36,11 @@ Supported:
 - explicit `server_time_zone`
 - conservative scalar type mapping with exact unsigned/high-width ranges
 
-Explicitly out of scope:
+For a local MergeTree table with multiple `host` entries, configure one reachable node per shard. Do not list multiple replicas containing the same local data as independent hosts, otherwise the same physical parts can be read more than once.
 
-- CDC / streaming / continuous polling
-- mutation-log or Keeper-based change capture
-- exactly-once streaming checkpoint semantics
-- automatic SQL rewrite for JOIN/GROUP BY/subquery parallelization
-- automatic Distributed-table-to-local-table SQL rewriting
-- ARRAY / MAP / TUPLE / NESTED native conversion
-- AggregateFunction state decoding
-- runtime schema evolution
-- ClickHouse Sink
+For a ClickHouse `Distributed` table, Stage 1 creates one bounded distributed query and lets ClickHouse execute the cluster fan-out. Custom SQL is also one bounded Link-Up split in this stage; JOIN/GROUP BY/subquery shard rewriting is intentionally not attempted.
 
-## Why part-level splits
-
-For a MergeTree-family table, ClickHouse stores current data in active data parts. `system.parts` exposes those parts and the `active` flag. SeaTunnel's ClickHouse Source uses the same model for table-mode parallel reads: parts are discovered per shard, grouped into source splits, and each split reads only its assigned `_part` values.
-
-Link-Up keeps that model because it maps directly to `SourceSplitEnumerator` / `SourceReader` and avoids OFFSET-based partitioning.
-
-For a local MergeTree table with multiple `host` entries, **configure one reachable node per shard**. Do not list multiple replicas containing the same local data as independent hosts, otherwise each replica would legitimately expose the same active parts and the job could read duplicate rows.
-
-For a ClickHouse `Distributed` table this stage intentionally does not enumerate every replica. It creates one bounded table-query split and lets ClickHouse execute the distributed query itself.
-
-## Single-table example
+### Source example
 
 ```hocon
 source {
@@ -81,59 +63,7 @@ source {
 }
 ```
 
-`split.size` means the maximum number of active ClickHouse parts grouped into one Link-Up split. Its default is `Integer.MAX_VALUE`, matching SeaTunnel's bounded ClickHouse Source default. `batch_size` defaults to `1024`.
-
-## Multi-table example
-
-```hocon
-source {
-  ClickHouse {
-    host = "ch-1:8123"
-    username = "default"
-    password = ""
-
-    table_list = [
-      {
-        table_path = "analytics.orders"
-        filter_query = "id >= 100"
-        split_size = 1
-        batch_size = 2048
-      },
-      {
-        table_path = "crm.customers"
-        partition_list = ["202609"]
-      }
-    ]
-  }
-}
-```
-
-Inside `table_list`, use `split_size`; the flattened single-table form also accepts the SeaTunnel-style `split.size`. Link-Up compatibility aliases such as `scan_filter`, `request_part_size`, and `scan_batch_rows` are accepted.
-
-## SQL mode
-
-```hocon
-source {
-  ClickHouse {
-    host = "ch-1:8123"
-    username = "default"
-    password = ""
-
-    table_path = "analytics.orders"
-    sql = "SELECT id, amount FROM analytics.orders WHERE created_at >= today() - 1"
-    filter_query = "amount > 0"
-    batch_size = 1024
-  }
-}
-```
-
-When `sql` is present, Link-Up treats it as a bounded query and wraps it as a subquery before applying an optional additional `filter_query`. `table_path` is optional in SQL mode; when omitted, the connector creates a synthetic dataset identity for the query result.
-
-Unlike SeaTunnel's later-stage SQL splitter, Stage 1 does **not** rewrite simple SQL onto individual cluster shards and does not try to classify JOIN/GROUP BY/subquery semantics. A custom SQL query is one Link-Up split. This is a deliberate correctness boundary, not a missing streaming feature.
-
-`partition_list` is table-mode-only. In SQL mode, write the partition predicate explicitly in SQL.
-
-## Type boundary
+### Source type boundary
 
 The bounded Source maps scalar ClickHouse types conservatively:
 
@@ -149,19 +79,112 @@ The bounded Source maps scalar ClickHouse types conservatively:
 - `Decimal*` -> `DECIMAL`
 - `Date` / `Date32` -> `DATE`
 - `DateTime` / `DateTime64` -> `TIMESTAMP`
-- `String`, `FixedString`, UUID/IP/Enum/JSON/Dynamic/Variant/geometric scalar-like values -> `STRING`
+- string/UUID/IP/Enum/JSON/Dynamic/Variant/geometric scalar-like values -> `STRING`
 - `Interval*` -> `BIGINT`
 
-`Nullable`, `LowCardinality`, and scalar `SimpleAggregateFunction` wrappers are unwrapped while preserving nullability/source type metadata.
+`Nullable`, `LowCardinality`, and scalar `SimpleAggregateFunction` wrappers are unwrapped while preserving nullability/source type metadata. `ARRAY`, `MAP`, `TUPLE`, `NESTED`, and `AggregateFunction` remain fail-fast until dedicated Flux conversion semantics exist.
 
-`UInt64` is not narrowed into Java signed `long`, and 128/256-bit integers are not narrowed into an insufficient decimal precision. This follows the same data-correctness rule used by the Link-Up StarRocks/Doris native sources.
+## Sink — Stage 2
 
-`ARRAY`, `MAP`, `TUPLE`, `NESTED`, and `AggregateFunction` fail during schema preparation in Stage 1 rather than being silently converted through `String.valueOf(...)`.
+The Sink is intentionally a bounded client-side batch writer:
+
+```text
+FluxRow
+  -> prepared target metadata
+  -> PreparedStatement.addBatch()
+  -> row threshold
+  -> executeBatch()
+  -> ClickHouse synchronous INSERT acknowledgement
+```
+
+The implementation follows ClickHouse's own recommendation to avoid small one-row inserts. Link-Up batches rows on the client and uses the official JDBC prepared batch path rather than inventing a custom transport.
+
+### Stage 2 semantics
+
+- exactly one target table per Sink task
+- exactly one configured write endpoint
+- target table must already exist
+- target metadata is discovered from `system.columns` before writers start
+- source/target field names must match; target physical order may differ
+- nullable source fields cannot target non-nullable columns
+- integer widening is allowed only when it is range-safe
+- Decimal target precision/scale must fully contain the source Decimal
+- default `sink.batch_size` is `10000`
+- flush happens at the configured row threshold and at `prepareCommit()`
+- each successful `executeBatch()` is already a remote ClickHouse write
+- `commit()` is therefore a Link-Up task lifecycle boundary, not a second database transaction
+- `abort()` only clears the not-yet-sent JDBC batch
+- `close()` does **not** flush implicitly
+- ambiguous `executeBatch()` failures are not retried automatically because replay can duplicate rows
+
+ClickHouse 26.3+ can enable asynchronous inserts by default. This bounded Sink deliberately pins its write connection to `async_insert=0` and `wait_for_async_insert=1`, so a successful `executeBatch()` remains a stable remote durability boundary independent of cluster/user defaults. A conflicting `clickhouse.config` is rejected during configuration parsing.
+
+### Sink example
+
+```hocon
+sink {
+  ClickHouse {
+    host = "ch-write:8123"
+    username = "default"
+    password = ""
+    database = "analytics"
+    table = "orders"
+
+    sink.batch_size = 10000
+    server_time_zone = "UTC"
+
+    clickhouse.config = {
+      socket_timeout = "300000"
+    }
+  }
+}
+```
+
+Use one load-balancer endpoint, one `Distributed` table endpoint, or one explicit ClickHouse node. Stage 2 does not round-robin writes across a comma-separated host list because a network failure after an ambiguous write acknowledgement cannot be safely replayed against another node without stronger target-side idempotency semantics.
+
+### Sink type boundary
+
+The bounded Sink accepts Flux scalar values with explicit JDBC binding for:
+
+- `BOOLEAN`
+- `TINYINT`
+- `SMALLINT`
+- `INT`
+- `BIGINT`
+- `FLOAT`
+- `DOUBLE`
+- `DECIMAL`
+- `STRING`
+- `DATE`
+- `TIMESTAMP`
+
+`TIMESTAMP` is bound as `LocalDateTime` instead of being forced through `java.sql.Timestamp`, avoiding an extra timezone reinterpretation for ClickHouse `DateTime64` paths.
+
+The current Stage 2 Sink fails before or during binding for `BYTES`, standalone `TIME`, `TIMESTAMP_TZ`, `ARRAY`, `MAP`, and `ROW`. Those need explicit ClickHouse target semantics instead of implicit stringification or timezone conversion.
+
+## Explicit non-goals
+
+The ClickHouse connector remains an offline/bounded connector. These capabilities are outside the current stages:
+
+- CDC / streaming / continuous polling
+- mutation-log or Keeper-based change capture
+- exactly-once streaming checkpoint semantics
+- job-level transaction/XA semantics
+- INSERT replay retries after ambiguous network failures
+- ReplacingMergeTree interpreted as a generic UPSERT API
+- DELETE / UPDATE / mutation semantics
+- runtime schema evolution
+- automatic target table creation in the Sink
+- automatic Distributed-table-to-local-table SQL rewriting
+- automatic JOIN/GROUP BY/subquery shard parallelization
+- complex ARRAY/MAP/TUPLE/NESTED conversion
 
 ## Operational notes
 
-- Table mode requires a MergeTree-family or `Distributed` table. For other engines, configure an explicit bounded `sql` query.
-- Empty MergeTree tables simply enumerate zero splits and finish successfully.
-- Part names and filters are pushed to ClickHouse; Link-Up does not read entire parts and discard rows locally.
-- Reader connections are split-scoped and are closed on split completion/failure.
-- `batch_size` controls the Link-Up read batch/fetch hint; it does not change ClickHouse table semantics.
+- Source table mode requires a MergeTree-family or `Distributed` table. For other engines, configure an explicit bounded `sql` query.
+- Empty MergeTree source tables simply enumerate zero splits and finish successfully.
+- Source part names and filters are pushed to ClickHouse; Link-Up does not discard rows locally after a full-table read.
+- Source Reader connections are split-scoped and closed on split completion/failure.
+- Sink target validation is preparation-time only; runtime schema changes are rejected.
+- A successful Sink flush cannot be rolled back by a later Link-Up task abort.
+- If a whole Sink task is retried after some successful batches, verify target data first or rely on explicit target-side deduplication/key semantics. The connector does not claim job-level exactly once.

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClient.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClient.java
@@ -1,0 +1,249 @@
+package com.link.up.connector.clickhouse.client;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
+import com.link.up.connector.clickhouse.converter.ClickHousePreparedStatementBinder;
+import com.link.up.connector.clickhouse.schema.ClickHouseTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+/** JDBC client for bounded ClickHouse target validation and prepared batch inserts. */
+public final class ClickHouseSinkJdbcClient implements AutoCloseable {
+
+    private static final String DRIVER_CLASS = "com.clickhouse.jdbc.ClickHouseDriver";
+
+    private final ClickHouseSinkConfig config;
+    private final CatalogTable targetTable;
+    private final ClickHousePreparedStatementBinder binder;
+
+    private Connection connection;
+    private PreparedStatement insertStatement;
+    private int pendingRows;
+
+    public ClickHouseSinkJdbcClient(
+            ClickHouseSinkConfig config,
+            CatalogTable targetTable,
+            TableSchema sourceSchema) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.targetTable = Objects.requireNonNull(targetTable, "targetTable must not be null");
+        this.binder = new ClickHousePreparedStatementBinder(
+                Objects.requireNonNull(sourceSchema, "sourceSchema must not be null"));
+        ensureDriver();
+    }
+
+    public static CatalogTable discoverTargetTable(ClickHouseSinkConfig config) throws Exception {
+        Objects.requireNonNull(config, "config must not be null");
+        ensureDriver();
+        String sql =
+                "SELECT name, type, is_in_primary_key "
+                        + "FROM system.columns "
+                        + "WHERE database = ? AND table = ? "
+                        + "ORDER BY position";
+
+        TableSchema.Builder builder = TableSchema.builder();
+        List<String> primaryKeys = new ArrayList<String>();
+        int columns = 0;
+        try (Connection connection = openConnection(config);
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.setString(1, config.getDatabase());
+            statement.setString(2, config.getTable());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                while (resultSet.next()) {
+                    String name = resultSet.getString(1);
+                    String sourceType = resultSet.getString(2);
+                    builder.column(ClickHouseTypeMapper.toColumn(name, sourceType));
+                    if (resultSet.getInt(3) != 0) {
+                        primaryKeys.add(name);
+                    }
+                    columns++;
+                }
+            }
+        }
+        if (columns == 0) {
+            throw new IllegalArgumentException(
+                    "ClickHouse sink target table does not exist or has no columns: "
+                            + config.getDatabase()
+                            + "."
+                            + config.getTable());
+        }
+        if (!primaryKeys.isEmpty()) {
+            builder.primaryKey(PrimaryKey.of("pk_" + String.join("_", primaryKeys), primaryKeys));
+        }
+        return CatalogTable.builder(config.getTargetPath(), builder.build())
+                .option("connector", "clickhouse")
+                .option("write_mode", "bounded-jdbc-batch")
+                .build();
+    }
+
+    public void open() throws Exception {
+        if (connection != null) {
+            throw new IllegalStateException("ClickHouse sink JDBC client is already open");
+        }
+        connection = openConnection(config);
+        insertStatement = connection.prepareStatement(buildInsertSql(targetTable));
+        pendingRows = 0;
+    }
+
+    public void add(FluxRow row) throws Exception {
+        checkOpen();
+        binder.bind(insertStatement, row);
+        insertStatement.addBatch();
+        pendingRows++;
+    }
+
+    public int flush() throws Exception {
+        checkOpen();
+        if (pendingRows == 0) {
+            return 0;
+        }
+        int rows = pendingRows;
+        int[] results = insertStatement.executeBatch();
+        if (results != null) {
+            for (int result : results) {
+                if (result == Statement.EXECUTE_FAILED) {
+                    throw new IllegalStateException(
+                            "ClickHouse JDBC executeBatch reported EXECUTE_FAILED; the batch outcome may be partial or ambiguous and is not retried automatically");
+                }
+            }
+        }
+        insertStatement.clearBatch();
+        pendingRows = 0;
+        return rows;
+    }
+
+    public void clearBatch() throws Exception {
+        if (insertStatement != null) {
+            insertStatement.clearBatch();
+        }
+        pendingRows = 0;
+    }
+
+    public int getPendingRows() {
+        return pendingRows;
+    }
+
+    static String buildInsertSql(CatalogTable targetTable) {
+        TableSchema schema = targetTable.getTableSchema();
+        StringBuilder columns = new StringBuilder();
+        StringBuilder values = new StringBuilder();
+        for (int index = 0; index < schema.getColumnCount(); index++) {
+            if (index > 0) {
+                columns.append(", ");
+                values.append(", ");
+            }
+            Column column = schema.getColumn(index);
+            columns.append(quoteIdentifier(column.getName()));
+            values.append('?');
+        }
+        TablePath path = targetTable.getTablePath();
+        return "INSERT INTO "
+                + quoteIdentifier(path.getDatabaseName())
+                + "."
+                + quoteIdentifier(path.getTableName())
+                + " ("
+                + columns
+                + ") VALUES ("
+                + values
+                + ")";
+    }
+
+    static Connection openConnection(ClickHouseSinkConfig config) throws Exception {
+        String url = buildSafeJdbcUrl(config);
+        Properties properties = new Properties();
+        for (Map.Entry<String, String> entry : config.getClientConfig().entrySet()) {
+            properties.setProperty(entry.getKey(), entry.getValue());
+        }
+        properties.setProperty("user", config.getUsername());
+        properties.setProperty("username", config.getUsername());
+        properties.setProperty("password", config.getPassword());
+        if (config.getServerTimeZone() != null) {
+            properties.setProperty("server_time_zone", config.getServerTimeZone());
+            properties.setProperty("use_server_time_zone", "true");
+        }
+        // Keep the bounded writer's durability boundary stable even when ClickHouse 26.3+
+        // enables async inserts by default at server/user level.
+        properties.setProperty("async_insert", "0");
+        properties.setProperty("wait_for_async_insert", "1");
+        return DriverManager.getConnection(url, properties);
+    }
+
+    static String buildSafeJdbcUrl(ClickHouseSinkConfig config) {
+        String base = ClickHouseJdbcClient.buildJdbcUrl(config.getHost(), config.getDatabase());
+        return base + "?async_insert=0&wait_for_async_insert=1";
+    }
+
+    private static String quoteIdentifier(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException("ClickHouse identifier must not be empty");
+        }
+        return "`" + value.replace("`", "``") + "`";
+    }
+
+    private static void ensureDriver() {
+        try {
+            Class.forName(DRIVER_CLASS);
+        } catch (ClassNotFoundException failure) {
+            throw new IllegalStateException(
+                    "ClickHouse JDBC driver is not available: " + DRIVER_CLASS,
+                    failure);
+        }
+    }
+
+    private void checkOpen() {
+        if (insertStatement == null || connection == null) {
+            throw new IllegalStateException("ClickHouse sink JDBC client is not open");
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        if (insertStatement != null) {
+            try {
+                insertStatement.clearBatch();
+            } catch (Exception clearFailure) {
+                failure = clearFailure;
+            }
+            try {
+                insertStatement.close();
+            } catch (Exception closeFailure) {
+                if (failure == null) {
+                    failure = closeFailure;
+                } else {
+                    failure.addSuppressed(closeFailure);
+                }
+            }
+        }
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (Exception closeFailure) {
+                if (failure == null) {
+                    failure = closeFailure;
+                } else {
+                    failure.addSuppressed(closeFailure);
+                }
+            }
+        }
+        insertStatement = null;
+        connection = null;
+        pendingRows = 0;
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClient.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClient.java
@@ -172,9 +172,20 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
             }
             Column targetColumn = targetSchema.getColumn(index);
             Column sourceColumn = sourceSchema.getColumn(index);
+            String targetSourceType = targetColumn.getSourceType();
+            if (targetSourceType == null || targetSourceType.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Prepared ClickHouse target column is missing sourceType: "
+                                + targetColumn.getName());
+            }
             String inputName = "c" + index;
             targetColumns.append(quoteIdentifier(targetColumn.getName()));
-            selectColumns.append(inputName);
+            selectColumns
+                    .append("CAST(")
+                    .append(inputName)
+                    .append(" AS ")
+                    .append(targetSourceType.trim())
+                    .append(')');
             inputSchema.append(inputName).append(' ').append(inputType(sourceColumn));
         }
         TablePath path = targetTable.getTablePath();
@@ -197,7 +208,6 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
         String type;
         switch (sqlType) {
             case BOOLEAN:
-                // UInt8 works across old/new ClickHouse releases and converts safely to Bool.
                 type = "UInt8";
                 break;
             case TINYINT:
@@ -259,8 +269,6 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
             properties.setProperty("server_time_zone", config.getServerTimeZone());
             properties.setProperty("use_server_time_zone", "true");
         }
-        // Keep the bounded writer's durability boundary stable even when ClickHouse 26.3+
-        // enables async inserts by default at server/user level.
         properties.setProperty("async_insert", "0");
         properties.setProperty("wait_for_async_insert", "1");
         return DriverManager.getConnection(url, properties);

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClient.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClient.java
@@ -17,6 +17,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
@@ -49,14 +50,14 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
         Objects.requireNonNull(config, "config must not be null");
         ensureDriver();
         String sql =
-                "SELECT name, type, is_in_primary_key "
+                "SELECT name, type, is_in_primary_key, default_kind "
                         + "FROM system.columns "
                         + "WHERE database = ? AND table = ? "
                         + "ORDER BY position";
 
         TableSchema.Builder builder = TableSchema.builder();
         List<String> primaryKeys = new ArrayList<String>();
-        int columns = 0;
+        int writableColumns = 0;
         try (Connection connection = openConnection(config);
              PreparedStatement statement = connection.prepareStatement(sql)) {
             statement.setString(1, config.getDatabase());
@@ -65,17 +66,22 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
                 while (resultSet.next()) {
                     String name = resultSet.getString(1);
                     String sourceType = resultSet.getString(2);
+                    int primaryKey = resultSet.getInt(3);
+                    String defaultKind = resultSet.getString(4);
+                    if (!isWritableColumn(defaultKind)) {
+                        continue;
+                    }
                     builder.column(ClickHouseTypeMapper.toColumn(name, sourceType));
-                    if (resultSet.getInt(3) != 0) {
+                    if (primaryKey != 0) {
                         primaryKeys.add(name);
                     }
-                    columns++;
+                    writableColumns++;
                 }
             }
         }
-        if (columns == 0) {
+        if (writableColumns == 0) {
             throw new IllegalArgumentException(
-                    "ClickHouse sink target table does not exist or has no columns: "
+                    "ClickHouse sink target table does not exist or has no writable columns: "
                             + config.getDatabase()
                             + "."
                             + config.getTable());
@@ -132,22 +138,27 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
         pendingRows = 0;
     }
 
-    public int getPendingRows() {
-        return pendingRows;
-    }
-
     static String buildInsertSql(CatalogTable targetTable) {
         TableSchema schema = targetTable.getTableSchema();
-        StringBuilder columns = new StringBuilder();
-        StringBuilder values = new StringBuilder();
+        StringBuilder targetColumns = new StringBuilder();
+        StringBuilder selectColumns = new StringBuilder();
+        StringBuilder inputSchema = new StringBuilder();
         for (int index = 0; index < schema.getColumnCount(); index++) {
             if (index > 0) {
-                columns.append(", ");
-                values.append(", ");
+                targetColumns.append(", ");
+                selectColumns.append(", ");
+                inputSchema.append(", ");
             }
             Column column = schema.getColumn(index);
-            columns.append(quoteIdentifier(column.getName()));
-            values.append('?');
+            String inputName = "c" + index;
+            String sourceType = column.getSourceType();
+            if (sourceType == null || sourceType.trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "ClickHouse prepared target column is missing sourceType: " + column.getName());
+            }
+            targetColumns.append(quoteIdentifier(column.getName()));
+            selectColumns.append(inputName);
+            inputSchema.append(inputName).append(' ').append(sourceType.trim());
         }
         TablePath path = targetTable.getTablePath();
         return "INSERT INTO "
@@ -155,10 +166,12 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
                 + "."
                 + quoteIdentifier(path.getTableName())
                 + " ("
-                + columns
-                + ") VALUES ("
-                + values
-                + ")";
+                + targetColumns
+                + ") SELECT "
+                + selectColumns
+                + " FROM input('"
+                + escapeStringLiteral(inputSchema.toString())
+                + "')";
     }
 
     static Connection openConnection(ClickHouseSinkConfig config) throws Exception {
@@ -186,11 +199,25 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
         return base + "?async_insert=0&wait_for_async_insert=1";
     }
 
+    static boolean isWritableColumn(String defaultKind) {
+        if (defaultKind == null || defaultKind.trim().isEmpty()) {
+            return true;
+        }
+        String kind = defaultKind.trim().toUpperCase(Locale.ROOT);
+        return !"MATERIALIZED".equals(kind)
+                && !"ALIAS".equals(kind)
+                && !"EPHEMERAL".equals(kind);
+    }
+
     private static String quoteIdentifier(String value) {
         if (value == null || value.trim().isEmpty()) {
             throw new IllegalArgumentException("ClickHouse identifier must not be empty");
         }
         return "`" + value.replace("`", "``") + "`";
+    }
+
+    private static String escapeStringLiteral(String value) {
+        return value.replace("\\", "\\\\").replace("'", "\\'");
     }
 
     private static void ensureDriver() {

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClient.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClient.java
@@ -5,10 +5,15 @@ import com.link.up.api.table.catalog.Column;
 import com.link.up.api.table.catalog.PrimaryKey;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
 import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.SqlType;
 import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
 import com.link.up.connector.clickhouse.converter.ClickHousePreparedStatementBinder;
 import com.link.up.connector.clickhouse.schema.ClickHouseTypeMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -25,10 +30,12 @@ import java.util.Properties;
 /** JDBC client for bounded ClickHouse target validation and prepared batch inserts. */
 public final class ClickHouseSinkJdbcClient implements AutoCloseable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ClickHouseSinkJdbcClient.class);
     private static final String DRIVER_CLASS = "com.clickhouse.jdbc.ClickHouseDriver";
 
     private final ClickHouseSinkConfig config;
     private final CatalogTable targetTable;
+    private final TableSchema sourceSchema;
     private final ClickHousePreparedStatementBinder binder;
 
     private Connection connection;
@@ -41,8 +48,8 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
             TableSchema sourceSchema) {
         this.config = Objects.requireNonNull(config, "config must not be null");
         this.targetTable = Objects.requireNonNull(targetTable, "targetTable must not be null");
-        this.binder = new ClickHousePreparedStatementBinder(
-                Objects.requireNonNull(sourceSchema, "sourceSchema must not be null"));
+        this.sourceSchema = Objects.requireNonNull(sourceSchema, "sourceSchema must not be null");
+        this.binder = new ClickHousePreparedStatementBinder(this.sourceSchema);
         ensureDriver();
     }
 
@@ -100,7 +107,7 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
             throw new IllegalStateException("ClickHouse sink JDBC client is already open");
         }
         connection = openConnection(config);
-        insertStatement = connection.prepareStatement(buildInsertSql(targetTable));
+        insertStatement = connection.prepareStatement(buildInsertSql(targetTable, sourceSchema));
         pendingRows = 0;
     }
 
@@ -126,8 +133,17 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
                 }
             }
         }
-        insertStatement.clearBatch();
+
+        // executeBatch has already crossed the remote durability boundary. Cleanup must not turn
+        // a successful insert into a retryable task failure.
         pendingRows = 0;
+        try {
+            insertStatement.clearBatch();
+        } catch (Exception cleanupFailure) {
+            LOG.warn(
+                    "ClickHouse executeBatch succeeded but clearBatch cleanup failed; the batch is already committed remotely",
+                    cleanupFailure);
+        }
         return rows;
     }
 
@@ -138,27 +154,28 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
         pendingRows = 0;
     }
 
-    static String buildInsertSql(CatalogTable targetTable) {
-        TableSchema schema = targetTable.getTableSchema();
+    static String buildInsertSql(CatalogTable targetTable, TableSchema sourceSchema) {
+        TableSchema targetSchema = targetTable.getTableSchema();
+        if (targetSchema.getColumnCount() != sourceSchema.getColumnCount()) {
+            throw new IllegalArgumentException(
+                    "Prepared ClickHouse source/target column counts differ");
+        }
+
         StringBuilder targetColumns = new StringBuilder();
         StringBuilder selectColumns = new StringBuilder();
         StringBuilder inputSchema = new StringBuilder();
-        for (int index = 0; index < schema.getColumnCount(); index++) {
+        for (int index = 0; index < targetSchema.getColumnCount(); index++) {
             if (index > 0) {
                 targetColumns.append(", ");
                 selectColumns.append(", ");
                 inputSchema.append(", ");
             }
-            Column column = schema.getColumn(index);
+            Column targetColumn = targetSchema.getColumn(index);
+            Column sourceColumn = sourceSchema.getColumn(index);
             String inputName = "c" + index;
-            String sourceType = column.getSourceType();
-            if (sourceType == null || sourceType.trim().isEmpty()) {
-                throw new IllegalArgumentException(
-                        "ClickHouse prepared target column is missing sourceType: " + column.getName());
-            }
-            targetColumns.append(quoteIdentifier(column.getName()));
+            targetColumns.append(quoteIdentifier(targetColumn.getName()));
             selectColumns.append(inputName);
-            inputSchema.append(inputName).append(' ').append(sourceType.trim());
+            inputSchema.append(inputName).append(' ').append(inputType(sourceColumn));
         }
         TablePath path = targetTable.getTablePath();
         return "INSERT INTO "
@@ -172,6 +189,61 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
                 + " FROM input('"
                 + escapeStringLiteral(inputSchema.toString())
                 + "')";
+    }
+
+    static String inputType(Column sourceColumn) {
+        FluxDataType<?> dataType = sourceColumn.getDataType();
+        SqlType sqlType = dataType.getSqlType();
+        String type;
+        switch (sqlType) {
+            case BOOLEAN:
+                // UInt8 works across old/new ClickHouse releases and converts safely to Bool.
+                type = "UInt8";
+                break;
+            case TINYINT:
+                type = "Int8";
+                break;
+            case SMALLINT:
+                type = "Int16";
+                break;
+            case INT:
+                type = "Int32";
+                break;
+            case BIGINT:
+                type = "Int64";
+                break;
+            case FLOAT:
+                type = "Float32";
+                break;
+            case DOUBLE:
+                type = "Float64";
+                break;
+            case DECIMAL:
+                if (!(dataType instanceof DecimalType)) {
+                    throw new IllegalArgumentException(
+                            "ClickHouse Sink DECIMAL source is missing precision/scale metadata: "
+                                    + sourceColumn.getName());
+                }
+                DecimalType decimal = (DecimalType) dataType;
+                type = "Decimal(" + decimal.getPrecision() + "," + decimal.getScale() + ")";
+                break;
+            case STRING:
+                type = "String";
+                break;
+            case DATE:
+                type = "Date32";
+                break;
+            case TIMESTAMP:
+                type = "DateTime64(9)";
+                break;
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported ClickHouse Sink input type for column "
+                                + sourceColumn.getName()
+                                + ": "
+                                + sqlType);
+        }
+        return sourceColumn.isNullable() ? "Nullable(" + type + ")" : type;
     }
 
     static Connection openConnection(ClickHouseSinkConfig config) throws Exception {
@@ -242,17 +314,13 @@ public final class ClickHouseSinkJdbcClient implements AutoCloseable {
         if (insertStatement != null) {
             try {
                 insertStatement.clearBatch();
-            } catch (Exception clearFailure) {
-                failure = clearFailure;
+            } catch (Exception cleanupFailure) {
+                LOG.debug("Failed to discard an unflushed ClickHouse batch during close", cleanupFailure);
             }
             try {
                 insertStatement.close();
             } catch (Exception closeFailure) {
-                if (failure == null) {
-                    failure = closeFailure;
-                } else {
-                    failure.addSuppressed(closeFailure);
-                }
+                failure = closeFailure;
             }
         }
         if (connection != null) {

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSinkConfig.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSinkConfig.java
@@ -1,0 +1,200 @@
+package com.link.up.connector.clickhouse.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/** Immutable runtime configuration for the bounded ClickHouse Sink. */
+public final class ClickHouseSinkConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String host;
+    private final String username;
+    private final String password;
+    private final String database;
+    private final String table;
+    private final int batchSize;
+    private final String serverTimeZone;
+    private final Map<String, String> clientConfig;
+
+    private ClickHouseSinkConfig(
+            String host,
+            String username,
+            String password,
+            String database,
+            String table,
+            int batchSize,
+            String serverTimeZone,
+            Map<String, String> clientConfig) {
+        this.host = host;
+        this.username = username;
+        this.password = password;
+        this.database = database;
+        this.table = table;
+        this.batchSize = batchSize;
+        this.serverTimeZone = serverTimeZone;
+        this.clientConfig =
+                Collections.unmodifiableMap(new LinkedHashMap<String, String>(clientConfig));
+    }
+
+    public static ClickHouseSinkConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        String host = normalizeHost(requireText(config.get(ClickHouseSinkOptions.HOST), "host"));
+        String username = requireText(config.get(ClickHouseSinkOptions.USERNAME), "username");
+        String password = config.get(ClickHouseSinkOptions.PASSWORD);
+        String database = requireText(config.get(ClickHouseSinkOptions.DATABASE), "database");
+        String table = requireText(config.get(ClickHouseSinkOptions.TABLE), "table");
+        int batchSize = config.get(ClickHouseSinkOptions.BATCH_SIZE);
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("sink.batch_size must be greater than 0");
+        }
+        String serverTimeZone =
+                normalize(config.getOptional(ClickHouseSinkOptions.SERVER_TIME_ZONE).orElse(null));
+        Map<String, String> rawClientConfig =
+                config.getOptional(ClickHouseSinkOptions.CLICKHOUSE_CONFIG)
+                        .orElse(Collections.<String, String>emptyMap());
+        Map<String, String> clientConfig = normalizeClientConfig(rawClientConfig);
+        validateSafeAcknowledgement(clientConfig);
+
+        return new ClickHouseSinkConfig(
+                host,
+                username,
+                password == null ? "" : password,
+                database,
+                table,
+                batchSize,
+                serverTimeZone,
+                clientConfig);
+    }
+
+    private static String normalizeHost(String value) {
+        if (value.indexOf(',') >= 0) {
+            throw new IllegalArgumentException(
+                    "ClickHouse bounded Sink requires exactly one host. Use one load-balancer, one Distributed-table endpoint, or one explicit node.");
+        }
+        String host = value.trim();
+        while (host.endsWith("/")) {
+            host = host.substring(0, host.length() - 1);
+        }
+        if (host.startsWith("jdbc:")) {
+            throw new IllegalArgumentException(
+                    "ClickHouse sink host must be an HTTP endpoint, not a JDBC URL: " + value);
+        }
+        if (host.indexOf('?') >= 0) {
+            throw new IllegalArgumentException(
+                    "ClickHouse sink host must not contain query parameters; use clickhouse.config instead");
+        }
+        return host;
+    }
+
+    private static Map<String, String> normalizeClientConfig(Map<String, String> input) {
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        for (Map.Entry<String, String> entry : input.entrySet()) {
+            if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+            }
+            String key = entry.getKey().trim();
+            if (key.isEmpty()) {
+                continue;
+            }
+            result.put(key, entry.getValue().trim());
+        }
+        return result;
+    }
+
+    private static void validateSafeAcknowledgement(Map<String, String> clientConfig) {
+        for (Map.Entry<String, String> entry : clientConfig.entrySet()) {
+            String key = entry.getKey().toLowerCase(Locale.ROOT);
+            if ("async_insert".equals(key) && isTrue(entry.getValue())) {
+                throw new IllegalArgumentException(
+                        "ClickHouse bounded Sink owns client-side batching and requires async_insert=0 so executeBatch is the remote durability boundary");
+            }
+            if ("wait_for_async_insert".equals(key) && isFalse(entry.getValue())) {
+                throw new IllegalArgumentException(
+                        "wait_for_async_insert=0 is not allowed because ClickHouse may acknowledge before buffered data is flushed");
+            }
+        }
+    }
+
+    private static boolean isTrue(String value) {
+        if (value == null) {
+            return false;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        return "1".equals(normalized)
+                || "true".equals(normalized)
+                || "yes".equals(normalized)
+                || "on".equals(normalized);
+    }
+
+    private static boolean isFalse(String value) {
+        if (value == null) {
+            return false;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        return "0".equals(normalized)
+                || "false".equals(normalized)
+                || "no".equals(normalized)
+                || "off".equals(normalized);
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static String requireText(String value, String name) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return normalized;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getTable() {
+        return table;
+    }
+
+    public TablePath getTargetPath() {
+        return TablePath.of(database, table);
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public String getServerTimeZone() {
+        return serverTimeZone;
+    }
+
+    public Map<String, String> getClientConfig() {
+        return clientConfig;
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSinkOptions.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/config/ClickHouseSinkOptions.java
@@ -1,0 +1,80 @@
+package com.link.up.connector.clickhouse.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.Map;
+
+/** Options for the bounded ClickHouse JDBC batch Sink. */
+public final class ClickHouseSinkOptions {
+
+    private ClickHouseSinkOptions() {
+    }
+
+    public static final Option<String> HOST =
+            Options.key("host")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Single ClickHouse HTTP endpoint used for bounded batch inserts")
+                    .withSemanticType("CLICKHOUSE_HOST")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("ClickHouse username")
+                    .withSemanticType("USERNAME")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .sensitive()
+                    .withDescription("ClickHouse password")
+                    .withSemanticType("PASSWORD")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> DATABASE =
+            Options.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Target ClickHouse database")
+                    .withSemanticType("DATABASE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> TABLE =
+            Options.key("table")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Target ClickHouse table")
+                    .withSemanticType("TABLE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> BATCH_SIZE =
+            Options.key("sink.batch_size")
+                    .intType()
+                    .defaultValue(10000)
+                    .withFallbackKeys("batch_size", "sink.batch-size")
+                    .withDescription("Rows accumulated before one synchronous ClickHouse executeBatch call")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<String> SERVER_TIME_ZONE =
+            Options.key("server_time_zone")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Explicit ClickHouse server/session time zone used by the JDBC client")
+                    .withSemanticType("TIME_ZONE")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<Map<String, String>> CLICKHOUSE_CONFIG =
+            Options.key("clickhouse.config")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription("Additional ClickHouse JDBC client properties; unsafe async acknowledgement is rejected")
+                    .withSemanticType("CLICKHOUSE_CLIENT_CONFIG")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/converter/ClickHousePreparedStatementBinder.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/converter/ClickHousePreparedStatementBinder.java
@@ -1,0 +1,145 @@
+package com.link.up.connector.clickhouse.converter;
+
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.SqlType;
+
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+/** Binds one FluxRow to a ClickHouse JDBC prepared INSERT without lossy coercion. */
+public final class ClickHousePreparedStatementBinder {
+
+    private final TableSchema sourceSchema;
+
+    public ClickHousePreparedStatementBinder(TableSchema sourceSchema) {
+        this.sourceSchema = Objects.requireNonNull(sourceSchema, "sourceSchema must not be null");
+    }
+
+    public void bind(PreparedStatement statement, FluxRow row) throws Exception {
+        Objects.requireNonNull(statement, "statement must not be null");
+        Objects.requireNonNull(row, "row must not be null");
+        if (row.getArity() != sourceSchema.getColumnCount()) {
+            throw new IllegalArgumentException(
+                    "ClickHouse sink row arity does not match source schema: row="
+                            + row.getArity()
+                            + ", schema="
+                            + sourceSchema.getColumnCount());
+        }
+
+        for (int index = 0; index < sourceSchema.getColumnCount(); index++) {
+            Object value = row.getField(index);
+            int parameter = index + 1;
+            if (value == null) {
+                statement.setObject(parameter, null);
+                continue;
+            }
+            bindValue(statement, parameter, value, sourceSchema.getColumn(index).getDataType());
+        }
+    }
+
+    private static void bindValue(
+            PreparedStatement statement,
+            int parameter,
+            Object value,
+            FluxDataType<?> type)
+            throws Exception {
+        SqlType sqlType = type.getSqlType();
+        switch (sqlType) {
+            case BOOLEAN:
+                statement.setBoolean(parameter, booleanValue(value));
+                return;
+            case TINYINT:
+                statement.setByte(parameter, number(value).byteValue());
+                return;
+            case SMALLINT:
+                statement.setShort(parameter, number(value).shortValue());
+                return;
+            case INT:
+                statement.setInt(parameter, number(value).intValue());
+                return;
+            case BIGINT:
+                statement.setLong(parameter, number(value).longValue());
+                return;
+            case FLOAT:
+                statement.setFloat(parameter, number(value).floatValue());
+                return;
+            case DOUBLE:
+                statement.setDouble(parameter, number(value).doubleValue());
+                return;
+            case DECIMAL:
+                statement.setBigDecimal(parameter, decimalValue(value));
+                return;
+            case STRING:
+                statement.setString(parameter, String.valueOf(value));
+                return;
+            case DATE:
+                if (value instanceof LocalDate) {
+                    statement.setObject(parameter, value);
+                } else if (value instanceof java.sql.Date) {
+                    statement.setObject(parameter, ((java.sql.Date) value).toLocalDate());
+                } else {
+                    statement.setObject(parameter, LocalDate.parse(String.valueOf(value)));
+                }
+                return;
+            case TIMESTAMP:
+                if (value instanceof LocalDateTime) {
+                    statement.setObject(parameter, value);
+                } else if (value instanceof Timestamp) {
+                    statement.setObject(parameter, ((Timestamp) value).toLocalDateTime());
+                } else {
+                    statement.setObject(
+                            parameter,
+                            LocalDateTime.parse(String.valueOf(value).replace(' ', 'T')));
+                }
+                return;
+            case BYTES:
+                throw unsupported(sqlType, "binary sink semantics are not defined for this stage");
+            case TIME:
+                throw unsupported(sqlType, "ClickHouse does not have a standalone TIME column type");
+            case TIMESTAMP_TZ:
+                throw unsupported(sqlType, "timezone conversion must be explicit before the ClickHouse sink");
+            case ARRAY:
+            case MAP:
+            case ROW:
+                throw unsupported(sqlType, "complex values need dedicated ClickHouse conversion semantics");
+            case NULL:
+            default:
+                throw unsupported(sqlType, "unsupported non-null value");
+        }
+    }
+
+    private static Boolean booleanValue(Object value) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+        return Boolean.valueOf(String.valueOf(value));
+    }
+
+    private static Number number(Object value) {
+        if (value instanceof Number) {
+            return (Number) value;
+        }
+        return new BigDecimal(String.valueOf(value));
+    }
+
+    private static BigDecimal decimalValue(Object value) {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        return new BigDecimal(String.valueOf(value));
+    }
+
+    private static IllegalArgumentException unsupported(SqlType type, String detail) {
+        return new IllegalArgumentException(
+                "Unsupported ClickHouse Sink Flux type " + type + ": " + detail);
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkFactory.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkFactory.java
@@ -1,0 +1,59 @@
+package com.link.up.connector.clickhouse.sink;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
+import com.link.up.connector.clickhouse.config.ClickHouseSinkOptions;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** SPI factory for the bounded ClickHouse JDBC batch Sink. */
+@AutoService(SinkFactory.class)
+public final class ClickHouseSinkFactory implements SinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return "clickhouse";
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        ClickHouseSinkOptions.HOST,
+                        ClickHouseSinkOptions.USERNAME,
+                        ClickHouseSinkOptions.DATABASE,
+                        ClickHouseSinkOptions.TABLE)
+                .optional(
+                        ClickHouseSinkOptions.PASSWORD,
+                        ClickHouseSinkOptions.BATCH_SIZE,
+                        ClickHouseSinkOptions.SERVER_TIME_ZONE,
+                        ClickHouseSinkOptions.CLICKHOUSE_CONFIG)
+                .build();
+    }
+
+    @Override
+    public SinkPreparer createPreparer(ReadonlyConfig config) {
+        return new ClickHouseSinkPreparer(ClickHouseSinkConfig.of(config));
+    }
+
+    @Override
+    public SinkWriter<FluxRow> createSink(
+            ReadonlyConfig config,
+            PreparedSinkMetadata metadata) {
+        return new ClickHouseSinkWriter(ClickHouseSinkConfig.of(config), metadata);
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkPreparer.java
@@ -14,6 +14,7 @@ import com.link.up.connector.clickhouse.client.ClickHouseSinkJdbcClient;
 import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
 
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /** Validates one bounded ClickHouse target before task writers start. */
@@ -58,9 +59,9 @@ final class ClickHouseSinkPreparer implements SinkPreparer {
         TableSchema target = targetTable.getTableSchema();
         if (source.getColumnCount() != target.getColumnCount()) {
             throw new IllegalArgumentException(
-                    "ClickHouse Sink Stage 2 requires source and target to have the same column count: source="
+                    "ClickHouse Sink Stage 2 requires the source fields to match all writable target fields: source="
                             + source.getColumnCount()
-                            + ", target="
+                            + ", writableTarget="
                             + target.getColumnCount());
         }
 
@@ -96,6 +97,18 @@ final class ClickHouseSinkPreparer implements SinkPreparer {
             throw new IllegalArgumentException(
                     "Nullable source column cannot be written to non-null ClickHouse target: "
                             + source.getName());
+        }
+
+        if (isInteger(sourceType)
+                && isUnsignedClickHouseType(target.getSourceType())
+                && !isExplicitlyUnsigned(source.getSourceType())) {
+            throw new IllegalArgumentException(
+                    "Signed/unknown integer source cannot be treated as a safe widening into unsigned ClickHouse target for column "
+                            + source.getName()
+                            + ": sourceType="
+                            + source.getSourceType()
+                            + ", targetType="
+                            + target.getSourceType());
         }
 
         if (sourceType == targetType) {
@@ -173,6 +186,37 @@ final class ClickHouseSinkPreparer implements SinkPreparer {
                             + ", target="
                             + targetDecimal);
         }
+    }
+
+    private static boolean isUnsignedClickHouseType(String sourceType) {
+        String value = unwrapTargetType(sourceType);
+        return value != null && value.toUpperCase(Locale.ROOT).startsWith("UINT");
+    }
+
+    private static boolean isExplicitlyUnsigned(String sourceType) {
+        if (sourceType == null) {
+            return false;
+        }
+        String upper = sourceType.trim().toUpperCase(Locale.ROOT);
+        return upper.startsWith("UINT") || upper.contains(" UNSIGNED");
+    }
+
+    private static String unwrapTargetType(String sourceType) {
+        if (sourceType == null) {
+            return null;
+        }
+        String value = sourceType.trim();
+        boolean changed = true;
+        while (changed) {
+            changed = false;
+            if ((value.regionMatches(true, 0, "Nullable(", 0, "Nullable(".length())
+                            || value.regionMatches(true, 0, "LowCardinality(", 0, "LowCardinality(".length()))
+                    && value.endsWith(")")) {
+                value = value.substring(value.indexOf('(') + 1, value.length() - 1).trim();
+                changed = true;
+            }
+        }
+        return value;
     }
 
     private static boolean isInteger(SqlType type) {

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkPreparer.java
@@ -1,0 +1,199 @@
+package com.link.up.connector.clickhouse.sink;
+
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPrepareContext;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.clickhouse.client.ClickHouseSinkJdbcClient;
+import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Validates one bounded ClickHouse target before task writers start. */
+final class ClickHouseSinkPreparer implements SinkPreparer {
+
+    private final ClickHouseSinkConfig config;
+
+    ClickHouseSinkPreparer(ClickHouseSinkConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public PreparedSinkMetadata prepare(SinkPrepareContext context) throws Exception {
+        if (context == null) {
+            throw new IllegalArgumentException("context must not be null");
+        }
+        if (context.getSourceTables().size() != 1) {
+            throw new IllegalArgumentException(
+                    "ClickHouse bounded Sink Stage 2 supports exactly one source table");
+        }
+
+        Map.Entry<TablePath, CatalogTable> sourceEntry =
+                context.getSourceTables().entrySet().iterator().next();
+        CatalogTable sourceTable = sourceEntry.getValue();
+        if (sourceTable == null || sourceTable.getTableSchema() == null) {
+            throw new IllegalArgumentException("ClickHouse Sink requires source table schema");
+        }
+
+        CatalogTable discoveredTarget = ClickHouseSinkJdbcClient.discoverTargetTable(config);
+        CatalogTable preparedTarget = validateAndReorder(sourceTable, discoveredTarget);
+
+        Map<TablePath, CatalogTable> targets =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        targets.put(sourceEntry.getKey(), preparedTarget);
+        return new PreparedSinkMetadata(targets);
+    }
+
+    static CatalogTable validateAndReorder(
+            CatalogTable sourceTable,
+            CatalogTable targetTable) {
+        TableSchema source = sourceTable.getTableSchema();
+        TableSchema target = targetTable.getTableSchema();
+        if (source.getColumnCount() != target.getColumnCount()) {
+            throw new IllegalArgumentException(
+                    "ClickHouse Sink Stage 2 requires source and target to have the same column count: source="
+                            + source.getColumnCount()
+                            + ", target="
+                            + target.getColumnCount());
+        }
+
+        TableSchema.Builder reordered = TableSchema.builder();
+        for (Column sourceColumn : source.getColumns()) {
+            if (!target.contains(sourceColumn.getName())) {
+                throw new IllegalArgumentException(
+                        "ClickHouse target is missing source column: " + sourceColumn.getName());
+            }
+            Column targetColumn = target.getColumn(sourceColumn.getName());
+            validateColumn(sourceColumn, targetColumn);
+            reordered.column(targetColumn);
+        }
+        if (target.getPrimaryKey() != null
+                && source.getColumns().stream()
+                        .map(Column::getName)
+                        .collect(java.util.stream.Collectors.toList())
+                        .containsAll(target.getPrimaryKey().getColumnNames())) {
+            reordered.primaryKey(target.getPrimaryKey());
+        }
+
+        return CatalogTable.builder(targetTable.getTablePath(), reordered.build())
+                .options(targetTable.getOptions())
+                .build();
+    }
+
+    private static void validateColumn(Column source, Column target) {
+        SqlType sourceType = source.getDataType().getSqlType();
+        SqlType targetType = target.getDataType().getSqlType();
+        validateSupportedSourceType(source.getName(), sourceType);
+
+        if (source.isNullable() && !target.isNullable()) {
+            throw new IllegalArgumentException(
+                    "Nullable source column cannot be written to non-null ClickHouse target: "
+                            + source.getName());
+        }
+
+        if (sourceType == targetType) {
+            if (sourceType == SqlType.DECIMAL) {
+                validateDecimal(source, target);
+            }
+            return;
+        }
+
+        if (isInteger(sourceType) && isInteger(targetType)) {
+            if (integerRank(targetType) >= integerRank(sourceType)) {
+                return;
+            }
+        }
+        if (sourceType == SqlType.FLOAT && targetType == SqlType.DOUBLE) {
+            return;
+        }
+
+        throw new IllegalArgumentException(
+                "ClickHouse target type is not a safe bounded-sink mapping for column "
+                        + source.getName()
+                        + ": source="
+                        + sourceType
+                        + ", target="
+                        + target.getSourceType());
+    }
+
+    private static void validateSupportedSourceType(String column, SqlType type) {
+        switch (type) {
+            case BOOLEAN:
+            case TINYINT:
+            case SMALLINT:
+            case INT:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+            case DECIMAL:
+            case STRING:
+            case DATE:
+            case TIMESTAMP:
+                return;
+            case BYTES:
+            case TIME:
+            case TIMESTAMP_TZ:
+            case ARRAY:
+            case MAP:
+            case ROW:
+            case NULL:
+            default:
+                throw new IllegalArgumentException(
+                        "ClickHouse Sink Stage 2 does not support source type "
+                                + type
+                                + " for column "
+                                + column);
+        }
+    }
+
+    private static void validateDecimal(Column source, Column target) {
+        FluxDataType<?> sourceDataType = source.getDataType();
+        FluxDataType<?> targetDataType = target.getDataType();
+        if (!(sourceDataType instanceof DecimalType) || !(targetDataType instanceof DecimalType)) {
+            return;
+        }
+        DecimalType sourceDecimal = (DecimalType) sourceDataType;
+        DecimalType targetDecimal = (DecimalType) targetDataType;
+        int sourceIntegerDigits = sourceDecimal.getPrecision() - sourceDecimal.getScale();
+        int targetIntegerDigits = targetDecimal.getPrecision() - targetDecimal.getScale();
+        if (targetDecimal.getScale() < sourceDecimal.getScale()
+                || targetIntegerDigits < sourceIntegerDigits) {
+            throw new IllegalArgumentException(
+                    "ClickHouse target decimal cannot represent source decimal for column "
+                            + source.getName()
+                            + ": source="
+                            + sourceDecimal
+                            + ", target="
+                            + targetDecimal);
+        }
+    }
+
+    private static boolean isInteger(SqlType type) {
+        return type == SqlType.TINYINT
+                || type == SqlType.SMALLINT
+                || type == SqlType.INT
+                || type == SqlType.BIGINT;
+    }
+
+    private static int integerRank(SqlType type) {
+        switch (type) {
+            case TINYINT:
+                return 1;
+            case SMALLINT:
+                return 2;
+            case INT:
+                return 3;
+            case BIGINT:
+                return 4;
+            default:
+                return -1;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkWriter.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/main/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkWriter.java
@@ -1,0 +1,253 @@
+package com.link.up.connector.clickhouse.sink;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.clickhouse.client.ClickHouseSinkJdbcClient;
+import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+
+/** Bounded ClickHouse writer using one synchronous JDBC prepared batch at a time. */
+public final class ClickHouseSinkWriter implements SinkWriter<FluxRow> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ClickHouseSinkWriter.class);
+
+    private final ClickHouseSinkConfig config;
+    private final PreparedSinkMetadata metadata;
+    private final BatchExecutor batchExecutor;
+
+    private TableSchema sourceSchema;
+    private int pendingRows;
+    private long totalWrittenRows;
+    private long totalBatchRequests;
+    private boolean executorOpened;
+    private boolean opened;
+
+    public ClickHouseSinkWriter(
+            ClickHouseSinkConfig config,
+            PreparedSinkMetadata metadata) {
+        this(config, metadata, new JdbcBatchExecutor(config));
+    }
+
+    ClickHouseSinkWriter(
+            ClickHouseSinkConfig config,
+            PreparedSinkMetadata metadata,
+            BatchExecutor batchExecutor) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
+        this.batchExecutor = Objects.requireNonNull(batchExecutor, "batchExecutor must not be null");
+    }
+
+    @Override
+    public void open() {
+        if (opened) {
+            throw new IllegalStateException("ClickHouseSinkWriter has already been opened");
+        }
+        opened = true;
+        LOG.info(
+                "ClickHouse SinkWriter opened: target={}.{}, batchSize={}, host={}",
+                config.getDatabase(),
+                config.getTable(),
+                config.getBatchSize(),
+                config.getHost());
+    }
+
+    @Override
+    public void write(
+            RecordBatch<FluxRow> batch,
+            CatalogTable sourceTable)
+            throws Exception {
+        checkOpened();
+        if (batch == null || batch.isEndOfInput() || batch.getRecords().isEmpty()) {
+            return;
+        }
+        initializeSchema(sourceTable);
+
+        for (FluxRow row : batch.getRecords()) {
+            batchExecutor.add(row);
+            pendingRows++;
+            if (pendingRows >= config.getBatchSize()) {
+                flush();
+            }
+        }
+    }
+
+    @Override
+    public void prepareCommit() throws Exception {
+        checkOpened();
+        flush();
+    }
+
+    @Override
+    public void commit() {
+        checkOpened();
+        LOG.info(
+                "ClickHouse SinkWriter commit boundary reached: totalWrittenRows={}, totalBatchRequests={}",
+                totalWrittenRows,
+                totalBatchRequests);
+    }
+
+    @Override
+    public void abort() throws Exception {
+        if (executorOpened) {
+            batchExecutor.clearBatch();
+        }
+        pendingRows = 0;
+        LOG.warn(
+                "ClickHouse SinkWriter aborted unsent batch; already successful executeBatch calls cannot be rolled back: writtenRows={}",
+                totalWrittenRows);
+    }
+
+    @Override
+    public CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    @Override
+    public String getRetryAdvice() {
+        return "ClickHouse commits every successful JDBC executeBatch independently. "
+                + "Ambiguous executeBatch failures are not retried automatically; verify already inserted target data before retrying a whole task.";
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        try {
+            if (executorOpened) {
+                batchExecutor.close();
+            }
+        } catch (Exception closeFailure) {
+            failure = closeFailure;
+        } finally {
+            opened = false;
+            executorOpened = false;
+            pendingRows = 0;
+        }
+        LOG.info(
+                "ClickHouse SinkWriter closed without implicit flush: totalWrittenRows={}, totalBatchRequests={}",
+                totalWrittenRows,
+                totalBatchRequests);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private void initializeSchema(CatalogTable sourceTable) throws Exception {
+        if (sourceTable == null || sourceTable.getTableSchema() == null) {
+            throw new IllegalArgumentException("ClickHouse Sink requires CatalogTable schema on write");
+        }
+        TableSchema incoming = sourceTable.getTableSchema();
+        if (sourceSchema != null) {
+            if (!sourceSchema.equals(incoming)) {
+                throw new IllegalArgumentException(
+                        "ClickHouse bounded Sink does not support runtime schema changes");
+            }
+            return;
+        }
+
+        CatalogTable targetTable = metadata.getTargetTable(sourceTable.getTablePath());
+        if (targetTable == null) {
+            throw new IllegalArgumentException(
+                    "Prepared ClickHouse target metadata is missing source table mapping: "
+                            + sourceTable.getTablePath());
+        }
+        sourceSchema = incoming;
+        batchExecutor.open(sourceTable, targetTable);
+        executorOpened = true;
+    }
+
+    private void flush() throws Exception {
+        if (pendingRows == 0) {
+            return;
+        }
+        if (!executorOpened) {
+            throw new IllegalStateException("Cannot flush ClickHouse Sink before schema initialization");
+        }
+        int expectedRows = pendingRows;
+        int flushedRows = batchExecutor.flush();
+        if (flushedRows != expectedRows) {
+            throw new IllegalStateException(
+                    "ClickHouse batch executor flushed an unexpected row count: expected="
+                            + expectedRows
+                            + ", actual="
+                            + flushedRows);
+        }
+        totalWrittenRows += flushedRows;
+        totalBatchRequests++;
+        pendingRows = 0;
+        LOG.debug(
+                "Flushed ClickHouse JDBC batch: rows={}, totalWrittenRows={}",
+                flushedRows,
+                totalWrittenRows);
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("ClickHouseSinkWriter has not been opened");
+        }
+    }
+
+    interface BatchExecutor extends AutoCloseable {
+        void open(CatalogTable sourceTable, CatalogTable targetTable) throws Exception;
+
+        void add(FluxRow row) throws Exception;
+
+        int flush() throws Exception;
+
+        void clearBatch() throws Exception;
+
+        @Override
+        void close() throws Exception;
+    }
+
+    private static final class JdbcBatchExecutor implements BatchExecutor {
+        private final ClickHouseSinkConfig config;
+        private ClickHouseSinkJdbcClient client;
+
+        private JdbcBatchExecutor(ClickHouseSinkConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public void open(CatalogTable sourceTable, CatalogTable targetTable) throws Exception {
+            client =
+                    new ClickHouseSinkJdbcClient(
+                            config,
+                            targetTable,
+                            sourceTable.getTableSchema());
+            client.open();
+        }
+
+        @Override
+        public void add(FluxRow row) throws Exception {
+            client.add(row);
+        }
+
+        @Override
+        public int flush() throws Exception {
+            return client.flush();
+        }
+
+        @Override
+        public void clearBatch() throws Exception {
+            if (client != null) {
+                client.clearBatch();
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (client != null) {
+                client.close();
+                client = null;
+            }
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/ClickHouseConnectorPackageBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/ClickHouseConnectorPackageBoundaryTest.java
@@ -1,6 +1,8 @@
 package com.link.up.connector.clickhouse;
 
+import com.link.up.connector.clickhouse.converter.ClickHousePreparedStatementBinder;
 import com.link.up.connector.clickhouse.converter.ClickHouseResultSetRowConverter;
+import com.link.up.connector.clickhouse.sink.ClickHouseSinkFactory;
 import com.link.up.connector.clickhouse.source.ClickHouseSourceFactory;
 import org.junit.Test;
 
@@ -12,8 +14,9 @@ import static org.junit.Assert.assertFalse;
 public class ClickHouseConnectorPackageBoundaryTest {
 
     @Test
-    public void sourceFactoryUsesStableIdentifier() {
+    public void factoriesUseStableIdentifier() {
         assertEquals("clickhouse", new ClickHouseSourceFactory().factoryIdentifier());
+        assertEquals("clickhouse", new ClickHouseSinkFactory().factoryIdentifier());
     }
 
     @Test
@@ -21,6 +24,9 @@ public class ClickHouseConnectorPackageBoundaryTest {
         assertEquals(
                 "com.link.up.connector.clickhouse.converter",
                 ClickHouseResultSetRowConverter.class.getPackage().getName());
+        assertEquals(
+                "com.link.up.connector.clickhouse.converter",
+                ClickHousePreparedStatementBinder.class.getPackage().getName());
     }
 
     @Test

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClientTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClientTest.java
@@ -6,6 +6,7 @@ import com.link.up.api.table.catalog.Column;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
 import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
 import org.junit.Test;
 
@@ -19,37 +20,40 @@ import static org.junit.Assert.assertTrue;
 public class ClickHouseSinkJdbcClientTest {
 
     @Test
-    public void buildsInputFunctionPreparedInsertInPreparedMetadataOrder() {
+    public void buildsInputFunctionPreparedInsertFromStableFluxTypes() {
+        TableSchema source =
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.LONG_TYPE).nullable(false).build())
+                        .column(Column.builder("name", BasicType.STRING_TYPE).nullable(true).build())
+                        .build();
         CatalogTable target =
                 CatalogTable.builder(
                                 TablePath.of("analytics", "orders"),
                                 TableSchema.builder()
-                                        .column(Column.builder("id", BasicType.LONG_TYPE).sourceType("Int64").build())
-                                        .column(Column.builder("order`name", BasicType.STRING_TYPE).sourceType("Nullable(String)").build())
+                                        .column(Column.builder("id", BasicType.LONG_TYPE).sourceType("Int128").build())
+                                        .column(Column.builder("order`name", BasicType.STRING_TYPE).sourceType("JSON").build())
                                         .build())
                         .build();
 
         assertEquals(
                 "INSERT INTO `analytics`.`orders` (`id`, `order``name`) SELECT c0, c1 FROM input('c0 Int64, c1 Nullable(String)')",
-                ClickHouseSinkJdbcClient.buildInsertSql(target));
+                ClickHouseSinkJdbcClient.buildInsertSql(target, source));
     }
 
     @Test
-    public void escapesQuotesInsideInputTypeDeclaration() {
-        CatalogTable target =
-                CatalogTable.builder(
-                                TablePath.of("analytics", "orders"),
-                                TableSchema.builder()
-                                        .column(
-                                                Column.builder("kind", BasicType.STRING_TYPE)
-                                                        .sourceType("Enum8('a' = 1, 'b' = 2)")
-                                                        .build())
-                                        .build())
-                        .build();
-
+    public void mapsFluxInputTypesWithoutDependingOnTargetTypeParser() {
         assertEquals(
-                "INSERT INTO `analytics`.`orders` (`kind`) SELECT c0 FROM input('c0 Enum8(\\'a\\' = 1, \\'b\\' = 2)')",
-                ClickHouseSinkJdbcClient.buildInsertSql(target));
+                "UInt8",
+                ClickHouseSinkJdbcClient.inputType(
+                        Column.builder("flag", BasicType.BOOLEAN_TYPE).nullable(false).build()));
+        assertEquals(
+                "Nullable(Decimal(20,0))",
+                ClickHouseSinkJdbcClient.inputType(
+                        Column.builder("u64", new DecimalType(20, 0)).nullable(true).build()));
+        assertEquals(
+                "DateTime64(9)",
+                ClickHouseSinkJdbcClient.inputType(
+                        Column.builder("ts", BasicType.TIMESTAMP_TYPE).nullable(false).build()));
     }
 
     @Test

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClientTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClientTest.java
@@ -1,0 +1,52 @@
+package com.link.up.connector.clickhouse.client;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClickHouseSinkJdbcClientTest {
+
+    @Test
+    public void buildsNamedPreparedInsertInPreparedMetadataOrder() {
+        CatalogTable target =
+                CatalogTable.builder(
+                                TablePath.of("analytics", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                                        .column(Column.builder("order`name", BasicType.STRING_TYPE).build())
+                                        .build())
+                        .build();
+
+        assertEquals(
+                "INSERT INTO `analytics`.`orders` (`id`, `order``name`) VALUES (?, ?)",
+                ClickHouseSinkJdbcClient.buildInsertSql(target));
+    }
+
+    @Test
+    public void jdbcUrlPinsSynchronousInsertBoundary() {
+        ClickHouseSinkConfig config = config();
+        assertEquals(
+                "jdbc:clickhouse:http://ch-1:8123/analytics?async_insert=0&wait_for_async_insert=1",
+                ClickHouseSinkJdbcClient.buildSafeJdbcUrl(config));
+    }
+
+    private static ClickHouseSinkConfig config() {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("host", "ch-1:8123");
+        values.put("username", "default");
+        values.put("password", "");
+        values.put("database", "analytics");
+        values.put("table", "orders");
+        return ClickHouseSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClientTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClientTest.java
@@ -13,22 +13,42 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ClickHouseSinkJdbcClientTest {
 
     @Test
-    public void buildsNamedPreparedInsertInPreparedMetadataOrder() {
+    public void buildsInputFunctionPreparedInsertInPreparedMetadataOrder() {
         CatalogTable target =
                 CatalogTable.builder(
                                 TablePath.of("analytics", "orders"),
                                 TableSchema.builder()
-                                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
-                                        .column(Column.builder("order`name", BasicType.STRING_TYPE).build())
+                                        .column(Column.builder("id", BasicType.LONG_TYPE).sourceType("Int64").build())
+                                        .column(Column.builder("order`name", BasicType.STRING_TYPE).sourceType("Nullable(String)").build())
                                         .build())
                         .build();
 
         assertEquals(
-                "INSERT INTO `analytics`.`orders` (`id`, `order``name`) VALUES (?, ?)",
+                "INSERT INTO `analytics`.`orders` (`id`, `order``name`) SELECT c0, c1 FROM input('c0 Int64, c1 Nullable(String)')",
+                ClickHouseSinkJdbcClient.buildInsertSql(target));
+    }
+
+    @Test
+    public void escapesQuotesInsideInputTypeDeclaration() {
+        CatalogTable target =
+                CatalogTable.builder(
+                                TablePath.of("analytics", "orders"),
+                                TableSchema.builder()
+                                        .column(
+                                                Column.builder("kind", BasicType.STRING_TYPE)
+                                                        .sourceType("Enum8('a' = 1, 'b' = 2)")
+                                                        .build())
+                                        .build())
+                        .build();
+
+        assertEquals(
+                "INSERT INTO `analytics`.`orders` (`kind`) SELECT c0 FROM input('c0 Enum8(\\'a\\' = 1, \\'b\\' = 2)')",
                 ClickHouseSinkJdbcClient.buildInsertSql(target));
     }
 
@@ -38,6 +58,15 @@ public class ClickHouseSinkJdbcClientTest {
         assertEquals(
                 "jdbc:clickhouse:http://ch-1:8123/analytics?async_insert=0&wait_for_async_insert=1",
                 ClickHouseSinkJdbcClient.buildSafeJdbcUrl(config));
+    }
+
+    @Test
+    public void materializedAliasAndEphemeralColumnsAreNotWritable() {
+        assertTrue(ClickHouseSinkJdbcClient.isWritableColumn(""));
+        assertTrue(ClickHouseSinkJdbcClient.isWritableColumn("DEFAULT"));
+        assertFalse(ClickHouseSinkJdbcClient.isWritableColumn("MATERIALIZED"));
+        assertFalse(ClickHouseSinkJdbcClient.isWritableColumn("alias"));
+        assertFalse(ClickHouseSinkJdbcClient.isWritableColumn("EPHEMERAL"));
     }
 
     private static ClickHouseSinkConfig config() {

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClientTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/client/ClickHouseSinkJdbcClientTest.java
@@ -30,13 +30,13 @@ public class ClickHouseSinkJdbcClientTest {
                 CatalogTable.builder(
                                 TablePath.of("analytics", "orders"),
                                 TableSchema.builder()
-                                        .column(Column.builder("id", BasicType.LONG_TYPE).sourceType("Int128").build())
+                                        .column(Column.builder("id", BasicType.STRING_TYPE).sourceType("Int128").build())
                                         .column(Column.builder("order`name", BasicType.STRING_TYPE).sourceType("JSON").build())
                                         .build())
                         .build();
 
         assertEquals(
-                "INSERT INTO `analytics`.`orders` (`id`, `order``name`) SELECT c0, c1 FROM input('c0 Int64, c1 Nullable(String)')",
+                "INSERT INTO `analytics`.`orders` (`id`, `order``name`) SELECT CAST(c0 AS Int128), CAST(c1 AS JSON) FROM input('c0 Int64, c1 Nullable(String)')",
                 ClickHouseSinkJdbcClient.buildInsertSql(target, source));
     }
 

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/config/ClickHouseSinkConfigTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/config/ClickHouseSinkConfigTest.java
@@ -1,0 +1,58 @@
+package com.link.up.connector.clickhouse.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClickHouseSinkConfigTest {
+
+    @Test
+    public void parsesBoundedSinkDefaults() {
+        ClickHouseSinkConfig config = ClickHouseSinkConfig.of(ReadonlyConfig.fromMap(base()));
+
+        assertEquals("ch-1:8123", config.getHost());
+        assertEquals("analytics", config.getDatabase());
+        assertEquals("orders", config.getTable());
+        assertEquals(10000, config.getBatchSize());
+        assertEquals("analytics.orders", config.getTargetPath().toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsMultipleSinkHosts() {
+        Map<String, Object> values = base();
+        values.put("host", "ch-1:8123,ch-2:8123");
+        ClickHouseSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsFireAndForgetAsyncAcknowledgement() {
+        Map<String, Object> values = base();
+        Map<String, String> clientConfig = new LinkedHashMap<String, String>();
+        clientConfig.put("wait_for_async_insert", "0");
+        values.put("clickhouse.config", clientConfig);
+        ClickHouseSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsAsyncInsertBecauseWriterOwnsBatchBoundary() {
+        Map<String, Object> values = base();
+        Map<String, String> clientConfig = new LinkedHashMap<String, String>();
+        clientConfig.put("async_insert", "1");
+        values.put("clickhouse.config", clientConfig);
+        ClickHouseSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static Map<String, Object> base() {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("host", "ch-1:8123/");
+        values.put("username", "default");
+        values.put("password", "");
+        values.put("database", "analytics");
+        values.put("table", "orders");
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/converter/ClickHousePreparedStatementBinderTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/converter/ClickHousePreparedStatementBinderTest.java
@@ -1,0 +1,67 @@
+package com.link.up.connector.clickhouse.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxRow;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.math.BigDecimal;
+import java.sql.PreparedStatement;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class ClickHousePreparedStatementBinderTest {
+
+    @Test
+    public void preservesDecimalTextAndLocalDateTime() throws Exception {
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                        .column(Column.builder("u64", new DecimalType(20, 0)).build())
+                        .column(Column.builder("ts", BasicType.TIMESTAMP_TYPE).build())
+                        .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                        .build();
+        ClickHousePreparedStatementBinder binder = new ClickHousePreparedStatementBinder(schema);
+        Map<String, Object[]> calls = new LinkedHashMap<String, Object[]>();
+        PreparedStatement statement = recordingStatement(calls);
+        BigDecimal maxUInt64 = new BigDecimal("18446744073709551615");
+        LocalDateTime timestamp = LocalDateTime.of(2026, 9, 6, 12, 34, 56, 123456000);
+
+        binder.bind(statement, FluxRow.of(7L, maxUInt64, timestamp, "order"));
+
+        assertEquals(7L, ((Long) calls.get("setLong")[1]).longValue());
+        assertEquals(maxUInt64, calls.get("setBigDecimal")[1]);
+        assertSame(timestamp, calls.get("setObject")[1]);
+        assertEquals("order", calls.get("setString")[1]);
+    }
+
+    private static PreparedStatement recordingStatement(final Map<String, Object[]> calls) {
+        return (PreparedStatement)
+                Proxy.newProxyInstance(
+                        ClickHousePreparedStatementBinderTest.class.getClassLoader(),
+                        new Class<?>[] {PreparedStatement.class},
+                        (proxy, method, args) -> {
+                            if (method.getName().startsWith("set")) {
+                                calls.put(method.getName(), args);
+                            }
+                            Class<?> returnType = method.getReturnType();
+                            if (returnType == boolean.class) {
+                                return false;
+                            }
+                            if (returnType == int.class) {
+                                return 0;
+                            }
+                            if (returnType == long.class) {
+                                return 0L;
+                            }
+                            return null;
+                        });
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkPreparerTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkPreparerTest.java
@@ -1,0 +1,80 @@
+package com.link.up.connector.clickhouse.sink;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ClickHouseSinkPreparerTest {
+
+    @Test
+    public void reordersTargetColumnsToSourceOrderAndAllowsIntegerWidening() {
+        CatalogTable source =
+                CatalogTable.builder(
+                                TablePath.of("src", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("id", BasicType.INT_TYPE).nullable(false).build())
+                                        .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                                        .build())
+                        .build();
+
+        CatalogTable target =
+                CatalogTable.builder(
+                                TablePath.of("analytics", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("name", BasicType.STRING_TYPE).sourceType("String").build())
+                                        .column(Column.builder("id", BasicType.LONG_TYPE).nullable(false).sourceType("Int64").build())
+                                        .build())
+                        .build();
+
+        CatalogTable prepared = ClickHouseSinkPreparer.validateAndReorder(source, target);
+
+        assertEquals("id", prepared.getTableSchema().getColumn(0).getName());
+        assertEquals("name", prepared.getTableSchema().getColumn(1).getName());
+        assertEquals("analytics.orders", prepared.getTablePath().toString());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsNullableSourceIntoNonNullableTarget() {
+        CatalogTable source =
+                CatalogTable.builder(
+                                TablePath.of("src", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("id", BasicType.LONG_TYPE).nullable(true).build())
+                                        .build())
+                        .build();
+        CatalogTable target =
+                CatalogTable.builder(
+                                TablePath.of("analytics", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("id", BasicType.LONG_TYPE).nullable(false).sourceType("Int64").build())
+                                        .build())
+                        .build();
+
+        ClickHouseSinkPreparer.validateAndReorder(source, target);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsUnsupportedBinarySource() {
+        CatalogTable source =
+                CatalogTable.builder(
+                                TablePath.of("src", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("payload", BasicType.BYTES_TYPE).build())
+                                        .build())
+                        .build();
+        CatalogTable target =
+                CatalogTable.builder(
+                                TablePath.of("analytics", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("payload", BasicType.STRING_TYPE).sourceType("String").build())
+                                        .build())
+                        .build();
+
+        ClickHouseSinkPreparer.validateAndReorder(source, target);
+    }
+}

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkPreparerTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkPreparerTest.java
@@ -12,12 +12,12 @@ import static org.junit.Assert.assertEquals;
 public class ClickHouseSinkPreparerTest {
 
     @Test
-    public void reordersTargetColumnsToSourceOrderAndAllowsIntegerWidening() {
+    public void reordersTargetColumnsToSourceOrderAndAllowsSignedIntegerWidening() {
         CatalogTable source =
                 CatalogTable.builder(
                                 TablePath.of("src", "orders"),
                                 TableSchema.builder()
-                                        .column(Column.builder("id", BasicType.INT_TYPE).nullable(false).build())
+                                        .column(Column.builder("id", BasicType.INT_TYPE).nullable(false).sourceType("Int32").build())
                                         .column(Column.builder("name", BasicType.STRING_TYPE).build())
                                         .build())
                         .build();
@@ -39,12 +39,52 @@ public class ClickHouseSinkPreparerTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
+    public void rejectsSignedSourceIntoUnsignedTargetEvenWhenFluxWidthLooksWider() {
+        CatalogTable source =
+                CatalogTable.builder(
+                                TablePath.of("src", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("id", BasicType.INT_TYPE).nullable(false).sourceType("INTEGER").build())
+                                        .build())
+                        .build();
+        CatalogTable target =
+                CatalogTable.builder(
+                                TablePath.of("analytics", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("id", BasicType.INT_TYPE).nullable(false).sourceType("UInt16").build())
+                                        .build())
+                        .build();
+
+        ClickHouseSinkPreparer.validateAndReorder(source, target);
+    }
+
+    @Test
+    public void allowsExplicitUnsignedSourceIntoSameUnsignedTarget() {
+        CatalogTable source =
+                CatalogTable.builder(
+                                TablePath.of("src", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("id", BasicType.INT_TYPE).nullable(false).sourceType("UInt16").build())
+                                        .build())
+                        .build();
+        CatalogTable target =
+                CatalogTable.builder(
+                                TablePath.of("analytics", "orders"),
+                                TableSchema.builder()
+                                        .column(Column.builder("id", BasicType.INT_TYPE).nullable(false).sourceType("UInt16").build())
+                                        .build())
+                        .build();
+
+        ClickHouseSinkPreparer.validateAndReorder(source, target);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void rejectsNullableSourceIntoNonNullableTarget() {
         CatalogTable source =
                 CatalogTable.builder(
                                 TablePath.of("src", "orders"),
                                 TableSchema.builder()
-                                        .column(Column.builder("id", BasicType.LONG_TYPE).nullable(true).build())
+                                        .column(Column.builder("id", BasicType.LONG_TYPE).nullable(true).sourceType("Int64").build())
                                         .build())
                         .build();
         CatalogTable target =

--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkWriterTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkWriterTest.java
@@ -1,0 +1,173 @@
+package com.link.up.connector.clickhouse.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.clickhouse.config.ClickHouseSinkConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClickHouseSinkWriterTest {
+
+    @Test
+    public void flushesAtThresholdAndPrepareCommitFlushesRemainder() throws Exception {
+        ClickHouseSinkConfig config = config(2);
+        CatalogTable source = sourceTable(schema());
+        RecordingExecutor executor = new RecordingExecutor();
+        ClickHouseSinkWriter writer = writer(config, source, executor);
+
+        writer.open();
+        writer.write(
+                RecordBatch.data(
+                        Arrays.asList(
+                                FluxRow.of(1L, "a"),
+                                FluxRow.of(2L, "b"),
+                                FluxRow.of(3L, "c"))),
+                source);
+
+        assertEquals(1, executor.flushCount);
+        assertEquals(1, executor.pendingRows);
+
+        writer.prepareCommit();
+        assertEquals(2, executor.flushCount);
+        assertEquals(0, executor.pendingRows);
+
+        writer.commit();
+        writer.close();
+        assertTrue(executor.closed);
+    }
+
+    @Test
+    public void abortClearsPendingAndCloseDoesNotFlush() throws Exception {
+        ClickHouseSinkConfig config = config(10);
+        CatalogTable source = sourceTable(schema());
+        RecordingExecutor executor = new RecordingExecutor();
+        ClickHouseSinkWriter writer = writer(config, source, executor);
+
+        writer.open();
+        writer.write(
+                RecordBatch.data(Collections.singletonList(FluxRow.of(1L, "a"))),
+                source);
+        assertEquals(1, executor.pendingRows);
+        assertEquals(0, executor.flushCount);
+
+        writer.abort();
+        assertEquals(0, executor.pendingRows);
+        writer.close();
+
+        assertEquals(0, executor.flushCount);
+        assertTrue(executor.closed);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsRuntimeSchemaChanges() throws Exception {
+        ClickHouseSinkConfig config = config(10);
+        CatalogTable source = sourceTable(schema());
+        RecordingExecutor executor = new RecordingExecutor();
+        ClickHouseSinkWriter writer = writer(config, source, executor);
+
+        TableSchema changed =
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                        .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                        .column(Column.builder("extra", BasicType.STRING_TYPE).build())
+                        .build();
+
+        writer.open();
+        try {
+            writer.write(
+                    RecordBatch.data(Collections.singletonList(FluxRow.of(1L, "a"))),
+                    source);
+            writer.write(
+                    RecordBatch.data(Collections.singletonList(FluxRow.of(2L, "b", "x"))),
+                    sourceTable(changed));
+        } finally {
+            writer.close();
+        }
+    }
+
+    private static ClickHouseSinkWriter writer(
+            ClickHouseSinkConfig config,
+            CatalogTable source,
+            RecordingExecutor executor) {
+        Map<TablePath, CatalogTable> targets = new LinkedHashMap<TablePath, CatalogTable>();
+        targets.put(
+                source.getTablePath(),
+                CatalogTable.builder(TablePath.of("analytics", "orders"), source.getTableSchema())
+                        .build());
+        return new ClickHouseSinkWriter(config, new PreparedSinkMetadata(targets), executor);
+    }
+
+    private static ClickHouseSinkConfig config(int batchSize) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("host", "ch-1:8123");
+        values.put("username", "default");
+        values.put("password", "");
+        values.put("database", "analytics");
+        values.put("table", "orders");
+        values.put("sink.batch_size", batchSize);
+        return ClickHouseSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static TableSchema schema() {
+        return TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .build();
+    }
+
+    private static CatalogTable sourceTable(TableSchema schema) {
+        return CatalogTable.builder(TablePath.of("source", "orders"), schema).build();
+    }
+
+    private static final class RecordingExecutor implements ClickHouseSinkWriter.BatchExecutor {
+        private int pendingRows;
+        private int flushCount;
+        private boolean opened;
+        private boolean closed;
+
+        @Override
+        public void open(CatalogTable sourceTable, CatalogTable targetTable) {
+            opened = true;
+        }
+
+        @Override
+        public void add(FluxRow row) {
+            if (!opened) {
+                throw new IllegalStateException("not open");
+            }
+            pendingRows++;
+        }
+
+        @Override
+        public int flush() {
+            int rows = pendingRows;
+            pendingRows = 0;
+            flushCount++;
+            return rows;
+        }
+
+        @Override
+        public void clearBatch() {
+            pendingRows = 0;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Stage 2 bounded/offline ClickHouse Sink support to the existing standalone `link-up-connector-clickhouse` module.

The write path is deliberately simple and explicit:

`FluxRow -> prepared target metadata -> JDBC input() prepared batch -> executeBatch() -> ClickHouse synchronous acknowledgement`

This PR does not add CDC, mutation/update semantics, streaming checkpoints, or job-level transaction claims.

## Design references

The implementation follows the mature ClickHouse/SeaTunnel write direction while keeping the Link-Up stage narrower:

- ClickHouse officially recommends client-side batching for synchronous inserts and its Java/JDBC examples use `PreparedStatement.addBatch()` + `executeBatch()`.
- `clickhouse-jdbc 0.3.2-patch11`, already used by the ClickHouse Source module, performs better for batch writes through the `input(...)` table function than by composing long `VALUES (?,...)` batches.
- ClickHouse 26.3 LTS enables async inserts by default. This bounded Sink explicitly pins `async_insert=0` and `wait_for_async_insert=1` so a successful `executeBatch()` remains the remote durability boundary regardless of server/user defaults.

## What changed

- add `ClickHouseSinkFactory` with the stable `clickhouse` identifier
- add bounded Sink configuration for `host`, credentials, target database/table, batch size, timezone, and ClickHouse JDBC properties
- require exactly one write endpoint; no connector-side round-robin/failover after ambiguous insert outcomes
- reject conflicting async insert acknowledgement settings
- default client-side batch size to `10000`
- add preparation-time target discovery through `system.columns`
- exclude `MATERIALIZED`, `ALIAS`, and `EPHEMERAL` columns from writable target metadata
- require one source table and one existing ClickHouse target table
- validate source/target column names and nullability before writers start
- reorder prepared target columns to source order so physical target order cannot misroute values
- allow only safe signed integer widening
- treat ClickHouse `UInt*` specially so a signed/unknown source is not mislabeled as a safe widening
- validate Decimal precision/scale containment
- add scalar prepared-statement binding for boolean, integer, floating point, decimal, string, date, and timestamp values
- bind `LocalDateTime` directly for timestamp values instead of forcing a `java.sql.Timestamp` timezone reinterpretation
- use stable Flux-derived `input(...)` types so the old JDBC parser does not need to understand every target-side modern ClickHouse type
- explicitly `CAST` input fields to the discovered target ClickHouse type on the server
- use `PreparedStatement.addBatch()` and `executeBatch()` for client-side batching
- do not retry ambiguous `executeBatch()` failures automatically
- `prepareCommit()` flushes the remaining batch
- `commit()` is a Link-Up lifecycle boundary only; it does not call a fake JDBC/database transaction commit
- `abort()` clears only the unsent local batch
- `close()` never performs an implicit flush
- document Stage 2 semantics and non-goals in the ClickHouse connector README

## Sink configuration

```hocon
sink {
  ClickHouse {
    host = "ch-write:8123"
    username = "default"
    password = ""
    database = "analytics"
    table = "orders"

    sink.batch_size = 10000
    server_time_zone = "UTC"

    clickhouse.config = {
      socket_timeout = "300000"
    }
  }
}
```

`sink.batch_size` also accepts `batch_size` / `sink.batch-size` as compatibility keys.

## Durability / retry boundary

Each successful ClickHouse `executeBatch()` is already a remote write and cannot be rolled back by a later Link-Up task abort.

The writer therefore reports `TASK_LOCAL` commit scope and does not claim job-level exactly once. An ambiguous network failure during `executeBatch()` is propagated without an automatic replay because retrying the same batch can duplicate rows.

Whole-task retries must verify already inserted target data first or rely on explicit target-side deduplication/key semantics.

## Type boundary

Stage 2 accepts these Flux scalar values:

- BOOLEAN
- TINYINT / SMALLINT / INT / BIGINT
- FLOAT / DOUBLE
- DECIMAL
- STRING
- DATE
- TIMESTAMP

The `input(...)` temporary schema is derived from stable Flux types (`UInt8` for boolean, signed integer widths, `Decimal(p,s)`, `String`, `Date32`, `DateTime64(9)`), then ClickHouse performs an explicit server-side cast to the discovered target type.

The following remain fail-fast in this stage:

- BYTES
- standalone TIME
- TIMESTAMP_TZ
- ARRAY
- MAP
- ROW/TUPLE/NESTED

These require explicit binary/timezone/complex target semantics rather than implicit coercion.

## Scope / non-goals

This remains a bounded/offline Sink. It intentionally does **not** add:

- CDC or continuous streaming writes
- UPDATE / DELETE / ClickHouse mutation semantics
- ReplacingMergeTree interpreted as a generic UPSERT API
- exactly-once streaming checkpoint semantics
- XA or job-level database transactions
- automatic target table creation
- runtime schema evolution
- connector-side host failover after ambiguous writes
- automatic replay retries for failed `executeBatch()` calls
- complex ARRAY/MAP/TUPLE/NESTED bindings

## Tests added

Coverage includes:

- bounded Sink defaults
- multi-host rejection
- unsafe async acknowledgement rejection
- target-column reordering
- nullable source -> non-null target rejection
- safe signed integer widening
- signed/unknown source -> UInt target rejection
- explicit unsigned source compatibility
- unsupported binary source rejection
- `input(...)` prepared INSERT generation
- stable Flux input type generation
- synchronous insert URL settings
- generated-column writability filtering
- exact `UInt64` BigDecimal binding path
- `LocalDateTime` timestamp binding
- row-threshold flush
- `prepareCommit()` remainder flush
- `abort()` pending batch discard
- `close()` no implicit flush
- runtime schema-change rejection
- Source/Sink factory identifier package boundary

## Validation note

The implementation was statically reviewed against:

- Apache SeaTunnel ClickHouse Sink implementation and connector architecture
- ClickHouse official Java/JDBC batch insert guidance
- ClickHouse async insert acknowledgement guidance/current 26.3 behavior
- current Link-Up `SinkFactory` / `SinkPreparer` / `SinkWriter` lifecycle

A repository-side Maven test and a real ClickHouse smoke test are still required before merge. Suggested merge gate:

`mvn -pl link-up-connectors/link-up-connector-clickhouse -am test`

Then run one real target test with:

- a MergeTree target
- a MATERIALIZED column
- `UInt64`
- `DateTime64`
- at least two client batches
- one `prepareCommit()` tail flush

The PR is intentionally left as Draft until those checks are complete.