### PR TITLE
feat(elasticsearch): add bounded Elasticsearch 7 sink

### DIFF
--- a/link-up-connectors/ELASTICSEARCH.md
+++ b/link-up-connectors/ELASTICSEARCH.md
@@ -43,94 +43,87 @@ Link-Up 当前仍以 Java 8 为基线。ES8 module 继续排除 Jackson 3 runtim
 
 ## Stage 0 — module and runtime boundary
 
-Stage 0 已完成：
+Stage 0 已完成 `common / es7 / es8` module、独立 client version pin、connector identifier 和 flattened runtime guard。
 
-- `common / es7 / es8` 三个 Maven module
-- 独立 client version pin
-- 稳定且不同的 connector identifiers
-- compile/test classpath 隔离测试
-- flattened runtime guard
-
-Link-Up 当前 `launcher` 会直接依赖 built-in connectors，`dist` 再把 runtime dependencies 平铺到同一个 `lib/` classpath。ES7 和 ES8 都会使用 `org.elasticsearch.client:elasticsearch-rest-client`，但版本不同，因此仅拆 Maven module 不能保证两个版本同时运行时安全。
-
-在 connector classloader isolation、shade/relocation 或其他等价 dependency island 方案完成并验证前，`elasticsearch7` / `elasticsearch8` 仍禁止直接加入 `link-up-launcher` 或 `link-up-server`。
+Link-Up 当前 `launcher` / `dist` 仍是扁平 runtime classpath。ES7 和 ES8 都依赖不同版本的 `org.elasticsearch.client:elasticsearch-rest-client`，因此在 connector classloader isolation、shade/relocation 或等价 dependency island 方案完成前，两个版本仍禁止直接进入 launcher/server runtime。
 
 ## Stage 1 — Elasticsearch 7 bounded Source
 
-Stage 1 已实现独立的 `elasticsearch7` bounded Source，保持离线读取语义：
+Stage 1 已实现：
 
-- `TableSourceFactory` SPI identifier: `elasticsearch7`
-- 单 index / 单 index alias schema discovery
-- Elasticsearch mapping -> Link-Up `TableSchema`
-- bounded Scroll 读取
-- sliced-scroll split 并行
-- framework reader batch 输出
-- `_source` 字段投影
-- Query DSL wrapper query
-- Basic Auth
-- server major version=7 校验
-- split 结束、异常关闭时清理 scroll context
+- `TableSourceFactory` SPI identifier `elasticsearch7`
+- 单 index / 单 index alias mapping discovery
+- bounded Scroll + sliced-scroll splits
+- `_source` projection、Query DSL、Basic Auth
+- ES major version=7 校验和 clear-scroll 生命周期
+- mapping -> `TableSchema` -> `FluxRow`
+
+Elasticsearch mapping 不区分单值/多值，所以 Stage 1 不自动推断 Array。确定的 boolean/integer/floating 类型保持强类型，其余 date/object/nested/geo/vector/range 等保留为字符串/JSON。
+
+## Stage 2 — Elasticsearch 7 bounded Sink
+
+Stage 2 已实现离线 Bulk 写入：
+
+- `SinkFactory` SPI identifier `elasticsearch7`
+- 只支持一个已存在的 target index，或解析到单一 concrete index 的 alias
+- SinkPreparer 在 task 启动前校验 ES major version、target mapping、source/target field compatibility
+- target index 不存在时直接失败，不做自动建 index
+- 同步 Bulk writer，按 `batch_size` flush
+- `prepareCommit()` flush 剩余文档；`close()` 不隐式 flush
+- 可选 `document_id_field` 作为稳定 `_id`
+- Bulk item 明确返回 `408/429/502/503/504` 时按指数 backoff 重试失败项
+- 整个 Bulk HTTP 调用抛 IOException 时不自动重试，因为服务端成功范围不可判定
+- 成功 Bulk 立即形成 task-local durable boundary，`abort()` 只能丢弃尚未发送的数据
 
 示例：
 
 ```hocon
-source {
+sink {
   Elasticsearch7 {
     hosts = ["http://127.0.0.1:9200"]
-    index = "orders"
+    index = "orders_target"
 
     username = "elastic"
     password = "secret"
 
-    source = ["order_id", "amount", "customer.name"]
-    query = """{"range":{"created_at":{"gte":"2026-01-01"}}}"""
-
-    scroll_time = "1m"
-    scroll_size = 1000
-    slices = 4
+    document_id_field = "order_id"
+    batch_size = 1000
+    max_retries = 3
+    retry_backoff_ms = 200
+    max_retry_backoff_ms = 5000
   }
 }
 ```
 
-`slices` 未配置时，split 数量跟随 Link-Up Source reader parallelism；显式配置后则保持固定 split 数量。
+### Stage 2 semantic boundary
 
-### Stage 1 type boundary
+Stage 2 使用 Elasticsearch `IndexRequest` 写文档，但不向 Link-Up 暴露 `UPSERT` capability，也不把相同 `_id` 的覆盖行为包装成 CDC UPDATE 语义。
 
-Elasticsearch mapping 不区分某字段在文档中是单值还是多值，因此 Stage 1 不自动推断 Array 类型。
+`document_id_field` 未配置时由 Elasticsearch 自动生成 `_id`。此时整任务重试可能产生重复文档；配置稳定 `_id` 可改善重跑确定性，但仍不提供 Job 级事务原子性。
 
-强类型映射保持在确定范围：
+目标 mapping 兼容性保持保守：
 
-- `boolean` -> `BOOLEAN`
-- `byte` -> `TINYINT`
-- `short` -> `SMALLINT`
-- `integer` / `token_count` -> `INT`
-- `long` -> `BIGINT`
-- `unsigned_long` -> `DECIMAL(20,0)`
-- `half_float` / `float` -> `FLOAT`
-- `double` / `scaled_float` / `rank_feature` -> `DOUBLE`
+- integer 只允许安全 widening
+- float -> double 可接受，numeric narrowing 拒绝
+- date 接受 STRING/DATE/TIMESTAMP/TIMESTAMP_TZ
+- object/nested/geo/vector/range 等复杂字段接受 Link-Up STRING(JSON) / ROW / ARRAY 边界
+- `unsigned_long` 在运行时检查非负、整数和 `0..18446744073709551615` 范围
+- runtime schema evolution 不支持
 
-其余类型，包括 `keyword/text/date/date_nanos/ip/binary/object/nested/flattened/geo/vector/range`，Stage 1 统一保留为字符串；对象、嵌套结构和字符串数组会 JSON 序列化。强类型数值/布尔字段如果实际文档出现数组值会直接失败，不做静默猜测。
+明确不包含：
 
-### Stage 1 scope boundary
+- 自动创建 index / 自动更新 mapping
+- UPDATE / DELETE request
+- CDC、实时同步、RowKind 语义
+- Job-level transaction / exactly-once 声明
 
-本阶段明确不包含：
+## ES7 compatibility boundary
 
-- Elasticsearch Sink
-- PIT / search_after
-- Elasticsearch SQL
-- wildcard / comma-separated multi-index read
-- alias resolving to multiple concrete indices
-- runtime schema evolution
-- CDC、实时同步、RowKind / DELETE / UPDATE 语义
-
-### ES7 compatibility boundary
-
-`elasticsearch7` 当前 client 固定为 `7.17.29`，因此 Stage 1 首要目标是 Elasticsearch 7.17.x。Elastic High Level REST Client 的兼容保证是同 major 内“client minor <= server minor”，不是 7.17 client 对所有更早 7.x server 的反向保证。更早的 ES7 minor 需要单独验证后再扩大支持声明。
+`elasticsearch7` client 固定为 `7.17.29`，当前首要兼容目标为 Elasticsearch 7.17.x。更早 ES7 minor 需要单独验证后再扩大支持声明。
 
 ## Next stages
 
 ```text
-Stage 2  Elasticsearch 7 bounded Sink
 Stage 3  Elasticsearch 8 bounded Source
 Stage 4  Elasticsearch 8 bounded Sink
 ```

--- a/link-up-connectors/link-up-connector-elasticsearch7/README.md
+++ b/link-up-connectors/link-up-connector-elasticsearch7/README.md
@@ -1,29 +1,62 @@
 # Link-Up Elasticsearch 7 Connector
 
-Stage 1 provides a bounded Elasticsearch 7 Source under connector identifier `elasticsearch7`.
+The `elasticsearch7` connector now provides bounded Source and Sink support while keeping ES7 isolated from the ES8 SDK dependency island.
 
-## Source scope
+## Bounded Source
 
-Supported in this stage:
+Supported:
 
 - one concrete index, or an alias resolving to one concrete index
 - mapping-based schema discovery
-- bounded Scroll reads
-- sliced-scroll parallelism
-- Query DSL wrapper query
-- `_source` projection
-- Basic Auth
-- explicit clear-scroll lifecycle
+- bounded Scroll reads and sliced-scroll parallelism
+- Query DSL wrapper query and `_source` projection
+- Basic Auth and explicit clear-scroll lifecycle
 
-Not supported in this stage:
+## Bounded Sink
 
