### PR TITLE
feat(elasticsearch): add bounded Elasticsearch 8 source

### DIFF
--- a/link-up-connectors/ELASTICSEARCH.md
+++ b/link-up-connectors/ELASTICSEARCH.md
@@ -38,8 +38,9 @@ es8     -X-> es7
 
 - ES7 client: `org.elasticsearch.client:elasticsearch-rest-high-level-client:7.17.29`
 - ES8 client: `co.elastic.clients:elasticsearch-java:8.19.21`
+- ES8 Jackson 2 mapper runtime: `com.fasterxml.jackson.core:jackson-databind:2.18.8`
 
-Link-Up 当前仍以 Java 8 为基线。ES8 module 继续排除 Jackson 3 runtime artifacts，具体 ES8 JSON mapper 留到 ES8 implementation stage 决定。
+Link-Up 当前仍以 Java 8 为基线。ES8 Java API Client 8.19.21 本身使用 Java `--release 8`；Stage 3 显式采用 `JacksonJsonpMapper` 的 Jackson 2 路径，并继续排除 Java 17-only 的 Jackson 3 runtime artifacts。ES8 的 Jackson 2 pin 仅存在于 ES8 dependency island，不修改其他模块现有 Jackson 版本。
 
 ## Stage 0 — module and runtime boundary
 
@@ -117,14 +118,66 @@ Stage 2 使用 Elasticsearch `IndexRequest` 写文档，但不向 Link-Up 暴露
 - CDC、实时同步、RowKind 语义
 - Job-level transaction / exactly-once 声明
 
-## ES7 compatibility boundary
+## Stage 3 — Elasticsearch 8 bounded Source
+
+Stage 3 已实现独立的 `elasticsearch8` bounded Source，产品语义与 ES7 Source 保持一致，但 vendor API 完全使用 Elasticsearch Java API Client 8.19.21：
+
+- `TableSourceFactory` SPI identifier `elasticsearch8`
+- 单 index / 单 index alias mapping discovery
+- `RestClientTransport + ElasticsearchClient`
+- `JacksonJsonpMapper`（Jackson 2.18.8）
+- bounded Scroll + sliced-scroll splits
+- `_source` projection、Query DSL JSON、Basic Auth
+- ES major version=8 校验
+- split 完成 / Reader 关闭时显式 clear scroll
+- mapping -> `TableSchema` -> `FluxRow`
+
+示例：
+
+```hocon
+source {
+  Elasticsearch8 {
+    hosts = ["http://127.0.0.1:9200"]
+    index = "orders"
+
+    username = "elastic"
+    password = "secret"
+
+    source = ["order_id", "amount", "customer.name"]
+    query = """{"range":{"created_at":{"gte":"2026-01-01"}}}"""
+
+    scroll_time = "1m"
+    scroll_size = 1000
+    slices = 4
+  }
+}
+```
+
+### Stage 3 semantic boundary
+
+Stage 3 延续 ES7 Source 的保守类型策略：确定的 boolean/integer/floating scalar mapping 使用强类型，`unsigned_long` 使用 `DECIMAL(20,0)`；date/object/nested/geo/vector/range 等复杂类型保留为 STRING/JSON。mapping 无法声明 scalar-vs-array cardinality，因此强类型字段实际出现数组时直接失败，不静默猜测 Array。
+
+本阶段继续使用 bounded sliced Scroll。虽然 ES8 对 deep pagination 更推荐 PIT + `search_after`，但 PIT 会引入跨 split 的共享 PIT 生命周期、一致性和恢复设计，因此不在 Stage 3 顺带扩入。
+
+明确不包含：
+
+- Elasticsearch 8 Sink
+- PIT / `search_after`
+- Elasticsearch SQL
+- wildcard / comma-separated multi-index read
+- alias resolving to multiple concrete indices
+- runtime schema evolution
+- CDC、实时同步、RowKind 语义
+
+## Compatibility boundary
 
 `elasticsearch7` client 固定为 `7.17.29`，当前首要兼容目标为 Elasticsearch 7.17.x。更早 ES7 minor 需要单独验证后再扩大支持声明。
 
-## Next stages
+`elasticsearch8` client 固定为 `8.19.21`，Stage 3 当前首要兼容目标为 Elasticsearch 8.19.x；更广的 ES8 minor 范围在单独验证后再扩大声明。
+
+## Next stage
 
 ```text
-Stage 3  Elasticsearch 8 bounded Source
 Stage 4  Elasticsearch 8 bounded Sink
 ```
 

--- a/link-up-connectors/link-up-connector-elasticsearch8/README.md
+++ b/link-up-connectors/link-up-connector-elasticsearch8/README.md
@@ -1,0 +1,69 @@
+# Link-Up Elasticsearch 8 Connector
+
+Stage 3 provides a bounded Elasticsearch 8 Source under connector identifier `elasticsearch8`.
+
+## Bounded Source
+
+Supported:
+
+- one concrete index, or an alias resolving to one concrete index
+- mapping-based schema discovery
+- bounded Scroll reads through the Elasticsearch Java API Client 8.19.21
+- sliced-scroll parallelism
+- Query DSL JSON
+- `_source` projection
+- Basic Auth
+- explicit clear-scroll lifecycle
+- server major-version validation (`8`)
+
+Example:
+
+```hocon
+source {
+  Elasticsearch8 {
+    hosts = ["http://127.0.0.1:9200"]
+    index = "orders"
+
+    username = "elastic"
+    password = "secret"
+
+    source = ["order_id", "amount", "customer.name"]
+    query = """{"range":{"created_at":{"gte":"2026-01-01"}}}"""
+
+    scroll_time = "1m"
+    scroll_size = 1000
+    slices = 4
+  }
+}
+```
+
+`slices` defaults to Link-Up Source reader parallelism when omitted.
+
+## Java / JSON boundary
+
+Link-Up remains on Java 8. Elasticsearch Java API Client 8.19.21 is itself compiled with Java `--release 8`. Its Jackson 2 integration is `compileOnly` and built against Jackson 2.18.8, so the ES8 leaf explicitly provides Jackson 2.18.8 and uses `JacksonJsonpMapper`.
+
+Jackson 3 runtime artifacts remain excluded because they require Java 17. The project's existing global Jackson 2.15.4 pin is left unchanged for other modules; the ES8 leaf has its own Jackson 2 pin as part of its dependency island.
+
+No Elasticsearch SDK type is moved into `elasticsearch-common`.
+
+## Type boundary
+
+The Stage 3 mapping boundary intentionally mirrors the ES7 bounded Source:
+
+- boolean/integer/floating scalar mappings use Link-Up scalar types
+- `unsigned_long` maps to `DECIMAL(20,0)`
+- date/object/nested/geo/vector/range and other complex mappings are preserved as STRING/JSON
+- Elasticsearch mappings do not declare scalar-vs-array cardinality, so typed numeric/boolean fields that arrive as arrays fail explicitly rather than silently guessing an array type
+
+## Deliberately excluded
+
+- Elasticsearch 8 Sink (Stage 4)
+- PIT / `search_after`
+- Elasticsearch SQL
+- wildcard or comma-separated multi-index reads
+- aliases resolving to multiple concrete indices
+- runtime schema evolution
+- CDC / streaming / RowKind semantics
+
+The module is still not wired into the current flat launcher/server runtime classpath. ES7 and ES8 remain separate dependency islands until runtime connector isolation is completed.

