### PR TITLE
feat(elasticsearch): add bounded Elasticsearch 7 source

### DIFF
--- a/link-up-connectors/ELASTICSEARCH.md
+++ b/link-up-connectors/ELASTICSEARCH.md
@@ -1,8 +1,13 @@
 # Elasticsearch Connector Family
 
-Stage 0 只建立模块与依赖边界，不实现 Source / Sink，也不注册 SPI factory。
+Elasticsearch 按产品族维护，但运行时对外保留两个明确的 connector identifier：
 
-## Module layout
+```text
+elasticsearch7
+elasticsearch8
+```
+
+代码模块保持三层：
 
 ```text
 link-up-connector-elasticsearch-common
@@ -17,18 +22,9 @@ link-up-connector-elasticsearch8
   -> ES 8.19 Java API Client
 ```
 
-对外预留两个独立 connector identifier：
-
-```text
-elasticsearch7
-elasticsearch8
-```
-
-`elasticsearch-common` 不是用户可选择的 Connector，只承载两个版本都能复用的 Link-Up / Elasticsearch 产品语义。
+`elasticsearch-common` 不是用户可选择的 Connector，只承载两个版本都能复用的 Link-Up / Elasticsearch 产品语义，并且不允许 import 或依赖任何 Elasticsearch vendor SDK。
 
 ## Dependency boundary
-
-`elasticsearch-common` 不允许 import 或依赖任何 Elasticsearch vendor SDK。
 
 版本依赖只能存在于叶子模块：
 
@@ -43,19 +39,11 @@ es8     -X-> es7
 - ES7 client: `org.elasticsearch.client:elasticsearch-rest-high-level-client:7.17.29`
 - ES8 client: `co.elastic.clients:elasticsearch-java:8.19.21`
 
-ES8 8.19 仍支持 Java 8。Stage 0 排除 `elasticsearch-java` 的 Jackson 3 runtime artifacts，避免把 Java 17-only mapper implementation 带入 Link-Up 的 Java 8 基线；具体 JSON mapper 在 ES8 implementation stage 再决定。
+Link-Up 当前仍以 Java 8 为基线。ES8 module 继续排除 Jackson 3 runtime artifacts，具体 ES8 JSON mapper 留到 ES8 implementation stage 决定。
 
-## Runtime boundary
+## Stage 0 — module and runtime boundary
 
-Link-Up 当前 `launcher` 会直接依赖 built-in connectors，`dist` 再把 runtime dependencies 平铺到同一个 `lib/` classpath。
-
-ES7 High Level REST Client 和 ES8 Java API Client 都会使用 `org.elasticsearch.client:elasticsearch-rest-client`，但版本不同。因此仅拆 Maven module 不能保证两个版本同时运行时安全。
-
-Stage 0 明确禁止把 `elasticsearch7` / `elasticsearch8` 直接加入 `link-up-launcher` 或 `link-up-server`。测试会守住这个边界，直到后续引入并验证 connector classloader isolation、shade/relocation 或其他等价的 dependency island 方案。
-
-## Stage boundary
-
-Stage 0 包含：
+Stage 0 已完成：
 
 - `common / es7 / es8` 三个 Maven module
 - 独立 client version pin
@@ -63,10 +51,88 @@ Stage 0 包含：
 - compile/test classpath 隔离测试
 - flattened runtime guard
 
-Stage 0 不包含：
+Link-Up 当前 `launcher` 会直接依赖 built-in connectors，`dist` 再把 runtime dependencies 平铺到同一个 `lib/` classpath。ES7 和 ES8 都会使用 `org.elasticsearch.client:elasticsearch-rest-client`，但版本不同，因此仅拆 Maven module 不能保证两个版本同时运行时安全。
 
-- Source / Sink factory
-- Schema / mapping / query / bulk 实现
-- Catalog
-- runtime plugin loader 改造
-- CDC、实时同步或 RowKind 语义
+在 connector classloader isolation、shade/relocation 或其他等价 dependency island 方案完成并验证前，`elasticsearch7` / `elasticsearch8` 仍禁止直接加入 `link-up-launcher` 或 `link-up-server`。
+
+## Stage 1 — Elasticsearch 7 bounded Source
+
+Stage 1 已实现独立的 `elasticsearch7` bounded Source，保持离线读取语义：
+
+- `TableSourceFactory` SPI identifier: `elasticsearch7`
+- 单 index / 单 index alias schema discovery
+- Elasticsearch mapping -> Link-Up `TableSchema`
+- bounded Scroll 读取
+- sliced-scroll split 并行
+- framework reader batch 输出
+- `_source` 字段投影
+- Query DSL wrapper query
+- Basic Auth
+- server major version=7 校验
+- split 结束、异常关闭时清理 scroll context
+
+示例：
+
+```hocon
+source {
+  Elasticsearch7 {
+    hosts = ["http://127.0.0.1:9200"]
+    index = "orders"
+
+    username = "elastic"
+    password = "secret"
+
+    source = ["order_id", "amount", "customer.name"]
+    query = """{"range":{"created_at":{"gte":"2026-01-01"}}}"""
+
+    scroll_time = "1m"
+    scroll_size = 1000
+    slices = 4
+  }
+}
+```
+
+`slices` 未配置时，split 数量跟随 Link-Up Source reader parallelism；显式配置后则保持固定 split 数量。
+
+### Stage 1 type boundary
+
+Elasticsearch mapping 不区分某字段在文档中是单值还是多值，因此 Stage 1 不自动推断 Array 类型。
+
+强类型映射保持在确定范围：
+
+- `boolean` -> `BOOLEAN`
+- `byte` -> `TINYINT`
+- `short` -> `SMALLINT`
+- `integer` / `token_count` -> `INT`
+- `long` -> `BIGINT`
+- `unsigned_long` -> `DECIMAL(20,0)`
+- `half_float` / `float` -> `FLOAT`
+- `double` / `scaled_float` / `rank_feature` -> `DOUBLE`
+
+其余类型，包括 `keyword/text/date/date_nanos/ip/binary/object/nested/flattened/geo/vector/range`，Stage 1 统一保留为字符串；对象、嵌套结构和字符串数组会 JSON 序列化。强类型数值/布尔字段如果实际文档出现数组值会直接失败，不做静默猜测。
+
+### Stage 1 scope boundary
+
+本阶段明确不包含：
+
+- Elasticsearch Sink
+- PIT / search_after
+- Elasticsearch SQL
+- wildcard / comma-separated multi-index read
+- alias resolving to multiple concrete indices
+- runtime schema evolution
+- CDC、实时同步、RowKind / DELETE / UPDATE 语义
+
+### ES7 compatibility boundary
+
+`elasticsearch7` 当前 client 固定为 `7.17.29`，因此 Stage 1 首要目标是 Elasticsearch 7.17.x。Elastic High Level REST Client 的兼容保证是同 major 内“client minor <= server minor”，不是 7.17 client 对所有更早 7.x server 的反向保证。更早的 ES7 minor 需要单独验证后再扩大支持声明。
+
+## Next stages
+
+```text
+Stage 2  Elasticsearch 7 bounded Sink
+Stage 3  Elasticsearch 8 bounded Source
+Stage 4  Elasticsearch 8 bounded Sink
+```
+
+所有阶段继续保持离线 / bounded connector 语义，不把 CDC 或实时同步语义顺带引入 Elasticsearch connector family。