-- Sink
-- PIT / search_after
-- SQL
-- wildcard or multi-index expressions
+Stage 2 supports:
+
+- one existing target index, or an alias resolving to one concrete index
+- target mapping validation before writers start
+- synchronous Bulk indexing
+- configurable `batch_size`
+- optional `document_id_field` for stable Elasticsearch `_id`
+- retries only for explicit Bulk item status `408/429/502/503/504`
+- no automatic retry for transport-level Bulk failures because server-side success is ambiguous
+- task-local commit boundary: successful Bulk requests cannot be rolled back
+
+Example:
+
+```hocon
+sink {
+  Elasticsearch7 {
+    hosts = ["http://127.0.0.1:9200"]
+    index = "orders_target"
+
+    username = "elastic"
+    password = "secret"
+
+    document_id_field = "order_id"
+    batch_size = 1000
+    max_retries = 3
+    retry_backoff_ms = 200
+    max_retry_backoff_ms = 5000
+  }
+}
+```
+
+The target index must already exist. Stage 2 intentionally does not auto-create indices or evolve mappings.
+
+`document_id_field` is optional. Without it Elasticsearch generates IDs, so retrying a whole failed task can create duplicate documents. With it the same source key produces a stable `_id`, but the connector still does not claim job-level atomicity or CDC/UPSERT semantics.
+
+## Still out of scope
+
+- PIT / search_after and Elasticsearch SQL
+- wildcard or multi-index operations
 - aliases resolving to multiple concrete indices
-- CDC / streaming / RowKind semantics
+- automatic index creation / mapping evolution
+- UPDATE / DELETE / CDC / streaming / RowKind semantics
 
 The module is intentionally not wired into the current flat launcher/server runtime classpath yet. ES7 and ES8 remain separate dependency islands until runtime connector isolation is completed.
 
-See `../ELASTICSEARCH.md` for the connector-family boundary and configuration example.
+See `../ELASTICSEARCH.md` for the connector-family boundary.

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7Client.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7Client.java
@@ -7,17 +7,11 @@ import com.link.up.connector.elasticsearch7.Elasticsearch7ConnectorIdentity;
 import com.link.up.connector.elasticsearch7.config.Elasticsearch7SourceConfig;
 import com.link.up.connector.elasticsearch7.schema.Elasticsearch7TypeMapper;
 import com.link.up.connector.elasticsearch7.source.Elasticsearch7SourceSplit;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.client.core.MainResponse;
 import org.elasticsearch.client.indices.GetMappingsRequest;