--- a/link-up-connectors/link-up-connector-elasticsearch8/pom.xml
+++ b/link-up-connectors/link-up-connector-elasticsearch8/pom.xml
@@ -27,11 +27,31 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto-service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
+        <!-- elasticsearch-java 8.19.21 compiles its JacksonJsonpMapper against Jackson 2.18.8 as compileOnly. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${elasticsearch8.jackson2.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>co.elastic.clients</groupId>
             <artifactId>elasticsearch-java</artifactId>
             <version>${elasticsearch8.client.version}</version>
             <exclusions>
-                <!-- Jackson 3 requires Java 17. Link-Up remains on Java 8 in Stage 0. -->
+                <!-- Jackson 3 requires Java 17. Stage 3 explicitly uses JacksonJsonpMapper (Jackson 2). -->
                 <exclusion>
                     <groupId>tools.jackson.core</groupId>
                     <artifactId>jackson-core</artifactId>

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8Client.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8Client.java
@@ -1,0 +1,240 @@
+package com.link.up.connector.elasticsearch8.client;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
+import co.elastic.clients.elasticsearch.core.ScrollRequest;
+import co.elastic.clients.elasticsearch.core.ScrollResponse;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.InfoResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.core.search.ResponseBody;
+import co.elastic.clients.elasticsearch.indices.GetMappingResponse;
+import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.elasticsearch8.Elasticsearch8ConnectorIdentity;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SourceConfig;
+import com.link.up.connector.elasticsearch8.schema.Elasticsearch8TypeMapper;
+import com.link.up.connector.elasticsearch8.source.Elasticsearch8SourceSplit;
+import jakarta.json.stream.JsonParser;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** ES8 Java API Client boundary for mapping discovery and bounded scroll reads. */
+public final class Elasticsearch8Client implements AutoCloseable {
+
+    private final Elasticsearch8SourceConfig config;
+    private final JacksonJsonpMapper jsonpMapper;
+    private final RestClientTransport transport;
+    private final ElasticsearchClient client;
+
+    public Elasticsearch8Client(Elasticsearch8SourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        RestClient restClient = buildRestClient(config);
+        this.jsonpMapper = new JacksonJsonpMapper(new ObjectMapper());
+        this.transport = new RestClientTransport(restClient, jsonpMapper);
+        this.client = new ElasticsearchClient(transport);
+    }
+
+    public void verifyMajorVersion() throws IOException {
+        InfoResponse response = client.info();
+        String version = response.version().number();
+        int dot = version == null ? -1 : version.indexOf('.');
+        String majorText = dot < 0 ? version : version.substring(0, dot);
+        final int major;
+        try {
+            major = Integer.parseInt(majorText);
+        } catch (RuntimeException failure) {
+            throw new IllegalStateException("Cannot parse Elasticsearch server version: " + version, failure);
+        }
+        if (major != Elasticsearch8ConnectorIdentity.MAJOR_VERSION) {
+            throw new IllegalStateException(
+                    "Connector '" + Elasticsearch8ConnectorIdentity.IDENTIFIER
+                            + "' requires Elasticsearch major version 8, but server reported " + version);
+        }
+    }
+
+    public CatalogTable discoverTable() throws IOException {
+        verifyMajorVersion();
+        GetMappingResponse response =
+                client.indices().getMapping(request -> request.index(config.getIndex()));
+        Map<String, IndexMappingRecord> mappings = response.result();
+        if (mappings == null || mappings.isEmpty()) {
+            throw new IllegalArgumentException("No mapping found for Elasticsearch index: " + config.getIndex());
+        }
+
+        String resolvedIndex = config.getIndex();
+        IndexMappingRecord record = mappings.get(config.getIndex());
+        if (record == null) {
+            if (mappings.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Stage 3 Elasticsearch 8 Source requires one concrete index; alias '"
+                                + config.getIndex() + "' resolved to " + mappings.keySet());
+            }
+            Map.Entry<String, IndexMappingRecord> only = mappings.entrySet().iterator().next();
+            resolvedIndex = only.getKey();
+            record = only.getValue();
+        }
+
+        TableSchema schema =
+                Elasticsearch8TypeMapper.toTableSchema(
+                        record.mappings(),
+                        config.getSourceFields());
+        return CatalogTable.builder(TablePath.of(config.getIndex()), schema)
+                .option("resolved_index", resolvedIndex)
+                .build();
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public ScrollPage startScroll(Elasticsearch8SourceSplit split) throws IOException {
+        Objects.requireNonNull(split, "split must not be null");
+        SearchRequest.Builder builder = new SearchRequest.Builder()
+                .index(split.getIndex())
+                .size(config.getScrollSize())
+                .scroll(time -> time.time(config.getScrollTime()))
+                .sort(sort -> sort.doc(doc -> doc))
+                .query(config.getQuery() == null
+                        ? Query.of(query -> query.matchAll(matchAll -> matchAll))
+                        : parseQuery(config.getQuery()));
+
+        if (!config.getSourceFields().isEmpty()) {
+            builder.source(source -> source.filter(
+                    filter -> filter.includes(config.getSourceFields())));
+        }
+        if (split.getSliceMax() > 1) {
+            builder.slice(slice -> slice
+                    .id(String.valueOf(split.getSliceId()))
+                    .max(split.getSliceMax()));
+        }
+
+        SearchResponse<Map> response = client.search(builder.build(), Map.class);
+        return toPage(response);
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public ScrollPage continueScroll(String scrollId) throws IOException {
+        String id = requireText(scrollId, "scrollId");
+        ScrollRequest request = ScrollRequest.of(builder -> builder
+                .scrollId(id)
+                .scroll(time -> time.time(config.getScrollTime())));
+        ScrollResponse<Map> response = client.scroll(request, Map.class);
+        return toPage(response);
+    }
+
+    public void clearScroll(String scrollId) throws IOException {
+        if (scrollId == null || scrollId.trim().isEmpty()) {
+            return;
+        }
+        ClearScrollRequest request = ClearScrollRequest.of(builder -> builder.scrollId(scrollId));
+        client.clearScroll(request);
+    }
+
+    private Query parseQuery(String json) {
+        JsonParser parser = jsonpMapper.jsonProvider().createParser(new StringReader(json));
+        try {
+            return Query._DESERIALIZER.deserialize(parser, jsonpMapper);
+        } catch (RuntimeException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch 8 Query DSL JSON", failure);
+        } finally {
+            parser.close();
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static ScrollPage toPage(ResponseBody<Map> response) {
+        List<Map<String, Object>> documents = new ArrayList<Map<String, Object>>();
+        for (Hit<Map> hit : response.hits().hits()) {
+            Map source = hit.source();
+            if (source == null) {
+                throw new IllegalStateException(
+                        "Elasticsearch document '" + hit.id()
+                                + "' has no _source. Stage 3 bounded Source requires _source to be enabled.");
+            }
+            documents.add(new java.util.LinkedHashMap<String, Object>((Map<String, Object>) source));
+        }
+        return new ScrollPage(response.scrollId(), documents);
+    }
+
+    private static RestClient buildRestClient(Elasticsearch8SourceConfig config) {
+        HttpHost[] hosts = new HttpHost[config.getHosts().size()];
+        for (int index = 0; index < config.getHosts().size(); index++) {
+            hosts[index] = toHttpHost(config.getHosts().get(index));
+        }
+
+        RestClientBuilder builder = RestClient.builder(hosts);
+        builder.setRequestConfigCallback(
+                request -> request
+                        .setConnectTimeout(config.getConnectTimeoutMs())
+                        .setSocketTimeout(config.getSocketTimeoutMs()));
+        if (!config.getUsername().isEmpty()) {
+            BasicCredentialsProvider credentials = new BasicCredentialsProvider();
+            credentials.setCredentials(
+                    AuthScope.ANY,
+                    new UsernamePasswordCredentials(config.getUsername(), config.getPassword()));
+            builder.setHttpClientConfigCallback(
+                    http -> http.setDefaultCredentialsProvider(credentials));
+        }
+        return builder.build();
+    }
+
+    private static HttpHost toHttpHost(String value) {
+        final URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
+        }
+        int port = uri.getPort();
+        if (port < 0) {
+            port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 9200;
+        }
+        return new HttpHost(uri.getHost(), port, uri.getScheme());
+    }
+
+    private static String requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return value.trim();
+    }
+
+    @Override
+    public void close() throws IOException {
+        transport.close();
+    }
+
+    /** One connector-neutral scroll page; SDK response types do not leak into the Reader. */
+    public static final class ScrollPage {
+        private final String scrollId;
+        private final List<Map<String, Object>> documents;
+
+        ScrollPage(String scrollId, List<Map<String, Object>> documents) {
+            this.scrollId = scrollId;
+            this.documents = Collections.unmodifiableList(
+                    new ArrayList<Map<String, Object>>(documents));
+        }
+
+        public String getScrollId() { return scrollId; }
+        public List<Map<String, Object>> getDocuments() { return documents; }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SourceConfig.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SourceConfig.java
@@ -1,0 +1,238 @@
+package com.link.up.connector.elasticsearch8.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable configuration for the bounded Elasticsearch 8 Source. */
+public final class Elasticsearch8SourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> hosts;
+    private final String username;
+    private final String password;
+    private final String index;
+    private final List<String> sourceFields;
+    private final String query;
+    private final String scrollTime;
+    private final int scrollSize;
+    private final Integer slices;
+    private final int connectTimeoutMs;
+    private final int socketTimeoutMs;
+
+    private Elasticsearch8SourceConfig(
+            List<String> hosts,
+            String username,
+            String password,
+            String index,
+            List<String> sourceFields,
+            String query,
+            String scrollTime,
+            int scrollSize,
+            Integer slices,
+            int connectTimeoutMs,
+            int socketTimeoutMs) {
+        this.hosts = Collections.unmodifiableList(new ArrayList<String>(hosts));
+        this.username = username;
+        this.password = password;
+        this.index = index;
+        this.sourceFields = Collections.unmodifiableList(new ArrayList<String>(sourceFields));
+        this.query = query;
+        this.scrollTime = scrollTime;
+        this.scrollSize = scrollSize;
+        this.slices = slices;
+        this.connectTimeoutMs = connectTimeoutMs;
+        this.socketTimeoutMs = socketTimeoutMs;
+    }
+
+    public static Elasticsearch8SourceConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        List<String> hosts = normalizeHosts(
+                config.getOptional(Elasticsearch8SourceOptions.HOSTS)
+                        .orElse(Collections.<String>emptyList()));
+        String username = normalize(config.get(Elasticsearch8SourceOptions.USERNAME));
+        String password = config.get(Elasticsearch8SourceOptions.PASSWORD);
+        String index = requireConcreteIndex(config.get(Elasticsearch8SourceOptions.INDEX));
+        List<String> sourceFields = normalizeSourceFields(
+                config.getOptional(Elasticsearch8SourceOptions.SOURCE)
+                        .orElse(Collections.<String>emptyList()));
+        String query = normalize(config.get(Elasticsearch8SourceOptions.QUERY));
+        String scrollTime = requireDuration(config.get(Elasticsearch8SourceOptions.SCROLL_TIME), "scroll_time");
+        int scrollSize = config.get(Elasticsearch8SourceOptions.SCROLL_SIZE);
+        Integer slices = config.getOptional(Elasticsearch8SourceOptions.SLICES).orElse(null);
+        int connectTimeoutMs = config.get(Elasticsearch8SourceOptions.CONNECT_TIMEOUT_MS);
+        int socketTimeoutMs = config.get(Elasticsearch8SourceOptions.SOCKET_TIMEOUT_MS);
+
+        validatePositive(scrollSize, "scroll_size");
+        validatePositive(connectTimeoutMs, "connect_timeout_ms");
+        validatePositive(socketTimeoutMs, "socket_timeout_ms");
+        if (slices != null) {
+            validatePositive(slices, "slices");
+        }
+
+        return new Elasticsearch8SourceConfig(
+                hosts,
+                username == null ? "" : username,
+                password == null ? "" : password,
+                index,
+                sourceFields,
+                query,
+                scrollTime,
+                scrollSize,
+                slices,
+                connectTimeoutMs,
+                socketTimeoutMs);
+    }
+
+    private static List<String> normalizeHosts(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("hosts must contain at least one Elasticsearch node");
+        }
+        List<String> result = new ArrayList<String>();
+        for (String value : values) {
+            String host = normalize(value);
+            if (host == null) {
+                throw new IllegalArgumentException("hosts values must not be blank");
+            }
+            validateHost(host);
+            result.add(stripTrailingSlash(host));
+        }
+        return result;
+    }
+
+    private static void validateHost(String value) {
+        final URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null
+                || (!("http".equalsIgnoreCase(scheme)) && !("https".equalsIgnoreCase(scheme)))) {
+            throw new IllegalArgumentException("Elasticsearch host must use http or https: " + value);
+        }
+        if (uri.getHost() == null) {
+            throw new IllegalArgumentException("Elasticsearch host must include a hostname: " + value);
+        }
+        String path = uri.getPath();
+        if (path != null && !path.isEmpty() && !"/".equals(path)) {
+            throw new IllegalArgumentException("Elasticsearch host must not include a path: " + value);
+        }
+        if (uri.getQuery() != null || uri.getFragment() != null || uri.getUserInfo() != null) {
+            throw new IllegalArgumentException("Elasticsearch host must not include credentials, query, or fragment: " + value);
+        }
+    }
+
+    private static String requireConcreteIndex(String value) {
+        String index = normalize(value);
+        if (index == null) {
+            throw new IllegalArgumentException("index must not be empty");
+        }
+        if (index.indexOf(',') >= 0 || index.indexOf('*') >= 0 || index.indexOf('?') >= 0) {
+            throw new IllegalArgumentException(
+                    "Stage 3 Elasticsearch 8 Source requires one concrete index or single-index alias; wildcards and multi-index expressions are not supported: "
+                            + index);
+        }
+        return index;
+    }
+
+    private static List<String> normalizeSourceFields(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+        Set<String> unique = new LinkedHashSet<String>();
+        for (String value : values) {
+            String field = normalize(value);
+            if (field == null) {
+                throw new IllegalArgumentException("source values must not be blank");
+            }
+            if (!unique.add(field)) {
+                throw new IllegalArgumentException("Duplicate source field: " + field);
+            }
+        }
+        return new ArrayList<String>(unique);
+    }
+
+    static String requireDuration(String value, String name) {
+        String text = normalize(value);
+        if (text == null) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        String normalized = text.toLowerCase(Locale.ROOT);
+        long multiplier;
+        String number;
+        if (normalized.endsWith("ms")) {
+            multiplier = 1L;
+            number = normalized.substring(0, normalized.length() - 2);
+        } else if (normalized.endsWith("s")) {
+            multiplier = 1000L;
+            number = normalized.substring(0, normalized.length() - 1);
+        } else if (normalized.endsWith("m")) {
+            multiplier = 60_000L;
+            number = normalized.substring(0, normalized.length() - 1);
+        } else if (normalized.endsWith("h")) {
+            multiplier = 3_600_000L;
+            number = normalized.substring(0, normalized.length() - 1);
+        } else {
+            throw new IllegalArgumentException(name + " must use ms, s, m, or h: " + value);
+        }
+        final long amount;
+        try {
+            amount = Long.parseLong(number.trim());
+        } catch (NumberFormatException failure) {
+            throw new IllegalArgumentException(name + " must be a positive duration: " + value, failure);
+        }
+        if (amount <= 0L || amount > Long.MAX_VALUE / multiplier) {
+            throw new IllegalArgumentException(name + " must be a positive duration: " + value);
+        }
+        return normalized;
+    }
+
+    private static String stripTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private static void validatePositive(int value, String name) {
+        if (value <= 0) {
+            throw new IllegalArgumentException(name + " must be greater than 0");
+        }
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    public List<String> getHosts() { return hosts; }
+    public String getUsername() { return username; }
+    public String getPassword() { return password; }
+    public String getIndex() { return index; }
+    public List<String> getSourceFields() { return sourceFields; }
+    public String getQuery() { return query; }
+    public String getScrollTime() { return scrollTime; }
+    public int getScrollSize() { return scrollSize; }
+    public Integer getSlices() { return slices; }
+
+    public int resolveSlices(int parallelism) {
+        validatePositive(parallelism, "parallelism");
+        return slices == null ? parallelism : slices;
+    }
+
+    public int getConnectTimeoutMs() { return connectTimeoutMs; }
+    public int getSocketTimeoutMs() { return socketTimeoutMs; }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SourceOptions.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SourceOptions.java
@@ -1,0 +1,103 @@
+package com.link.up.connector.elasticsearch8.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+
+/** Options for the bounded Elasticsearch 8 Source. */
+public final class Elasticsearch8SourceOptions {
+
+    private Elasticsearch8SourceOptions() {
+    }
+
+    public static final Option<List<String>> HOSTS =
+            Options.key("hosts")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Elasticsearch HTTP nodes, for example http://localhost:9200")
+                    .withSemanticType("ELASTICSEARCH_HOSTS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Elasticsearch username")
+                    .withSemanticType("USERNAME")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .sensitive()
+                    .withDescription("Elasticsearch password")
+                    .withSemanticType("PASSWORD")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> INDEX =
+            Options.key("index")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("One concrete Elasticsearch index or alias resolving to one index")
+                    .withSemanticType("INDEX")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<List<String>> SOURCE =
+            Options.key("source")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Optional _source projection; dotted nested paths are supported")
+                    .withSemanticType("SOURCE_FIELDS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> QUERY =
+            Options.key("query")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Optional Elasticsearch Query DSL object; blank means match_all")
+                    .withSemanticType("QUERY")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> SCROLL_TIME =
+            Options.key("scroll_time")
+                    .stringType()
+                    .defaultValue("1m")
+                    .withDescription("Scroll context keep-alive, supporting ms, s, m, or h")
+                    .withSemanticType("SCROLL_TIME")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SCROLL_SIZE =
+            Options.key("scroll_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("Documents requested from Elasticsearch per scroll page")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> SLICES =
+            Options.key("slices")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription("Optional fixed number of sliced-scroll splits; defaults to reader parallelism")
+                    .withSemanticType("SPLIT_COUNT")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> CONNECT_TIMEOUT_MS =
+            Options.key("connect_timeout_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription("Elasticsearch HTTP connect timeout in milliseconds")
+                    .withSemanticType("CONNECT_TIMEOUT_MS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<Integer> SOCKET_TIMEOUT_MS =
+            Options.key("socket_timeout_ms")
+                    .intType()
+                    .defaultValue(60000)
+                    .withDescription("Elasticsearch HTTP socket timeout in milliseconds")
+                    .withSemanticType("SOCKET_TIMEOUT_MS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8RowConverter.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8RowConverter.java
@@ -1,0 +1,141 @@
+package com.link.up.connector.elasticsearch8.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.SqlType;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+
+/** Converts one Elasticsearch 8 _source document into a Link-Up FluxRow. */
+public final class Elasticsearch8RowConverter {
+
+    private final TableSchema schema;
+    private final ObjectMapper objectMapper;
+
+    public Elasticsearch8RowConverter(TableSchema schema) {
+        this(schema, new ObjectMapper());
+    }
+
+    Elasticsearch8RowConverter(TableSchema schema, ObjectMapper objectMapper) {
+        this.schema = Objects.requireNonNull(schema, "schema must not be null");
+        this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
+    }
+
+    public FluxRow convert(Map<String, Object> source) {
+        Objects.requireNonNull(source, "source must not be null");
+        FluxRow row = new FluxRow(schema.getColumnCount());
+        for (int index = 0; index < schema.getColumnCount(); index++) {
+            Column column = schema.getColumn(index);
+            Object value = resolveValue(source, column.getName());
+            row.setField(index, convertValue(value, column));
+        }
+        return row;
+    }
+
+    private Object convertValue(Object value, Column column) {
+        if (value == null) {
+            return null;
+        }
+        SqlType target = column.getDataType().getSqlType();
+        if (target != SqlType.STRING && isMultiValue(value)) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch field '" + column.getName()
+                            + "' is multi-valued but mappings do not declare array cardinality; "
+                            + "Stage 3 only auto-converts multi-valued/object content to STRING/JSON fields");
+        }
+        switch (target) {
+            case STRING:
+                return toStringValue(value);
+            case BOOLEAN:
+                return toBoolean(value, column.getName());
+            case TINYINT:
+                return number(value, column.getName()).byteValue();
+            case SMALLINT:
+                return number(value, column.getName()).shortValue();
+            case INT:
+                return number(value, column.getName()).intValue();
+            case BIGINT:
+                return number(value, column.getName()).longValue();
+            case FLOAT:
+                return number(value, column.getName()).floatValue();
+            case DOUBLE:
+                return number(value, column.getName()).doubleValue();
+            case DECIMAL:
+                return value instanceof BigDecimal ? value : new BigDecimal(String.valueOf(value));
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported Elasticsearch 8 Stage 3 target type for field '"
+                                + column.getName() + "': " + target);
+        }
+    }
+
+    private String toStringValue(Object value) {
+        if (value instanceof CharSequence) {
+            return value.toString();
+        }
+        if (value instanceof Map || value instanceof Collection || value.getClass().isArray()) {
+            try {
+                return objectMapper.writeValueAsString(value);
+            } catch (JsonProcessingException failure) {
+                throw new IllegalArgumentException("Failed to serialize Elasticsearch field as JSON", failure);
+            }
+        }
+        return String.valueOf(value);
+    }
+
+    private static Boolean toBoolean(Object value, String field) {
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        String text = String.valueOf(value).trim();
+        if ("true".equalsIgnoreCase(text)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equalsIgnoreCase(text)) {
+            return Boolean.FALSE;
+        }
+        throw new IllegalArgumentException("Cannot convert Elasticsearch field '" + field + "' to boolean: " + value);
+    }
+
+    private static Number number(Object value, String field) {
+        if (value instanceof Number) {
+            return (Number) value;
+        }
+        try {
+            return new BigDecimal(String.valueOf(value));
+        } catch (NumberFormatException failure) {
+            throw new IllegalArgumentException(
+                    "Cannot convert Elasticsearch field '" + field + "' to number: " + value,
+                    failure);
+        }
+    }
+
+    private static boolean isMultiValue(Object value) {
+        return value instanceof Collection || value.getClass().isArray();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Object resolveValue(Map<String, Object> source, String fieldPath) {
+        if (source.containsKey(fieldPath)) {
+            return source.get(fieldPath);
+        }
+        Object current = source;
+        for (String part : fieldPath.split("\\.")) {
+            if (!(current instanceof Map)) {
+                return null;
+            }
+            Map<String, Object> map = (Map<String, Object>) current;
+            if (!map.containsKey(part)) {
+                return null;
+            }
+            current = map.get(part);
+        }
+        return current;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/schema/Elasticsearch8TypeMapper.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/schema/Elasticsearch8TypeMapper.java
@@ -1,0 +1,151 @@
+package com.link.up.connector.elasticsearch8.schema;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Restrained ES8 mapping conversion matching the Stage 1 product type boundary. */
+public final class Elasticsearch8TypeMapper {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private Elasticsearch8TypeMapper() {
+    }
+
+    public static TableSchema toTableSchema(
+            TypeMapping mapping,
+            List<String> projectedFields) {
+        if (mapping == null) {
+            throw new IllegalArgumentException("Elasticsearch index mapping must not be null");
+        }
+        final Map<String, Object> raw;
+        try {
+            raw = OBJECT_MAPPER.readValue(
+                    mapping.toString(),
+                    new TypeReference<Map<String, Object>>() { });
+        } catch (IOException failure) {
+            throw new IllegalArgumentException("Failed to read Elasticsearch 8 mapping JSON", failure);
+        }
+        return toTableSchema(raw, projectedFields);
+    }
+
+    static TableSchema toTableSchema(
+            Map<String, Object> mapping,
+            List<String> projectedFields) {
+        Map<String, Object> properties = mapValue(mapping == null ? null : mapping.get("properties"));
+        if (properties.isEmpty()) {
+            throw new IllegalArgumentException("Elasticsearch index mapping does not contain any properties");
+        }
+
+        List<String> fields = projectedFields == null || projectedFields.isEmpty()
+                ? new ArrayList<String>(properties.keySet())
+                : new ArrayList<String>(projectedFields);
+
+        TableSchema.Builder builder = TableSchema.builder();
+        for (String field : fields) {
+            Map<String, Object> fieldMapping = findFieldMapping(properties, field);
+            if (fieldMapping == null) {
+                throw new IllegalArgumentException("Cannot find Elasticsearch mapping for source field: " + field);
+            }
+            String sourceType = stringValue(fieldMapping.get("type"));
+            if (sourceType == null && fieldMapping.containsKey("properties")) {
+                sourceType = "object";
+            }
+            if (sourceType == null) {
+                sourceType = "unknown";
+            }
+            Column.Builder column = Column.builder(field, toFluxType(sourceType))
+                    .nullable(true)
+                    .sourceType(sourceType);
+            String format = stringValue(fieldMapping.get("format"));
+            if (format != null) {
+                column.attribute("format", format);
+            }
+            builder.column(column.build());
+        }
+        return builder.build();
+    }
+
+    private static FluxDataType<?> toFluxType(String sourceType) {
+        String type = sourceType == null ? "" : sourceType;
+        switch (type) {
+            case "boolean":
+                return BasicType.BOOLEAN_TYPE;
+            case "byte":
+                return BasicType.BYTE_TYPE;
+            case "short":
+                return BasicType.SHORT_TYPE;
+            case "integer":
+            case "token_count":
+                return BasicType.INT_TYPE;
+            case "long":
+                return BasicType.LONG_TYPE;
+            case "unsigned_long":
+                return new DecimalType(20, 0);
+            case "half_float":
+            case "float":
+                return BasicType.FLOAT_TYPE;
+            case "double":
+            case "scaled_float":
+            case "rank_feature":
+                return BasicType.DOUBLE_TYPE;
+            default:
+                return BasicType.STRING_TYPE;
+        }
+    }
+
+    private static Map<String, Object> findFieldMapping(
+            Map<String, Object> rootProperties,
+            String fieldPath) {
+        String[] parts = fieldPath.split("\\.");
+        Map<String, Object> properties = rootProperties;
+        Map<String, Object> current = null;
+        for (int index = 0; index < parts.length; index++) {
+            current = mapValue(properties.get(parts[index]));
+            if (current.isEmpty()) {
+                return null;
+            }
+            if (index < parts.length - 1) {
+                properties = mapValue(current.get("properties"));
+                if (properties.isEmpty()) {
+                    return null;
+                }
+            }
+        }
+        return current;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> mapValue(Object value) {
+        if (!(value instanceof Map)) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+            if (entry.getKey() != null) {
+                result.put(String.valueOf(entry.getKey()), entry.getValue());
+            }
+        }
+        return result;
+    }
+
+    private static String stringValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = String.valueOf(value).trim();
+        return text.isEmpty() ? null : text;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8Source.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8Source.java
@@ -1,0 +1,57 @@
+package com.link.up.connector.elasticsearch8.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SourceConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Elasticsearch 8 bounded Source using sliced Scroll reads. */
+public final class Elasticsearch8Source implements Source<Elasticsearch8SourceSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Elasticsearch8SourceConfig config;
+
+    public Elasticsearch8Source(Elasticsearch8SourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public SourceSplitEnumerator<Elasticsearch8SourceSplit> createEnumerator(
+            Map<TablePath, CatalogTable> tables,
+            SourceEnumeratorContext context) {
+        Objects.requireNonNull(tables, "tables must not be null");
+        Objects.requireNonNull(context, "context must not be null");
+        return new Elasticsearch8SourceSplitEnumerator(config, context.getParallelism());
+    }
+
+    @Override
+    @Deprecated
+    public List<Elasticsearch8SourceSplit> createSplits(
+            Map<TablePath, CatalogTable> tables,
+            int parallelism) throws Exception {
+        try (Elasticsearch8SourceSplitEnumerator enumerator =
+                     new Elasticsearch8SourceSplitEnumerator(config, parallelism)) {
+            return enumerator.enumerateSplits();
+        }
+    }
+
+    @Override
+    public SourceReader<FluxRow, Elasticsearch8SourceSplit> createReader(
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        return new Elasticsearch8SourceReader(config, tables, batchSize);
+    }
+
+    public Elasticsearch8SourceConfig getConfig() {
+        return config;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceFactory.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceFactory.java
@@ -1,0 +1,79 @@
+package com.link.up.connector.elasticsearch8.source;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.connector.elasticsearch8.Elasticsearch8ConnectorIdentity;
+import com.link.up.connector.elasticsearch8.client.Elasticsearch8Client;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SourceConfig;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SourceOptions;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** SPI factory for the bounded Elasticsearch 8 Source. */
+@AutoService(TableSourceFactory.class)
+public final class Elasticsearch8SourceFactory
+        implements TableSourceFactory<Elasticsearch8SourceSplit> {
+
+    @Override
+    public String factoryIdentifier() {
+        return Elasticsearch8ConnectorIdentity.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(
+                        ConnectorCapability.TABLE_SCHEMA_DISCOVERY,
+                        ConnectorCapability.PARTITION_SPLIT));
+    }
+
+    @Override
+    public Source<Elasticsearch8SourceSplit> createSource(SourceFactoryContext context) {
+        return new Elasticsearch8Source(createConfig(context));
+    }
+
+    @Override
+    public List<CatalogTable> discoverTableSchemas(SourceFactoryContext context)
+            throws Exception {
+        Elasticsearch8SourceConfig config = createConfig(context);
+        try (Elasticsearch8Client client = new Elasticsearch8Client(config)) {
+            return Collections.singletonList(client.discoverTable());
+        }
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        Elasticsearch8SourceOptions.HOSTS,
+                        Elasticsearch8SourceOptions.INDEX)
+                .optional(
+                        Elasticsearch8SourceOptions.USERNAME,
+                        Elasticsearch8SourceOptions.PASSWORD,
+                        Elasticsearch8SourceOptions.SOURCE,
+                        Elasticsearch8SourceOptions.QUERY,
+                        Elasticsearch8SourceOptions.SCROLL_TIME,
+                        Elasticsearch8SourceOptions.SCROLL_SIZE,
+                        Elasticsearch8SourceOptions.SLICES,
+                        Elasticsearch8SourceOptions.CONNECT_TIMEOUT_MS,
+                        Elasticsearch8SourceOptions.SOCKET_TIMEOUT_MS)
+                .build();
+    }
+
+    private Elasticsearch8SourceConfig createConfig(SourceFactoryContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        ReadonlyConfig options = Objects.requireNonNull(
+                context.getOptions(), "source options must not be null");
+        return Elasticsearch8SourceConfig.of(options);
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceReader.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceReader.java
@@ -1,0 +1,213 @@
+package com.link.up.connector.elasticsearch8.source;
+
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch8.client.Elasticsearch8Client;
+import com.link.up.connector.elasticsearch8.client.Elasticsearch8Client.ScrollPage;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SourceConfig;
+import com.link.up.connector.elasticsearch8.converter.Elasticsearch8RowConverter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Bounded ES8 reader with one active scroll context per split. */
+public final class Elasticsearch8SourceReader
+        implements SourceReader<FluxRow, Elasticsearch8SourceSplit> {
+
+    private final Elasticsearch8SourceConfig config;
+    private final Map<TablePath, CatalogTable> tables;
+    private final int batchSize;
+
+    private Elasticsearch8Client client;
+    private List<Elasticsearch8SourceSplit> assignedSplits = Collections.emptyList();
+    private int nextSplitIndex;
+    private Elasticsearch8SourceSplit currentSplit;
+    private Elasticsearch8RowConverter rowConverter;
+    private ScrollPage currentPage;
+    private int currentPageOffset;
+    private String currentScrollId;
+    private boolean opened;
+    private boolean closed;
+
+    public Elasticsearch8SourceReader(
+            Elasticsearch8SourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(tables, "tables must not be null");
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+        this.tables = Collections.unmodifiableMap(
+                new LinkedHashMap<TablePath, CatalogTable>(tables));
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public void open(List<Elasticsearch8SourceSplit> splits) throws Exception {
+        ensureNotOpened();
+        this.assignedSplits = splits == null
+                ? Collections.<Elasticsearch8SourceSplit>emptyList()
+                : Collections.unmodifiableList(new ArrayList<Elasticsearch8SourceSplit>(splits));
+        initializeClient();
+    }
+
+    @Override
+    public void open() throws Exception {
+        open(Collections.<Elasticsearch8SourceSplit>emptyList());
+    }
+
+    @Override
+    public void openSplit(Elasticsearch8SourceSplit split) throws Exception {
+        Objects.requireNonNull(split, "split must not be null");
+        if (!opened) {
+            open();
+        }
+        ensureUsable();
+        if (currentSplit != null) {
+            throw new IllegalStateException("A split is already open: " + currentSplit.splitId());
+        }
+        openCurrentSplit(split);
+    }
+
+    @Override
+    public RecordBatch<FluxRow> readBatch() throws Exception {
+        ensureUsable();
+        while (true) {
+            if (currentSplit == null && !openNextAssignedSplit()) {
+                return RecordBatch.endOfInput();
+            }
+
+            Elasticsearch8SourceSplit batchSplit = currentSplit;
+            List<FluxRow> rows = new ArrayList<FluxRow>(batchSize);
+            while (rows.size() < batchSize && currentSplit == batchSplit) {
+                if (currentPageOffset < currentPage.getDocuments().size()) {
+                    rows.add(rowConverter.convert(
+                            currentPage.getDocuments().get(currentPageOffset++)));
+                    continue;
+                }
+
+                if (currentPage.getDocuments().isEmpty()
+                        || currentScrollId == null
+                        || currentScrollId.trim().isEmpty()) {
+                    closeSplit();
+                    break;
+                }
+
+                ScrollPage nextPage = client.continueScroll(currentScrollId);
+                currentPage = nextPage;
+                currentPageOffset = 0;
+                currentScrollId = nextPage.getScrollId();
+                if (nextPage.getDocuments().isEmpty()) {
+                    closeSplit();
+                    break;
+                }
+            }
+
+            if (!rows.isEmpty()) {
+                return RecordBatch.of(batchSplit, rows);
+            }
+        }
+    }
+
+    private boolean openNextAssignedSplit() throws Exception {
+        while (nextSplitIndex < assignedSplits.size()) {
+            openCurrentSplit(assignedSplits.get(nextSplitIndex++));
+            return true;
+        }
+        return false;
+    }
+
+    private void openCurrentSplit(Elasticsearch8SourceSplit split) throws Exception {
+        CatalogTable table = tables.get(split.getTablePath());
+        if (table == null) {
+            throw new IllegalArgumentException(
+                    "No prepared schema found for Elasticsearch index: " + split.getTablePath());
+        }
+        this.currentSplit = split;
+        this.rowConverter = new Elasticsearch8RowConverter(table.getTableSchema());
+        this.currentPage = client.startScroll(split);
+        this.currentPageOffset = 0;
+        this.currentScrollId = currentPage.getScrollId();
+    }
+
+    @Override
+    public void closeSplit() throws Exception {
+        String scrollId = currentScrollId;
+        currentSplit = null;
+        rowConverter = null;
+        currentPage = null;
+        currentPageOffset = 0;
+        currentScrollId = null;
+        if (scrollId != null && client != null) {
+            client.clearScroll(scrollId);
+        }
+    }
+
+    private void initializeClient() throws Exception {
+        this.client = new Elasticsearch8Client(config);
+        boolean success = false;
+        try {
+            client.verifyMajorVersion();
+            opened = true;
+            success = true;
+        } finally {
+            if (!success) {
+                client.close();
+                client = null;
+            }
+        }
+    }
+
+    private void ensureNotOpened() {
+        if (opened || closed) {
+            throw new IllegalStateException("Elasticsearch8SourceReader has already been opened or closed");
+        }
+    }
+
+    private void ensureUsable() {
+        if (!opened || closed || client == null) {
+            throw new IllegalStateException("Elasticsearch8SourceReader is not open");
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (closed) {
+            return;
+        }
+        Exception failure = null;
+        try {
+            if (currentSplit != null || currentScrollId != null) {
+                closeSplit();
+            }
+        } catch (Exception closeFailure) {
+            failure = closeFailure;
+        }
+        try {
+            if (client != null) {
+                client.close();
+            }
+        } catch (Exception closeFailure) {
+            if (failure == null) {
+                failure = closeFailure;
+            } else {
+                failure.addSuppressed(closeFailure);
+            }
+        } finally {
+            client = null;
+            opened = false;
+            closed = true;
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceSplit.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceSplit.java
@@ -1,0 +1,62 @@
+package com.link.up.connector.elasticsearch8.source;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.TablePath;
+
+import java.util.Objects;
+
+/** One bounded Elasticsearch 8 sliced-scroll unit. */
+public final class Elasticsearch8SourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String index;
+    private final int sliceId;
+    private final int sliceMax;
+    private final String splitId;
+
+    public Elasticsearch8SourceSplit(String index, int sliceId, int sliceMax) {
+        this.index = requireText(index, "index");
+        if (sliceMax <= 0) {
+            throw new IllegalArgumentException("sliceMax must be greater than 0");
+        }
+        if (sliceId < 0 || sliceId >= sliceMax) {
+            throw new IllegalArgumentException("sliceId must be in [0, sliceMax)");
+        }
+        this.sliceId = sliceId;
+        this.sliceMax = sliceMax;
+        this.splitId = index + "#slice-" + sliceId + "-of-" + sliceMax;
+    }
+
+    @Override
+    public String splitId() {
+        return splitId;
+    }
+
+    @Override
+    public String dataSetId() {
+        return index;
+    }
+
+    public String getIndex() { return index; }
+    public int getSliceId() { return sliceId; }
+    public int getSliceMax() { return sliceMax; }
+    public TablePath getTablePath() { return TablePath.of(index); }
+
+    private static String requireText(String value, String name) {
+        Objects.requireNonNull(value, name + " must not be null");
+        String normalized = value.trim();
+        if (normalized.isEmpty()) {
+            throw new IllegalArgumentException(name + " must not be empty");
+        }
+        return normalized;
+    }
+
+    @Override
+    public String toString() {
+        return "Elasticsearch8SourceSplit{index='" + index + '\''
+                + ", sliceId=" + sliceId
+                + ", sliceMax=" + sliceMax
+                + '}';
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceSplitEnumerator.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceSplitEnumerator.java
@@ -1,0 +1,38 @@
+package com.link.up.connector.elasticsearch8.source;
+
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SourceConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Plans one sliced-scroll split per configured or execution parallel slice. */
+public final class Elasticsearch8SourceSplitEnumerator
+        implements SourceSplitEnumerator<Elasticsearch8SourceSplit> {
+
+    private final Elasticsearch8SourceConfig config;
+    private final int parallelism;
+
+    public Elasticsearch8SourceSplitEnumerator(
+            Elasticsearch8SourceConfig config,
+            int parallelism) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        if (parallelism <= 0) {
+            throw new IllegalArgumentException("parallelism must be greater than 0");
+        }
+        this.parallelism = parallelism;
+    }
+
+    @Override
+    public List<Elasticsearch8SourceSplit> enumerateSplits() {
+        int sliceMax = config.resolveSlices(parallelism);
+        List<Elasticsearch8SourceSplit> result =
+                new ArrayList<Elasticsearch8SourceSplit>(sliceMax);
+        for (int sliceId = 0; sliceId < sliceMax; sliceId++) {
+            result.add(new Elasticsearch8SourceSplit(config.getIndex(), sliceId, sliceMax));
+        }
+        return Collections.unmodifiableList(result);
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/Elasticsearch8DependencyBoundaryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/Elasticsearch8DependencyBoundaryTest.java
@@ -1,6 +1,7 @@
 package com.link.up.connector.elasticsearch8;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -9,21 +10,25 @@ import static org.junit.Assert.fail;
 public class Elasticsearch8DependencyBoundaryTest {
 
     @Test
-    public void moduleOwnsElasticsearch8SdkOnly() {
+    public void moduleOwnsElasticsearch8SdkAndJackson2MapperOnly() {
         assertEquals("elasticsearch8", Elasticsearch8ConnectorIdentity.IDENTIFIER);
         assertEquals(8, Elasticsearch8ConnectorIdentity.MAJOR_VERSION);
         assertEquals(
                 "co.elastic.clients.elasticsearch.ElasticsearchClient",
                 ElasticsearchClient.class.getName());
+        assertEquals(
+                "co.elastic.clients.json.jackson.JacksonJsonpMapper",
+                JacksonJsonpMapper.class.getName());
         assertClassNotPresent("org.elasticsearch.client.RestHighLevelClient");
+        assertClassNotPresent("tools.jackson.databind.ObjectMapper");
     }
 
     private static void assertClassNotPresent(String className) {
         try {
             Class.forName(className);
-            fail("Elasticsearch 7 SDK leaked into Elasticsearch 8 module: " + className);
+            fail("Unexpected dependency leaked into Elasticsearch 8 module: " + className);
         } catch (ClassNotFoundException expected) {
-            // Expected: ES8 and ES7 SDK classpaths stay separate at module level.
+            // Expected by the version / Java 8 dependency boundary.
         }
     }
 }

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8JacksonMapperTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8JacksonMapperTest.java
@@ -1,0 +1,28 @@
+package com.link.up.connector.elasticsearch8.client;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.stream.JsonParser;
+import org.junit.Test;
+
+import java.io.StringReader;
+
+import static org.junit.Assert.assertTrue;
+
+/** Verifies Stage 3 can parse Query DSL with the Jackson 2 mapper path on the Java 8 baseline. */
+public class Elasticsearch8JacksonMapperTest {
+
+    @Test
+    public void jackson2MapperParsesQueryDsl() {
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper(new ObjectMapper());
+        JsonParser parser = mapper.jsonProvider().createParser(
+                new StringReader("{\"range\":{\"created_at\":{\"gte\":\"2026-01-01\"}}}"));
+        try {
+            Query query = Query._DESERIALIZER.deserialize(parser, mapper);
+            assertTrue(query.isRange());
+        } finally {
+            parser.close();
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SourceConfigTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SourceConfigTest.java
@@ -1,0 +1,69 @@
+package com.link.up.connector.elasticsearch8.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch8SourceConfigTest {
+
+    @Test
+    public void usesBoundedDefaultsAndRuntimeParallelism() {
+        Elasticsearch8SourceConfig config = Elasticsearch8SourceConfig.of(
+                ReadonlyConfig.fromMap(base("orders")));
+        assertEquals("orders", config.getIndex());
+        assertEquals("1m", config.getScrollTime());
+        assertEquals(1000, config.getScrollSize());
+        assertNull(config.getSlices());
+        assertEquals(3, config.resolveSlices(3));
+    }
+
+    @Test
+    public void fixedSlicesOverrideRuntimeParallelism() {
+        Map<String, Object> values = base("orders");
+        values.put("slices", 4);
+        Elasticsearch8SourceConfig config = Elasticsearch8SourceConfig.of(
+                ReadonlyConfig.fromMap(values));
+        assertEquals(4, config.resolveSlices(2));
+    }
+
+    @Test
+    public void rejectsMultiIndexExpressions() {
+        try {
+            Elasticsearch8SourceConfig.of(ReadonlyConfig.fromMap(base("orders-*")));
+            fail("Expected wildcard index rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void validatesScrollDuration() {
+        Map<String, Object> values = base("orders");
+        values.put("scroll_time", "30s");
+        Elasticsearch8SourceConfig config = Elasticsearch8SourceConfig.of(
+                ReadonlyConfig.fromMap(values));
+        assertEquals("30s", config.getScrollTime());
+
+        values.put("scroll_time", "forever");
+        try {
+            Elasticsearch8SourceConfig.of(ReadonlyConfig.fromMap(values));
+            fail("Expected invalid duration rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    private static Map<String, Object> base(String index) {
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("hosts", Arrays.asList("http://localhost:9200"));
+        values.put("index", index);
+        return values;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8RowConverterTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8RowConverterTest.java
@@ -1,0 +1,55 @@
+package com.link.up.connector.elasticsearch8.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch8RowConverterTest {
+
+    @Test
+    public void convertsNestedProjectionAndComplexJson() {
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.STRING_TYPE).sourceType("keyword").build())
+                .column(Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("keyword").build())
+                .column(Column.builder("payload", BasicType.STRING_TYPE).sourceType("object").build())
+                .build();
+
+        Map<String, Object> customer = new LinkedHashMap<String, Object>();
+        customer.put("name", "Ada");
+        Map<String, Object> payload = new LinkedHashMap<String, Object>();
+        payload.put("x", 1);
+        Map<String, Object> source = new LinkedHashMap<String, Object>();
+        source.put("id", "o-1");
+        source.put("customer", customer);
+        source.put("payload", payload);
+
+        FluxRow row = new Elasticsearch8RowConverter(schema).convert(source);
+        assertEquals("o-1", row.getField(0));
+        assertEquals("Ada", row.getField(1));
+        assertEquals("{\"x\":1}", row.getField(2));
+    }
+
+    @Test
+    public void rejectsTypedMultiValueWhenMappingCannotDeclareArrayCardinality() {
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("count", BasicType.LONG_TYPE).sourceType("long").build())
+                .build();
+        Map<String, Object> source = new LinkedHashMap<String, Object>();
+        source.put("count", Arrays.asList(1, 2));
+        try {
+            new Elasticsearch8RowConverter(schema).convert(source);
+            fail("Expected typed multi-value rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/schema/Elasticsearch8TypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/schema/Elasticsearch8TypeMapperTest.java
@@ -1,0 +1,71 @@
+package com.link.up.connector.elasticsearch8.schema;
+
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import jakarta.json.stream.JsonParser;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Elasticsearch8TypeMapperTest {
+
+    @Test
+    public void mapsStableScalarsAndProjectedNestedFields() {
+        Map<String, Object> properties = new LinkedHashMap<String, Object>();
+        properties.put("active", field("boolean"));
+        properties.put("count", field("long"));
+        properties.put("unsigned", field("unsigned_long"));
+
+        Map<String, Object> customerProperties = new LinkedHashMap<String, Object>();
+        customerProperties.put("name", field("keyword"));
+        Map<String, Object> customer = new LinkedHashMap<String, Object>();
+        customer.put("properties", customerProperties);
+        properties.put("customer", customer);
+
+        Map<String, Object> mapping = new LinkedHashMap<String, Object>();
+        mapping.put("properties", properties);
+
+        TableSchema schema = Elasticsearch8TypeMapper.toTableSchema(
+                mapping,
+                Arrays.asList("active", "count", "unsigned", "customer.name"));
+
+        assertEquals(BasicType.BOOLEAN_TYPE, schema.getColumn("active").getDataType());
+        assertEquals(BasicType.LONG_TYPE, schema.getColumn("count").getDataType());
+        assertEquals(new DecimalType(20, 0), schema.getColumn("unsigned").getDataType());
+        assertEquals(BasicType.STRING_TYPE, schema.getColumn("customer.name").getDataType());
+    }
+
+    @Test
+    public void mapsTypedJavaClientMappingThroughPublicBoundary() {
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper(new ObjectMapper());
+        JsonParser parser = mapper.jsonProvider().createParser(new StringReader(
+                "{\"properties\":{\"count\":{\"type\":\"long\"},\"name\":{\"type\":\"keyword\"}}}"));
+        final TypeMapping mapping;
+        try {
+            mapping = TypeMapping._DESERIALIZER.deserialize(parser, mapper);
+        } finally {
+            parser.close();
+        }
+
+        TableSchema schema = Elasticsearch8TypeMapper.toTableSchema(
+                mapping,
+                Arrays.asList("count", "name"));
+        assertEquals(BasicType.LONG_TYPE, schema.getColumn("count").getDataType());
+        assertEquals(BasicType.STRING_TYPE, schema.getColumn("name").getDataType());
+    }
+
+    private static Map<String, Object> field(String type) {
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        result.put("type", type);
+        return result;
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceFactoryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceFactoryTest.java
@@ -1,0 +1,21 @@
+package com.link.up.connector.elasticsearch8.source;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Elasticsearch8SourceFactoryTest {
+
+    @Test
+    public void exposesOnlyBoundedSourceCapabilities() {
+        Elasticsearch8SourceFactory factory = new Elasticsearch8SourceFactory();
+        assertEquals("elasticsearch8", factory.factoryIdentifier());
+        assertTrue(factory.capabilities().contains(ConnectorCapability.TABLE_SCHEMA_DISCOVERY));
+        assertTrue(factory.capabilities().contains(ConnectorCapability.PARTITION_SPLIT));
+        assertFalse(factory.capabilities().contains(ConnectorCapability.MULTI_TABLE));
+        assertFalse(factory.capabilities().contains(ConnectorCapability.UPSERT));
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceSplitEnumeratorTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/source/Elasticsearch8SourceSplitEnumeratorTest.java
@@ -1,0 +1,44 @@
+package com.link.up.connector.elasticsearch8.source;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SourceConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Elasticsearch8SourceSplitEnumeratorTest {
+
+    @Test
+    public void usesRuntimeParallelismWhenSlicesAreNotFixed() throws Exception {
+        Elasticsearch8SourceConfig config = config(null);
+        List<Elasticsearch8SourceSplit> splits =
+                new Elasticsearch8SourceSplitEnumerator(config, 3).enumerateSplits();
+        assertEquals(3, splits.size());
+        assertEquals(0, splits.get(0).getSliceId());
+        assertEquals(3, splits.get(0).getSliceMax());
+    }
+
+    @Test
+    public void usesConfiguredSliceCount() throws Exception {
+        Elasticsearch8SourceConfig config = config(4);
+        List<Elasticsearch8SourceSplit> splits =
+                new Elasticsearch8SourceSplitEnumerator(config, 2).enumerateSplits();
+        assertEquals(4, splits.size());
+        assertEquals("orders#slice-3-of-4", splits.get(3).splitId());
+    }
+
+    private static Elasticsearch8SourceConfig config(Integer slices) {
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("hosts", Arrays.asList("http://localhost:9200"));
+        values.put("index", "orders");
+        if (slices != null) {
+            values.put("slices", slices);
+        }
+        return Elasticsearch8SourceConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <arrow.version>5.0.0</arrow.version>
         <elasticsearch7.client.version>7.17.29</elasticsearch7.client.version>
         <elasticsearch8.client.version>8.19.21</elasticsearch8.client.version>
+        <elasticsearch8.jackson2.version>2.18.8</elasticsearch8.jackson2.version>
 
 
     </properties>


### PR DESCRIPTION
## Summary

Continue the Elasticsearch connector family with **Stage 3: a restrained Elasticsearch 8 bounded Source**.

This PR is based directly on the current `main`, including merged Elasticsearch 7 Source + Sink work from Stages 1–2. It keeps the Stage 0 ES7/ES8 dependency-island boundary intact.

## What is included

### Connector / Source boundary

- register `TableSourceFactory` under versioned identifier `elasticsearch8`
- expose `TABLE_SCHEMA_DISCOVERY` and `PARTITION_SPLIT`
- intentionally do not advertise `MULTI_TABLE`, `UPSERT`, CDC, or realtime capabilities
- support one concrete index, or one alias resolving to exactly one concrete index
- validate Elasticsearch server major version = 8

### Elasticsearch 8 Java API Client

Stage 3 uses the Elasticsearch Java API Client directly:

- `co.elastic.clients:elasticsearch-java:8.19.21`
- `RestClientTransport`
- `ElasticsearchClient`
- `indices.getMapping`
- typed Search / Scroll / ClearScroll APIs
- ES8 Query DSL deserialization through `Query._DESERIALIZER`

No ES7 High Level REST Client is reused by the ES8 implementation.

### Java 8 / JSON mapper boundary

Link-Up remains on Java 8.

The `elasticsearch-java` 8.19.21 source/build confirms it is compiled with Java `--release 8`. Its Jackson 2 integration is compile-only and built against Jackson 2.18.8, while Jackson 3 requires Java 17.

Therefore this PR:

- keeps Java 8 unchanged
- explicitly uses `JacksonJsonpMapper`
- pins Jackson 2.18.8 only for the ES8 dependency island
- keeps Jackson 3 runtime artifacts excluded
- leaves the existing global Jackson 2.15.4 version unchanged for other modules
- keeps all Elasticsearch vendor SDK types out of `elasticsearch-common`

### Bounded read model

- mapping -> Link-Up `TableSchema`
- `_source` -> `FluxRow`
- bounded Scroll reads
- sliced-scroll split planning
- default slice count follows Source reader parallelism
- optional fixed `slices`
- `_source` projection
- optional Query DSL JSON
- Basic Auth
- connect/socket timeouts
- explicit clear-scroll lifecycle when a split completes or the reader closes

## Why Scroll instead of PIT in Stage 3

Elasticsearch 8 recommends PIT + `search_after` for deep pagination, but adding PIT here would also require a deliberate design for shared PIT lifecycle across splits, consistency, ownership, cleanup, and recovery.

Stage 3 therefore keeps the same bounded sliced-Scroll execution model as the ES7 Source. PIT / `search_after` remains a separate future design concern instead of being introduced incidentally.

## Type boundary

The Stage 3 type policy mirrors the bounded ES7 Source:

- `boolean` -> `BOOLEAN`
- `byte` -> `TINYINT`
- `short` -> `SMALLINT`
- `integer` / `token_count` -> `INT`
- `long` -> `BIGINT`
- `unsigned_long` -> `DECIMAL(20,0)`
- `half_float` / `float` -> `FLOAT`
- `double` / `scaled_float` / `rank_feature` -> `DOUBLE`

Date/object/nested/geo/vector/range and other complex mappings remain STRING/JSON in Stage 3 rather than introducing lossy or version-specific semantics.

Elasticsearch mappings do not declare scalar-vs-array cardinality. Typed numeric/boolean fields that actually contain arrays therefore fail explicitly rather than silently guessing an array type.

## Configuration

```hocon
source {
  Elasticsearch8 {
    hosts = ["http://127.0.0.1:9200"]
    index = "orders"

    username = "elastic"
    password = "secret"

    source = ["order_id", "amount", "customer.name"]
    query = """{"range":{"created_at":{"gte":"2026-01-01"}}}"""

    scroll_time = "1m"
    scroll_size = 1000
    slices = 4
  }
}
```

## Tests added

Unit coverage includes:

- Source configuration defaults and validation
- wildcard / multi-index rejection
- runtime parallelism vs fixed sliced-scroll count
- mapping scalar conversion and dotted nested projection
- real ES8 `TypeMapping` -> Link-Up schema boundary
- nested `_source` conversion and complex JSON serialization
- typed multi-value rejection
- factory identifier / bounded Source capabilities
- Jackson 2 `JacksonJsonpMapper` Query DSL parsing
- dependency boundary: ES8 client + Jackson2 mapper present, ES7 HLRC + Jackson3 mapper classes absent

## Scope deliberately excluded

- Elasticsearch 8 Sink (Stage 4)
- PIT / `search_after`
- Elasticsearch SQL
- wildcard or comma-separated multi-index reads
- aliases resolving to multiple concrete indices
- runtime schema evolution
- CDC / streaming / RowKind semantics

## Runtime packaging boundary

This PR still does **not** add `link-up-connector-elasticsearch8` (or ES7) to the current flat `link-up-launcher` / `link-up-server` runtime classpath.

ES7 and ES8 bring incompatible versions of `org.elasticsearch.client:elasticsearch-rest-client`; the Stage 0 dependency-island guard remains unchanged until connector classloader isolation, shading/relocation, or an equivalent runtime isolation mechanism is completed and verified.

## Validation

- branch is based directly on current `main` after merged Stage 2 (#110)
- final compare: branch ahead only, not behind
- static API review was performed against Elasticsearch Java API Client `v8.19.21` generated/source APIs for Info, mappings, Search, Scroll, ClearScroll, SourceFilter, sliced scroll, sort, Time, Query deserialization, and transport construction
- Elasticsearch Java Client 8.19.21 build metadata confirms Java 8 release and Jackson 2.18.8 compile-only integration
- unit tests are included without requiring a live Elasticsearch cluster
- Maven and live Elasticsearch integration tests could not be executed from the current ChatGPT execution environment because outbound DNS cannot resolve `github.com`; this limitation is intentionally not represented as a passing build

## Next stage

Stage 4 can add the bounded Elasticsearch 8 Sink while preserving the same dependency island and offline-only semantics.