--- a/link-up-connectors/link-up-connector-elasticsearch7/README.md
+++ b/link-up-connectors/link-up-connector-elasticsearch7/README.md
@@ -1,0 +1,29 @@
+# Link-Up Elasticsearch 7 Connector
+
+Stage 1 provides a bounded Elasticsearch 7 Source under connector identifier `elasticsearch7`.
+
+## Source scope
+
+Supported in this stage:
+
+- one concrete index, or an alias resolving to one concrete index
+- mapping-based schema discovery
+- bounded Scroll reads
+- sliced-scroll parallelism
+- Query DSL wrapper query
+- `_source` projection
+- Basic Auth
+- explicit clear-scroll lifecycle
+
+Not supported in this stage:
+
+- Sink
+- PIT / search_after
+- SQL
+- wildcard or multi-index expressions
+- aliases resolving to multiple concrete indices
+- CDC / streaming / RowKind semantics
+
+The module is intentionally not wired into the current flat launcher/server runtime classpath yet. ES7 and ES8 remain separate dependency islands until runtime connector isolation is completed.
+
+See `../ELASTICSEARCH.md` for the connector-family boundary and configuration example.

--- a/link-up-connectors/link-up-connector-elasticsearch7/pom.xml
+++ b/link-up-connectors/link-up-connector-elasticsearch7/pom.xml
@@ -27,6 +27,25 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto-service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
             <version>${elasticsearch7.client.version}</version>

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7Client.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7Client.java
@@ -1,0 +1,227 @@
+package com.link.up.connector.elasticsearch7.client;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.elasticsearch7.Elasticsearch7ConnectorIdentity;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SourceConfig;
+import com.link.up.connector.elasticsearch7.schema.Elasticsearch7TypeMapper;
+import com.link.up.connector.elasticsearch7.source.Elasticsearch7SourceSplit;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.action.search.ClearScrollRequest;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.core.MainResponse;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.slice.SliceBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** ES7 SDK boundary used by schema discovery and bounded scroll readers. */
+public final class Elasticsearch7Client implements AutoCloseable {
+
+    private final Elasticsearch7SourceConfig config;
+    private final RestHighLevelClient client;
+
+    public Elasticsearch7Client(Elasticsearch7SourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.client = buildClient(config);
+    }
+
+    public void verifyMajorVersion() throws IOException {
+        MainResponse response = client.info(RequestOptions.DEFAULT);
+        String version = response.getVersion().getNumber();
+        int dot = version == null ? -1 : version.indexOf('.');
+        String majorText = dot < 0 ? version : version.substring(0, dot);
+        final int major;
+        try {
+            major = Integer.parseInt(majorText);
+        } catch (RuntimeException failure) {
+            throw new IllegalStateException("Cannot parse Elasticsearch server version: " + version, failure);
+        }
+        if (major != Elasticsearch7ConnectorIdentity.MAJOR_VERSION) {
+            throw new IllegalStateException(
+                    "Connector '" + Elasticsearch7ConnectorIdentity.IDENTIFIER
+                            + "' requires Elasticsearch major version 7, but server reported " + version);
+        }
+    }
+
+    public CatalogTable discoverTable() throws IOException {
+        verifyMajorVersion();
+        GetMappingsRequest request = new GetMappingsRequest().indices(config.getIndex());
+        GetMappingsResponse response = client.indices().getMapping(request, RequestOptions.DEFAULT);
+        Map<String, MappingMetadata> mappings = response.mappings();
+        if (mappings == null || mappings.isEmpty()) {
+            throw new IllegalArgumentException("No mapping found for Elasticsearch index: " + config.getIndex());
+        }
+
+        String resolvedIndex = config.getIndex();
+        MappingMetadata mapping = mappings.get(config.getIndex());
+        if (mapping == null) {
+            if (mappings.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Stage 1 Elasticsearch 7 Source requires one concrete index; alias '"
+                                + config.getIndex() + "' resolved to " + mappings.keySet());
+            }
+            Map.Entry<String, MappingMetadata> only = mappings.entrySet().iterator().next();
+            resolvedIndex = only.getKey();
+            mapping = only.getValue();
+        }
+
+        TableSchema schema =
+                Elasticsearch7TypeMapper.toTableSchema(
+                        mapping.sourceAsMap(),
+                        config.getSourceFields());
+        return CatalogTable.builder(TablePath.of(config.getIndex()), schema)
+                .option("resolved_index", resolvedIndex)
+                .build();
+    }
+
+    public ScrollPage startScroll(Elasticsearch7SourceSplit split) throws IOException {
+        Objects.requireNonNull(split, "split must not be null");
+        SearchSourceBuilder source = new SearchSourceBuilder();
+        source.size(config.getScrollSize());
+        source.sort(SortBuilders.fieldSort("_doc"));
+        source.query(
+                config.getQuery() == null
+                        ? QueryBuilders.matchAllQuery()
+                        : QueryBuilders.wrapperQuery(config.getQuery()));
+        if (!config.getSourceFields().isEmpty()) {
+            source.fetchSource(
+                    config.getSourceFields().toArray(new String[0]),
+                    new String[0]);
+        }
+        if (split.getSliceMax() > 1) {
+            source.slice(new SliceBuilder(split.getSliceId(), split.getSliceMax()));
+        }
+
+        SearchRequest request = new SearchRequest(split.getIndex());
+        request.source(source);
+        request.scroll(TimeValue.timeValueMillis(config.getScrollTimeMillis()));
+        return toPage(client.search(request, RequestOptions.DEFAULT));
+    }
+
+    public ScrollPage continueScroll(String scrollId) throws IOException {
+        String id = requireText(scrollId, "scrollId");
+        SearchScrollRequest request = new SearchScrollRequest(id);
+        request.scroll(TimeValue.timeValueMillis(config.getScrollTimeMillis()));
+        return toPage(client.scroll(request, RequestOptions.DEFAULT));
+    }
+
+    public void clearScroll(String scrollId) throws IOException {
+        if (scrollId == null || scrollId.trim().isEmpty()) {
+            return;
+        }
+        ClearScrollRequest request = new ClearScrollRequest();
+        request.addScrollId(scrollId);
+        client.clearScroll(request, RequestOptions.DEFAULT);
+    }
+
+    private static ScrollPage toPage(SearchResponse response) {
+        List<Map<String, Object>> documents = new ArrayList<Map<String, Object>>();
+        for (SearchHit hit : response.getHits().getHits()) {
+            Map<String, Object> source = hit.getSourceAsMap();
+            if (source == null) {
+                throw new IllegalStateException(
+                        "Elasticsearch document '" + hit.getId()
+                                + "' has no _source. Stage 1 bounded Source requires _source to be enabled.");
+            }
+            documents.add(source);
+        }
+        return new ScrollPage(response.getScrollId(), documents);
+    }
+
+    private static RestHighLevelClient buildClient(Elasticsearch7SourceConfig config) {
+        HttpHost[] hosts = new HttpHost[config.getHosts().size()];
+        for (int index = 0; index < config.getHosts().size(); index++) {
+            hosts[index] = toHttpHost(config.getHosts().get(index));
+        }
+
+        RestClientBuilder builder = RestClient.builder(hosts);
+        builder.setRequestConfigCallback(
+                request -> request
+                        .setConnectTimeout(config.getConnectTimeoutMs())
+                        .setSocketTimeout(config.getSocketTimeoutMs()));
+
+        if (!config.getUsername().isEmpty()) {
+            BasicCredentialsProvider credentials = new BasicCredentialsProvider();
+            credentials.setCredentials(
+                    AuthScope.ANY,
+                    new UsernamePasswordCredentials(
+                            config.getUsername(),
+                            config.getPassword()));
+            builder.setHttpClientConfigCallback(
+                    http -> http.setDefaultCredentialsProvider(credentials));
+        }
+        return new RestHighLevelClient(builder);
+    }
+
+    private static HttpHost toHttpHost(String value) {
+        final URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
+        }
+        int port = uri.getPort();
+        if (port < 0) {
+            port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 9200;
+        }
+        return new HttpHost(uri.getHost(), port, uri.getScheme());
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value.trim();
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.close();
+    }
+
+    /** One neutral scroll page; Elasticsearch SDK response types do not leak into the Reader. */
+    public static final class ScrollPage {
+        private final String scrollId;
+        private final List<Map<String, Object>> documents;
+
+        ScrollPage(String scrollId, List<Map<String, Object>> documents) {
+            this.scrollId = scrollId;
+            this.documents =
+                    Collections.unmodifiableList(
+                            new ArrayList<Map<String, Object>>(documents));
+        }
+
+        public String getScrollId() {
+            return scrollId;
+        }
+
+        public List<Map<String, Object>> getDocuments() {
+            return documents;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SourceConfig.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SourceConfig.java
@@ -1,0 +1,274 @@
+package com.link.up.connector.elasticsearch7.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable configuration for the bounded Elasticsearch 7 Source. */
+public final class Elasticsearch7SourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> hosts;
+    private final String username;
+    private final String password;
+    private final String index;
+    private final List<String> sourceFields;
+    private final String query;
+    private final long scrollTimeMillis;
+    private final int scrollSize;
+    private final Integer slices;
+    private final int connectTimeoutMs;
+    private final int socketTimeoutMs;
+
+    private Elasticsearch7SourceConfig(
+            List<String> hosts,
+            String username,
+            String password,
+            String index,
+            List<String> sourceFields,
+            String query,
+            long scrollTimeMillis,
+            int scrollSize,
+            Integer slices,
+            int connectTimeoutMs,
+            int socketTimeoutMs) {
+        this.hosts = Collections.unmodifiableList(new ArrayList<String>(hosts));
+        this.username = username;
+        this.password = password;
+        this.index = index;
+        this.sourceFields = Collections.unmodifiableList(new ArrayList<String>(sourceFields));
+        this.query = query;
+        this.scrollTimeMillis = scrollTimeMillis;
+        this.scrollSize = scrollSize;
+        this.slices = slices;
+        this.connectTimeoutMs = connectTimeoutMs;
+        this.socketTimeoutMs = socketTimeoutMs;
+    }
+
+    public static Elasticsearch7SourceConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        List<String> hosts =
+                normalizeHosts(
+                        config.getOptional(Elasticsearch7SourceOptions.HOSTS)
+                                .orElse(Collections.<String>emptyList()));
+        String username = normalize(config.get(Elasticsearch7SourceOptions.USERNAME));
+        String password = config.get(Elasticsearch7SourceOptions.PASSWORD);
+        String index = requireConcreteIndex(config.get(Elasticsearch7SourceOptions.INDEX));
+        List<String> sourceFields =
+                normalizeSourceFields(
+                        config.getOptional(Elasticsearch7SourceOptions.SOURCE)
+                                .orElse(Collections.<String>emptyList()));
+        String query = normalize(config.get(Elasticsearch7SourceOptions.QUERY));
+        long scrollTimeMillis =
+                parsePositiveDurationMillis(
+                        config.get(Elasticsearch7SourceOptions.SCROLL_TIME),
+                        "scroll_time");
+        int scrollSize = config.get(Elasticsearch7SourceOptions.SCROLL_SIZE);
+        Integer slices = config.getOptional(Elasticsearch7SourceOptions.SLICES).orElse(null);
+        int connectTimeoutMs = config.get(Elasticsearch7SourceOptions.CONNECT_TIMEOUT_MS);
+        int socketTimeoutMs = config.get(Elasticsearch7SourceOptions.SOCKET_TIMEOUT_MS);
+
+        validatePositive(scrollSize, "scroll_size");
+        validatePositive(connectTimeoutMs, "connect_timeout_ms");
+        validatePositive(socketTimeoutMs, "socket_timeout_ms");
+        if (slices != null) {
+            validatePositive(slices, "slices");
+        }
+
+        return new Elasticsearch7SourceConfig(
+                hosts,
+                username == null ? "" : username,
+                password == null ? "" : password,
+                index,
+                sourceFields,
+                query,
+                scrollTimeMillis,
+                scrollSize,
+                slices,
+                connectTimeoutMs,
+                socketTimeoutMs);
+    }
+
+    private static List<String> normalizeHosts(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("hosts must contain at least one Elasticsearch node");
+        }
+        List<String> result = new ArrayList<String>();
+        for (String value : values) {
+            String host = normalize(value);
+            if (host == null) {
+                throw new IllegalArgumentException("hosts values must not be blank");
+            }
+            validateHost(host);
+            result.add(stripTrailingSlash(host));
+        }
+        return result;
+    }
+
+    private static void validateHost(String value) {
+        final URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null
+                || (!("http".equalsIgnoreCase(scheme)) && !("https".equalsIgnoreCase(scheme)))) {
+            throw new IllegalArgumentException("Elasticsearch host must use http or https: " + value);
+        }
+        if (uri.getHost() == null) {
+            throw new IllegalArgumentException("Elasticsearch host must include a hostname: " + value);
+        }
+        String path = uri.getPath();
+        if (path != null && !path.isEmpty() && !"/".equals(path)) {
+            throw new IllegalArgumentException("Elasticsearch host must not include a path: " + value);
+        }
+        if (uri.getQuery() != null || uri.getFragment() != null || uri.getUserInfo() != null) {
+            throw new IllegalArgumentException("Elasticsearch host must not include credentials, query, or fragment: " + value);
+        }
+    }
+
+    private static String requireConcreteIndex(String value) {
+        String index = normalize(value);
+        if (index == null) {
+            throw new IllegalArgumentException("index must not be empty");
+        }
+        if (index.indexOf(',') >= 0 || index.indexOf('*') >= 0 || index.indexOf('?') >= 0) {
+            throw new IllegalArgumentException(
+                    "Stage 1 Elasticsearch 7 Source requires one concrete index or single-index alias; wildcards and multi-index expressions are not supported: "
+                            + index);
+        }
+        return index;
+    }
+
+    private static List<String> normalizeSourceFields(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Set<String> unique = new LinkedHashSet<String>();
+        for (String value : values) {
+            String field = normalize(value);
+            if (field == null) {
+                throw new IllegalArgumentException("source values must not be blank");
+            }
+            if (!unique.add(field)) {
+                throw new IllegalArgumentException("Duplicate source field: " + field);
+            }
+        }
+        return new ArrayList<String>(unique);
+    }
+
+    static long parsePositiveDurationMillis(String value, String name) {
+        String text = normalize(value);
+        if (text == null) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        String normalized = text.toLowerCase(Locale.ROOT);
+        long multiplier;
+        String number;
+        if (normalized.endsWith("ms")) {
+            multiplier = 1L;
+            number = normalized.substring(0, normalized.length() - 2);
+        } else if (normalized.endsWith("s")) {
+            multiplier = 1000L;
+            number = normalized.substring(0, normalized.length() - 1);
+        } else if (normalized.endsWith("m")) {
+            multiplier = 60_000L;
+            number = normalized.substring(0, normalized.length() - 1);
+        } else if (normalized.endsWith("h")) {
+            multiplier = 3_600_000L;
+            number = normalized.substring(0, normalized.length() - 1);
+        } else {
+            throw new IllegalArgumentException(name + " must use ms, s, m, or h: " + value);
+        }
+        final long amount;
+        try {
+            amount = Long.parseLong(number.trim());
+        } catch (NumberFormatException failure) {
+            throw new IllegalArgumentException(name + " must be a positive duration: " + value, failure);
+        }
+        if (amount <= 0L || amount > Long.MAX_VALUE / multiplier) {
+            throw new IllegalArgumentException(name + " must be a positive duration: " + value);
+        }
+        return amount * multiplier;
+    }
+
+    private static String stripTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private static void validatePositive(int value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be greater than 0");
+        }
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    public List<String> getHosts() {
+        return hosts;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public List<String> getSourceFields() {
+        return sourceFields;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public long getScrollTimeMillis() {
+        return scrollTimeMillis;
+    }
+
+    public int getScrollSize() {
+        return scrollSize;
+    }
+
+    public Integer getSlices() {
+        return slices;
+    }
+
+    public int resolveSlices(int parallelism) {
+        validatePositive(parallelism, "parallelism");
+        return slices == null ? parallelism : slices;
+    }
+
+    public int getConnectTimeoutMs() {
+        return connectTimeoutMs;
+    }
+
+    public int getSocketTimeoutMs() {
+        return socketTimeoutMs;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SourceOptions.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SourceOptions.java
@@ -1,0 +1,103 @@
+package com.link.up.connector.elasticsearch7.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+
+/** Options for the bounded Elasticsearch 7 Source. */
+public final class Elasticsearch7SourceOptions {
+
+    private Elasticsearch7SourceOptions() {
+    }
+
+    public static final Option<List<String>> HOSTS =
+            Options.key("hosts")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Elasticsearch HTTP nodes, for example http://localhost:9200")
+                    .withSemanticType("ELASTICSEARCH_HOSTS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Elasticsearch username")
+                    .withSemanticType("USERNAME")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .sensitive()
+                    .withDescription("Elasticsearch password")
+                    .withSemanticType("PASSWORD")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> INDEX =
+            Options.key("index")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("One concrete Elasticsearch index or alias resolving to one index")
+                    .withSemanticType("INDEX")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<List<String>> SOURCE =
+            Options.key("source")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Optional _source projection; dotted nested paths are supported")
+                    .withSemanticType("SOURCE_FIELDS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> QUERY =
+            Options.key("query")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Optional Elasticsearch Query DSL object; blank means match_all")
+                    .withSemanticType("QUERY")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> SCROLL_TIME =
+            Options.key("scroll_time")
+                    .stringType()
+                    .defaultValue("1m")
+                    .withDescription("Scroll context keep-alive, supporting ms, s, m, or h")
+                    .withSemanticType("SCROLL_TIME")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SCROLL_SIZE =
+            Options.key("scroll_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("Documents requested from Elasticsearch per scroll page")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SLICES =
+            Options.key("slices")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription("Optional fixed number of sliced-scroll splits; defaults to reader parallelism")
+                    .withSemanticType("SPLIT_COUNT")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> CONNECT_TIMEOUT_MS =
+            Options.key("connect_timeout_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription("Elasticsearch HTTP connect timeout in milliseconds")
+                    .withSemanticType("CONNECT_TIMEOUT_MS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<Integer> SOCKET_TIMEOUT_MS =
+            Options.key("socket_timeout_ms")
+                    .intType()
+                    .defaultValue(60000)
+                    .withDescription("Elasticsearch HTTP socket timeout in milliseconds")
+                    .withSemanticType("SOCKET_TIMEOUT_MS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7RowConverter.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7RowConverter.java
@@ -1,0 +1,143 @@
+package com.link.up.connector.elasticsearch7.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.SqlType;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+
+/** Converts one Elasticsearch _source document into a Link-Up FluxRow. */
+public final class Elasticsearch7RowConverter {
+
+    private final TableSchema schema;
+    private final ObjectMapper objectMapper;
+
+    public Elasticsearch7RowConverter(TableSchema schema) {
+        this(schema, new ObjectMapper());
+    }
+
+    Elasticsearch7RowConverter(TableSchema schema, ObjectMapper objectMapper) {
+        this.schema = Objects.requireNonNull(schema, "schema must not be null");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+    }
+
+    public FluxRow convert(Map<String, Object> source) {
+        Objects.requireNonNull(source, "source must not be null");
+        FluxRow row = new FluxRow(schema.getColumnCount());
+        for (int index = 0; index < schema.getColumnCount(); index++) {
+            Column column = schema.getColumn(index);
+            Object value = resolveValue(source, column.getName());
+            row.setField(index, convertValue(value, column));
+        }
+        return row;
+    }
+
+    private Object convertValue(Object value, Column column) {
+        if (value == null) {
+            return null;
+        }
+        SqlType target = column.getDataType().getSqlType();
+        if (target != SqlType.STRING && isMultiValue(value)) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch field '" + column.getName()
+                            + "' is multi-valued but mappings do not declare array cardinality; "
+                            + "Stage 1 only auto-converts multi-valued/object content to STRING/JSON fields");
+        }
+        switch (target) {
+            case STRING:
+                return toStringValue(value);
+            case BOOLEAN:
+                return toBoolean(value, column.getName());
+            case TINYINT:
+                return number(value, column.getName()).byteValue();
+            case SMALLINT:
+                return number(value, column.getName()).shortValue();
+            case INT:
+                return number(value, column.getName()).intValue();
+            case BIGINT:
+                return number(value, column.getName()).longValue();
+            case FLOAT:
+                return number(value, column.getName()).floatValue();
+            case DOUBLE:
+                return number(value, column.getName()).doubleValue();
+            case DECIMAL:
+                return value instanceof BigDecimal
+                        ? value
+                        : new BigDecimal(String.valueOf(value));
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported Elasticsearch 7 Stage 1 target type for field '"
+                                + column.getName() + "': " + target);
+        }
+    }
+
+    private String toStringValue(Object value) {
+        if (value instanceof CharSequence) {
+            return value.toString();
+        }
+        if (value instanceof Map || value instanceof Collection || value.getClass().isArray()) {
+            try {
+                return objectMapper.writeValueAsString(value);
+            } catch (JsonProcessingException failure) {
+                throw new IllegalArgumentException("Failed to serialize Elasticsearch field as JSON", failure);
+            }
+        }
+        return String.valueOf(value);
+    }
+
+    private static Boolean toBoolean(Object value, String field) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        String text = String.valueOf(value).trim();
+        if ("true".equalsIgnoreCase(text)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equalsIgnoreCase(text)) {
+            return Boolean.FALSE;
+        }
+        throw new IllegalArgumentException("Cannot convert Elasticsearch field '" + field + "' to boolean: " + value);
+    }
+
+    private static Number number(Object value, String field) {
+        if (value instanceof Number) {
+            return (Number) value;
+        }
+        try {
+            return new BigDecimal(String.valueOf(value));
+        } catch (NumberFormatException failure) {
+            throw new IllegalArgumentException(
+                    "Cannot convert Elasticsearch field '" + field + "' to number: " + value,
+                    failure);
+        }
+    }
+
+    private static boolean isMultiValue(Object value) {
+        return value instanceof Collection || value.getClass().isArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object resolveValue(Map<String, Object> source, String fieldPath) {
+        if (source.containsKey(fieldPath)) {
+            return source.get(fieldPath);
+        }
+        Object current = source;
+        for (String part : fieldPath.split("\\.")) {
+            if (!(current instanceof Map)) {
+                return null;
+            }
+            Map<String, Object> map = (Map<String, Object>) current;
+            if (!map.containsKey(part)) {
+                return null;
+            }
+            current = map.get(part);
+        }
+        return current;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/schema/Elasticsearch7TypeMapper.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/schema/Elasticsearch7TypeMapper.java
@@ -1,0 +1,132 @@
+package com.link.up.connector.elasticsearch7.schema;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Restrained Elasticsearch mapping-to-Link-Up schema conversion for bounded ES7 reads. */
+public final class Elasticsearch7TypeMapper {
+
+    private Elasticsearch7TypeMapper() {
+    }
+
+    public static TableSchema toTableSchema(
+            Map<String, Object> mapping,
+            List<String> projectedFields) {
+        Map<String, Object> properties = mapValue(mapping == null ? null : mapping.get("properties"));
+        if (properties.isEmpty()) {
+            throw new IllegalArgumentException("Elasticsearch index mapping does not contain any properties");
+        }
+
+        List<String> fields =
+                projectedFields == null || projectedFields.isEmpty()
+                        ? new ArrayList<String>(properties.keySet())
+                        : new ArrayList<String>(projectedFields);
+
+        TableSchema.Builder builder = TableSchema.builder();
+        for (String field : fields) {
+            Map<String, Object> fieldMapping = findFieldMapping(properties, field);
+            if (fieldMapping == null) {
+                throw new IllegalArgumentException("Cannot find Elasticsearch mapping for source field: " + field);
+            }
+            String sourceType = stringValue(fieldMapping.get("type"));
+            if (sourceType == null && fieldMapping.containsKey("properties")) {
+                sourceType = "object";
+            }
+            if (sourceType == null) {
+                sourceType = "unknown";
+            }
+            Column.Builder column =
+                    Column.builder(field, toFluxType(sourceType))
+                            .nullable(true)
+                            .sourceType(sourceType);
+            String format = stringValue(fieldMapping.get("format"));
+            if (format != null) {
+                column.attribute("format", format);
+            }
+            builder.column(column.build());
+        }
+        return builder.build();
+    }
+
+    private static FluxDataType<?> toFluxType(String sourceType) {
+        String type = sourceType == null ? "" : sourceType;
+        switch (type) {
+            case "boolean":
+                return BasicType.BOOLEAN_TYPE;
+            case "byte":
+                return BasicType.BYTE_TYPE;
+            case "short":
+                return BasicType.SHORT_TYPE;
+            case "integer":
+            case "token_count":
+                return BasicType.INT_TYPE;
+            case "long":
+                return BasicType.LONG_TYPE;
+            case "unsigned_long":
+                return new DecimalType(20, 0);
+            case "half_float":
+            case "float":
+                return BasicType.FLOAT_TYPE;
+            case "double":
+            case "scaled_float":
+            case "rank_feature":
+                return BasicType.DOUBLE_TYPE;
+            default:
+                // Stage 1 intentionally preserves date/object/nested/geo/vector/range values
+                // as source text/JSON instead of inventing lossy typed semantics.
+                return BasicType.STRING_TYPE;
+        }
+    }
+
+    private static Map<String, Object> findFieldMapping(
+            Map<String, Object> rootProperties,
+            String fieldPath) {
+        String[] parts = fieldPath.split("\\.");
+        Map<String, Object> properties = rootProperties;
+        Map<String, Object> current = null;
+        for (int index = 0; index < parts.length; index++) {
+            current = mapValue(properties.get(parts[index]));
+            if (current.isEmpty()) {
+                return null;
+            }
+            if (index < parts.length - 1) {
+                properties = mapValue(current.get("properties"));
+                if (properties.isEmpty()) {
+                    return null;
+                }
+            }
+        }
+        return current;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> mapValue(Object value) {
+        if (!(value instanceof Map)) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+            if (entry.getKey() != null) {
+                result.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    private static String stringValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = String.valueOf(value).trim();
+        return text.isEmpty() ? null : text;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7Source.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7Source.java
@@ -1,0 +1,57 @@
+package com.link.up.connector.elasticsearch7.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SourceConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Bounded Elasticsearch 7 Source backed by scroll/sliced-scroll reads. */
+public final class Elasticsearch7Source implements Source<Elasticsearch7SourceSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Elasticsearch7SourceConfig config;
+
+    public Elasticsearch7Source(Elasticsearch7SourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public SourceSplitEnumerator<Elasticsearch7SourceSplit> createEnumerator(
+            Map<TablePath, CatalogTable> tables,
+            SourceEnumeratorContext context) {
+        Objects.requireNonNull(tables, "tables must not be null");
+        Objects.requireNonNull(context, "context must not be null");
+        return new Elasticsearch7SourceSplitEnumerator(config, context.getParallelism());
+    }
+
+    @Override
+    @Deprecated
+    public List<Elasticsearch7SourceSplit> createSplits(
+            Map<TablePath, CatalogTable> tables) throws Exception {
+        Objects.requireNonNull(tables, "tables must not be null");
+        try (Elasticsearch7SourceSplitEnumerator enumerator =
+                     new Elasticsearch7SourceSplitEnumerator(config, 1)) {
+            return enumerator.enumerateSplits();
+        }
+    }
+
+    @Override
+    public SourceReader<FluxRow, Elasticsearch7SourceSplit> createReader(
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        return new Elasticsearch7SourceReader(config, tables, batchSize);
+    }
+
+    public Elasticsearch7SourceConfig getConfig() {
+        return config;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceFactory.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceFactory.java
@@ -1,0 +1,79 @@
+package com.link.up.connector.elasticsearch7.source;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.connector.elasticsearch7.Elasticsearch7ConnectorIdentity;
+import com.link.up.connector.elasticsearch7.client.Elasticsearch7Client;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SourceConfig;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SourceOptions;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** SPI factory for the bounded Elasticsearch 7 Source. */
+@AutoService(TableSourceFactory.class)
+public final class Elasticsearch7SourceFactory
+        implements TableSourceFactory<Elasticsearch7SourceSplit> {
+
+    @Override
+    public String factoryIdentifier() {
+        return Elasticsearch7ConnectorIdentity.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY,
+                        ConnectorCapability.PARTITION_SPLIT));
+    }
+
+    @Override
+    public Source<Elasticsearch7SourceSplit> createSource(SourceFactoryContext context) {
+        return new Elasticsearch7Source(createConfig(context));
+    }
+
+    @Override
+    public List<CatalogTable> discoverTableSchemas(SourceFactoryContext context)
+            throws Exception {
+        Elasticsearch7SourceConfig config = createConfig(context);
+        try (Elasticsearch7Client client = new Elasticsearch7Client(config)) {
+            return Collections.singletonList(client.discoverTable());
+        }
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        Elasticsearch7SourceOptions.HOSTS,
+                        Elasticsearch7SourceOptions.INDEX)
+                .optional(
+                        Elasticsearch7SourceOptions.USERNAME,
+                        Elasticsearch7SourceOptions.PASSWORD,
+                        Elasticsearch7SourceOptions.SOURCE,
+                        Elasticsearch7SourceOptions.QUERY,
+                        Elasticsearch7SourceOptions.SCROLL_TIME,
+                        Elasticsearch7SourceOptions.SCROLL_SIZE,
+                        Elasticsearch7SourceOptions.SLICES,
+                        Elasticsearch7SourceOptions.CONNECT_TIMEOUT_MS,
+                        Elasticsearch7SourceOptions.SOCKET_TIMEOUT_MS)
+                .build();
+    }
+
+    private Elasticsearch7SourceConfig createConfig(SourceFactoryContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        ReadonlyConfig options =
+                Objects.requireNonNull(context.getOptions(), "source options must not be null");
+        return Elasticsearch7SourceConfig.of(options);
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceReader.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceReader.java
@@ -1,0 +1,220 @@
+package com.link.up.connector.elasticsearch7.source;
+
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch7.client.Elasticsearch7Client;
+import com.link.up.connector.elasticsearch7.client.Elasticsearch7Client.ScrollPage;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SourceConfig;
+import com.link.up.connector.elasticsearch7.converter.Elasticsearch7RowConverter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Bounded ES7 reader with one active scroll context per split. */
+public final class Elasticsearch7SourceReader
+        implements SourceReader<FluxRow, Elasticsearch7SourceSplit> {
+
+    private final Elasticsearch7SourceConfig config;
+    private final Map<TablePath, CatalogTable> tables;
+    private final int batchSize;
+
+    private Elasticsearch7Client client;
+    private List<Elasticsearch7SourceSplit> assignedSplits = Collections.emptyList();
+    private int nextSplitIndex;
+    private Elasticsearch7SourceSplit currentSplit;
+    private Elasticsearch7RowConverter rowConverter;
+    private ScrollPage currentPage;
+    private int currentPageOffset;
+    private String currentScrollId;
+    private boolean opened;
+    private boolean closed;
+
+    public Elasticsearch7SourceReader(
+            Elasticsearch7SourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(tables, "tables must not be null");
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+        this.tables =
+                Collections.unmodifiableMap(
+                        new LinkedHashMap<TablePath, CatalogTable>(tables));
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public void open(List<Elasticsearch7SourceSplit> splits) throws Exception {
+        ensureNotOpened();
+        this.assignedSplits =
+                splits == null
+                        ? Collections.<Elasticsearch7SourceSplit>emptyList()
+                        : Collections.unmodifiableList(
+                                new ArrayList<Elasticsearch7SourceSplit>(splits));
+        initializeClient();
+    }
+
+    @Override
+    public void open() throws Exception {
+        open(Collections.<Elasticsearch7SourceSplit>emptyList());
+    }
+
+    @Override
+    public void openSplit(Elasticsearch7SourceSplit split) throws Exception {
+        Objects.requireNonNull(split, "split must not be null");
+        if (!opened) {
+            open();
+        }
+        ensureUsable();
+        if (currentSplit != null) {
+            throw new IllegalStateException("A split is already open: " + currentSplit.splitId());
+        }
+        openCurrentSplit(split);
+    }
+
+    @Override
+    public RecordBatch<FluxRow> readBatch() throws Exception {
+        ensureUsable();
+
+        while (true) {
+            if (currentSplit == null && !openNextAssignedSplit()) {
+                return RecordBatch.endOfInput();
+            }
+
+            Elasticsearch7SourceSplit batchSplit = currentSplit;
+            List<FluxRow> rows = new ArrayList<FluxRow>(batchSize);
+
+            while (rows.size() < batchSize && currentSplit == batchSplit) {
+                if (currentPageOffset < currentPage.getDocuments().size()) {
+                    rows.add(
+                            rowConverter.convert(
+                                    currentPage.getDocuments().get(currentPageOffset++)));
+                    continue;
+                }
+
+                if (currentPage.getDocuments().isEmpty()
+                        || currentScrollId == null
+                        || currentScrollId.trim().isEmpty()) {
+                    closeSplit();
+                    break;
+                }
+
+                ScrollPage nextPage = client.continueScroll(currentScrollId);
+                currentPage = nextPage;
+                currentPageOffset = 0;
+                currentScrollId = nextPage.getScrollId();
+                if (nextPage.getDocuments().isEmpty()) {
+                    closeSplit();
+                    break;
+                }
+            }
+
+            if (!rows.isEmpty()) {
+                return RecordBatch.of(batchSplit, rows);
+            }
+        }
+    }
+
+    private boolean openNextAssignedSplit() throws Exception {
+        while (nextSplitIndex < assignedSplits.size()) {
+            Elasticsearch7SourceSplit split = assignedSplits.get(nextSplitIndex++);
+            openCurrentSplit(split);
+            return true;
+        }
+        return false;
+    }
+
+    private void openCurrentSplit(Elasticsearch7SourceSplit split) throws Exception {
+        CatalogTable table = tables.get(split.getTablePath());
+        if (table == null) {
+            throw new IllegalArgumentException(
+                    "No prepared schema found for Elasticsearch index: " + split.getTablePath());
+        }
+        this.currentSplit = split;
+        this.rowConverter = new Elasticsearch7RowConverter(table.getTableSchema());
+        this.currentPage = client.startScroll(split);
+        this.currentPageOffset = 0;
+        this.currentScrollId = currentPage.getScrollId();
+    }
+
+    @Override
+    public void closeSplit() throws Exception {
+        String scrollId = currentScrollId;
+        currentSplit = null;
+        rowConverter = null;
+        currentPage = null;
+        currentPageOffset = 0;
+        currentScrollId = null;
+        if (scrollId != null && client != null) {
+            client.clearScroll(scrollId);
+        }
+    }
+
+    private void initializeClient() throws Exception {
+        this.client = new Elasticsearch7Client(config);
+        boolean success = false;
+        try {
+            client.verifyMajorVersion();
+            opened = true;
+            success = true;
+        } finally {
+            if (!success) {
+                client.close();
+                client = null;
+            }
+        }
+    }
+
+    private void ensureNotOpened() {
+        if (opened || closed) {
+            throw new IllegalStateException("Elasticsearch7SourceReader has already been opened or closed");
+        }
+    }
+
+    private void ensureUsable() {
+        if (!opened || closed || client == null) {
+            throw new IllegalStateException("Elasticsearch7SourceReader is not open");
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (closed) {
+            return;
+        }
+        Exception failure = null;
+        try {
+            if (currentSplit != null || currentScrollId != null) {
+                closeSplit();
+            }
+        } catch (Exception closeFailure) {
+            failure = closeFailure;
+        }
+        try {
+            if (client != null) {
+                client.close();
+            }
+        } catch (Exception closeFailure) {
+            if (failure == null) {
+                failure = closeFailure;
+            } else {
+                failure.addSuppressed(closeFailure);
+            }
+        } finally {
+            client = null;
+            opened = false;
+            closed = true;
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceSplit.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceSplit.java
@@ -1,0 +1,77 @@
+package com.link.up.connector.elasticsearch7.source;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.TablePath;
+
+import java.util.Objects;
+
+/** One bounded Elasticsearch sliced-scroll read unit. */
+public final class Elasticsearch7SourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TablePath tablePath;
+    private final String index;
+    private final int sliceId;
+    private final int sliceMax;
+    private final String splitId;
+
+    public Elasticsearch7SourceSplit(String index, int sliceId, int sliceMax) {
+        String normalizedIndex = requireText(index, "index");
+        if (sliceMax <= 0) {
+            throw new IllegalArgumentException("sliceMax must be greater than 0");
+        }
+        if (sliceId < 0 || sliceId >= sliceMax) {
+            throw new IllegalArgumentException("sliceId must be in [0, sliceMax)");
+        }
+        this.index = normalizedIndex;
+        this.tablePath = TablePath.of(normalizedIndex);
+        this.sliceId = sliceId;
+        this.sliceMax = sliceMax;
+        this.splitId = normalizedIndex + ":slice-" + sliceId + "-of-" + sliceMax;
+    }
+
+    @Override
+    public String splitId() {
+        return splitId;
+    }
+
+    @Override
+    public String dataSetId() {
+        return tablePath.toString();
+    }
+
+    public TablePath getTablePath() {
+        return tablePath;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public int getSliceId() {
+        return sliceId;
+    }
+
+    public int getSliceMax() {
+        return sliceMax;
+    }
+
+    private static String requireText(String value, String name) {
+        Objects.requireNonNull(value, name + " must not be null");
+        String normalized = value.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return normalized;
+    }
+
+    @Override
+    public String toString() {
+        return "Elasticsearch7SourceSplit{"
+                + "index='" + index + '\''
+                + ", sliceId=" + sliceId
+                + ", sliceMax=" + sliceMax
+                + '}';
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceSplitEnumerator.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceSplitEnumerator.java
@@ -1,0 +1,42 @@
+package com.link.up.connector.elasticsearch7.source;
+
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SourceConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Plans one sliced-scroll split per configured or execution parallel slice. */
+public final class Elasticsearch7SourceSplitEnumerator
+        implements SourceSplitEnumerator<Elasticsearch7SourceSplit> {
+
+    private final Elasticsearch7SourceConfig config;
+    private final int parallelism;
+
+    public Elasticsearch7SourceSplitEnumerator(
+            Elasticsearch7SourceConfig config,
+            int parallelism) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException("parallelism must be greater than 0");
+        }
+        this.parallelism = parallelism;
+    }
+
+    @Override
+    public List<Elasticsearch7SourceSplit> enumerateSplits() {
+        int sliceMax = config.resolveSlices(parallelism);
+        List<Elasticsearch7SourceSplit> result =
+                new ArrayList<Elasticsearch7SourceSplit>(sliceMax);
+        for (int sliceId = 0; sliceId < sliceMax; sliceId++) {
+            result.add(
+                    new Elasticsearch7SourceSplit(
+                            config.getIndex(),
+                            sliceId,
+                            sliceMax));
+        }
+        return Collections.unmodifiableList(result);
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SourceConfigTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SourceConfigTest.java
@@ -1,0 +1,68 @@
+package com.link.up.connector.elasticsearch7.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch7SourceConfigTest {
+
+    @Test
+    public void defaultsStayBoundedAndUseFrameworkParallelism() {
+        Elasticsearch7SourceConfig config = config("orders");
+        assertEquals(Arrays.asList("http://localhost:9200"), config.getHosts());
+        assertEquals(60000L, config.getScrollTimeMillis());
+        assertEquals(1000, config.getScrollSize());
+        assertNull(config.getSlices());
+        assertEquals(4, config.resolveSlices(4));
+    }
+
+    @Test
+    public void explicitSlicesOverrideExecutionParallelism() {
+        Map<String, Object> values = base("orders");
+        values.put("slices", 3);
+        Elasticsearch7SourceConfig config = Elasticsearch7SourceConfig.of(ReadonlyConfig.fromMap(values));
+        assertEquals(3, config.resolveSlices(8));
+    }
+
+    @Test
+    public void rejectsWildcardAndMultiIndexExpressions() {
+        assertInvalidIndex("orders-*");
+        assertInvalidIndex("orders,customers");
+        assertInvalidIndex("orders-?");
+    }
+
+    @Test
+    public void parsesMillisecondDuration() {
+        Map<String, Object> values = base("orders");
+        values.put("scroll_time", "1500ms");
+        Elasticsearch7SourceConfig config = Elasticsearch7SourceConfig.of(ReadonlyConfig.fromMap(values));
+        assertEquals(1500L, config.getScrollTimeMillis());
+    }
+
+    private static void assertInvalidIndex(String index) {
+        try {
+            Elasticsearch7SourceConfig.of(ReadonlyConfig.fromMap(base(index)));
+            fail("Expected invalid Stage 1 index expression: " + index);
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    private static Elasticsearch7SourceConfig config(String index) {
+        return Elasticsearch7SourceConfig.of(ReadonlyConfig.fromMap(base(index)));
+    }
+
+    private static Map<String, Object> base(String index) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("hosts", Arrays.asList("http://localhost:9200"));
+        values.put("index", index);
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7RowConverterTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7RowConverterTest.java
@@ -1,0 +1,55 @@
+package com.link.up.connector.elasticsearch7.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch7RowConverterTest {
+
+    @Test
+    public void convertsDottedFieldsAndComplexJson() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("count", BasicType.INT_TYPE).build())
+                        .column(Column.builder("customer.name", BasicType.STRING_TYPE).build())
+                        .column(Column.builder("customer", BasicType.STRING_TYPE).build())
+                        .build();
+
+        Map<String, Object> customer = new LinkedHashMap<String, Object>();
+        customer.put("name", "Ada");
+        customer.put("tags", Arrays.asList("a", "b"));
+        Map<String, Object> document = new LinkedHashMap<String, Object>();
+        document.put("count", 7);
+        document.put("customer", customer);
+
+        FluxRow row = new Elasticsearch7RowConverter(schema).convert(document);
+        assertEquals(7, row.getField(0));
+        assertEquals("Ada", row.getField(1));
+        assertEquals("{\"name\":\"Ada\",\"tags\":[\"a\",\"b\"]}", row.getField(2));
+    }
+
+    @Test
+    public void refusesToGuessNumericArrayCardinality() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("count", BasicType.INT_TYPE).build())
+                        .build();
+        Map<String, Object> document = new LinkedHashMap<String, Object>();
+        document.put("count", Arrays.asList(1, 2));
+        try {
+            new Elasticsearch7RowConverter(schema).convert(document);
+            fail("Expected multi-valued numeric field to be rejected");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/schema/Elasticsearch7TypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/schema/Elasticsearch7TypeMapperTest.java
@@ -1,0 +1,61 @@
+package com.link.up.connector.elasticsearch7.schema;
+
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.SqlType;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Elasticsearch7TypeMapperTest {
+
+    @Test
+    public void mapsScalarTypesAndKeepsComplexValuesAsStrings() {
+        Map<String, Object> mapping = mapping();
+        TableSchema schema =
+                Elasticsearch7TypeMapper.toTableSchema(mapping, Collections.<String>emptyList());
+
+        assertEquals(SqlType.STRING, schema.getColumn("id").getDataType().getSqlType());
+        assertEquals(SqlType.INT, schema.getColumn("count").getDataType().getSqlType());
+        assertEquals(SqlType.DOUBLE, schema.getColumn("price").getDataType().getSqlType());
+        assertEquals(SqlType.STRING, schema.getColumn("customer").getDataType().getSqlType());
+    }
+
+    @Test
+    public void resolvesProjectedDottedFieldFromNestedProperties() {
+        TableSchema schema =
+                Elasticsearch7TypeMapper.toTableSchema(
+                        mapping(),
+                        Arrays.asList("customer.name"));
+        assertEquals(1, schema.getColumnCount());
+        assertEquals("customer.name", schema.getColumn(0).getName());
+        assertEquals(SqlType.STRING, schema.getColumn(0).getDataType().getSqlType());
+    }
+
+    private static Map<String, Object> mapping() {
+        Map<String, Object> properties = new LinkedHashMap<String, Object>();
+        properties.put("id", field("keyword"));
+        properties.put("count", field("integer"));
+        properties.put("price", field("scaled_float"));
+
+        Map<String, Object> customerProperties = new LinkedHashMap<String, Object>();
+        customerProperties.put("name", field("keyword"));
+        Map<String, Object> customer = field("object");
+        customer.put("properties", customerProperties);
+        properties.put("customer", customer);
+
+        Map<String, Object> mapping = new LinkedHashMap<String, Object>();
+        mapping.put("properties", properties);
+        return mapping;
+    }
+
+    private static Map<String, Object> field(String type) {
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        result.put("type", type);
+        return result;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceFactoryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceFactoryTest.java
@@ -1,0 +1,20 @@
+package com.link.up.connector.elasticsearch7.source;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Elasticsearch7SourceFactoryTest {
+
+    @Test
+    public void exposesVersionedBoundedSourceIdentityOnly() {
+        Elasticsearch7SourceFactory factory = new Elasticsearch7SourceFactory();
+        assertEquals("elasticsearch7", factory.factoryIdentifier());
+        assertTrue(factory.capabilities().contains(ConnectorCapability.TABLE_SCHEMA_DISCOVERY));
+        assertTrue(factory.capabilities().contains(ConnectorCapability.PARTITION_SPLIT));
+        assertFalse(factory.capabilities().contains(ConnectorCapability.MULTI_TABLE));
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceSplitEnumeratorTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/source/Elasticsearch7SourceSplitEnumeratorTest.java
@@ -1,0 +1,45 @@
+package com.link.up.connector.elasticsearch7.source;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SourceConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Elasticsearch7SourceSplitEnumeratorTest {
+
+    @Test
+    public void defaultsToReaderParallelism() throws Exception {
+        Elasticsearch7SourceConfig config = config(null);
+        List<Elasticsearch7SourceSplit> splits =
+                new Elasticsearch7SourceSplitEnumerator(config, 3).enumerateSplits();
+        assertEquals(3, splits.size());
+        assertEquals("orders:slice-0-of-3", splits.get(0).splitId());
+        assertEquals(2, splits.get(2).getSliceId());
+        assertEquals(3, splits.get(2).getSliceMax());
+    }
+
+    @Test
+    public void fixedSlicesStayStableAcrossRuntimeParallelism() throws Exception {
+        Elasticsearch7SourceConfig config = config(2);
+        List<Elasticsearch7SourceSplit> splits =
+                new Elasticsearch7SourceSplitEnumerator(config, 8).enumerateSplits();
+        assertEquals(2, splits.size());
+        assertEquals("orders:slice-1-of-2", splits.get(1).splitId());
+    }
+
+    private static Elasticsearch7SourceConfig config(Integer slices) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("hosts", Arrays.asList("http://localhost:9200"));
+        values.put("index", "orders");
+        if (slices != null) {
+            values.put("slices", slices);
+        }
+        return Elasticsearch7SourceConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}


### PR DESCRIPTION
## Summary

Continue the Elasticsearch connector family after merged Stage 0 (#108) with a restrained **Elasticsearch 7 bounded Source** implementation.

This PR is based directly on the current `main` merge commit from Stage 0 and keeps the existing ES7/ES8 dependency-island boundary intact.

## What is included

### Connector identity and factory

- register `TableSourceFactory` for connector identifier `elasticsearch7`
- expose `TABLE_SCHEMA_DISCOVERY` and `PARTITION_SPLIT`
- intentionally do not advertise `MULTI_TABLE`

### Bounded read model

- one concrete index, or one alias resolving to exactly one concrete index
- schema discovery from Elasticsearch mappings
- bounded Scroll reads using the ES 7.17 High Level REST Client
- sliced-scroll split planning
- default slice count follows Link-Up Source reader parallelism
- optional fixed `slices` override
- `_source` projection
- optional Query DSL wrapper query
- Basic Auth
- connect/socket timeout options
- Elasticsearch server major-version validation (`7`)
- explicit clear-scroll lifecycle on split completion / reader close

### Link-Up integration

- `Elasticsearch7Source`
- `Elasticsearch7SourceFactory`
- `Elasticsearch7SourceSplit`
- `Elasticsearch7SourceSplitEnumerator`
- `Elasticsearch7SourceReader`
- mapping -> `TableSchema`
- `_source` -> `FluxRow`

## Type boundary

Stage 1 only maps types where the Elasticsearch mapping gives sufficiently stable scalar semantics:

- `boolean` -> `BOOLEAN`
- `byte` -> `TINYINT`
- `short` -> `SMALLINT`
- `integer` / `token_count` -> `INT`
- `long` -> `BIGINT`
- `unsigned_long` -> `DECIMAL(20,0)`
- `half_float` / `float` -> `FLOAT`
- `double` / `scaled_float` / `rank_feature` -> `DOUBLE`

Other values (including date/object/nested/geo/vector/range families) are preserved as STRING/JSON in Stage 1 rather than introducing lossy or version-specific semantics.

Elasticsearch mappings do not encode scalar-vs-array cardinality. Therefore typed numeric/boolean fields that arrive as multi-valued arrays fail explicitly instead of silently guessing an array type. Complex/string values can be JSON serialized.

## Configuration

Example:

```hocon
source {
  Elasticsearch7 {
    hosts = ["http://127.0.0.1:9200"]
    index = "orders"

    username = "elastic"
    password = "secret"

    source = ["order_id", "amount", "customer.name"]
    query = """{"range":{"created_at":{"gte":"2026-01-01"}}}"""

    scroll_time = "1m"
    scroll_size = 1000
    slices = 4
  }
}
```

## Tests added

Unit coverage for:

- Source configuration defaults and validation
- rejecting wildcard / comma-separated multi-index expressions
- scroll duration parsing
- split planning from runtime parallelism or fixed `slices`
- scalar mapping conversion
- dotted nested field projection
- JSON conversion for complex `_source` values
- explicit rejection of typed multi-valued numeric fields
- factory identifier and capabilities

## Scope deliberately excluded

- Elasticsearch 7 Sink (Stage 2)
- Elasticsearch 8 Source/Sink
- PIT / `search_after`
- Elasticsearch SQL
- wildcard / comma-separated multi-index reads
- aliases resolving to multiple concrete indices
- runtime schema evolution
- CDC / streaming / RowKind / DELETE / UPDATE semantics

## Runtime packaging boundary

This PR intentionally does **not** add `link-up-connector-elasticsearch7` to the current flat `link-up-launcher` / `link-up-server` runtime classpath.

Stage 0 established that ES7 and ES8 must remain separate dependency islands because both use incompatible versions of `org.elasticsearch.client:elasticsearch-rest-client`. The existing guard remains unchanged; Stage 1 does not weaken it merely to make ServiceLoader discovery appear complete.

## Compatibility boundary

The ES7 client remains pinned to `7.17.29`. Stage 1 therefore treats Elasticsearch 7.17.x as the primary verified compatibility target. Broader older-7.x compatibility should only be claimed after explicit compatibility testing.

## Validation

- branch is based directly on the current `main` after merged Stage 0 (#108)
- static API review was performed against Link-Up current interfaces and Elasticsearch 7.17.29 source signatures (`info`, mappings, scroll, fetch-source, sort, slice)
- unit tests are included in the module
- Maven and live Elasticsearch integration tests could not be executed from the current ChatGPT execution container because outbound DNS cannot resolve `github.com`; this limitation is intentionally not represented as a passing build

## Next stage

Stage 2 can add the bounded Elasticsearch 7 Sink without introducing CDC or realtime synchronization semantics.