### PR TITLE
chore(elasticsearch): establish versioned connector module boundaries

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -39,10 +39,28 @@ internal
 
 JDBC 历史 `core/converter`、`core/dialect`、`core/split` 暂时保留，但不得新增新的 `core/*` 子域。
 
+### 多 Major Version Connector Family
+
+同一个外部系统存在不兼容的 Major Version SDK 时，可以拆成一个 family common 模块和多个版本叶子模块，例如 Elasticsearch：
+
+```text
+elasticsearch-common -> api
+elasticsearch7       -> elasticsearch-common + ES7 SDK
+elasticsearch8       -> elasticsearch-common + ES8 SDK
+```
+
+边界规则：
+
+- family common 模块只放 Link-Up / 产品公共语义，不得依赖任一版本的 vendor SDK。
+- 版本 SDK 只能存在于对应的叶子模块，版本叶子之间不得互相依赖。
+- 对外 connector identifier 必须体现不兼容的 Major Version，例如 `elasticsearch7` / `elasticsearch8`。
+- 如果多个叶子模块依赖同一个 Maven GAV 的不兼容版本，在 classloader / relocation 等隔离机制完成前，禁止同时平铺进 `launcher` / `server` runtime classpath。
+- “拆 Maven module”不是 runtime dependency isolation；是否能进入发行包必须单独验证。
+
 ## 第三方依赖原则
 
 - 能用 JDK 解决的简单问题，不额外引库。
-- 依赖版本由根 POM / BOM 统一管理。
+- 依赖版本由根 POM / BOM 统一管理；多 Major Version family 使用独立的版本属性显式 pin。
 - Connector 专用 SDK 放在 Connector 模块，不泄漏到 API。
 - Server 的 HTTP、JSON、日志依赖不能进入 `link-up-api`。
 - 测试依赖使用 test scope。

--- a/link-up-connectors/ELASTICSEARCH.md
+++ b/link-up-connectors/ELASTICSEARCH.md
@@ -1,0 +1,72 @@
+# Elasticsearch Connector Family
+
+Stage 0 只建立模块与依赖边界，不实现 Source / Sink，也不注册 SPI factory。
+
+## Module layout
+
+```text
+link-up-connector-elasticsearch-common
+  -> link-up-api
+
+link-up-connector-elasticsearch7
+  -> elasticsearch-common
+  -> ES 7.17 High Level REST Client
+
+link-up-connector-elasticsearch8
+  -> elasticsearch-common
+  -> ES 8.19 Java API Client
+```
+
+对外预留两个独立 connector identifier：
+
+```text
+elasticsearch7
+elasticsearch8
+```
+
+`elasticsearch-common` 不是用户可选择的 Connector，只承载两个版本都能复用的 Link-Up / Elasticsearch 产品语义。
+
+## Dependency boundary
+
+`elasticsearch-common` 不允许 import 或依赖任何 Elasticsearch vendor SDK。
+
+版本依赖只能存在于叶子模块：
+
+```text
+common  -X-> ES SDK
+es7     -X-> es8
+es8     -X-> es7
+```
+
+当前版本 pin：
+
+- ES7 client: `org.elasticsearch.client:elasticsearch-rest-high-level-client:7.17.29`
+- ES8 client: `co.elastic.clients:elasticsearch-java:8.19.21`
+
+ES8 8.19 仍支持 Java 8。Stage 0 排除 `elasticsearch-java` 的 Jackson 3 runtime artifacts，避免把 Java 17-only mapper implementation 带入 Link-Up 的 Java 8 基线；具体 JSON mapper 在 ES8 implementation stage 再决定。
+
+## Runtime boundary
+
+Link-Up 当前 `launcher` 会直接依赖 built-in connectors，`dist` 再把 runtime dependencies 平铺到同一个 `lib/` classpath。
+
+ES7 High Level REST Client 和 ES8 Java API Client 都会使用 `org.elasticsearch.client:elasticsearch-rest-client`，但版本不同。因此仅拆 Maven module 不能保证两个版本同时运行时安全。
+
+Stage 0 明确禁止把 `elasticsearch7` / `elasticsearch8` 直接加入 `link-up-launcher` 或 `link-up-server`。测试会守住这个边界，直到后续引入并验证 connector classloader isolation、shade/relocation 或其他等价的 dependency island 方案。
+
+## Stage boundary
+
+Stage 0 包含：
+
+- `common / es7 / es8` 三个 Maven module
+- 独立 client version pin
+- 稳定且不同的 connector identifiers
+- compile/test classpath 隔离测试
+- flattened runtime guard
+
+Stage 0 不包含：
+
+- Source / Sink factory
+- Schema / mapping / query / bulk 实现
+- Catalog
+- runtime plugin loader 改造
+- CDC、实时同步或 RowKind 语义