@@ -31,8 +25,6 @@ import org.elasticsearch.search.slice.SliceBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +39,13 @@ public final class Elasticsearch7Client implements AutoCloseable {
 
     public Elasticsearch7Client(Elasticsearch7SourceConfig config) {
         this.config = Objects.requireNonNull(config, "config must not be null");
-        this.client = buildClient(config);
+        this.client =
+                Elasticsearch7RestClientFactory.create(
+                        config.getHosts(),
+                        config.getUsername(),
+                        config.getPassword(),
+                        config.getConnectTimeoutMs(),
+                        config.getSocketTimeoutMs());
     }
 
     public void verifyMajorVersion() throws IOException {
@@ -151,45 +149,6 @@ public final class Elasticsearch7Client implements AutoCloseable {
             documents.add(source);
         }
         return new ScrollPage(response.getScrollId(), documents);
-    }
-
-    private static RestHighLevelClient buildClient(Elasticsearch7SourceConfig config) {
-        HttpHost[] hosts = new HttpHost[config.getHosts().size()];
-        for (int index = 0; index < config.getHosts().size(); index++) {
-            hosts[index] = toHttpHost(config.getHosts().get(index));
-        }
-
-        RestClientBuilder builder = RestClient.builder(hosts);
-        builder.setRequestConfigCallback(
-                request -> request
-                        .setConnectTimeout(config.getConnectTimeoutMs())
-                        .setSocketTimeout(config.getSocketTimeoutMs()));
-
-        if (!config.getUsername().isEmpty()) {
-            BasicCredentialsProvider credentials = new BasicCredentialsProvider();
-            credentials.setCredentials(
-                    AuthScope.ANY,
-                    new UsernamePasswordCredentials(
-                            config.getUsername(),
-                            config.getPassword()));
-            builder.setHttpClientConfigCallback(
-                    http -> http.setDefaultCredentialsProvider(credentials));
-        }
-        return new RestHighLevelClient(builder);
-    }
-
-    private static HttpHost toHttpHost(String value) {
-        final URI uri;
-        try {
-            uri = new URI(value);
-        } catch (URISyntaxException failure) {
-            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
-        }
-        int port = uri.getPort();
-        if (port < 0) {
-            port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 9200;
-        }
-        return new HttpHost(uri.getHost(), port, uri.getScheme());
     }
 
     private static String requireText(String value, String name) {

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7RestClientFactory.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7RestClientFactory.java
@@ -1,0 +1,64 @@
+package com.link.up.connector.elasticsearch7.client;
+
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+/** Shared ES7 HTTP client construction kept inside the version-specific dependency island. */
+final class Elasticsearch7RestClientFactory {
+
+    private Elasticsearch7RestClientFactory() {
+    }
+
+    static RestHighLevelClient create(
+            List<String> hostValues,
+            String username,
+            String password,
+            int connectTimeoutMs,
+            int socketTimeoutMs) {
+        HttpHost[] hosts = new HttpHost[hostValues.size()];
+        for (int index = 0; index < hostValues.size(); index++) {
+            hosts[index] = toHttpHost(hostValues.get(index));
+        }
+
+        RestClientBuilder builder = RestClient.builder(hosts);
+        builder.setRequestConfigCallback(
+                request -> request
+                        .setConnectTimeout(connectTimeoutMs)
+                        .setSocketTimeout(socketTimeoutMs));
+
+        if (username != null && !username.isEmpty()) {
+            BasicCredentialsProvider credentials = new BasicCredentialsProvider();
+            credentials.setCredentials(
+                    AuthScope.ANY,
+                    new UsernamePasswordCredentials(
+                            username,
+                            password == null ? "" : password));
+            builder.setHttpClientConfigCallback(
+                    http -> http.setDefaultCredentialsProvider(credentials));
+        }
+        return new RestHighLevelClient(builder);
+    }
+
+    private static HttpHost toHttpHost(String value) {
+        final URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
+        }
+        int port = uri.getPort();
+        if (port < 0) {
+            port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 9200;
+        }
+        return new HttpHost(uri.getHost(), port, uri.getScheme());
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7SinkClient.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7SinkClient.java
@@ -1,0 +1,181 @@
+package com.link.up.connector.elasticsearch7.client;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.elasticsearch7.Elasticsearch7ConnectorIdentity;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SinkConfig;
+import com.link.up.connector.elasticsearch7.converter.Elasticsearch7DocumentConverter.Document;
+import com.link.up.connector.elasticsearch7.schema.Elasticsearch7TypeMapper;
+import org.elasticsearch.action.bulk.BulkItemResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.core.MainResponse;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** ES7 SDK boundary for target mapping discovery and synchronous bounded Bulk writes. */
+public final class Elasticsearch7SinkClient implements AutoCloseable {
+
+    private final Elasticsearch7SinkConfig config;
+    private final RestHighLevelClient client;
+
+    public Elasticsearch7SinkClient(Elasticsearch7SinkConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.client =
+                Elasticsearch7RestClientFactory.create(
+                        config.getHosts(),
+                        config.getUsername(),
+                        config.getPassword(),
+                        config.getConnectTimeoutMs(),
+                        config.getSocketTimeoutMs());
+    }
+
+    public void verifyMajorVersion() throws IOException {
+        MainResponse response = client.info(RequestOptions.DEFAULT);
+        String version = response.getVersion().getNumber();
+        int dot = version == null ? -1 : version.indexOf('.');
+        String majorText = dot < 0 ? version : version.substring(0, dot);
+        final int major;
+        try {
+            major = Integer.parseInt(majorText);
+        } catch (RuntimeException failure) {
+            throw new IllegalStateException("Cannot parse Elasticsearch server version: " + version, failure);
+        }
+        if (major != Elasticsearch7ConnectorIdentity.MAJOR_VERSION) {
+            throw new IllegalStateException(
+                    "Connector '" + Elasticsearch7ConnectorIdentity.IDENTIFIER
+                            + "' requires Elasticsearch major version 7, but server reported " + version);
+        }
+    }
+
+    public CatalogTable discoverTargetTable(List<String> projectedFields) throws IOException {
+        verifyMajorVersion();
+        GetMappingsRequest request = new GetMappingsRequest().indices(config.getIndex());
+        GetMappingsResponse response = client.indices().getMapping(request, RequestOptions.DEFAULT);
+        Map<String, MappingMetadata> mappings = response.mappings();
+        if (mappings == null || mappings.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch 7 Sink target index must already exist and contain a mapping: "
+                            + config.getIndex());
+        }
+
+        String resolvedIndex = config.getIndex();
+        MappingMetadata mapping = mappings.get(config.getIndex());
+        if (mapping == null) {
+            if (mappings.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Stage 2 Elasticsearch 7 Sink requires one concrete target index; alias '"
+                                + config.getIndex() + "' resolved to " + mappings.keySet());
+            }
+            Map.Entry<String, MappingMetadata> only = mappings.entrySet().iterator().next();
+            resolvedIndex = only.getKey();
+            mapping = only.getValue();
+        }
+
+        TableSchema schema =
+                Elasticsearch7TypeMapper.toTableSchema(mapping.sourceAsMap(), projectedFields);
+        return CatalogTable.builder(TablePath.of(config.getIndex()), schema)
+                .option("resolved_index", resolvedIndex)
+                .build();
+    }
+
+    /**
+     * Indexes all supplied documents. Only explicit retryable item failures are retried.
+     * IOException from the whole Bulk call is deliberately propagated without retry because
+     * server-side success is ambiguous at that boundary.
+     */
+    public int bulkIndex(List<Document> documents) throws IOException {
+        Objects.requireNonNull(documents, "documents must not be null");
+        if (documents.isEmpty()) {
+            return 0;
+        }
+
+        List<Document> pending = new ArrayList<Document>(documents);
+        int retryNumber = 0;
+        while (true) {
+            BulkRequest request = new BulkRequest();
+            for (Document document : pending) {
+                IndexRequest indexRequest =
+                        new IndexRequest(config.getIndex()).source(document.getSource());
+                if (document.getId() != null) {
+                    indexRequest.id(document.getId());
+                }
+                request.add(indexRequest);
+            }
+
+            BulkResponse response = client.bulk(request, RequestOptions.DEFAULT);
+            BulkItemResponse[] items = response.getItems();
+            if (items.length != pending.size()) {
+                throw new IllegalStateException(
+                        "Elasticsearch Bulk response item count mismatch: expected="
+                                + pending.size() + ", actual=" + items.length);
+            }
+
+            List<Document> retryable = new ArrayList<Document>();
+            List<String> permanentFailures = new ArrayList<String>();
+            for (int index = 0; index < items.length; index++) {
+                BulkItemResponse item = items[index];
+                if (!item.isFailed()) {
+                    continue;
+                }
+                int status = item.status().getStatus();
+                if (isRetryableStatus(status) && retryNumber < config.getMaxRetries()) {
+                    retryable.add(pending.get(index));
+                } else {
+                    permanentFailures.add(
+                            "status=" + status
+                                    + ", id=" + item.getId()
+                                    + ", message=" + item.getFailureMessage());
+                }
+            }
+
+            if (!permanentFailures.isEmpty()) {
+                throw new IllegalStateException(
+                        "Elasticsearch Bulk item failure(s): " + permanentFailures);
+            }
+            if (retryable.isEmpty()) {
+                return documents.size();
+            }
+
+            long backoff = config.retryBackoffMs(retryNumber);
+            retryNumber++;
+            sleep(backoff);
+            pending = retryable;
+        }
+    }
+
+    static boolean isRetryableStatus(int status) {
+        return status == 408
+                || status == 429
+                || status == 502
+                || status == 503
+                || status == 504;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrupted while backing off Elasticsearch Bulk item retry",
+                    interrupted);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        client.close();
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SinkConfig.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SinkConfig.java
@@ -1,0 +1,227 @@
+package com.link.up.connector.elasticsearch7.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable configuration for the bounded Elasticsearch 7 Sink. */
+public final class Elasticsearch7SinkConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> hosts;
+    private final String username;
+    private final String password;
+    private final String index;
+    private final String documentIdField;
+    private final int batchSize;
+    private final int maxRetries;
+    private final long retryBackoffMs;
+    private final long maxRetryBackoffMs;
+    private final int connectTimeoutMs;
+    private final int socketTimeoutMs;
+
+    private Elasticsearch7SinkConfig(
+            List<String> hosts,
+            String username,
+            String password,
+            String index,
+            String documentIdField,
+            int batchSize,
+            int maxRetries,
+            long retryBackoffMs,
+            long maxRetryBackoffMs,
+            int connectTimeoutMs,
+            int socketTimeoutMs) {
+        this.hosts = Collections.unmodifiableList(new ArrayList<String>(hosts));
+        this.username = username;
+        this.password = password;
+        this.index = index;
+        this.documentIdField = documentIdField;
+        this.batchSize = batchSize;
+        this.maxRetries = maxRetries;
+        this.retryBackoffMs = retryBackoffMs;
+        this.maxRetryBackoffMs = maxRetryBackoffMs;
+        this.connectTimeoutMs = connectTimeoutMs;
+        this.socketTimeoutMs = socketTimeoutMs;
+    }
+
+    public static Elasticsearch7SinkConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        List<String> hosts =
+                normalizeHosts(
+                        config.getOptional(Elasticsearch7SinkOptions.HOSTS)
+                                .orElse(Collections.<String>emptyList()));
+        String username = normalize(config.get(Elasticsearch7SinkOptions.USERNAME));
+        String password = config.get(Elasticsearch7SinkOptions.PASSWORD);
+        String index = requireConcreteIndex(config.get(Elasticsearch7SinkOptions.INDEX));
+        String documentIdField =
+                normalize(config.getOptional(Elasticsearch7SinkOptions.DOCUMENT_ID_FIELD).orElse(null));
+        int batchSize = config.get(Elasticsearch7SinkOptions.BATCH_SIZE);
+        int maxRetries = config.get(Elasticsearch7SinkOptions.MAX_RETRIES);
+        long retryBackoffMs = config.get(Elasticsearch7SinkOptions.RETRY_BACKOFF_MS);
+        long maxRetryBackoffMs = config.get(Elasticsearch7SinkOptions.MAX_RETRY_BACKOFF_MS);
+        int connectTimeoutMs = config.get(Elasticsearch7SinkOptions.CONNECT_TIMEOUT_MS);
+        int socketTimeoutMs = config.get(Elasticsearch7SinkOptions.SOCKET_TIMEOUT_MS);
+
+        validatePositive(batchSize, "batch_size");
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("max_retries must not be negative");
+        }
+        validatePositive(retryBackoffMs, "retry_backoff_ms");
+        validatePositive(maxRetryBackoffMs, "max_retry_backoff_ms");
+        if (maxRetryBackoffMs < retryBackoffMs) {
+            throw new IllegalArgumentException(
+                    "max_retry_backoff_ms must be greater than or equal to retry_backoff_ms");
+        }
+        validatePositive(connectTimeoutMs, "connect_timeout_ms");
+        validatePositive(socketTimeoutMs, "socket_timeout_ms");
+
+        return new Elasticsearch7SinkConfig(
+                hosts,
+                username == null ? "" : username,
+                password == null ? "" : password,
+                index,
+                documentIdField,
+                batchSize,
+                maxRetries,
+                retryBackoffMs,
+                maxRetryBackoffMs,
+                connectTimeoutMs,
+                socketTimeoutMs);
+    }
+
+    private static List<String> normalizeHosts(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("hosts must contain at least one Elasticsearch node");
+        }
+        List<String> result = new ArrayList<String>();
+        for (String value : values) {
+            String host = normalize(value);
+            if (host == null) {
+                throw new IllegalArgumentException("hosts values must not be blank");
+            }
+            validateHost(host);
+            result.add(stripTrailingSlash(host));
+        }
+        return result;
+    }
+
+    private static void validateHost(String value) {
+        final URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null
+                || (!("http".equalsIgnoreCase(scheme)) && !("https".equalsIgnoreCase(scheme)))) {
+            throw new IllegalArgumentException("Elasticsearch host must use http or https: " + value);
+        }
+        if (uri.getHost() == null) {
+            throw new IllegalArgumentException("Elasticsearch host must include a hostname: " + value);
+        }
+        String path = uri.getPath();
+        if (path != null && !path.isEmpty() && !"/".equals(path)) {
+            throw new IllegalArgumentException("Elasticsearch host must not include a path: " + value);
+        }
+        if (uri.getQuery() != null || uri.getFragment() != null || uri.getUserInfo() != null) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch host must not include credentials, query, or fragment: " + value);
+        }
+    }
+
+    private static String requireConcreteIndex(String value) {
+        String index = normalize(value);
+        if (index == null) {
+            throw new IllegalArgumentException("index must not be empty");
+        }
+        if (index.indexOf(',') >= 0 || index.indexOf('*') >= 0 || index.indexOf('?') >= 0) {
+            throw new IllegalArgumentException(
+                    "Stage 2 Elasticsearch 7 Sink requires one existing concrete index or single-index alias; wildcards and multi-index expressions are not supported: "
+                            + index);
+        }
+        return index;
+    }
+
+    private static String stripTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private static void validatePositive(long value, String name) {
+        if (value <= 0L) {
+            throw new IllegalArgumentException(name + " must be greater than 0");
+        }
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    public List<String> getHosts() {
+        return hosts;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getIndex() {
+        return index;
+    }
+
+    public String getDocumentIdField() {
+        return documentIdField;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public int getMaxRetries() {
+        return maxRetries;
+    }
+
+    public long getRetryBackoffMs() {
+        return retryBackoffMs;
+    }
+
+    public long getMaxRetryBackoffMs() {
+        return maxRetryBackoffMs;
+    }
+
+    public long retryBackoffMs(int retryNumber) {
+        if (retryNumber <= 0) {
+            return retryBackoffMs;
+        }
+        long value = retryBackoffMs;
+        for (int index = 0; index < retryNumber && value < maxRetryBackoffMs; index++) {
+            value = Math.min(maxRetryBackoffMs, value > Long.MAX_VALUE / 2 ? maxRetryBackoffMs : value * 2L);
+        }
+        return value;
+    }
+
+    public int getConnectTimeoutMs() {
+        return connectTimeoutMs;
+    }
+
+    public int getSocketTimeoutMs() {
+        return socketTimeoutMs;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SinkOptions.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SinkOptions.java
@@ -1,0 +1,103 @@
+package com.link.up.connector.elasticsearch7.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+
+/** Options for the bounded Elasticsearch 7 Sink. */
+public final class Elasticsearch7SinkOptions {
+
+    private Elasticsearch7SinkOptions() {
+    }
+
+    public static final Option<List<String>> HOSTS =
+            Options.key("hosts")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Elasticsearch HTTP nodes, for example http://localhost:9200")
+                    .withSemanticType("ELASTICSEARCH_HOSTS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Elasticsearch username")
+                    .withSemanticType("USERNAME")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .sensitive()
+                    .withDescription("Elasticsearch password")
+                    .withSemanticType("PASSWORD")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> INDEX =
+            Options.key("index")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("One existing Elasticsearch target index or single-index alias")
+                    .withSemanticType("INDEX")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> DOCUMENT_ID_FIELD =
+            Options.key("document_id_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Optional source field used as Elasticsearch _id for deterministic re-indexing")
+                    .withSemanticType("DOCUMENT_ID_FIELD")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> BATCH_SIZE =
+            Options.key("batch_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("Maximum documents in one synchronous Elasticsearch Bulk request")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> MAX_RETRIES =
+            Options.key("max_retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("Retries for explicit retryable Bulk item failures; transport-level failures are never retried")
+                    .withSemanticType("MAX_RETRIES")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Long> RETRY_BACKOFF_MS =
+            Options.key("retry_backoff_ms")
+                    .longType()
+                    .defaultValue(200L)
+                    .withDescription("Initial backoff for retryable Bulk item failures")
+                    .withSemanticType("RETRY_BACKOFF_MS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Long> MAX_RETRY_BACKOFF_MS =
+            Options.key("max_retry_backoff_ms")
+                    .longType()
+                    .defaultValue(5000L)
+                    .withDescription("Maximum backoff for retryable Bulk item failures")
+                    .withSemanticType("MAX_RETRY_BACKOFF_MS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> CONNECT_TIMEOUT_MS =
+            Options.key("connect_timeout_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription("Elasticsearch HTTP connect timeout in milliseconds")
+                    .withSemanticType("CONNECT_TIMEOUT_MS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<Integer> SOCKET_TIMEOUT_MS =
+            Options.key("socket_timeout_ms")
+                    .intType()
+                    .defaultValue(60000)
+                    .withDescription("Elasticsearch HTTP socket timeout in milliseconds")
+                    .withSemanticType("SOCKET_TIMEOUT_MS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7DocumentConverter.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7DocumentConverter.java
@@ -1,0 +1,261 @@
+package com.link.up.connector.elasticsearch7.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.ArrayType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.FluxRowType;
+import com.link.up.api.table.type.SqlType;
+
+import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/** Converts one Link-Up row into one Elasticsearch index document. */
+public final class Elasticsearch7DocumentConverter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final java.math.BigDecimal UNSIGNED_LONG_MAX =
+            new java.math.BigDecimal("18446744073709551615");
+
+    private final TableSchema sourceSchema;
+    private final TableSchema targetSchema;
+    private final int documentIdIndex;
+
+    public Elasticsearch7DocumentConverter(
+            CatalogTable sourceTable,
+            CatalogTable targetTable,
+            String documentIdField) {
+        Objects.requireNonNull(sourceTable, "sourceTable must not be null");
+        Objects.requireNonNull(targetTable, "targetTable must not be null");
+        this.sourceSchema = Objects.requireNonNull(sourceTable.getTableSchema(), "source schema must not be null");
+        this.targetSchema = Objects.requireNonNull(targetTable.getTableSchema(), "target schema must not be null");
+        if (sourceSchema.getColumnCount() != targetSchema.getColumnCount()) {
+            throw new IllegalArgumentException("Prepared Elasticsearch target schema must match source field count");
+        }
+        this.documentIdIndex =
+                documentIdField == null ? -1 : sourceSchema.indexOf(documentIdField);
+        if (documentIdField != null && documentIdIndex < 0) {
+            throw new IllegalArgumentException(
+                    "document_id_field does not exist in source schema: " + documentIdField);
+        }
+    }
+
+    public Document convert(FluxRow row) {
+        Objects.requireNonNull(row, "row must not be null");
+        sourceSchema.toRowType().validate(row);
+
+        Map<String, Object> document = new LinkedHashMap<String, Object>();
+        for (int index = 0; index < sourceSchema.getColumnCount(); index++) {
+            Column sourceColumn = sourceSchema.getColumn(index);
+            Column targetColumn = targetSchema.getColumn(index);
+            if (!sourceColumn.getName().equals(targetColumn.getName())) {
+                throw new IllegalStateException(
+                        "Prepared Elasticsearch target schema order does not match source schema at column "
+                                + sourceColumn.getName());
+            }
+            Object converted =
+                    convertValue(
+                            row.getField(index),
+                            sourceColumn.getDataType(),
+                            targetColumn.getSourceType(),
+                            sourceColumn.getName());
+            putDotted(document, sourceColumn.getName(), converted);
+        }
+
+        String documentId = null;
+        if (documentIdIndex >= 0) {
+            Object value = row.getField(documentIdIndex);
+            if (value == null || String.valueOf(value).trim().isEmpty()) {
+                throw new IllegalArgumentException("document_id_field value must not be null or blank");
+            }
+            documentId = String.valueOf(value);
+            if (documentId.getBytes(StandardCharsets.UTF_8).length > 512) {
+                throw new IllegalArgumentException("Elasticsearch document _id must not exceed 512 UTF-8 bytes");
+            }
+        }
+        return new Document(documentId, document);
+    }
+
+    private static Object convertValue(
+            Object value,
+            FluxDataType<?> sourceType,
+            String targetSourceType,
+            String fieldName) {
+        if (value == null) {
+            return null;
+        }
+        String target = targetSourceType == null ? "" : targetSourceType.toLowerCase(Locale.ROOT);
+        SqlType sqlType = sourceType.getSqlType();
+
+        if ("unsigned_long".equals(target)) {
+            java.math.BigDecimal decimal = toBigDecimal(value, fieldName);
+            if (decimal.scale() > 0 || decimal.signum() < 0 || decimal.compareTo(UNSIGNED_LONG_MAX) > 0) {
+                throw new IllegalArgumentException(
+                        "Value is outside Elasticsearch unsigned_long range for field " + fieldName + ": " + value);
+            }
+            return decimal.toBigIntegerExact();
+        }
+
+        switch (sqlType) {
+            case BYTES:
+                if (!(value instanceof byte[])) {
+                    throw new IllegalArgumentException("Expected byte[] for field " + fieldName);
+                }
+                return Base64.getEncoder().encodeToString((byte[]) value);
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case TIMESTAMP_TZ:
+                return String.valueOf(value);
+            case ROW:
+                if (!(sourceType instanceof FluxRowType) || !(value instanceof FluxRow)) {
+                    throw new IllegalArgumentException("Expected FluxRow value for field " + fieldName);
+                }
+                return rowToMap((FluxRowType) sourceType, (FluxRow) value, fieldName);
+            case ARRAY:
+                return arrayToList(value, sourceType, fieldName);
+            case STRING:
+                return convertString(String.valueOf(value), target, fieldName);
+            default:
+                return value;
+        }
+    }
+
+    private static Object convertString(String value, String target, String fieldName) {
+        if (isStructuredTarget(target)) {
+            String trimmed = value.trim();
+            if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+                if ("geo_point".equals(target) || "completion".equals(target)) {
+                    return value;
+                }
+                throw new IllegalArgumentException(
+                        "Elasticsearch target type " + target + " requires JSON object/array text for field " + fieldName);
+            }
+            try {
+                return OBJECT_MAPPER.readValue(trimmed, Object.class);
+            } catch (JsonProcessingException failure) {
+                throw new IllegalArgumentException(
+                        "Invalid JSON text for Elasticsearch field " + fieldName,
+                        failure);
+            }
+        }
+        return value;
+    }
+
+    private static boolean isStructuredTarget(String target) {
+        return "object".equals(target)
+                || "nested".equals(target)
+                || "flattened".equals(target)
+                || "geo_shape".equals(target)
+                || "shape".equals(target)
+                || "point".equals(target)
+                || "dense_vector".equals(target)
+                || "sparse_vector".equals(target)
+                || "histogram".equals(target)
+                || target.endsWith("_range")
+                || "rank_features".equals(target);
+    }
+
+    private static Map<String, Object> rowToMap(
+            FluxRowType rowType,
+            FluxRow row,
+            String fieldName) {
+        rowType.validate(row);
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        for (int index = 0; index < rowType.getFieldCount(); index++) {
+            result.put(
+                    rowType.getFieldName(index),
+                    convertValue(
+                            row.getField(index),
+                            rowType.getFieldType(index),
+                            "object",
+                            fieldName + "." + rowType.getFieldName(index)));
+        }
+        return result;
+    }
+
+    private static List<Object> arrayToList(
+            Object value,
+            FluxDataType<?> sourceType,
+            String fieldName) {
+        if (!(sourceType instanceof ArrayType)) {
+            throw new IllegalArgumentException("Expected ArrayType for field " + fieldName);
+        }
+        if (!value.getClass().isArray()) {
+            throw new IllegalArgumentException("Expected array value for field " + fieldName);
+        }
+        FluxDataType<?> elementType = ((ArrayType<?>) sourceType).getElementType();
+        int length = Array.getLength(value);
+        List<Object> result = new ArrayList<Object>(length);
+        for (int index = 0; index < length; index++) {
+            result.add(convertValue(Array.get(value, index), elementType, "object", fieldName));
+        }
+        return result;
+    }
+
+    private static java.math.BigDecimal toBigDecimal(Object value, String fieldName) {
+        if (value instanceof java.math.BigDecimal) {
+            return (java.math.BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return new java.math.BigDecimal(String.valueOf(value));
+        }
+        try {
+            return new java.math.BigDecimal(String.valueOf(value));
+        } catch (NumberFormatException failure) {
+            throw new IllegalArgumentException("Expected numeric value for field " + fieldName, failure);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void putDotted(Map<String, Object> root, String path, Object value) {
+        String[] parts = path.split("\\.");
+        Map<String, Object> current = root;
+        for (int index = 0; index < parts.length - 1; index++) {
+            Object existing = current.get(parts[index]);
+            if (existing == null) {
+                Map<String, Object> child = new LinkedHashMap<String, Object>();
+                current.put(parts[index], child);
+                current = child;
+            } else if (existing instanceof Map) {
+                current = (Map<String, Object>) existing;
+            } else {
+                throw new IllegalArgumentException(
+                        "Conflicting Elasticsearch dotted field path: " + path);
+            }
+        }
+        Object old = current.put(parts[parts.length - 1], value);
+        if (old != null) {
+            throw new IllegalArgumentException("Duplicate Elasticsearch document field path: " + path);
+        }
+    }
+
+    public static final class Document {
+        private final String id;
+        private final Map<String, Object> source;
+
+        Document(String id, Map<String, Object> source) {
+            this.id = id;
+            this.source = source;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public Map<String, Object> getSource() {
+            return source;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7DocumentConverter.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7DocumentConverter.java
@@ -43,6 +43,7 @@ public final class Elasticsearch7DocumentConverter {
         if (sourceSchema.getColumnCount() != targetSchema.getColumnCount()) {
             throw new IllegalArgumentException("Prepared Elasticsearch target schema must match source field count");
         }
+        validateNoOverlappingFieldPaths(sourceSchema);
         this.documentIdIndex =
                 documentIdField == null ? -1 : sourceSchema.indexOf(documentIdField);
         if (documentIdField != null && documentIdIndex < 0) {
@@ -85,6 +86,21 @@ public final class Elasticsearch7DocumentConverter {
             }
         }
         return new Document(documentId, document);
+    }
+
+    private static void validateNoOverlappingFieldPaths(TableSchema schema) {
+        List<Column> columns = schema.getColumns();
+        for (int leftIndex = 0; leftIndex < columns.size(); leftIndex++) {
+            String left = columns.get(leftIndex).getName();
+            for (int rightIndex = leftIndex + 1; rightIndex < columns.size(); rightIndex++) {
+                String right = columns.get(rightIndex).getName();
+                if (left.startsWith(right + ".") || right.startsWith(left + ".")) {
+                    throw new IllegalArgumentException(
+                            "Overlapping Elasticsearch document field paths are not supported: "
+                                    + left + " and " + right);
+                }
+            }
+        }
     }
 
     private static Object convertValue(
@@ -235,10 +251,11 @@ public final class Elasticsearch7DocumentConverter {
                         "Conflicting Elasticsearch dotted field path: " + path);
             }
         }
-        Object old = current.put(parts[parts.length - 1], value);
-        if (old != null) {
+        String leaf = parts[parts.length - 1];
+        if (current.containsKey(leaf)) {
             throw new IllegalArgumentException("Duplicate Elasticsearch document field path: " + path);
         }
+        current.put(leaf, value);
     }
 
     public static final class Document {

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkFactory.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkFactory.java
@@ -1,0 +1,65 @@
+package com.link.up.connector.elasticsearch7.sink;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch7.Elasticsearch7ConnectorIdentity;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SinkConfig;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SinkOptions;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** SPI factory for the bounded Elasticsearch 7 Bulk Sink. */
+@AutoService(SinkFactory.class)
+public final class Elasticsearch7SinkFactory implements SinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return Elasticsearch7ConnectorIdentity.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        // IndexRequest may replace a document when an explicit _id already exists,
+        // but Stage 2 does not expose CDC/UPSERT semantics as a connector capability.
+        return Collections.emptySet();
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        Elasticsearch7SinkOptions.HOSTS,
+                        Elasticsearch7SinkOptions.INDEX)
+                .optional(
+                        Elasticsearch7SinkOptions.USERNAME,
+                        Elasticsearch7SinkOptions.PASSWORD,
+                        Elasticsearch7SinkOptions.DOCUMENT_ID_FIELD,
+                        Elasticsearch7SinkOptions.BATCH_SIZE,
+                        Elasticsearch7SinkOptions.MAX_RETRIES,
+                        Elasticsearch7SinkOptions.RETRY_BACKOFF_MS,
+                        Elasticsearch7SinkOptions.MAX_RETRY_BACKOFF_MS,
+                        Elasticsearch7SinkOptions.CONNECT_TIMEOUT_MS,
+                        Elasticsearch7SinkOptions.SOCKET_TIMEOUT_MS)
+                .build();
+    }
+
+    @Override
+    public SinkPreparer createPreparer(ReadonlyConfig config) {
+        return new Elasticsearch7SinkPreparer(Elasticsearch7SinkConfig.of(config));
+    }
+
+    @Override
+    public SinkWriter<FluxRow> createSink(
+            ReadonlyConfig config,
+            PreparedSinkMetadata metadata) {
+        return new Elasticsearch7SinkWriter(Elasticsearch7SinkConfig.of(config), metadata);
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkPreparer.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkPreparer.java
@@ -1,0 +1,250 @@
+package com.link.up.connector.elasticsearch7.sink;
+
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPrepareContext;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.elasticsearch7.client.Elasticsearch7SinkClient;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SinkConfig;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Validates one existing Elasticsearch 7 target before bounded task writers start. */
+final class Elasticsearch7SinkPreparer implements SinkPreparer {
+
+    private final Elasticsearch7SinkConfig config;
+
+    Elasticsearch7SinkPreparer(Elasticsearch7SinkConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public PreparedSinkMetadata prepare(SinkPrepareContext context) throws Exception {
+        if (context == null) {
+            throw new IllegalArgumentException("context must not be null");
+        }
+        if (context.getSourceTables().size() != 1) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch 7 bounded Sink Stage 2 supports exactly one source table");
+        }
+
+        Map.Entry<TablePath, CatalogTable> sourceEntry =
+                context.getSourceTables().entrySet().iterator().next();
+        CatalogTable sourceTable = sourceEntry.getValue();
+        if (sourceTable == null || sourceTable.getTableSchema() == null) {
+            throw new IllegalArgumentException("Elasticsearch 7 Sink requires source table schema");
+        }
+
+        List<String> sourceFields = new ArrayList<String>();
+        for (Column column : sourceTable.getTableSchema().getColumns()) {
+            sourceFields.add(column.getName());
+        }
+
+        CatalogTable targetTable;
+        try (Elasticsearch7SinkClient client = new Elasticsearch7SinkClient(config)) {
+            targetTable = client.discoverTargetTable(sourceFields);
+        }
+        CatalogTable preparedTarget =
+                validateAndReorder(sourceTable, targetTable, config.getDocumentIdField());
+
+        Map<TablePath, CatalogTable> targets =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        targets.put(sourceEntry.getKey(), preparedTarget);
+        return new PreparedSinkMetadata(targets);
+    }
+
+    static CatalogTable validateAndReorder(
+            CatalogTable sourceTable,
+            CatalogTable targetTable,
+            String documentIdField) {
+        TableSchema source = sourceTable.getTableSchema();
+        TableSchema target = targetTable.getTableSchema();
+        if (documentIdField != null && !source.contains(documentIdField)) {
+            throw new IllegalArgumentException(
+                    "document_id_field does not exist in source schema: " + documentIdField);
+        }
+
+        TableSchema.Builder reordered = TableSchema.builder();
+        for (Column sourceColumn : source.getColumns()) {
+            if (!target.contains(sourceColumn.getName())) {
+                throw new IllegalArgumentException(
+                        "Elasticsearch target mapping is missing source field: " + sourceColumn.getName());
+            }
+            Column targetColumn = target.getColumn(sourceColumn.getName());
+            validateColumn(sourceColumn, targetColumn);
+            reordered.column(targetColumn);
+        }
+        return CatalogTable.builder(targetTable.getTablePath(), reordered.build())
+                .options(targetTable.getOptions())
+                .build();
+    }
+
+    private static void validateColumn(Column source, Column target) {
+        SqlType sourceType = source.getDataType().getSqlType();
+        String targetType =
+                target.getSourceType() == null
+                        ? "unknown"
+                        : target.getSourceType().toLowerCase(Locale.ROOT);
+
+        if ("boolean".equals(targetType)) {
+            require(source, sourceType == SqlType.BOOLEAN, targetType);
+            return;
+        }
+        if (isIntegerTarget(targetType)) {
+            require(source, isSafeIntegerSource(sourceType, targetType), targetType);
+            return;
+        }
+        if ("unsigned_long".equals(targetType)) {
+            boolean supported = isInteger(sourceType);
+            if (sourceType == SqlType.DECIMAL && source.getDataType() instanceof DecimalType) {
+                DecimalType decimal = (DecimalType) source.getDataType();
+                supported = decimal.getScale() == 0 && decimal.getPrecision() <= 20;
+            }
+            require(source, supported, targetType);
+            return;
+        }
+        if ("half_float".equals(targetType) || "float".equals(targetType)) {
+            require(source, sourceType == SqlType.FLOAT, targetType);
+            return;
+        }
+        if ("double".equals(targetType)
+                || "scaled_float".equals(targetType)
+                || "rank_feature".equals(targetType)) {
+            require(source, sourceType == SqlType.FLOAT || sourceType == SqlType.DOUBLE, targetType);
+            return;
+        }
+        if (isTextTarget(targetType)) {
+            require(source, sourceType == SqlType.STRING, targetType);
+            return;
+        }
+        if ("date".equals(targetType) || "date_nanos".equals(targetType)) {
+            require(
+                    source,
+                    sourceType == SqlType.STRING
+                            || sourceType == SqlType.DATE
+                            || sourceType == SqlType.TIMESTAMP
+                            || sourceType == SqlType.TIMESTAMP_TZ,
+                    targetType);
+            return;
+        }
+        if ("binary".equals(targetType)) {
+            require(source, sourceType == SqlType.BYTES || sourceType == SqlType.STRING, targetType);
+            return;
+        }
+        if (isStructuredTarget(targetType)) {
+            require(
+                    source,
+                    sourceType == SqlType.STRING
+                            || sourceType == SqlType.ROW
+                            || sourceType == SqlType.ARRAY,
+                    targetType);
+            return;
+        }
+
+        // Unknown/plugin mapping types stay intentionally conservative in Stage 2.
+        require(source, sourceType == SqlType.STRING, targetType);
+    }
+
+    private static void require(Column source, boolean condition, String targetType) {
+        if (!condition) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch 7 target mapping is not a safe bounded-sink conversion for field "
+                            + source.getName()
+                            + ": source="
+                            + source.getDataType().getSqlType()
+                            + ", target="
+                            + targetType);
+        }
+    }
+
+    private static boolean isSafeIntegerSource(SqlType sourceType, String targetType) {
+        if (!isInteger(sourceType)) {
+            return false;
+        }
+        return integerRank(sourceType) <= integerRank(targetType);
+    }
+
+    private static boolean isInteger(SqlType type) {
+        return type == SqlType.TINYINT
+                || type == SqlType.SMALLINT
+                || type == SqlType.INT
+                || type == SqlType.BIGINT;
+    }
+
+    private static boolean isIntegerTarget(String targetType) {
+        return "byte".equals(targetType)
+                || "short".equals(targetType)
+                || "integer".equals(targetType)
+                || "token_count".equals(targetType)
+                || "long".equals(targetType);
+    }
+
+    private static int integerRank(SqlType type) {
+        switch (type) {
+            case TINYINT:
+                return 1;
+            case SMALLINT:
+                return 2;
+            case INT:
+                return 3;
+            case BIGINT:
+                return 4;
+            default:
+                return -1;
+        }
+    }
+
+    private static int integerRank(String targetType) {
+        if ("byte".equals(targetType)) {
+            return 1;
+        }
+        if ("short".equals(targetType)) {
+            return 2;
+        }
+        if ("integer".equals(targetType) || "token_count".equals(targetType)) {
+            return 3;
+        }
+        if ("long".equals(targetType)) {
+            return 4;
+        }
+        return -1;
+    }
+
+    private static boolean isTextTarget(String targetType) {
+        return "text".equals(targetType)
+                || "keyword".equals(targetType)
+                || "constant_keyword".equals(targetType)
+                || "wildcard".equals(targetType)
+                || "ip".equals(targetType)
+                || "version".equals(targetType)
+                || "search_as_you_type".equals(targetType)
+                || "match_only_text".equals(targetType);
+    }
+
+    private static boolean isStructuredTarget(String targetType) {
+        return "object".equals(targetType)
+                || "nested".equals(targetType)
+                || "flattened".equals(targetType)
+                || "geo_point".equals(targetType)
+                || "geo_shape".equals(targetType)
+                || "shape".equals(targetType)
+                || "point".equals(targetType)
+                || "dense_vector".equals(targetType)
+                || "sparse_vector".equals(targetType)
+                || "histogram".equals(targetType)
+                || "rank_features".equals(targetType)
+                || "completion".equals(targetType)
+                || "join".equals(targetType)
+                || "percolator".equals(targetType)
+                || targetType.endsWith("_range");
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkWriter.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/main/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkWriter.java
@@ -1,0 +1,266 @@
+package com.link.up.connector.elasticsearch7.sink;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch7.client.Elasticsearch7SinkClient;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SinkConfig;
+import com.link.up.connector.elasticsearch7.converter.Elasticsearch7DocumentConverter;
+import com.link.up.connector.elasticsearch7.converter.Elasticsearch7DocumentConverter.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Bounded Elasticsearch 7 writer using synchronous Bulk requests. */
+public final class Elasticsearch7SinkWriter implements SinkWriter<FluxRow> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Elasticsearch7SinkWriter.class);
+
+    private final Elasticsearch7SinkConfig config;
+    private final PreparedSinkMetadata metadata;
+    private final BulkExecutor bulkExecutor;
+    private final List<Document> pending = new ArrayList<Document>();
+
+    private TableSchema sourceSchema;
+    private Elasticsearch7DocumentConverter converter;
+    private long totalWrittenRows;
+    private long totalBulkRequests;
+    private boolean executorOpened;
+    private boolean opened;
+    private boolean failed;
+
+    public Elasticsearch7SinkWriter(
+            Elasticsearch7SinkConfig config,
+            PreparedSinkMetadata metadata) {
+        this(config, metadata, new ClientBulkExecutor(config));
+    }
+
+    Elasticsearch7SinkWriter(
+            Elasticsearch7SinkConfig config,
+            PreparedSinkMetadata metadata,
+            BulkExecutor bulkExecutor) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
+        this.bulkExecutor = Objects.requireNonNull(bulkExecutor, "bulkExecutor must not be null");
+    }
+
+    @Override
+    public void open() {
+        if (opened) {
+            throw new IllegalStateException("Elasticsearch7SinkWriter has already been opened");
+        }
+        opened = true;
+        LOG.info(
+                "Elasticsearch 7 SinkWriter opened: target={}, batchSize={}, documentIdField={}",
+                config.getIndex(),
+                config.getBatchSize(),
+                config.getDocumentIdField());
+    }
+
+    @Override
+    public void write(
+            RecordBatch<FluxRow> batch,
+            CatalogTable sourceTable)
+            throws Exception {
+        checkWritable();
+        if (batch == null || batch.isEndOfInput() || batch.getRecords().isEmpty()) {
+            return;
+        }
+        initializeSchema(sourceTable);
+
+        for (FluxRow row : batch.getRecords()) {
+            pending.add(converter.convert(row));
+            if (pending.size() >= config.getBatchSize()) {
+                flush();
+            }
+        }
+    }
+
+    @Override
+    public void prepareCommit() throws Exception {
+        checkWritable();
+        flush();
+    }
+
+    @Override
+    public void commit() {
+        checkOpened();
+        LOG.info(
+                "Elasticsearch 7 SinkWriter commit boundary reached: totalWrittenRows={}, totalBulkRequests={}",
+                totalWrittenRows,
+                totalBulkRequests);
+    }
+
+    @Override
+    public void abort() {
+        pending.clear();
+        LOG.warn(
+                "Elasticsearch 7 SinkWriter aborted unsent documents; successful Bulk requests cannot be rolled back: writtenRows={}",
+                totalWrittenRows);
+    }
+
+    @Override
+    public CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    @Override
+    public String getRetryAdvice() {
+        if (config.getDocumentIdField() == null) {
+            return "Elasticsearch Bulk requests are durable as they succeed. Whole-task retry may create duplicate documents because document_id_field is not configured. Transport-level Bulk failures are not retried automatically because server-side success is ambiguous.";
+        }
+        return "Elasticsearch Bulk requests are durable as they succeed. document_id_field provides stable _id values for deterministic re-indexing, but this Sink still does not provide job-level atomicity. Transport-level Bulk failures are not retried automatically because server-side success is ambiguous.";
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        try {
+            if (executorOpened) {
+                bulkExecutor.close();
+            }
+        } catch (Exception closeFailure) {
+            failure = closeFailure;
+        } finally {
+            pending.clear();
+            converter = null;
+            sourceSchema = null;
+            executorOpened = false;
+            opened = false;
+        }
+        LOG.info(
+                "Elasticsearch 7 SinkWriter closed without implicit flush: totalWrittenRows={}, totalBulkRequests={}",
+                totalWrittenRows,
+                totalBulkRequests);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private void initializeSchema(CatalogTable sourceTable) throws Exception {
+        if (sourceTable == null || sourceTable.getTableSchema() == null) {
+            throw new IllegalArgumentException("Elasticsearch 7 Sink requires CatalogTable schema on write");
+        }
+        TableSchema incoming = sourceTable.getTableSchema();
+        if (sourceSchema != null) {
+            if (!sourceSchema.equals(incoming)) {
+                throw new IllegalArgumentException(
+                        "Elasticsearch 7 bounded Sink does not support runtime schema changes");
+            }
+            return;
+        }
+
+        CatalogTable targetTable = metadata.getTargetTable(sourceTable.getTablePath());
+        if (targetTable == null) {
+            throw new IllegalArgumentException(
+                    "Prepared Elasticsearch 7 target metadata is missing source table mapping: "
+                            + sourceTable.getTablePath());
+        }
+        sourceSchema = incoming;
+        converter =
+                new Elasticsearch7DocumentConverter(
+                        sourceTable,
+                        targetTable,
+                        config.getDocumentIdField());
+        bulkExecutor.open();
+        executorOpened = true;
+    }
+
+    private void flush() throws Exception {
+        if (pending.isEmpty()) {
+            return;
+        }
+        if (!executorOpened) {
+            throw new IllegalStateException("Cannot flush Elasticsearch 7 Sink before schema initialization");
+        }
+
+        List<Document> batch =
+                Collections.unmodifiableList(new ArrayList<Document>(pending));
+        try {
+            int written = bulkExecutor.execute(batch);
+            if (written != batch.size()) {
+                throw new IllegalStateException(
+                        "Elasticsearch Bulk executor wrote an unexpected document count: expected="
+                                + batch.size() + ", actual=" + written);
+            }
+            pending.clear();
+            totalWrittenRows += written;
+            totalBulkRequests++;
+            LOG.debug(
+                    "Flushed Elasticsearch 7 Bulk request: rows={}, totalWrittenRows={}",
+                    written,
+                    totalWrittenRows);
+        } catch (Exception failure) {
+            failed = true;
+            throw failure;
+        }
+    }
+
+    private void checkWritable() {
+        checkOpened();
+        if (failed) {
+            throw new IllegalStateException(
+                    "Elasticsearch7SinkWriter is in failed state after a previous Bulk failure");
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Elasticsearch7SinkWriter has not been opened");
+        }
+    }
+
+    interface BulkExecutor extends AutoCloseable {
+        void open() throws Exception;
+
+        int execute(List<Document> documents) throws Exception;
+
+        @Override
+        void close() throws Exception;
+    }
+
+    private static final class ClientBulkExecutor implements BulkExecutor {
+        private final Elasticsearch7SinkConfig config;
+        private Elasticsearch7SinkClient client;
+
+        private ClientBulkExecutor(Elasticsearch7SinkConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public void open() throws Exception {
+            client = new Elasticsearch7SinkClient(config);
+            boolean success = false;
+            try {
+                client.verifyMajorVersion();
+                success = true;
+            } finally {
+                if (!success) {
+                    client.close();
+                    client = null;
+                }
+            }
+        }
+
+        @Override
+        public int execute(List<Document> documents) throws Exception {
+            return client.bulkIndex(documents);
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (client != null) {
+                client.close();
+                client = null;
+            }
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7SinkClientTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/client/Elasticsearch7SinkClientTest.java
@@ -1,0 +1,20 @@
+package com.link.up.connector.elasticsearch7.client;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Elasticsearch7SinkClientTest {
+
+    @Test
+    public void retryPolicyOnlyCoversExplicitTransientItemStatuses() {
+        assertTrue(Elasticsearch7SinkClient.isRetryableStatus(408));
+        assertTrue(Elasticsearch7SinkClient.isRetryableStatus(429));
+        assertTrue(Elasticsearch7SinkClient.isRetryableStatus(502));
+        assertTrue(Elasticsearch7SinkClient.isRetryableStatus(503));
+        assertTrue(Elasticsearch7SinkClient.isRetryableStatus(504));
+        assertFalse(Elasticsearch7SinkClient.isRetryableStatus(400));
+        assertFalse(Elasticsearch7SinkClient.isRetryableStatus(409));
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SinkConfigTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SinkConfigTest.java
@@ -1,0 +1,67 @@
+package com.link.up.connector.elasticsearch7.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch7SinkConfigTest {
+
+    @Test
+    public void parsesBoundedSinkDefaults() {
+        Elasticsearch7SinkConfig config = Elasticsearch7SinkConfig.of(config("orders"));
+        assertEquals(1000, config.getBatchSize());
+        assertEquals(3, config.getMaxRetries());
+        assertEquals(200L, config.getRetryBackoffMs());
+        assertEquals(5000L, config.getMaxRetryBackoffMs());
+        assertNull(config.getDocumentIdField());
+        assertEquals("http://localhost:9200", config.getHosts().get(0));
+    }
+
+    @Test
+    public void rejectsWildcardTargetIndex() {
+        expectFailure("orders-*", "wildcards");
+    }
+
+    @Test
+    public void rejectsNegativeRetries() {
+        Map<String, Object> values = config("orders");
+        values.put("max_retries", -1);
+        try {
+            Elasticsearch7SinkConfig.of(ReadonlyConfig.fromMap(values));
+            fail("Expected max_retries validation failure");
+        } catch (IllegalArgumentException expected) {
+            org.junit.Assert.assertTrue(expected.getMessage().contains("max_retries"));
+        }
+    }
+
+    @Test
+    public void trimsDocumentIdField() {
+        Map<String, Object> values = config("orders");
+        values.put("document_id_field", " order_id ");
+        Elasticsearch7SinkConfig config = Elasticsearch7SinkConfig.of(ReadonlyConfig.fromMap(values));
+        assertEquals("order_id", config.getDocumentIdField());
+    }
+
+    private static void expectFailure(String index, String message) {
+        try {
+            Elasticsearch7SinkConfig.of(ReadonlyConfig.fromMap(config(index)));
+            fail("Expected validation failure");
+        } catch (IllegalArgumentException expected) {
+            org.junit.Assert.assertTrue(expected.getMessage().contains(message));
+        }
+    }
+
+    private static Map<String, Object> config(String index) {
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("hosts", Arrays.asList("http://localhost:9200/"));
+        values.put("index", index);
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7DocumentConverterTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7DocumentConverterTest.java
@@ -1,0 +1,63 @@
+package com.link.up.connector.elasticsearch7.converter;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Elasticsearch7DocumentConverterTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void rebuildsDottedPathsAndUsesStableDocumentId() {
+        CatalogTable source =
+                table(
+                        Column.builder("order_id", BasicType.STRING_TYPE).sourceType("varchar").build(),
+                        Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("varchar").build());
+        CatalogTable target =
+                table(
+                        Column.builder("order_id", BasicType.STRING_TYPE).sourceType("keyword").build(),
+                        Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("keyword").build());
+
+        Elasticsearch7DocumentConverter converter =
+                new Elasticsearch7DocumentConverter(source, target, "order_id");
+        Elasticsearch7DocumentConverter.Document document =
+                converter.convert(FluxRow.of("o-1", "Ada"));
+
+        assertEquals("o-1", document.getId());
+        assertEquals("o-1", document.getSource().get("order_id"));
+        Map<String, Object> customer = (Map<String, Object>) document.getSource().get("customer");
+        assertEquals("Ada", customer.get("name"));
+    }
+
+    @Test
+    public void parsesObjectJsonFromStringBoundary() {
+        CatalogTable source =
+                table(Column.builder("payload", BasicType.STRING_TYPE).sourceType("text").build());
+        CatalogTable target =
+                table(Column.builder("payload", BasicType.STRING_TYPE).sourceType("object").build());
+        Elasticsearch7DocumentConverter converter =
+                new Elasticsearch7DocumentConverter(source, target, null);
+
+        Object payload = converter.convert(FluxRow.of("{\"x\":1}"))
+                .getSource().get("payload");
+        assertTrue(payload instanceof Map);
+        assertEquals(1, ((Number) ((Map<?, ?>) payload).get("x")).intValue());
+    }
+
+    private static CatalogTable table(Column... columns) {
+        TableSchema.Builder schema = TableSchema.builder();
+        for (Column column : columns) {
+            schema.column(column);
+        }
+        return CatalogTable.builder(TablePath.of("orders"), schema.build()).build();
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7DocumentConverterTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/converter/Elasticsearch7DocumentConverterTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class Elasticsearch7DocumentConverterTest {
 
@@ -51,6 +52,25 @@ public class Elasticsearch7DocumentConverterTest {
                 .getSource().get("payload");
         assertTrue(payload instanceof Map);
         assertEquals(1, ((Number) ((Map<?, ?>) payload).get("x")).intValue());
+    }
+
+    @Test
+    public void rejectsOverlappingDocumentFieldPaths() {
+        CatalogTable source =
+                table(
+                        Column.builder("customer", BasicType.STRING_TYPE).sourceType("text").build(),
+                        Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("text").build());
+        CatalogTable target =
+                table(
+                        Column.builder("customer", BasicType.STRING_TYPE).sourceType("object").build(),
+                        Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("keyword").build());
+
+        try {
+            new Elasticsearch7DocumentConverter(source, target, null);
+            fail("Expected overlapping field path validation failure");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("Overlapping Elasticsearch document field paths"));
+        }
     }
 
     private static CatalogTable table(Column... columns) {

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkFactoryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkFactoryTest.java
@@ -1,0 +1,16 @@
+package com.link.up.connector.elasticsearch7.sink;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Elasticsearch7SinkFactoryTest {
+
+    @Test
+    public void exposesVersionedIdentifierWithoutRealtimeCapabilities() {
+        Elasticsearch7SinkFactory factory = new Elasticsearch7SinkFactory();
+        assertEquals("elasticsearch7", factory.factoryIdentifier());
+        assertTrue(factory.capabilities().isEmpty());
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkPreparerTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkPreparerTest.java
@@ -1,0 +1,55 @@
+package com.link.up.connector.elasticsearch7.sink;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch7SinkPreparerTest {
+
+    @Test
+    public void allowsSafeIntegerWidening() {
+        CatalogTable source = table(Column.builder("count", BasicType.INT_TYPE).build());
+        CatalogTable target = table(Column.builder("count", BasicType.LONG_TYPE).sourceType("long").build());
+        CatalogTable prepared =
+                Elasticsearch7SinkPreparer.validateAndReorder(source, target, null);
+        assertEquals("long", prepared.getTableSchema().getColumn(0).getSourceType());
+    }
+
+    @Test
+    public void rejectsNumericNarrowing() {
+        CatalogTable source = table(Column.builder("count", BasicType.LONG_TYPE).build());
+        CatalogTable target = table(Column.builder("count", BasicType.INT_TYPE).sourceType("integer").build());
+        try {
+            Elasticsearch7SinkPreparer.validateAndReorder(source, target, null);
+            fail("Expected safe mapping validation failure");
+        } catch (IllegalArgumentException expected) {
+            org.junit.Assert.assertTrue(expected.getMessage().contains("safe bounded-sink"));
+        }
+    }
+
+    @Test
+    public void requiresConfiguredDocumentIdFieldInSourceSchema() {
+        CatalogTable source = table(Column.builder("name", BasicType.STRING_TYPE).build());
+        CatalogTable target = table(Column.builder("name", BasicType.STRING_TYPE).sourceType("keyword").build());
+        try {
+            Elasticsearch7SinkPreparer.validateAndReorder(source, target, "id");
+            fail("Expected document id field validation failure");
+        } catch (IllegalArgumentException expected) {
+            org.junit.Assert.assertTrue(expected.getMessage().contains("document_id_field"));
+        }
+    }
+
+    private static CatalogTable table(Column... columns) {
+        TableSchema.Builder schema = TableSchema.builder();
+        for (Column column : columns) {
+            schema.column(column);
+        }
+        return CatalogTable.builder(TablePath.of("orders"), schema.build()).build();
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkWriterTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/sink/Elasticsearch7SinkWriterTest.java
@@ -1,0 +1,125 @@
+package com.link.up.connector.elasticsearch7.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch7.config.Elasticsearch7SinkConfig;
+import com.link.up.connector.elasticsearch7.converter.Elasticsearch7DocumentConverter.Document;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Elasticsearch7SinkWriterTest {
+
+    @Test
+    public void flushesAtBatchSizeAndPrepareCommit() throws Exception {
+        CatalogTable source = sourceTable();
+        PreparedSinkMetadata metadata = metadata(source);
+        FakeBulkExecutor executor = new FakeBulkExecutor();
+        Elasticsearch7SinkWriter writer =
+                new Elasticsearch7SinkWriter(config(2), metadata, executor);
+
+        writer.open();
+        writer.write(
+                RecordBatch.of(
+                        "orders",
+                        "split-0",
+                        Arrays.asList(
+                                FluxRow.of("1", 10L),
+                                FluxRow.of("2", 20L),
+                                FluxRow.of("3", 30L))),
+                source);
+        assertEquals(1, executor.executions.size());
+        assertEquals(2, executor.executions.get(0).size());
+
+        writer.prepareCommit();
+        assertEquals(2, executor.executions.size());
+        assertEquals(1, executor.executions.get(1).size());
+        writer.commit();
+        writer.close();
+    }
+
+    @Test
+    public void closeDoesNotImplicitlyFlushPendingDocuments() throws Exception {
+        CatalogTable source = sourceTable();
+        FakeBulkExecutor executor = new FakeBulkExecutor();
+        Elasticsearch7SinkWriter writer =
+                new Elasticsearch7SinkWriter(config(2), metadata(source), executor);
+
+        writer.open();
+        writer.write(
+                RecordBatch.of(
+                        "orders",
+                        "split-0",
+                        Arrays.asList(FluxRow.of("1", 10L))),
+                source);
+        writer.close();
+
+        assertEquals(0, executor.executions.size());
+    }
+
+    private static Elasticsearch7SinkConfig config(int batchSize) {
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("hosts", Arrays.asList("http://localhost:9200"));
+        values.put("index", "orders_target");
+        values.put("document_id_field", "id");
+        values.put("batch_size", batchSize);
+        return Elasticsearch7SinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static CatalogTable sourceTable() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.STRING_TYPE).sourceType("varchar").build())
+                        .column(Column.builder("amount", BasicType.LONG_TYPE).sourceType("bigint").build())
+                        .build();
+        return CatalogTable.builder(TablePath.of("orders"), schema).build();
+    }
+
+    private static PreparedSinkMetadata metadata(CatalogTable source) {
+        TableSchema targetSchema =
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.STRING_TYPE).sourceType("keyword").build())
+                        .column(Column.builder("amount", BasicType.LONG_TYPE).sourceType("long").build())
+                        .build();
+        CatalogTable target =
+                CatalogTable.builder(TablePath.of("orders_target"), targetSchema).build();
+        Map<TablePath, CatalogTable> targets =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        targets.put(source.getTablePath(), target);
+        return new PreparedSinkMetadata(targets);
+    }
+
+    private static final class FakeBulkExecutor
+            implements Elasticsearch7SinkWriter.BulkExecutor {
+        private final List<List<Document>> executions =
+                new ArrayList<List<Document>>();
+
+        @Override
+        public void open() {
+        }
+
+        @Override
+        public int execute(List<Document> documents) {
+            executions.add(new ArrayList<Document>(documents));
+            return documents.size();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Continue the Elasticsearch connector family after merged Stage 1 (#109) with a restrained **Elasticsearch 7 bounded Sink**.

This PR is based directly on the current `main` merge commit from Stage 1 and keeps the Stage 0 ES7/ES8 dependency-island boundary intact.

## What is included

### Connector and preparation boundary

- register `SinkFactory` under the existing versioned identifier `elasticsearch7`
- intentionally expose no `UPSERT`, `AUTO_CREATE_TABLE`, CDC, or realtime capability
- support exactly one source table and one existing Elasticsearch target index
- allow an alias only when it resolves to one concrete target index
- validate Elasticsearch server major version = 7 before task writers start
- discover the existing target mapping and validate source/target field compatibility
- reject runtime schema changes
- reject overlapping document paths such as `customer` + `customer.name` before conversion can become order-dependent

### Bounded Bulk writer

- synchronous Elasticsearch 7 Bulk `IndexRequest` writes
- configurable `batch_size`
- `prepareCommit()` flushes the remaining buffered documents
- `close()` deliberately does **not** implicitly flush
- successful Bulk requests form a task-local durability boundary and cannot be rolled back
- `abort()` only discards documents that have not yet been sent

### Retry boundary

Stage 2 separates explicit item failures from ambiguous transport failures:

- retry only Bulk items explicitly returned with status `408`, `429`, `502`, `503`, or `504`
- retry only the failed items, using capped exponential backoff
- do **not** automatically retry a whole Bulk call that throws `IOException`

A transport-level exception does not prove whether Elasticsearch committed none, some, or all of the submitted documents. Retrying the whole request would therefore manufacture duplicate-write risk.

### Document identity

`document_id_field` is optional.

- without it, Elasticsearch generates `_id`; retrying a whole failed task may create duplicate documents
- with it, one source field is converted to a stable Elasticsearch `_id`, improving deterministic re-indexing
- stable `_id` does **not** make this connector a CDC/UPSERT connector and does not provide Job-level atomicity
- `_id` values are validated as nonblank and <= 512 UTF-8 bytes

### Type / mapping boundary

Target mapping validation remains conservative:

- integer types permit safe widening only; narrowing is rejected
- `float -> double` is accepted
- `unsigned_long` is runtime checked for integer semantics and range `0..18446744073709551615`
- date targets accept Link-Up STRING / DATE / TIMESTAMP / TIMESTAMP_TZ values
- binary accepts BYTES / STRING
- object/nested/geo/vector/range-style targets accept the bounded STRING(JSON) / ROW / ARRAY representation where applicable
- dotted source fields are rebuilt into Elasticsearch JSON objects
- overlapping parent/child paths are rejected rather than resolved by field order

## Configuration

```hocon
sink {
  Elasticsearch7 {
    hosts = ["http://127.0.0.1:9200"]
    index = "orders_target"

    username = "elastic"
    password = "secret"

    document_id_field = "order_id"
    batch_size = 1000
    max_retries = 3
    retry_backoff_ms = 200
    max_retry_backoff_ms = 5000
  }
}
```

The target index must already exist. Stage 2 intentionally does not auto-create indices or evolve mappings.

## Internal reuse

The existing ES7 Source client now reuses a package-local `Elasticsearch7RestClientFactory` for the same hosts / Basic Auth / timeout construction needed by the Sink. This helper remains inside `link-up-connector-elasticsearch7`; no Elasticsearch SDK type leaks into `elasticsearch-common`.

No Stage 1 read semantics are changed.

## Tests added

Unit coverage includes:

- Sink configuration defaults / validation
- wildcard target rejection and retry configuration validation
- optional `document_id_field`
- safe integer widening and narrowing rejection
- target field / document-id validation
- dotted document reconstruction
- structured JSON conversion
- overlapping parent/child document-path rejection
- explicit retryable Bulk status policy
- factory identifier / no realtime capabilities
- batch-size flush and `prepareCommit()` flush
- `close()` does not implicitly flush

## Scope deliberately excluded

- automatic index creation
- automatic mapping evolution
- Elasticsearch `UpdateRequest` / `DeleteRequest`
- CDC / streaming / RowKind semantics
- exposed UPSERT semantics
- two-phase commit / Job-level exactly-once claim
- Elasticsearch 8 Source/Sink

## Runtime packaging boundary

This PR still does **not** add `link-up-connector-elasticsearch7` to the current flat `link-up-launcher` / `link-up-server` runtime classpath.

Stage 0 established that ES7 and ES8 use incompatible versions of `org.elasticsearch.client:elasticsearch-rest-client`; the dependency-island guard remains unchanged.

## Validation

- branch is based directly on current `main` after merged Stage 1 (#109), with no behind commits
- static API review was performed against current Link-Up `SinkFactory` / `SinkPreparer` / `SinkWriter` contracts
- Elasticsearch 7.17.29 signatures were checked for synchronous `bulk(BulkRequest, RequestOptions)`, `BulkItemResponse.status()`, and `IndexRequest.source(Map)` / optional generated `_id`
- unit tests are included without requiring a live Elasticsearch cluster
- Maven and live Elasticsearch integration tests could not be executed from the current ChatGPT execution environment because outbound repository/DNS access is unavailable; this limitation is intentionally not represented as a passing build

## Next stage

Stage 3 can implement the bounded Elasticsearch 8 Source while preserving the version-specific dependency island and the same offline-only semantics.