--- a/link-up-connectors/link-up-connector-elasticsearch-common/pom.xml
+++ b/link-up-connectors/link-up-connector-elasticsearch-common/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.link.up</groupId>
+        <artifactId>link-up-connectors</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>link-up-connector-elasticsearch-common</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/link-up-connectors/link-up-connector-elasticsearch-common/src/main/java/com/link/up/connector/elasticsearch/ElasticsearchConnectorFamily.java
+++ b/link-up-connectors/link-up-connector-elasticsearch-common/src/main/java/com/link/up/connector/elasticsearch/ElasticsearchConnectorFamily.java
@@ -1,0 +1,17 @@
+package com.link.up.connector.elasticsearch;
+
+/**
+ * Stable identifiers shared by the versioned Elasticsearch connector modules.
+ *
+ * <p>This class intentionally contains no Elasticsearch SDK types. The common module is the
+ * product-semantic boundary shared by Elasticsearch 7 and 8, not a runtime connector itself.
+ */
+public final class ElasticsearchConnectorFamily {
+
+    public static final String FAMILY_IDENTIFIER = "elasticsearch";
+    public static final String ELASTICSEARCH7_IDENTIFIER = "elasticsearch7";
+    public static final String ELASTICSEARCH8_IDENTIFIER = "elasticsearch8";
+
+    private ElasticsearchConnectorFamily() {
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch-common/src/test/java/com/link/up/connector/elasticsearch/ElasticsearchCommonDependencyBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch-common/src/test/java/com/link/up/connector/elasticsearch/ElasticsearchCommonDependencyBoundaryTest.java
@@ -52,13 +52,25 @@ public class ElasticsearchCommonDependencyBoundaryTest {
     }
 
     private static String readRepositoryFile(String relativePath) throws IOException {
-        Path moduleDirectory = Paths.get("").toAbsolutePath();
-        Path repositoryRoot = moduleDirectory.getParent().getParent();
-        Path file = repositoryRoot.resolve(relativePath);
+        Path file = findRepositoryRoot().resolve(relativePath);
         if (!Files.isRegularFile(file)) {
             fail("Expected repository file does not exist: " + file);
         }
         return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+    }
+
+    private static Path findRepositoryRoot() {
+        Path current = Paths.get("").toAbsolutePath();
+        while (current != null) {
+            if (Files.isRegularFile(current.resolve("pom.xml"))
+                    && Files.isDirectory(current.resolve("link-up-connectors"))
+                    && Files.isDirectory(current.resolve("link-up-launcher"))) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        fail("Could not locate Link-Up repository root from current working directory");
+        return Paths.get("");
     }
 
     private static void assertClassNotPresent(String className) {

--- a/link-up-connectors/link-up-connector-elasticsearch-common/src/test/java/com/link/up/connector/elasticsearch/ElasticsearchCommonDependencyBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch-common/src/test/java/com/link/up/connector/elasticsearch/ElasticsearchCommonDependencyBoundaryTest.java
@@ -1,0 +1,72 @@
+package com.link.up.connector.elasticsearch;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class ElasticsearchCommonDependencyBoundaryTest {
+
+    @Test
+    public void commonModuleMustNotSeeVersionedElasticsearchSdk() {
+        assertClassNotPresent("org.elasticsearch.client.RestHighLevelClient");
+        assertClassNotPresent("co.elastic.clients.elasticsearch.ElasticsearchClient");
+    }
+
+    @Test
+    public void connectorIdentifiersAreStableAndDistinct() {
+        assertTrue(ElasticsearchConnectorFamily.ELASTICSEARCH7_IDENTIFIER.startsWith(
+                ElasticsearchConnectorFamily.FAMILY_IDENTIFIER));
+        assertTrue(ElasticsearchConnectorFamily.ELASTICSEARCH8_IDENTIFIER.startsWith(
+                ElasticsearchConnectorFamily.FAMILY_IDENTIFIER));
+        assertNotEquals(
+                ElasticsearchConnectorFamily.ELASTICSEARCH7_IDENTIFIER,
+                ElasticsearchConnectorFamily.ELASTICSEARCH8_IDENTIFIER);
+    }
+
+    @Test
+    public void versionedConnectorsMustNotBeFlattenedIntoCurrentRuntimeClasspath()
+            throws IOException {
+        String launcherPom = readRepositoryFile("link-up-launcher/pom.xml");
+        String serverPom = readRepositoryFile("link-up-server/pom.xml");
+
+        assertNotFlattened(launcherPom, "link-up-launcher");
+        assertNotFlattened(serverPom, "link-up-server");
+    }
+
+    private static void assertNotFlattened(String pom, String moduleName) {
+        assertFalse(
+                moduleName + " must not directly depend on Elasticsearch 7 before runtime isolation exists",
+                pom.contains("<artifactId>link-up-connector-elasticsearch7</artifactId>"));
+        assertFalse(
+                moduleName + " must not directly depend on Elasticsearch 8 before runtime isolation exists",
+                pom.contains("<artifactId>link-up-connector-elasticsearch8</artifactId>"));
+    }
+
+    private static String readRepositoryFile(String relativePath) throws IOException {
+        Path moduleDirectory = Paths.get("").toAbsolutePath();
+        Path repositoryRoot = moduleDirectory.getParent().getParent();
+        Path file = repositoryRoot.resolve(relativePath);
+        if (!Files.isRegularFile(file)) {
+            fail("Expected repository file does not exist: " + file);
+        }
+        return new String(Files.readAllBytes(file), StandardCharsets.UTF_8);
+    }
+
+    private static void assertClassNotPresent(String className) {
+        try {
+            Class.forName(className);
+            fail("Version-specific Elasticsearch SDK leaked into common module: " + className);
+        } catch (ClassNotFoundException expected) {
+            // Expected: common deliberately has no Elasticsearch SDK dependency.
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/pom.xml
+++ b/link-up-connectors/link-up-connector-elasticsearch7/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.link.up</groupId>
+        <artifactId>link-up-connectors</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>link-up-connector-elasticsearch7</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-connector-elasticsearch-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${elasticsearch7.client.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/Elasticsearch7ConnectorIdentity.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/Elasticsearch7ConnectorIdentity.java
@@ -1,0 +1,14 @@
+package com.link.up.connector.elasticsearch7;
+
+import com.link.up.connector.elasticsearch.ElasticsearchConnectorFamily;
+
+/** Stage 0 identity boundary for the Elasticsearch 7 connector. */
+public final class Elasticsearch7ConnectorIdentity {
+
+    public static final String IDENTIFIER =
+            ElasticsearchConnectorFamily.ELASTICSEARCH7_IDENTIFIER;
+    public static final int MAJOR_VERSION = 7;
+
+    private Elasticsearch7ConnectorIdentity() {
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/Elasticsearch7DependencyBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/Elasticsearch7DependencyBoundaryTest.java
@@ -1,0 +1,29 @@
+package com.link.up.connector.elasticsearch7;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch7DependencyBoundaryTest {
+
+    @Test
+    public void moduleOwnsElasticsearch7SdkOnly() {
+        assertEquals("elasticsearch7", Elasticsearch7ConnectorIdentity.IDENTIFIER);
+        assertEquals(7, Elasticsearch7ConnectorIdentity.MAJOR_VERSION);
+        assertEquals(
+                "org.elasticsearch.client.RestHighLevelClient",
+                RestHighLevelClient.class.getName());
+        assertClassNotPresent("co.elastic.clients.elasticsearch.ElasticsearchClient");
+    }
+
+    private static void assertClassNotPresent(String className) {
+        try {
+            Class.forName(className);
+            fail("Elasticsearch 8 SDK leaked into Elasticsearch 7 module: " + className);
+        } catch (ClassNotFoundException expected) {
+            // Expected: ES7 and ES8 SDK classpaths stay separate at module level.
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/pom.xml
+++ b/link-up-connectors/link-up-connector-elasticsearch8/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.link.up</groupId>
+        <artifactId>link-up-connectors</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>link-up-connector-elasticsearch8</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-connector-elasticsearch-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
+            <version>${elasticsearch8.client.version}</version>
+            <exclusions>
+                <!-- Jackson 3 requires Java 17. Link-Up remains on Java 8 in Stage 0. -->
+                <exclusion>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>tools.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/Elasticsearch8ConnectorIdentity.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/Elasticsearch8ConnectorIdentity.java
@@ -1,0 +1,14 @@
+package com.link.up.connector.elasticsearch8;
+
+import com.link.up.connector.elasticsearch.ElasticsearchConnectorFamily;
+
+/** Stage 0 identity boundary for the Elasticsearch 8 connector. */
+public final class Elasticsearch8ConnectorIdentity {
+
+    public static final String IDENTIFIER =
+            ElasticsearchConnectorFamily.ELASTICSEARCH8_IDENTIFIER;
+    public static final int MAJOR_VERSION = 8;
+
+    private Elasticsearch8ConnectorIdentity() {
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/Elasticsearch8DependencyBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/Elasticsearch8DependencyBoundaryTest.java
@@ -1,0 +1,29 @@
+package com.link.up.connector.elasticsearch8;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch8DependencyBoundaryTest {
+
+    @Test
+    public void moduleOwnsElasticsearch8SdkOnly() {
+        assertEquals("elasticsearch8", Elasticsearch8ConnectorIdentity.IDENTIFIER);
+        assertEquals(8, Elasticsearch8ConnectorIdentity.MAJOR_VERSION);
+        assertEquals(
+                "co.elastic.clients.elasticsearch.ElasticsearchClient",
+                ElasticsearchClient.class.getName());
+        assertClassNotPresent("org.elasticsearch.client.RestHighLevelClient");
+    }
+
+    private static void assertClassNotPresent(String className) {
+        try {
+            Class.forName(className);
+            fail("Elasticsearch 7 SDK leaked into Elasticsearch 8 module: " + className);
+        } catch (ClassNotFoundException expected) {
+            // Expected: ES8 and ES7 SDK classpaths stay separate at module level.
+        }
+    }
+}

--- a/link-up-connectors/pom.xml
+++ b/link-up-connectors/pom.xml
@@ -20,6 +20,9 @@
         <module>link-up-connector-http</module>
         <module>link-up-connector-starrocks</module>
         <module>link-up-connector-clickhouse</module>
+        <module>link-up-connector-elasticsearch-common</module>
+        <module>link-up-connector-elasticsearch7</module>
+        <module>link-up-connector-elasticsearch8</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,8 @@
         <jackson.version>2.15.4</jackson.version>
         <starrocks.thrift.sdk.version>1.0.1</starrocks.thrift.sdk.version>
         <arrow.version>5.0.0</arrow.version>
+        <elasticsearch7.client.version>7.17.29</elasticsearch7.client.version>
+        <elasticsearch8.client.version>8.19.21</elasticsearch8.client.version>
 
 
     </properties>


### PR DESCRIPTION
## Summary

Establish Elasticsearch Stage 0 module and dependency boundaries before implementing any Source/Sink behavior.

### Module layout

- `link-up-connector-elasticsearch-common`
  - shared Link-Up / Elasticsearch family semantics only
  - intentionally has no Elasticsearch vendor SDK dependency
- `link-up-connector-elasticsearch7`
  - reserved connector identifier: `elasticsearch7`
  - pins `elasticsearch-rest-high-level-client:7.17.29`
- `link-up-connector-elasticsearch8`
  - reserved connector identifier: `elasticsearch8`
  - pins `elasticsearch-java:8.19.21`
  - excludes Jackson 3 runtime artifacts so Stage 0 does not raise Link-Up's Java 8 baseline

## Dependency boundary

The versioned leaves depend on `elasticsearch-common`, never on each other. `common` must not see either vendor SDK.

Stage 0 deliberately does **not** add Elasticsearch 7/8 to `link-up-launcher` or `link-up-server`. The current distribution flattens runtime dependencies into one classpath, while ES7 and ES8 both bring incompatible versions of `org.elasticsearch.client:elasticsearch-rest-client`. Splitting Maven modules alone is therefore not treated as runtime isolation.

Boundary tests cover:

- common module cannot load ES7/ES8 SDK classes
- ES7 module sees the ES7 client but not the ES8 Java client
- ES8 module sees the ES8 Java client but not the ES7 high-level client
- current launcher/server POMs must not flatten either versioned connector before an isolation mechanism is introduced
- versioned connector identifiers remain distinct and stable

## Scope

Included:

- `common / es7 / es8` Maven modules
- independent client version pins
- connector identity boundaries
- dependency/runtime boundary documentation
- boundary tests

Not included:

- Source / Sink factories
- schema mapping, query, scroll/PIT, bulk write, catalog
- connector classloader or shade/relocation implementation
- CDC / streaming / RowKind semantics

## Validation

- Compared branch against `main`: 13 changed files, 2 commits, no unrelated changes.
- Elastic 7.17 documentation confirms the High Level REST Client requires Java 8+.
- Elastic 8.19 Java API Client documentation confirms Java 8+ support; Jackson 3 is Java 17+, so its runtime artifacts are excluded in the ES8 leaf for Stage 0.
- Maven execution could not be run from the current ChatGPT container because outbound DNS/network access is unavailable, and this repository currently has no `.github/workflows` CI to execute the build remotely.

## Next stage

Stage 1 can implement the bounded Elasticsearch 7 Source inside `link-up-connector-elasticsearch7` while keeping the runtime packaging boundary explicit.