### PR TITLE
feat(elasticsearch): add bounded Elasticsearch 8 sink

### DIFF
--- a/link-up-connectors/ELASTICSEARCH.md
+++ b/link-up-connectors/ELASTICSEARCH.md
@@ -1,6 +1,6 @@
 # Elasticsearch Connector Family
 
-Elasticsearch 按产品族维护，但运行时对外保留两个明确的 connector identifier：
+Elasticsearch 按产品族维护，对外保留两个明确的 connector identifier：
 
 ```text
 elasticsearch7
@@ -22,11 +22,9 @@ link-up-connector-elasticsearch8
   -> ES 8.19 Java API Client
 ```
 
-`elasticsearch-common` 不是用户可选择的 Connector，只承载两个版本都能复用的 Link-Up / Elasticsearch 产品语义，并且不允许 import 或依赖任何 Elasticsearch vendor SDK。
+`elasticsearch-common` 不是用户可选择的 Connector，只承载版本无关的 Link-Up / Elasticsearch 产品语义，并且不允许依赖 Elasticsearch vendor SDK。
 
 ## Dependency boundary
-
-版本依赖只能存在于叶子模块：
 
 ```text
 common  -X-> ES SDK
@@ -40,53 +38,84 @@ es8     -X-> es7
 - ES8 client: `co.elastic.clients:elasticsearch-java:8.19.21`
 - ES8 Jackson 2 mapper runtime: `com.fasterxml.jackson.core:jackson-databind:2.18.8`
 
-Link-Up 当前仍以 Java 8 为基线。ES8 Java API Client 8.19.21 本身使用 Java `--release 8`；Stage 3 显式采用 `JacksonJsonpMapper` 的 Jackson 2 路径，并继续排除 Java 17-only 的 Jackson 3 runtime artifacts。ES8 的 Jackson 2 pin 仅存在于 ES8 dependency island，不修改其他模块现有 Jackson 版本。
+Link-Up 保持 Java 8。ES8 Java API Client 8.19.21 本身以 Java `--release 8` 编译；ES8 leaf 显式采用 `JacksonJsonpMapper` + Jackson 2.18.8，并继续排除 Java 17-only 的 Jackson 3 runtime artifacts。其他模块现有 Jackson 版本不变。
 
 ## Stage 0 — module and runtime boundary
 
-Stage 0 已完成 `common / es7 / es8` module、独立 client version pin、connector identifier 和 flattened runtime guard。
+已完成 `common / es7 / es8` module、独立 client version pin、稳定 connector identifier 和 flattened runtime guard。
 
-Link-Up 当前 `launcher` / `dist` 仍是扁平 runtime classpath。ES7 和 ES8 都依赖不同版本的 `org.elasticsearch.client:elasticsearch-rest-client`，因此在 connector classloader isolation、shade/relocation 或等价 dependency island 方案完成前，两个版本仍禁止直接进入 launcher/server runtime。
+当前 `launcher` / `dist` 仍使用扁平 runtime classpath。ES7 和 ES8 带入不兼容版本的 `org.elasticsearch.client:elasticsearch-rest-client`，因此在 connector classloader isolation、shade/relocation 或等价方案完成前，两套 Elasticsearch connector 仍禁止直接进入 launcher/server runtime。
 
 ## Stage 1 — Elasticsearch 7 bounded Source
 
-Stage 1 已实现：
+已实现：
 
-- `TableSourceFactory` SPI identifier `elasticsearch7`
+- `TableSourceFactory` identifier `elasticsearch7`
 - 单 index / 单 index alias mapping discovery
 - bounded Scroll + sliced-scroll splits
 - `_source` projection、Query DSL、Basic Auth
 - ES major version=7 校验和 clear-scroll 生命周期
 - mapping -> `TableSchema` -> `FluxRow`
 
-Elasticsearch mapping 不区分单值/多值，所以 Stage 1 不自动推断 Array。确定的 boolean/integer/floating 类型保持强类型，其余 date/object/nested/geo/vector/range 等保留为字符串/JSON。
-
 ## Stage 2 — Elasticsearch 7 bounded Sink
 
-Stage 2 已实现离线 Bulk 写入：
+已实现：
 
-- `SinkFactory` SPI identifier `elasticsearch7`
-- 只支持一个已存在的 target index，或解析到单一 concrete index 的 alias
-- SinkPreparer 在 task 启动前校验 ES major version、target mapping、source/target field compatibility
-- target index 不存在时直接失败，不做自动建 index
-- 同步 Bulk writer，按 `batch_size` flush
-- `prepareCommit()` flush 剩余文档；`close()` 不隐式 flush
-- 可选 `document_id_field` 作为稳定 `_id`
-- Bulk item 明确返回 `408/429/502/503/504` 时按指数 backoff 重试失败项
-- 整个 Bulk HTTP 调用抛 IOException 时不自动重试，因为服务端成功范围不可判定
-- 成功 Bulk 立即形成 task-local durable boundary，`abort()` 只能丢弃尚未发送的数据
+- `SinkFactory` identifier `elasticsearch7`
+- 一个已存在的 target index / single-index alias
+- target mapping 与 source schema 预校验
+- 同步 Bulk `IndexRequest`
+- `batch_size` + `prepareCommit()` flush
+- 可选稳定 `document_id_field`
+- 仅对明确返回的 408/429/502/503/504 item failure 做重试
+- whole-request IOException 不自动重试
+- task-local durability；成功 Bulk 不可回滚
+- 不声明 UPSERT / CDC / realtime capability
+
+## Stage 3 — Elasticsearch 8 bounded Source
+
+已实现：
+
+- `TableSourceFactory` identifier `elasticsearch8`
+- 单 index / 单 index alias mapping discovery
+- `RestClientTransport + ElasticsearchClient`
+- `JacksonJsonpMapper`（Jackson 2.18.8）
+- bounded Scroll + sliced-scroll splits
+- `_source` projection、ES8 Query DSL JSON、Basic Auth
+- ES major version=8 校验
+- clear-scroll 生命周期
+- mapping -> `TableSchema` -> `FluxRow`
+
+Stage 3 继续使用 bounded sliced Scroll。PIT + `search_after` 涉及跨 split 的共享 PIT 生命周期、一致性、清理与恢复，不在当前离线 connector 范围内顺带引入。
+
+## Stage 4 — Elasticsearch 8 bounded Sink
+
+已实现：
+
+- `SinkFactory` identifier `elasticsearch8`
+- 一个已存在的 target index，或解析到单一 concrete index 的 alias
+- SinkPreparer 在 writer 启动前校验 ES major=8、target mapping、source/target compatibility
+- typed Java API Client `BulkRequest` + `IndexOperation<Map<String,Object>>`
+- `batch_size` 达阈值 flush；`prepareCommit()` flush 剩余文档；`close()` 不隐式 flush
+- 可选 `document_id_field` 转换为稳定 `_id`
+- `_id` 非空且限制在 512 UTF-8 bytes
+- 仅重试 Bulk response 中明确失败且状态为 408/429/502/503/504 的 item
+- 只重试失败 item，不重发已明确成功 item
+- whole-request IOException / request-level exception 不自动 retry，因为服务端成功范围不可判定
+- task-local durability；`abort()` 只能丢弃未发送数据，已成功 Bulk 无法回滚
+- dotted field 重建为 JSON object，并拒绝 `customer` + `customer.name` 这类父子路径冲突
+- 对 ES8 新增 structured mappings（如 `rank_vectors` / `aggregate_metric_double`）维持保守 STRING(JSON)/ROW/ARRAY 边界
+- 不声明 UPSERT、CDC、RowKind 或实时写入能力
 
 示例：
 
 ```hocon
 sink {
-  Elasticsearch7 {
+  Elasticsearch8 {
     hosts = ["http://127.0.0.1:9200"]
     index = "orders_target"
-
     username = "elastic"
     password = "secret"
-
     document_id_field = "order_id"
     batch_size = 1000
     max_retries = 3
@@ -96,89 +125,37 @@ sink {
 }
 ```
 
-### Stage 2 semantic boundary
+目标 index 必须预先存在，Stage 4 不自动创建 index，也不修改 mapping。
 
-Stage 2 使用 Elasticsearch `IndexRequest` 写文档，但不向 Link-Up 暴露 `UPSERT` capability，也不把相同 `_id` 的覆盖行为包装成 CDC UPDATE 语义。
+## Shared bounded semantics
 
-`document_id_field` 未配置时由 Elasticsearch 自动生成 `_id`。此时整任务重试可能产生重复文档；配置稳定 `_id` 可改善重跑确定性，但仍不提供 Job 级事务原子性。
+ES7 / ES8 两套 Source + Sink 现在保持同一产品边界：
 
-目标 mapping 兼容性保持保守：
+- bounded / offline only
+- one index per task
+- no CDC / streaming / RowKind
+- no automatic schema evolution
+- no job-level transaction / exactly-once claim
+- stable `_id` 只是重跑确定性手段，不等同于向 Link-Up 暴露 UPSERT capability
 
-- integer 只允许安全 widening
-- float -> double 可接受，numeric narrowing 拒绝
-- date 接受 STRING/DATE/TIMESTAMP/TIMESTAMP_TZ
-- object/nested/geo/vector/range 等复杂字段接受 Link-Up STRING(JSON) / ROW / ARRAY 边界
-- `unsigned_long` 在运行时检查非负、整数和 `0..18446744073709551615` 范围
-- runtime schema evolution 不支持
-
-明确不包含：
-
-- 自动创建 index / 自动更新 mapping
-- UPDATE / DELETE request
-- CDC、实时同步、RowKind 语义
-- Job-level transaction / exactly-once 声明
-
-## Stage 3 — Elasticsearch 8 bounded Source
-
-Stage 3 已实现独立的 `elasticsearch8` bounded Source，产品语义与 ES7 Source 保持一致，但 vendor API 完全使用 Elasticsearch Java API Client 8.19.21：
-
-- `TableSourceFactory` SPI identifier `elasticsearch8`
-- 单 index / 单 index alias mapping discovery
-- `RestClientTransport + ElasticsearchClient`
-- `JacksonJsonpMapper`（Jackson 2.18.8）
-- bounded Scroll + sliced-scroll splits
-- `_source` projection、Query DSL JSON、Basic Auth
-- ES major version=8 校验
-- split 完成 / Reader 关闭时显式 clear scroll
-- mapping -> `TableSchema` -> `FluxRow`
-
-示例：
-
-```hocon
-source {
-  Elasticsearch8 {
-    hosts = ["http://127.0.0.1:9200"]
-    index = "orders"
-
-    username = "elastic"
-    password = "secret"
-
-    source = ["order_id", "amount", "customer.name"]
-    query = """{"range":{"created_at":{"gte":"2026-01-01"}}}"""
-
-    scroll_time = "1m"
-    scroll_size = 1000
-    slices = 4
-  }
-}
-```
-
-### Stage 3 semantic boundary
-
-Stage 3 延续 ES7 Source 的保守类型策略：确定的 boolean/integer/floating scalar mapping 使用强类型，`unsigned_long` 使用 `DECIMAL(20,0)`；date/object/nested/geo/vector/range 等复杂类型保留为 STRING/JSON。mapping 无法声明 scalar-vs-array cardinality，因此强类型字段实际出现数组时直接失败，不静默猜测 Array。
-
-本阶段继续使用 bounded sliced Scroll。虽然 ES8 对 deep pagination 更推荐 PIT + `search_after`，但 PIT 会引入跨 split 的共享 PIT 生命周期、一致性和恢复设计，因此不在 Stage 3 顺带扩入。
-
-明确不包含：
-
-- Elasticsearch 8 Sink
-- PIT / `search_after`
-- Elasticsearch SQL
-- wildcard / comma-separated multi-index read
-- alias resolving to multiple concrete indices
-- runtime schema evolution
-- CDC、实时同步、RowKind 语义
+类型策略保持保守：确定的 boolean/integer/floating scalar 才做强类型；复杂 mapping 使用 STRING/JSON 等可控边界。Elasticsearch mapping 无法表达 scalar-vs-array cardinality，因此 Source 不猜 Array；Sink 不做不安全 numeric narrowing。
 
 ## Compatibility boundary
 
-`elasticsearch7` client 固定为 `7.17.29`，当前首要兼容目标为 Elasticsearch 7.17.x。更早 ES7 minor 需要单独验证后再扩大支持声明。
+`elasticsearch7` client 固定为 `7.17.29`，当前首要兼容目标为 Elasticsearch 7.17.x。
 
-`elasticsearch8` client 固定为 `8.19.21`，Stage 3 当前首要兼容目标为 Elasticsearch 8.19.x；更广的 ES8 minor 范围在单独验证后再扩大声明。
+`elasticsearch8` client 固定为 `8.19.21`，当前首要兼容目标为 Elasticsearch 8.19.x。
 
-## Next stage
+更广 minor version 兼容范围应在真实集成测试后再扩大声明。
+
+## Implementation status
 
 ```text
-Stage 4  Elasticsearch 8 bounded Sink
+Stage 0  module / dependency boundary        DONE
+Stage 1  Elasticsearch 7 bounded Source      DONE
+Stage 2  Elasticsearch 7 bounded Sink        DONE
+Stage 3  Elasticsearch 8 bounded Source      DONE
+Stage 4  Elasticsearch 8 bounded Sink        DONE
 ```
 
-所有阶段继续保持离线 / bounded connector 语义，不把 CDC 或实时同步语义顺带引入 Elasticsearch connector family。
+后续若要让 ES7 与 ES8 同时进入正式 launcher/server runtime，需要单独完成 connector runtime dependency isolation；这不属于 bounded Source/Sink 适配本身。

--- a/link-up-connectors/link-up-connector-elasticsearch8/README.md
+++ b/link-up-connectors/link-up-connector-elasticsearch8/README.md
@@ -1,6 +1,6 @@
 # Link-Up Elasticsearch 8 Connector
 
-Stage 3 provides a bounded Elasticsearch 8 Source under connector identifier `elasticsearch8`.
+The `elasticsearch8` connector provides bounded Source and Sink support through Elasticsearch Java API Client 8.19.21.
 
 ## Bounded Source
 
@@ -8,7 +8,7 @@ Supported:
 
 - one concrete index, or an alias resolving to one concrete index
 - mapping-based schema discovery
-- bounded Scroll reads through the Elasticsearch Java API Client 8.19.21
+- bounded Scroll reads
 - sliced-scroll parallelism
 - Query DSL JSON
 - `_source` projection
@@ -16,20 +16,15 @@ Supported:
 - explicit clear-scroll lifecycle
 - server major-version validation (`8`)
 
-Example:
-
 ```hocon
 source {
   Elasticsearch8 {
     hosts = ["http://127.0.0.1:9200"]
     index = "orders"
-
     username = "elastic"
     password = "secret"
-
     source = ["order_id", "amount", "customer.name"]
     query = """{"range":{"created_at":{"gte":"2026-01-01"}}}"""
-
     scroll_time = "1m"
     scroll_size = 1000
     slices = 4
@@ -37,33 +32,71 @@ source {
 }
 ```
 
-`slices` defaults to Link-Up Source reader parallelism when omitted.
+## Bounded Sink
+
+Supported:
+
+- exactly one source table and one existing target index
+- alias only when it resolves to one concrete target index
+- target mapping discovery and conservative source/target compatibility validation
+- synchronous typed Java API Client Bulk index operations
+- `batch_size` flushing and `prepareCommit()` final flush
+- optional `document_id_field` for stable `_id`
+- retry only explicit item failures with 408/429/502/503/504
+- capped exponential retry backoff
+- task-local durability boundary
+- `close()` never implicitly flushes
+
+```hocon
+sink {
+  Elasticsearch8 {
+    hosts = ["http://127.0.0.1:9200"]
+    index = "orders_target"
+    username = "elastic"
+    password = "secret"
+    document_id_field = "order_id"
+    batch_size = 1000
+    max_retries = 3
+    retry_backoff_ms = 200
+    max_retry_backoff_ms = 5000
+  }
+}
+```
+
+The target index must already exist. Stage 4 does not auto-create indices or evolve mappings.
+
+`document_id_field` improves deterministic re-indexing but does not expose CDC/UPSERT semantics and does not provide job-level atomicity. Successful Bulk requests are already durable and cannot be rolled back by `abort()`.
+
+Whole-request Bulk failures are not automatically retried because the server-side success range is ambiguous. Only individual failed items explicitly returned by Elasticsearch with retryable status codes are retried.
 
 ## Java / JSON boundary
 
-Link-Up remains on Java 8. Elasticsearch Java API Client 8.19.21 is itself compiled with Java `--release 8`. Its Jackson 2 integration is `compileOnly` and built against Jackson 2.18.8, so the ES8 leaf explicitly provides Jackson 2.18.8 and uses `JacksonJsonpMapper`.
+Link-Up remains on Java 8. Elasticsearch Java API Client 8.19.21 is compiled with Java `--release 8`. The ES8 leaf explicitly provides Jackson 2.18.8 and uses `JacksonJsonpMapper`; Jackson 3 runtime artifacts remain excluded because they require Java 17.
 
-Jackson 3 runtime artifacts remain excluded because they require Java 17. The project's existing global Jackson 2.15.4 pin is left unchanged for other modules; the ES8 leaf has its own Jackson 2 pin as part of its dependency island.
-
-No Elasticsearch SDK type is moved into `elasticsearch-common`.
+Source and Sink share one package-local ES8 client-resource initializer for hosts, Basic Auth, timeouts, Jackson mapper, `RestClientTransport`, and `ElasticsearchClient`. No Elasticsearch SDK type is moved into `elasticsearch-common`.
 
 ## Type boundary
 
-The Stage 3 mapping boundary intentionally mirrors the ES7 bounded Source:
+The connector intentionally keeps a conservative mapping boundary:
 
 - boolean/integer/floating scalar mappings use Link-Up scalar types
-- `unsigned_long` maps to `DECIMAL(20,0)`
-- date/object/nested/geo/vector/range and other complex mappings are preserved as STRING/JSON
-- Elasticsearch mappings do not declare scalar-vs-array cardinality, so typed numeric/boolean fields that arrive as arrays fail explicitly rather than silently guessing an array type
+- integer writes only allow safe widening
+- `unsigned_long` uses `DECIMAL(20,0)` on reads and validates the full unsigned 64-bit range on writes
+- date values stay at STRING/DATE/TIMESTAMP boundaries
+- object/nested/geo/vector/range and newer structured ES8 mappings use STRING(JSON)/ROW/ARRAY where safe
+- Elasticsearch mappings do not declare scalar-vs-array cardinality, so typed Source fields that actually contain arrays fail explicitly rather than silently guessing an Array type
+- runtime schema evolution is not supported
 
 ## Deliberately excluded
 
-- Elasticsearch 8 Sink (Stage 4)
+- automatic index creation or mapping evolution
+- `UpdateRequest` / `DeleteRequest`
+- exposed UPSERT semantics
 - PIT / `search_after`
 - Elasticsearch SQL
-- wildcard or comma-separated multi-index reads
+- wildcard or comma-separated multi-index reads/writes
 - aliases resolving to multiple concrete indices
-- runtime schema evolution
 - CDC / streaming / RowKind semantics
+- job-level transaction / exactly-once claims
 
 The module is still not wired into the current flat launcher/server runtime classpath. ES7 and ES8 remain separate dependency islands until runtime connector isolation is completed.

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8Client.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8Client.java
@@ -3,18 +3,16 @@ package com.link.up.connector.elasticsearch8.client;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import co.elastic.clients.elasticsearch.core.ClearScrollRequest;
+import co.elastic.clients.elasticsearch.core.InfoResponse;
 import co.elastic.clients.elasticsearch.core.ScrollRequest;
 import co.elastic.clients.elasticsearch.core.ScrollResponse;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
-import co.elastic.clients.elasticsearch.core.InfoResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.ResponseBody;
 import co.elastic.clients.elasticsearch.indices.GetMappingResponse;
 import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
-import co.elastic.clients.transport.rest_client.RestClientTransport;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.catalog.TableSchema;
@@ -23,17 +21,9 @@ import com.link.up.connector.elasticsearch8.config.Elasticsearch8SourceConfig;
 import com.link.up.connector.elasticsearch8.schema.Elasticsearch8TypeMapper;
 import com.link.up.connector.elasticsearch8.source.Elasticsearch8SourceSplit;
 import jakarta.json.stream.JsonParser;
-import org.apache.http.HttpHost;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.impl.client.BasicCredentialsProvider;
-import org.elasticsearch.client.RestClient;
-import org.elasticsearch.client.RestClientBuilder;
 
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,16 +34,20 @@ import java.util.Objects;
 public final class Elasticsearch8Client implements AutoCloseable {
 
     private final Elasticsearch8SourceConfig config;
+    private final Elasticsearch8ClientResources resources;
     private final JacksonJsonpMapper jsonpMapper;
-    private final RestClientTransport transport;
     private final ElasticsearchClient client;
 
     public Elasticsearch8Client(Elasticsearch8SourceConfig config) {
         this.config = Objects.requireNonNull(config, "config must not be null");
-        RestClient restClient = buildRestClient(config);
-        this.jsonpMapper = new JacksonJsonpMapper(new ObjectMapper());
-        this.transport = new RestClientTransport(restClient, jsonpMapper);
-        this.client = new ElasticsearchClient(transport);
+        this.resources = Elasticsearch8ClientResources.create(
+                config.getHosts(),
+                config.getUsername(),
+                config.getPassword(),
+                config.getConnectTimeoutMs(),
+                config.getSocketTimeoutMs());
+        this.jsonpMapper = resources.getJsonpMapper();
+        this.client = resources.getClient();
     }
 
     public void verifyMajorVersion() throws IOException {
@@ -145,8 +139,7 @@ public final class Elasticsearch8Client implements AutoCloseable {
         if (scrollId == null || scrollId.trim().isEmpty()) {
             return;
         }
-        ClearScrollRequest request = ClearScrollRequest.of(builder -> builder.scrollId(scrollId));
-        client.clearScroll(request);
+        client.clearScroll(ClearScrollRequest.of(builder -> builder.scrollId(scrollId)));
     }
 
     private Query parseQuery(String json) {
@@ -175,42 +168,6 @@ public final class Elasticsearch8Client implements AutoCloseable {
         return new ScrollPage(response.scrollId(), documents);
     }
 
-    private static RestClient buildRestClient(Elasticsearch8SourceConfig config) {
-        HttpHost[] hosts = new HttpHost[config.getHosts().size()];
-        for (int index = 0; index < config.getHosts().size(); index++) {
-            hosts[index] = toHttpHost(config.getHosts().get(index));
-        }
-
-        RestClientBuilder builder = RestClient.builder(hosts);
-        builder.setRequestConfigCallback(
-                request -> request
-                        .setConnectTimeout(config.getConnectTimeoutMs())
-                        .setSocketTimeout(config.getSocketTimeoutMs()));
-        if (!config.getUsername().isEmpty()) {
-            BasicCredentialsProvider credentials = new BasicCredentialsProvider();
-            credentials.setCredentials(
-                    AuthScope.ANY,
-                    new UsernamePasswordCredentials(config.getUsername(), config.getPassword()));
-            builder.setHttpClientConfigCallback(
-                    http -> http.setDefaultCredentialsProvider(credentials));
-        }
-        return builder.build();
-    }
-
-    private static HttpHost toHttpHost(String value) {
-        final URI uri;
-        try {
-            uri = new URI(value);
-        } catch (URISyntaxException failure) {
-            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
-        }
-        int port = uri.getPort();
-        if (port < 0) {
-            port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 9200;
-        }
-        return new HttpHost(uri.getHost(), port, uri.getScheme());
-    }
-
     private static String requireText(String value, String name) {
         if (value == null || value.trim().isEmpty()) {
             throw new IllegalArgumentException(name + " must not be empty");
@@ -220,7 +177,7 @@ public final class Elasticsearch8Client implements AutoCloseable {
 
     @Override
     public void close() throws IOException {
-        transport.close();
+        resources.close();
     }
 
     /** One connector-neutral scroll page; SDK response types do not leak into the Reader. */

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8ClientResources.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8ClientResources.java
@@ -1,0 +1,95 @@
+package com.link.up.connector.elasticsearch8.client;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+
+/** Package-local ES8 transport resources shared by the bounded Source and Sink. */
+final class Elasticsearch8ClientResources implements AutoCloseable {
+
+    private final JacksonJsonpMapper jsonpMapper;
+    private final RestClientTransport transport;
+    private final ElasticsearchClient client;
+
+    private Elasticsearch8ClientResources(
+            JacksonJsonpMapper jsonpMapper,
+            RestClientTransport transport,
+            ElasticsearchClient client) {
+        this.jsonpMapper = jsonpMapper;
+        this.transport = transport;
+        this.client = client;
+    }
+
+    static Elasticsearch8ClientResources create(
+            List<String> hosts,
+            String username,
+            String password,
+            int connectTimeoutMs,
+            int socketTimeoutMs) {
+        HttpHost[] httpHosts = new HttpHost[hosts.size()];
+        for (int index = 0; index < hosts.size(); index++) {
+            httpHosts[index] = toHttpHost(hosts.get(index));
+        }
+
+        RestClientBuilder builder = RestClient.builder(httpHosts);
+        builder.setRequestConfigCallback(
+                request -> request
+                        .setConnectTimeout(connectTimeoutMs)
+                        .setSocketTimeout(socketTimeoutMs));
+        if (username != null && !username.isEmpty()) {
+            BasicCredentialsProvider credentials = new BasicCredentialsProvider();
+            credentials.setCredentials(
+                    AuthScope.ANY,
+                    new UsernamePasswordCredentials(username, password == null ? "" : password));
+            builder.setHttpClientConfigCallback(
+                    http -> http.setDefaultCredentialsProvider(credentials));
+        }
+
+        RestClient restClient = builder.build();
+        JacksonJsonpMapper mapper = new JacksonJsonpMapper(new ObjectMapper());
+        RestClientTransport transport = new RestClientTransport(restClient, mapper);
+        return new Elasticsearch8ClientResources(
+                mapper,
+                transport,
+                new ElasticsearchClient(transport));
+    }
+
+    JacksonJsonpMapper getJsonpMapper() {
+        return jsonpMapper;
+    }
+
+    ElasticsearchClient getClient() {
+        return client;
+    }
+
+    private static HttpHost toHttpHost(String value) {
+        final URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
+        }
+        int port = uri.getPort();
+        if (port < 0) {
+            port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 9200;
+        }
+        return new HttpHost(uri.getHost(), port, uri.getScheme());
+    }
+
+    @Override
+    public void close() throws IOException {
+        transport.close();
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8SinkClient.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8SinkClient.java
@@ -1,0 +1,187 @@
+package com.link.up.connector.elasticsearch8.client;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.ErrorCause;
+import co.elastic.clients.elasticsearch.core.BulkRequest;
+import co.elastic.clients.elasticsearch.core.BulkResponse;
+import co.elastic.clients.elasticsearch.core.InfoResponse;
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.IndexOperation;
+import co.elastic.clients.elasticsearch.indices.GetMappingResponse;
+import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.elasticsearch8.Elasticsearch8ConnectorIdentity;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SinkConfig;
+import com.link.up.connector.elasticsearch8.converter.Elasticsearch8DocumentConverter.Document;
+import com.link.up.connector.elasticsearch8.schema.Elasticsearch8TypeMapper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** ES8 Java API Client boundary for target discovery and synchronous bounded Bulk writes. */
+public final class Elasticsearch8SinkClient implements AutoCloseable {
+
+    private final Elasticsearch8SinkConfig config;
+    private final Elasticsearch8ClientResources resources;
+    private final ElasticsearchClient client;
+
+    public Elasticsearch8SinkClient(Elasticsearch8SinkConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.resources = Elasticsearch8ClientResources.create(
+                config.getHosts(),
+                config.getUsername(),
+                config.getPassword(),
+                config.getConnectTimeoutMs(),
+                config.getSocketTimeoutMs());
+        this.client = resources.getClient();
+    }
+
+    public void verifyMajorVersion() throws IOException {
+        InfoResponse response = client.info();
+        String version = response.version().number();
+        int dot = version == null ? -1 : version.indexOf('.');
+        String majorText = dot < 0 ? version : version.substring(0, dot);
+        final int major;
+        try {
+            major = Integer.parseInt(majorText);
+        } catch (RuntimeException failure) {
+            throw new IllegalStateException("Cannot parse Elasticsearch server version: " + version, failure);
+        }
+        if (major != Elasticsearch8ConnectorIdentity.MAJOR_VERSION) {
+            throw new IllegalStateException(
+                    "Connector '" + Elasticsearch8ConnectorIdentity.IDENTIFIER
+                            + "' requires Elasticsearch major version 8, but server reported " + version);
+        }
+    }
+
+    public CatalogTable discoverTargetTable(List<String> projectedFields) throws IOException {
+        verifyMajorVersion();
+        GetMappingResponse response =
+                client.indices().getMapping(request -> request.index(config.getIndex()));
+        Map<String, IndexMappingRecord> mappings = response.result();
+        if (mappings == null || mappings.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch 8 Sink target index must already exist and contain a mapping: "
+                            + config.getIndex());
+        }
+
+        String resolvedIndex = config.getIndex();
+        IndexMappingRecord record = mappings.get(config.getIndex());
+        if (record == null) {
+            if (mappings.size() != 1) {
+                throw new IllegalArgumentException(
+                        "Stage 4 Elasticsearch 8 Sink requires one concrete target index; alias '"
+                                + config.getIndex() + "' resolved to " + mappings.keySet());
+            }
+            Map.Entry<String, IndexMappingRecord> only = mappings.entrySet().iterator().next();
+            resolvedIndex = only.getKey();
+            record = only.getValue();
+        }
+
+        TableSchema schema =
+                Elasticsearch8TypeMapper.toTableSchema(record.mappings(), projectedFields);
+        return CatalogTable.builder(TablePath.of(config.getIndex()), schema)
+                .option("resolved_index", resolvedIndex)
+                .build();
+    }
+
+    /**
+     * Indexes all supplied documents. Only explicit retryable item failures are retried.
+     * Whole-request exceptions are deliberately propagated without retry because server-side
+     * success is ambiguous at that boundary.
+     */
+    public int bulkIndex(List<Document> documents) throws IOException {
+        Objects.requireNonNull(documents, "documents must not be null");
+        if (documents.isEmpty()) {
+            return 0;
+        }
+
+        List<Document> pending = new ArrayList<Document>(documents);
+        int retryNumber = 0;
+        while (true) {
+            BulkRequest.Builder request = new BulkRequest.Builder();
+            for (Document document : pending) {
+                IndexOperation<Map<String, Object>> operation =
+                        IndexOperation.of(index -> index
+                                .index(config.getIndex())
+                                .id(document.getId())
+                                .document(document.getSource()));
+                request.operations(operation);
+            }
+
+            BulkResponse response = client.bulk(request.build());
+            List<BulkResponseItem> items = response.items();
+            if (items.size() != pending.size()) {
+                throw new IllegalStateException(
+                        "Elasticsearch Bulk response item count mismatch: expected="
+                                + pending.size() + ", actual=" + items.size());
+            }
+
+            List<Document> retryable = new ArrayList<Document>();
+            List<String> permanentFailures = new ArrayList<String>();
+            for (int index = 0; index < items.size(); index++) {
+                BulkResponseItem item = items.get(index);
+                if (!isFailure(item)) {
+                    continue;
+                }
+                int status = item.status();
+                if (isRetryableStatus(status) && retryNumber < config.getMaxRetries()) {
+                    retryable.add(pending.get(index));
+                } else {
+                    ErrorCause error = item.error();
+                    permanentFailures.add(
+                            "status=" + status
+                                    + ", id=" + item.id()
+                                    + ", message="
+                                    + (error == null ? "bulk item failed" : error.reason()));
+                }
+            }
+
+            if (!permanentFailures.isEmpty()) {
+                throw new IllegalStateException(
+                        "Elasticsearch Bulk item failure(s): " + permanentFailures);
+            }
+            if (retryable.isEmpty()) {
+                return documents.size();
+            }
+
+            long backoff = config.retryBackoffMs(retryNumber);
+            retryNumber++;
+            sleep(backoff);
+            pending = retryable;
+        }
+    }
+
+    static boolean isFailure(BulkResponseItem item) {
+        return item.error() != null || item.status() >= 300;
+    }
+
+    static boolean isRetryableStatus(int status) {
+        return status == 408
+                || status == 429
+                || status == 502
+                || status == 503
+                || status == 504;
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(
+                    "Interrupted while backing off Elasticsearch Bulk item retry",
+                    interrupted);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        resources.close();
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SinkConfig.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SinkConfig.java
@@ -1,0 +1,197 @@
+package com.link.up.connector.elasticsearch8.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Immutable configuration for the bounded Elasticsearch 8 Sink. */
+public final class Elasticsearch8SinkConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<String> hosts;
+    private final String username;
+    private final String password;
+    private final String index;
+    private final String documentIdField;
+    private final int batchSize;
+    private final int maxRetries;
+    private final long retryBackoffMs;
+    private final long maxRetryBackoffMs;
+    private final int connectTimeoutMs;
+    private final int socketTimeoutMs;
+
+    private Elasticsearch8SinkConfig(
+            List<String> hosts,
+            String username,
+            String password,
+            String index,
+            String documentIdField,
+            int batchSize,
+            int maxRetries,
+            long retryBackoffMs,
+            long maxRetryBackoffMs,
+            int connectTimeoutMs,
+            int socketTimeoutMs) {
+        this.hosts = Collections.unmodifiableList(new ArrayList<String>(hosts));
+        this.username = username;
+        this.password = password;
+        this.index = index;
+        this.documentIdField = documentIdField;
+        this.batchSize = batchSize;
+        this.maxRetries = maxRetries;
+        this.retryBackoffMs = retryBackoffMs;
+        this.maxRetryBackoffMs = maxRetryBackoffMs;
+        this.connectTimeoutMs = connectTimeoutMs;
+        this.socketTimeoutMs = socketTimeoutMs;
+    }
+
+    public static Elasticsearch8SinkConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        List<String> hosts = normalizeHosts(
+                config.getOptional(Elasticsearch8SinkOptions.HOSTS)
+                        .orElse(Collections.<String>emptyList()));
+        String username = normalize(config.get(Elasticsearch8SinkOptions.USERNAME));
+        String password = config.get(Elasticsearch8SinkOptions.PASSWORD);
+        String index = requireConcreteIndex(config.get(Elasticsearch8SinkOptions.INDEX));
+        String documentIdField =
+                normalize(config.getOptional(Elasticsearch8SinkOptions.DOCUMENT_ID_FIELD).orElse(null));
+        int batchSize = config.get(Elasticsearch8SinkOptions.BATCH_SIZE);
+        int maxRetries = config.get(Elasticsearch8SinkOptions.MAX_RETRIES);
+        long retryBackoffMs = config.get(Elasticsearch8SinkOptions.RETRY_BACKOFF_MS);
+        long maxRetryBackoffMs = config.get(Elasticsearch8SinkOptions.MAX_RETRY_BACKOFF_MS);
+        int connectTimeoutMs = config.get(Elasticsearch8SinkOptions.CONNECT_TIMEOUT_MS);
+        int socketTimeoutMs = config.get(Elasticsearch8SinkOptions.SOCKET_TIMEOUT_MS);
+
+        validatePositive(batchSize, "batch_size");
+        if (maxRetries < 0) {
+            throw new IllegalArgumentException("max_retries must not be negative");
+        }
+        validatePositive(retryBackoffMs, "retry_backoff_ms");
+        validatePositive(maxRetryBackoffMs, "max_retry_backoff_ms");
+        if (maxRetryBackoffMs < retryBackoffMs) {
+            throw new IllegalArgumentException(
+                    "max_retry_backoff_ms must be greater than or equal to retry_backoff_ms");
+        }
+        validatePositive(connectTimeoutMs, "connect_timeout_ms");
+        validatePositive(socketTimeoutMs, "socket_timeout_ms");
+
+        return new Elasticsearch8SinkConfig(
+                hosts,
+                username == null ? "" : username,
+                password == null ? "" : password,
+                index,
+                documentIdField,
+                batchSize,
+                maxRetries,
+                retryBackoffMs,
+                maxRetryBackoffMs,
+                connectTimeoutMs,
+                socketTimeoutMs);
+    }
+
+    private static List<String> normalizeHosts(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            throw new IllegalArgumentException("hosts must contain at least one Elasticsearch node");
+        }
+        List<String> result = new ArrayList<String>();
+        for (String value : values) {
+            String host = normalize(value);
+            if (host == null) {
+                throw new IllegalArgumentException("hosts values must not be blank");
+            }
+            validateHost(host);
+            result.add(stripTrailingSlash(host));
+        }
+        return result;
+    }
+
+    private static void validateHost(String value) {
+        final URI uri;
+        try {
+            uri = new URI(value);
+        } catch (URISyntaxException failure) {
+            throw new IllegalArgumentException("Invalid Elasticsearch host: " + value, failure);
+        }
+        String scheme = uri.getScheme();
+        if (scheme == null
+                || (!("http".equalsIgnoreCase(scheme)) && !("https".equalsIgnoreCase(scheme)))) {
+            throw new IllegalArgumentException("Elasticsearch host must use http or https: " + value);
+        }
+        if (uri.getHost() == null) {
+            throw new IllegalArgumentException("Elasticsearch host must include a hostname: " + value);
+        }
+        String path = uri.getPath();
+        if (path != null && !path.isEmpty() && !"/".equals(path)) {
+            throw new IllegalArgumentException("Elasticsearch host must not include a path: " + value);
+        }
+        if (uri.getQuery() != null || uri.getFragment() != null || uri.getUserInfo() != null) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch host must not include credentials, query, or fragment: " + value);
+        }
+    }
+
+    private static String requireConcreteIndex(String value) {
+        String index = normalize(value);
+        if (index == null) {
+            throw new IllegalArgumentException("index must not be empty");
+        }
+        if (index.indexOf(',') >= 0 || index.indexOf('*') >= 0 || index.indexOf('?') >= 0) {
+            throw new IllegalArgumentException(
+                    "Stage 4 Elasticsearch 8 Sink requires one existing concrete index or single-index alias; wildcards and multi-index expressions are not supported: "
+                            + index);
+        }
+        return index;
+    }
+
+    private static String stripTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    private static void validatePositive(long value, String name) {
+        if (value <= 0L) {
+            throw new IllegalArgumentException(name + " must be greater than 0");
+        }
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    public List<String> getHosts() { return hosts; }
+    public String getUsername() { return username; }
+    public String getPassword() { return password; }
+    public String getIndex() { return index; }
+    public String getDocumentIdField() { return documentIdField; }
+    public int getBatchSize() { return batchSize; }
+    public int getMaxRetries() { return maxRetries; }
+    public long getRetryBackoffMs() { return retryBackoffMs; }
+    public long getMaxRetryBackoffMs() { return maxRetryBackoffMs; }
+
+    public long retryBackoffMs(int retryNumber) {
+        if (retryNumber <= 0) {
+            return retryBackoffMs;
+        }
+        long value = retryBackoffMs;
+        for (int index = 0; index < retryNumber && value < maxRetryBackoffMs; index++) {
+            value = Math.min(
+                    maxRetryBackoffMs,
+                    value > Long.MAX_VALUE / 2 ? maxRetryBackoffMs : value * 2L);
+        }
+        return value;
+    }
+
+    public int getConnectTimeoutMs() { return connectTimeoutMs; }
+    public int getSocketTimeoutMs() { return socketTimeoutMs; }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SinkOptions.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SinkOptions.java
@@ -1,0 +1,103 @@
+package com.link.up.connector.elasticsearch8.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+
+/** Options for the bounded Elasticsearch 8 Sink. */
+public final class Elasticsearch8SinkOptions {
+
+    private Elasticsearch8SinkOptions() {
+    }
+
+    public static final Option<List<String>> HOSTS =
+            Options.key("hosts")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Elasticsearch HTTP nodes, for example http://localhost:9200")
+                    .withSemanticType("ELASTICSEARCH_HOSTS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> USERNAME =
+            Options.key("username")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Elasticsearch username")
+                    .withSemanticType("USERNAME")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> PASSWORD =
+            Options.key("password")
+                    .stringType()
+                    .defaultValue("")
+                    .sensitive()
+                    .withDescription("Elasticsearch password")
+                    .withSemanticType("PASSWORD")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> INDEX =
+            Options.key("index")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("One existing Elasticsearch target index or single-index alias")
+                    .withSemanticType("INDEX")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> DOCUMENT_ID_FIELD =
+            Options.key("document_id_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Optional source field used as Elasticsearch _id for deterministic re-indexing")
+                    .withSemanticType("DOCUMENT_ID_FIELD")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> BATCH_SIZE =
+            Options.key("batch_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("Maximum documents in one synchronous Elasticsearch Bulk request")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> MAX_RETRIES =
+            Options.key("max_retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("Retries for explicit retryable Bulk item failures; whole-request failures are never retried")
+                    .withSemanticType("MAX_RETRIES")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Long> RETRY_BACKOFF_MS =
+            Options.key("retry_backoff_ms")
+                    .longType()
+                    .defaultValue(200L)
+                    .withDescription("Initial backoff for retryable Bulk item failures")
+                    .withSemanticType("RETRY_BACKOFF_MS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Long> MAX_RETRY_BACKOFF_MS =
+            Options.key("max_retry_backoff_ms")
+                    .longType()
+                    .defaultValue(5000L)
+                    .withDescription("Maximum backoff for retryable Bulk item failures")
+                    .withSemanticType("MAX_RETRY_BACKOFF_MS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+
+    public static final Option<Integer> CONNECT_TIMEOUT_MS =
+            Options.key("connect_timeout_ms")
+                    .intType()
+                    .defaultValue(10000)
+                    .withDescription("Elasticsearch HTTP connect timeout in milliseconds")
+                    .withSemanticType("CONNECT_TIMEOUT_MS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<Integer> SOCKET_TIMEOUT_MS =
+            Options.key("socket_timeout_ms")
+                    .intType()
+                    .defaultValue(60000)
+                    .withDescription("Elasticsearch HTTP socket timeout in milliseconds")
+                    .withSemanticType("SOCKET_TIMEOUT_MS")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8DocumentConverter.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8DocumentConverter.java
@@ -1,0 +1,288 @@
+package com.link.up.connector.elasticsearch8.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.ArrayType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.FluxRowType;
+import com.link.up.api.table.type.SqlType;
+
+import java.lang.reflect.Array;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+/** Converts one Link-Up row into one Elasticsearch 8 index document. */
+public final class Elasticsearch8DocumentConverter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final java.math.BigDecimal UNSIGNED_LONG_MAX =
+            new java.math.BigDecimal("18446744073709551615");
+
+    private final TableSchema sourceSchema;
+    private final TableSchema targetSchema;
+    private final int documentIdIndex;
+
+    public Elasticsearch8DocumentConverter(
+            CatalogTable sourceTable,
+            CatalogTable targetTable,
+            String documentIdField) {
+        Objects.requireNonNull(sourceTable, "sourceTable must not be null");
+        Objects.requireNonNull(targetTable, "targetTable must not be null");
+        this.sourceSchema = Objects.requireNonNull(
+                sourceTable.getTableSchema(), "source schema must not be null");
+        this.targetSchema = Objects.requireNonNull(
+                targetTable.getTableSchema(), "target schema must not be null");
+        if (sourceSchema.getColumnCount() != targetSchema.getColumnCount()) {
+            throw new IllegalArgumentException(
+                    "Prepared Elasticsearch target schema must match source field count");
+        }
+        validateNoOverlappingFieldPaths(sourceSchema);
+        this.documentIdIndex =
+                documentIdField == null ? -1 : sourceSchema.indexOf(documentIdField);
+        if (documentIdField != null && documentIdIndex < 0) {
+            throw new IllegalArgumentException(
+                    "document_id_field does not exist in source schema: " + documentIdField);
+        }
+    }
+
+    public Document convert(FluxRow row) {
+        Objects.requireNonNull(row, "row must not be null");
+        sourceSchema.toRowType().validate(row);
+
+        Map<String, Object> document = new LinkedHashMap<String, Object>();
+        for (int index = 0; index < sourceSchema.getColumnCount(); index++) {
+            Column sourceColumn = sourceSchema.getColumn(index);
+            Column targetColumn = targetSchema.getColumn(index);
+            if (!sourceColumn.getName().equals(targetColumn.getName())) {
+                throw new IllegalStateException(
+                        "Prepared Elasticsearch target schema order does not match source schema at column "
+                                + sourceColumn.getName());
+            }
+            Object converted = convertValue(
+                    row.getField(index),
+                    sourceColumn.getDataType(),
+                    targetColumn.getSourceType(),
+                    sourceColumn.getName());
+            putDotted(document, sourceColumn.getName(), converted);
+        }
+
+        String documentId = null;
+        if (documentIdIndex >= 0) {
+            Object value = row.getField(documentIdIndex);
+            if (value == null || String.valueOf(value).trim().isEmpty()) {
+                throw new IllegalArgumentException(
+                        "document_id_field value must not be null or blank");
+            }
+            documentId = String.valueOf(value);
+            if (documentId.getBytes(StandardCharsets.UTF_8).length > 512) {
+                throw new IllegalArgumentException(
+                        "Elasticsearch document _id must not exceed 512 UTF-8 bytes");
+            }
+        }
+        return new Document(documentId, document);
+    }
+
+    private static void validateNoOverlappingFieldPaths(TableSchema schema) {
+        List<Column> columns = schema.getColumns();
+        for (int leftIndex = 0; leftIndex < columns.size(); leftIndex++) {
+            String left = columns.get(leftIndex).getName();
+            for (int rightIndex = leftIndex + 1; rightIndex < columns.size(); rightIndex++) {
+                String right = columns.get(rightIndex).getName();
+                if (left.startsWith(right + ".") || right.startsWith(left + ".")) {
+                    throw new IllegalArgumentException(
+                            "Overlapping Elasticsearch document field paths are not supported: "
+                                    + left + " and " + right);
+                }
+            }
+        }
+    }
+
+    private static Object convertValue(
+            Object value,
+            FluxDataType<?> sourceType,
+            String targetSourceType,
+            String fieldName) {
+        if (value == null) {
+            return null;
+        }
+        String target = targetSourceType == null
+                ? ""
+                : targetSourceType.toLowerCase(Locale.ROOT);
+        SqlType sqlType = sourceType.getSqlType();
+
+        if ("unsigned_long".equals(target)) {
+            java.math.BigDecimal decimal = toBigDecimal(value, fieldName);
+            if (decimal.scale() > 0
+                    || decimal.signum() < 0
+                    || decimal.compareTo(UNSIGNED_LONG_MAX) > 0) {
+                throw new IllegalArgumentException(
+                        "Value is outside Elasticsearch unsigned_long range for field "
+                                + fieldName + ": " + value);
+            }
+            return decimal.toBigIntegerExact();
+        }
+
+        switch (sqlType) {
+            case BYTES:
+                if (!(value instanceof byte[])) {
+                    throw new IllegalArgumentException(
+                            "Expected byte[] for field " + fieldName);
+                }
+                return Base64.getEncoder().encodeToString((byte[]) value);
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case TIMESTAMP_TZ:
+                return String.valueOf(value);
+            case ROW:
+                if (!(sourceType instanceof FluxRowType) || !(value instanceof FluxRow)) {
+                    throw new IllegalArgumentException(
+                            "Expected FluxRow value for field " + fieldName);
+                }
+                return rowToMap((FluxRowType) sourceType, (FluxRow) value, fieldName);
+            case ARRAY:
+                return arrayToList(value, sourceType, fieldName);
+            case STRING:
+                return convertString(String.valueOf(value), target, fieldName);
+            default:
+                return value;
+        }
+    }
+
+    private static Object convertString(String value, String target, String fieldName) {
+        if (isStructuredTarget(target)) {
+            String trimmed = value.trim();
+            if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
+                if ("geo_point".equals(target) || "completion".equals(target)) {
+                    return value;
+                }
+                throw new IllegalArgumentException(
+                        "Elasticsearch target type " + target
+                                + " requires JSON object/array text for field " + fieldName);
+            }
+            try {
+                return OBJECT_MAPPER.readValue(trimmed, Object.class);
+            } catch (JsonProcessingException failure) {
+                throw new IllegalArgumentException(
+                        "Invalid JSON text for Elasticsearch field " + fieldName,
+                        failure);
+            }
+        }
+        return value;
+    }
+
+    private static boolean isStructuredTarget(String target) {
+        return "object".equals(target)
+                || "nested".equals(target)
+                || "flattened".equals(target)
+                || "geo_shape".equals(target)
+                || "shape".equals(target)
+                || "point".equals(target)
+                || "dense_vector".equals(target)
+                || "sparse_vector".equals(target)
+                || "histogram".equals(target)
+                || target.endsWith("_range")
+                || "rank_features".equals(target);
+    }
+
+    private static Map<String, Object> rowToMap(
+            FluxRowType rowType,
+            FluxRow row,
+            String fieldName) {
+        rowType.validate(row);
+        Map<String, Object> result = new LinkedHashMap<String, Object>();
+        for (int index = 0; index < rowType.getFieldCount(); index++) {
+            result.put(
+                    rowType.getFieldName(index),
+                    convertValue(
+                            row.getField(index),
+                            rowType.getFieldType(index),
+                            "object",
+                            fieldName + "." + rowType.getFieldName(index)));
+        }
+        return result;
+    }
+
+    private static List<Object> arrayToList(
+            Object value,
+            FluxDataType<?> sourceType,
+            String fieldName) {
+        if (!(sourceType instanceof ArrayType)) {
+            throw new IllegalArgumentException("Expected ArrayType for field " + fieldName);
+        }
+        if (!value.getClass().isArray()) {
+            throw new IllegalArgumentException("Expected array value for field " + fieldName);
+        }
+        FluxDataType<?> elementType = ((ArrayType<?>) sourceType).getElementType();
+        int length = Array.getLength(value);
+        List<Object> result = new ArrayList<Object>(length);
+        for (int index = 0; index < length; index++) {
+            result.add(convertValue(
+                    Array.get(value, index), elementType, "object", fieldName));
+        }
+        return result;
+    }
+
+    private static java.math.BigDecimal toBigDecimal(Object value, String fieldName) {
+        if (value instanceof java.math.BigDecimal) {
+            return (java.math.BigDecimal) value;
+        }
+        if (value instanceof Number) {
+            return new java.math.BigDecimal(String.valueOf(value));
+        }
+        try {
+            return new java.math.BigDecimal(String.valueOf(value));
+        } catch (NumberFormatException failure) {
+            throw new IllegalArgumentException(
+                    "Expected numeric value for field " + fieldName, failure);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void putDotted(Map<String, Object> root, String path, Object value) {
+        String[] parts = path.split("\\.");
+        Map<String, Object> current = root;
+        for (int index = 0; index < parts.length - 1; index++) {
+            Object existing = current.get(parts[index]);
+            if (existing == null) {
+                Map<String, Object> child = new LinkedHashMap<String, Object>();
+                current.put(parts[index], child);
+                current = child;
+            } else if (existing instanceof Map) {
+                current = (Map<String, Object>) existing;
+            } else {
+                throw new IllegalArgumentException(
+                        "Conflicting Elasticsearch dotted field path: " + path);
+            }
+        }
+        String leaf = parts[parts.length - 1];
+        if (current.containsKey(leaf)) {
+            throw new IllegalArgumentException(
+                    "Duplicate Elasticsearch document field path: " + path);
+        }
+        current.put(leaf, value);
+    }
+
+    public static final class Document {
+        private final String id;
+        private final Map<String, Object> source;
+
+        Document(String id, Map<String, Object> source) {
+            this.id = id;
+            this.source = source;
+        }
+
+        public String getId() { return id; }
+        public Map<String, Object> getSource() { return source; }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8DocumentConverter.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8DocumentConverter.java
@@ -163,7 +163,9 @@ public final class Elasticsearch8DocumentConverter {
         if (isStructuredTarget(target)) {
             String trimmed = value.trim();
             if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) {
-                if ("geo_point".equals(target) || "completion".equals(target)) {
+                if ("geo_point".equals(target)
+                        || "completion".equals(target)
+                        || "join".equals(target)) {
                     return value;
                 }
                 throw new IllegalArgumentException(
@@ -185,14 +187,20 @@ public final class Elasticsearch8DocumentConverter {
         return "object".equals(target)
                 || "nested".equals(target)
                 || "flattened".equals(target)
+                || "geo_point".equals(target)
                 || "geo_shape".equals(target)
                 || "shape".equals(target)
                 || "point".equals(target)
                 || "dense_vector".equals(target)
                 || "sparse_vector".equals(target)
+                || "rank_vectors".equals(target)
                 || "histogram".equals(target)
-                || target.endsWith("_range")
-                || "rank_features".equals(target);
+                || "aggregate_metric_double".equals(target)
+                || "rank_features".equals(target)
+                || "completion".equals(target)
+                || "join".equals(target)
+                || "percolator".equals(target)
+                || target.endsWith("_range");
     }
 
     private static Map<String, Object> rowToMap(

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkFactory.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkFactory.java
@@ -1,0 +1,66 @@
+package com.link.up.connector.elasticsearch8.sink;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch8.Elasticsearch8ConnectorIdentity;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SinkConfig;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SinkOptions;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** SPI factory for the bounded Elasticsearch 8 Bulk Sink. */
+@AutoService(SinkFactory.class)
+public final class Elasticsearch8SinkFactory implements SinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return Elasticsearch8ConnectorIdentity.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        // Index operations may replace an existing explicit _id, but Stage 4 does not
+        // expose that storage behavior as CDC/UPSERT connector semantics.
+        return Collections.emptySet();
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        Elasticsearch8SinkOptions.HOSTS,
+                        Elasticsearch8SinkOptions.INDEX)
+                .optional(
+                        Elasticsearch8SinkOptions.USERNAME,
+                        Elasticsearch8SinkOptions.PASSWORD,
+                        Elasticsearch8SinkOptions.DOCUMENT_ID_FIELD,
+                        Elasticsearch8SinkOptions.BATCH_SIZE,
+                        Elasticsearch8SinkOptions.MAX_RETRIES,
+                        Elasticsearch8SinkOptions.RETRY_BACKOFF_MS,
+                        Elasticsearch8SinkOptions.MAX_RETRY_BACKOFF_MS,
+                        Elasticsearch8SinkOptions.CONNECT_TIMEOUT_MS,
+                        Elasticsearch8SinkOptions.SOCKET_TIMEOUT_MS)
+                .build();
+    }
+
+    @Override
+    public SinkPreparer createPreparer(ReadonlyConfig config) {
+        return new Elasticsearch8SinkPreparer(Elasticsearch8SinkConfig.of(config));
+    }
+
+    @Override
+    public SinkWriter<FluxRow> createSink(
+            ReadonlyConfig config,
+            PreparedSinkMetadata metadata) {
+        return new Elasticsearch8SinkWriter(
+                Elasticsearch8SinkConfig.of(config), metadata);
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkPreparer.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkPreparer.java
@@ -1,0 +1,239 @@
+package com.link.up.connector.elasticsearch8.sink;
+
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPrepareContext;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.elasticsearch8.client.Elasticsearch8SinkClient;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SinkConfig;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Validates one existing Elasticsearch 8 target before bounded task writers start. */
+final class Elasticsearch8SinkPreparer implements SinkPreparer {
+
+    private final Elasticsearch8SinkConfig config;
+
+    Elasticsearch8SinkPreparer(Elasticsearch8SinkConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public PreparedSinkMetadata prepare(SinkPrepareContext context) throws Exception {
+        if (context == null) {
+            throw new IllegalArgumentException("context must not be null");
+        }
+        if (context.getSourceTables().size() != 1) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch 8 bounded Sink Stage 4 supports exactly one source table");
+        }
+
+        Map.Entry<TablePath, CatalogTable> sourceEntry =
+                context.getSourceTables().entrySet().iterator().next();
+        CatalogTable sourceTable = sourceEntry.getValue();
+        if (sourceTable == null || sourceTable.getTableSchema() == null) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch 8 Sink requires source table schema");
+        }
+
+        List<String> sourceFields = new ArrayList<String>();
+        for (Column column : sourceTable.getTableSchema().getColumns()) {
+            sourceFields.add(column.getName());
+        }
+
+        CatalogTable targetTable;
+        try (Elasticsearch8SinkClient client = new Elasticsearch8SinkClient(config)) {
+            targetTable = client.discoverTargetTable(sourceFields);
+        }
+        CatalogTable preparedTarget =
+                validateAndReorder(sourceTable, targetTable, config.getDocumentIdField());
+
+        Map<TablePath, CatalogTable> targets =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        targets.put(sourceEntry.getKey(), preparedTarget);
+        return new PreparedSinkMetadata(targets);
+    }
+
+    static CatalogTable validateAndReorder(
+            CatalogTable sourceTable,
+            CatalogTable targetTable,
+            String documentIdField) {
+        TableSchema source = sourceTable.getTableSchema();
+        TableSchema target = targetTable.getTableSchema();
+        if (documentIdField != null && !source.contains(documentIdField)) {
+            throw new IllegalArgumentException(
+                    "document_id_field does not exist in source schema: " + documentIdField);
+        }
+
+        TableSchema.Builder reordered = TableSchema.builder();
+        for (Column sourceColumn : source.getColumns()) {
+            if (!target.contains(sourceColumn.getName())) {
+                throw new IllegalArgumentException(
+                        "Elasticsearch target mapping is missing source field: "
+                                + sourceColumn.getName());
+            }
+            Column targetColumn = target.getColumn(sourceColumn.getName());
+            validateColumn(sourceColumn, targetColumn);
+            reordered.column(targetColumn);
+        }
+        return CatalogTable.builder(targetTable.getTablePath(), reordered.build())
+                .options(targetTable.getOptions())
+                .build();
+    }
+
+    private static void validateColumn(Column source, Column target) {
+        SqlType sourceType = source.getDataType().getSqlType();
+        String targetType = target.getSourceType() == null
+                ? "unknown"
+                : target.getSourceType().toLowerCase(Locale.ROOT);
+
+        if ("boolean".equals(targetType)) {
+            require(source, sourceType == SqlType.BOOLEAN, targetType);
+            return;
+        }
+        if (isIntegerTarget(targetType)) {
+            require(source, isSafeIntegerSource(sourceType, targetType), targetType);
+            return;
+        }
+        if ("unsigned_long".equals(targetType)) {
+            boolean supported = isInteger(sourceType);
+            if (sourceType == SqlType.DECIMAL && source.getDataType() instanceof DecimalType) {
+                DecimalType decimal = (DecimalType) source.getDataType();
+                supported = decimal.getScale() == 0 && decimal.getPrecision() <= 20;
+            }
+            require(source, supported, targetType);
+            return;
+        }
+        if ("half_float".equals(targetType) || "float".equals(targetType)) {
+            require(source, sourceType == SqlType.FLOAT, targetType);
+            return;
+        }
+        if ("double".equals(targetType)
+                || "scaled_float".equals(targetType)
+                || "rank_feature".equals(targetType)) {
+            require(source,
+                    sourceType == SqlType.FLOAT || sourceType == SqlType.DOUBLE,
+                    targetType);
+            return;
+        }
+        if (isTextTarget(targetType)) {
+            require(source, sourceType == SqlType.STRING, targetType);
+            return;
+        }
+        if ("date".equals(targetType) || "date_nanos".equals(targetType)) {
+            require(source,
+                    sourceType == SqlType.STRING
+                            || sourceType == SqlType.DATE
+                            || sourceType == SqlType.TIMESTAMP
+                            || sourceType == SqlType.TIMESTAMP_TZ,
+                    targetType);
+            return;
+        }
+        if ("binary".equals(targetType)) {
+            require(source,
+                    sourceType == SqlType.BYTES || sourceType == SqlType.STRING,
+                    targetType);
+            return;
+        }
+        if (isStructuredTarget(targetType)) {
+            require(source,
+                    sourceType == SqlType.STRING
+                            || sourceType == SqlType.ROW
+                            || sourceType == SqlType.ARRAY,
+                    targetType);
+            return;
+        }
+
+        require(source, sourceType == SqlType.STRING, targetType);
+    }
+
+    private static void require(Column source, boolean condition, String targetType) {
+        if (!condition) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch 8 target mapping is not a safe bounded-sink conversion for field "
+                            + source.getName()
+                            + ": source=" + source.getDataType().getSqlType()
+                            + ", target=" + targetType);
+        }
+    }
+
+    private static boolean isSafeIntegerSource(SqlType sourceType, String targetType) {
+        return isInteger(sourceType)
+                && integerRank(sourceType) <= integerRank(targetType);
+    }
+
+    private static boolean isInteger(SqlType type) {
+        return type == SqlType.TINYINT
+                || type == SqlType.SMALLINT
+                || type == SqlType.INT
+                || type == SqlType.BIGINT;
+    }
+
+    private static boolean isIntegerTarget(String targetType) {
+        return "byte".equals(targetType)
+                || "short".equals(targetType)
+                || "integer".equals(targetType)
+                || "token_count".equals(targetType)
+                || "long".equals(targetType);
+    }
+
+    private static int integerRank(SqlType type) {
+        switch (type) {
+            case TINYINT: return 1;
+            case SMALLINT: return 2;
+            case INT: return 3;
+            case BIGINT: return 4;
+            default: return -1;
+        }
+    }
+
+    private static int integerRank(String targetType) {
+        if ("byte".equals(targetType)) return 1;
+        if ("short".equals(targetType)) return 2;
+        if ("integer".equals(targetType) || "token_count".equals(targetType)) return 3;
+        if ("long".equals(targetType)) return 4;
+        return -1;
+    }
+
+    private static boolean isTextTarget(String targetType) {
+        return "text".equals(targetType)
+                || "keyword".equals(targetType)
+                || "constant_keyword".equals(targetType)
+                || "counted_keyword".equals(targetType)
+                || "wildcard".equals(targetType)
+                || "ip".equals(targetType)
+                || "version".equals(targetType)
+                || "search_as_you_type".equals(targetType)
+                || "match_only_text".equals(targetType)
+                || "semantic_text".equals(targetType);
+    }
+
+    private static boolean isStructuredTarget(String targetType) {
+        return "object".equals(targetType)
+                || "nested".equals(targetType)
+                || "flattened".equals(targetType)
+                || "geo_point".equals(targetType)
+                || "geo_shape".equals(targetType)
+                || "shape".equals(targetType)
+                || "point".equals(targetType)
+                || "dense_vector".equals(targetType)
+                || "sparse_vector".equals(targetType)
+                || "rank_vectors".equals(targetType)
+                || "histogram".equals(targetType)
+                || "aggregate_metric_double".equals(targetType)
+                || "rank_features".equals(targetType)
+                || "completion".equals(targetType)
+                || "join".equals(targetType)
+                || "percolator".equals(targetType)
+                || targetType.endsWith("_range");
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkWriter.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkWriter.java
@@ -1,0 +1,268 @@
+package com.link.up.connector.elasticsearch8.sink;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch8.client.Elasticsearch8SinkClient;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SinkConfig;
+import com.link.up.connector.elasticsearch8.converter.Elasticsearch8DocumentConverter;
+import com.link.up.connector.elasticsearch8.converter.Elasticsearch8DocumentConverter.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Bounded Elasticsearch 8 writer using synchronous Java API Client Bulk requests. */
+public final class Elasticsearch8SinkWriter implements SinkWriter<FluxRow> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Elasticsearch8SinkWriter.class);
+
+    private final Elasticsearch8SinkConfig config;
+    private final PreparedSinkMetadata metadata;
+    private final BulkExecutor bulkExecutor;
+    private final List<Document> pending = new ArrayList<Document>();
+
+    private TableSchema sourceSchema;
+    private Elasticsearch8DocumentConverter converter;
+    private long totalWrittenRows;
+    private long totalBulkRequests;
+    private boolean executorOpened;
+    private boolean opened;
+    private boolean failed;
+
+    public Elasticsearch8SinkWriter(
+            Elasticsearch8SinkConfig config,
+            PreparedSinkMetadata metadata) {
+        this(config, metadata, new ClientBulkExecutor(config));
+    }
+
+    Elasticsearch8SinkWriter(
+            Elasticsearch8SinkConfig config,
+            PreparedSinkMetadata metadata,
+            BulkExecutor bulkExecutor) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
+        this.bulkExecutor = Objects.requireNonNull(
+                bulkExecutor, "bulkExecutor must not be null");
+    }
+
+    @Override
+    public void open() {
+        if (opened) {
+            throw new IllegalStateException(
+                    "Elasticsearch8SinkWriter has already been opened");
+        }
+        opened = true;
+        LOG.info(
+                "Elasticsearch 8 SinkWriter opened: target={}, batchSize={}, documentIdField={}",
+                config.getIndex(),
+                config.getBatchSize(),
+                config.getDocumentIdField());
+    }
+
+    @Override
+    public void write(
+            RecordBatch<FluxRow> batch,
+            CatalogTable sourceTable)
+            throws Exception {
+        checkWritable();
+        if (batch == null || batch.isEndOfInput() || batch.getRecords().isEmpty()) {
+            return;
+        }
+        initializeSchema(sourceTable);
+
+        for (FluxRow row : batch.getRecords()) {
+            pending.add(converter.convert(row));
+            if (pending.size() >= config.getBatchSize()) {
+                flush();
+            }
+        }
+    }
+
+    @Override
+    public void prepareCommit() throws Exception {
+        checkWritable();
+        flush();
+    }
+
+    @Override
+    public void commit() {
+        checkOpened();
+        LOG.info(
+                "Elasticsearch 8 SinkWriter commit boundary reached: totalWrittenRows={}, totalBulkRequests={}",
+                totalWrittenRows,
+                totalBulkRequests);
+    }
+
+    @Override
+    public void abort() {
+        pending.clear();
+        LOG.warn(
+                "Elasticsearch 8 SinkWriter aborted unsent documents; successful Bulk requests cannot be rolled back: writtenRows={}",
+                totalWrittenRows);
+    }
+
+    @Override
+    public CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    @Override
+    public String getRetryAdvice() {
+        if (config.getDocumentIdField() == null) {
+            return "Elasticsearch Bulk requests are durable as they succeed. Whole-task retry may create duplicate documents because document_id_field is not configured. Whole-request Bulk failures are not retried automatically because server-side success is ambiguous.";
+        }
+        return "Elasticsearch Bulk requests are durable as they succeed. document_id_field provides stable _id values for deterministic re-indexing, but this Sink still does not provide job-level atomicity. Whole-request Bulk failures are not retried automatically because server-side success is ambiguous.";
+    }
+
+    @Override
+    public void close() throws Exception {
+        Exception failure = null;
+        try {
+            if (executorOpened) {
+                bulkExecutor.close();
+            }
+        } catch (Exception closeFailure) {
+            failure = closeFailure;
+        } finally {
+            pending.clear();
+            converter = null;
+            sourceSchema = null;
+            executorOpened = false;
+            opened = false;
+        }
+        LOG.info(
+                "Elasticsearch 8 SinkWriter closed without implicit flush: totalWrittenRows={}, totalBulkRequests={}",
+                totalWrittenRows,
+                totalBulkRequests);
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private void initializeSchema(CatalogTable sourceTable) throws Exception {
+        if (sourceTable == null || sourceTable.getTableSchema() == null) {
+            throw new IllegalArgumentException(
+                    "Elasticsearch 8 Sink requires CatalogTable schema on write");
+        }
+        TableSchema incoming = sourceTable.getTableSchema();
+        if (sourceSchema != null) {
+            if (!sourceSchema.equals(incoming)) {
+                throw new IllegalArgumentException(
+                        "Elasticsearch 8 bounded Sink does not support runtime schema changes");
+            }
+            return;
+        }
+
+        CatalogTable targetTable = metadata.getTargetTable(sourceTable.getTablePath());
+        if (targetTable == null) {
+            throw new IllegalArgumentException(
+                    "Prepared Elasticsearch 8 target metadata is missing source table mapping: "
+                            + sourceTable.getTablePath());
+        }
+        sourceSchema = incoming;
+        converter = new Elasticsearch8DocumentConverter(
+                sourceTable,
+                targetTable,
+                config.getDocumentIdField());
+        bulkExecutor.open();
+        executorOpened = true;
+    }
+
+    private void flush() throws Exception {
+        if (pending.isEmpty()) {
+            return;
+        }
+        if (!executorOpened) {
+            throw new IllegalStateException(
+                    "Cannot flush Elasticsearch 8 Sink before schema initialization");
+        }
+
+        List<Document> batch =
+                Collections.unmodifiableList(new ArrayList<Document>(pending));
+        try {
+            int written = bulkExecutor.execute(batch);
+            if (written != batch.size()) {
+                throw new IllegalStateException(
+                        "Elasticsearch Bulk executor wrote an unexpected document count: expected="
+                                + batch.size() + ", actual=" + written);
+            }
+            pending.clear();
+            totalWrittenRows += written;
+            totalBulkRequests++;
+            LOG.debug(
+                    "Flushed Elasticsearch 8 Bulk request: rows={}, totalWrittenRows={}",
+                    written,
+                    totalWrittenRows);
+        } catch (Exception failure) {
+            failed = true;
+            throw failure;
+        }
+    }
+
+    private void checkWritable() {
+        checkOpened();
+        if (failed) {
+            throw new IllegalStateException(
+                    "Elasticsearch8SinkWriter is in failed state after a previous Bulk failure");
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException(
+                    "Elasticsearch8SinkWriter has not been opened");
+        }
+    }
+
+    interface BulkExecutor extends AutoCloseable {
+        void open() throws Exception;
+        int execute(List<Document> documents) throws Exception;
+        @Override
+        void close() throws Exception;
+    }
+
+    private static final class ClientBulkExecutor implements BulkExecutor {
+        private final Elasticsearch8SinkConfig config;
+        private Elasticsearch8SinkClient client;
+
+        private ClientBulkExecutor(Elasticsearch8SinkConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public void open() throws Exception {
+            client = new Elasticsearch8SinkClient(config);
+            boolean success = false;
+            try {
+                client.verifyMajorVersion();
+                success = true;
+            } finally {
+                if (!success) {
+                    client.close();
+                    client = null;
+                }
+            }
+        }
+
+        @Override
+        public int execute(List<Document> documents) throws Exception {
+            return client.bulkIndex(documents);
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (client != null) {
+                client.close();
+                client = null;
+            }
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8SinkClientTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/client/Elasticsearch8SinkClientTest.java
@@ -1,0 +1,40 @@
+package com.link.up.connector.elasticsearch8.client;
+
+import co.elastic.clients.elasticsearch.core.bulk.BulkResponseItem;
+import co.elastic.clients.elasticsearch.core.bulk.OperationType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Elasticsearch8SinkClientTest {
+
+    @Test
+    public void classifiesRetryableStatuses() {
+        assertTrue(Elasticsearch8SinkClient.isRetryableStatus(408));
+        assertTrue(Elasticsearch8SinkClient.isRetryableStatus(429));
+        assertTrue(Elasticsearch8SinkClient.isRetryableStatus(502));
+        assertTrue(Elasticsearch8SinkClient.isRetryableStatus(503));
+        assertTrue(Elasticsearch8SinkClient.isRetryableStatus(504));
+        assertFalse(Elasticsearch8SinkClient.isRetryableStatus(400));
+        assertFalse(Elasticsearch8SinkClient.isRetryableStatus(409));
+    }
+
+    @Test
+    public void treatsErrorOrHttpFailureAsItemFailure() {
+        BulkResponseItem success = BulkResponseItem.of(item -> item
+                .operationType(OperationType.Index)
+                .index("orders")
+                .id("1")
+                .status(201));
+        BulkResponseItem failed = BulkResponseItem.of(item -> item
+                .operationType(OperationType.Index)
+                .index("orders")
+                .id("2")
+                .status(429)
+                .error(error -> error.reason("too many requests")));
+
+        assertFalse(Elasticsearch8SinkClient.isFailure(success));
+        assertTrue(Elasticsearch8SinkClient.isFailure(failed));
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SinkConfigTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/config/Elasticsearch8SinkConfigTest.java
@@ -1,0 +1,56 @@
+package com.link.up.connector.elasticsearch8.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch8SinkConfigTest {
+
+    @Test
+    public void usesBoundedSinkDefaults() {
+        Elasticsearch8SinkConfig config = config("orders_target", null);
+        assertEquals(1000, config.getBatchSize());
+        assertEquals(3, config.getMaxRetries());
+        assertEquals(200L, config.getRetryBackoffMs());
+        assertEquals(5000L, config.getMaxRetryBackoffMs());
+        assertEquals(10000, config.getConnectTimeoutMs());
+        assertEquals(60000, config.getSocketTimeoutMs());
+        assertNull(config.getDocumentIdField());
+    }
+
+    @Test
+    public void keepsStableDocumentIdAndCapsBackoff() {
+        Elasticsearch8SinkConfig config = config("orders_target", "order_id");
+        assertEquals("order_id", config.getDocumentIdField());
+        assertEquals(200L, config.retryBackoffMs(0));
+        assertEquals(400L, config.retryBackoffMs(1));
+        assertEquals(5000L, config.retryBackoffMs(20));
+    }
+
+    @Test
+    public void rejectsWildcardTarget() {
+        try {
+            config("orders-*", null);
+            fail("Expected wildcard target rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    private static Elasticsearch8SinkConfig config(String index, String idField) {
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("hosts", Arrays.asList("http://localhost:9200"));
+        values.put("index", index);
+        if (idField != null) {
+            values.put("document_id_field", idField);
+        }
+        return Elasticsearch8SinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8DocumentConverterTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/converter/Elasticsearch8DocumentConverterTest.java
@@ -1,0 +1,76 @@
+package com.link.up.connector.elasticsearch8.converter;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch8DocumentConverterTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void rebuildsDottedPathsAndUsesStableDocumentId() {
+        CatalogTable source = table(
+                Column.builder("order_id", BasicType.STRING_TYPE).sourceType("varchar").build(),
+                Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("varchar").build());
+        CatalogTable target = table(
+                Column.builder("order_id", BasicType.STRING_TYPE).sourceType("keyword").build(),
+                Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("keyword").build());
+
+        Elasticsearch8DocumentConverter.Document document =
+                new Elasticsearch8DocumentConverter(source, target, "order_id")
+                        .convert(FluxRow.of("o-1", "Ada"));
+
+        assertEquals("o-1", document.getId());
+        Map<String, Object> customer =
+                (Map<String, Object>) document.getSource().get("customer");
+        assertEquals("Ada", customer.get("name"));
+    }
+
+    @Test
+    public void parsesNewEs8StructuredJsonBoundaries() {
+        CatalogTable source = table(
+                Column.builder("metrics", BasicType.STRING_TYPE).sourceType("text").build());
+        CatalogTable target = table(
+                Column.builder("metrics", BasicType.STRING_TYPE)
+                        .sourceType("aggregate_metric_double")
+                        .build());
+        Object metrics = new Elasticsearch8DocumentConverter(source, target, null)
+                .convert(FluxRow.of("{\"min\":1.0,\"max\":2.0,\"sum\":3.0,\"value_count\":2}"))
+                .getSource().get("metrics");
+        assertTrue(metrics instanceof Map);
+    }
+
+    @Test
+    public void rejectsOverlappingParentChildPaths() {
+        CatalogTable source = table(
+                Column.builder("customer", BasicType.STRING_TYPE).sourceType("text").build(),
+                Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("text").build());
+        CatalogTable target = table(
+                Column.builder("customer", BasicType.STRING_TYPE).sourceType("object").build(),
+                Column.builder("customer.name", BasicType.STRING_TYPE).sourceType("keyword").build());
+        try {
+            new Elasticsearch8DocumentConverter(source, target, null);
+            fail("Expected overlapping path rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    private static CatalogTable table(Column... columns) {
+        TableSchema.Builder schema = TableSchema.builder();
+        for (Column column : columns) {
+            schema.column(column);
+        }
+        return CatalogTable.builder(TablePath.of("orders"), schema.build()).build();
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkFactoryTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkFactoryTest.java
@@ -1,0 +1,16 @@
+package com.link.up.connector.elasticsearch8.sink;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class Elasticsearch8SinkFactoryTest {
+
+    @Test
+    public void exposesVersionedIdentifierWithoutRealtimeCapabilities() {
+        Elasticsearch8SinkFactory factory = new Elasticsearch8SinkFactory();
+        assertEquals("elasticsearch8", factory.factoryIdentifier());
+        assertTrue(factory.capabilities().isEmpty());
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkPreparerTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkPreparerTest.java
@@ -1,0 +1,51 @@
+package com.link.up.connector.elasticsearch8.sink;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class Elasticsearch8SinkPreparerTest {
+
+    @Test
+    public void acceptsSafeIntegerWideningAndReordersTarget() {
+        CatalogTable source = table(
+                Column.builder("id", BasicType.STRING_TYPE).sourceType("varchar").build(),
+                Column.builder("amount", BasicType.INT_TYPE).sourceType("int").build());
+        CatalogTable target = table(
+                Column.builder("amount", BasicType.LONG_TYPE).sourceType("long").build(),
+                Column.builder("id", BasicType.STRING_TYPE).sourceType("keyword").build());
+
+        CatalogTable prepared = Elasticsearch8SinkPreparer.validateAndReorder(
+                source, target, "id");
+        assertEquals("id", prepared.getTableSchema().getColumn(0).getName());
+        assertEquals("amount", prepared.getTableSchema().getColumn(1).getName());
+    }
+
+    @Test
+    public void rejectsNumericNarrowing() {
+        CatalogTable source = table(
+                Column.builder("amount", BasicType.LONG_TYPE).sourceType("bigint").build());
+        CatalogTable target = table(
+                Column.builder("amount", BasicType.INT_TYPE).sourceType("integer").build());
+        try {
+            Elasticsearch8SinkPreparer.validateAndReorder(source, target, null);
+            fail("Expected narrowing rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    private static CatalogTable table(Column... columns) {
+        TableSchema.Builder schema = TableSchema.builder();
+        for (Column column : columns) {
+            schema.column(column);
+        }
+        return CatalogTable.builder(TablePath.of("orders"), schema.build()).build();
+    }
+}

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkWriterTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/test/java/com/link/up/connector/elasticsearch8/sink/Elasticsearch8SinkWriterTest.java
@@ -1,0 +1,122 @@
+package com.link.up.connector.elasticsearch8.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.elasticsearch8.config.Elasticsearch8SinkConfig;
+import com.link.up.connector.elasticsearch8.converter.Elasticsearch8DocumentConverter.Document;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class Elasticsearch8SinkWriterTest {
+
+    @Test
+    public void flushesAtBatchSizeAndPrepareCommit() throws Exception {
+        CatalogTable source = sourceTable();
+        FakeBulkExecutor executor = new FakeBulkExecutor();
+        Elasticsearch8SinkWriter writer =
+                new Elasticsearch8SinkWriter(config(2), metadata(source), executor);
+
+        writer.open();
+        writer.write(
+                RecordBatch.of(
+                        "orders",
+                        "split-0",
+                        Arrays.asList(
+                                FluxRow.of("1", 10L),
+                                FluxRow.of("2", 20L),
+                                FluxRow.of("3", 30L))),
+                source);
+        assertEquals(1, executor.executions.size());
+        assertEquals(2, executor.executions.get(0).size());
+
+        writer.prepareCommit();
+        assertEquals(2, executor.executions.size());
+        assertEquals(1, executor.executions.get(1).size());
+        writer.commit();
+        writer.close();
+    }
+
+    @Test
+    public void closeDoesNotImplicitlyFlushPendingDocuments() throws Exception {
+        CatalogTable source = sourceTable();
+        FakeBulkExecutor executor = new FakeBulkExecutor();
+        Elasticsearch8SinkWriter writer =
+                new Elasticsearch8SinkWriter(config(2), metadata(source), executor);
+
+        writer.open();
+        writer.write(
+                RecordBatch.of(
+                        "orders",
+                        "split-0",
+                        Arrays.asList(FluxRow.of("1", 10L))),
+                source);
+        writer.close();
+
+        assertEquals(0, executor.executions.size());
+    }
+
+    private static Elasticsearch8SinkConfig config(int batchSize) {
+        Map<String, Object> values = new HashMap<String, Object>();
+        values.put("hosts", Arrays.asList("http://localhost:9200"));
+        values.put("index", "orders_target");
+        values.put("document_id_field", "id");
+        values.put("batch_size", batchSize);
+        return Elasticsearch8SinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static CatalogTable sourceTable() {
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.STRING_TYPE).sourceType("varchar").build())
+                .column(Column.builder("amount", BasicType.LONG_TYPE).sourceType("bigint").build())
+                .build();
+        return CatalogTable.builder(TablePath.of("orders"), schema).build();
+    }
+
+    private static PreparedSinkMetadata metadata(CatalogTable source) {
+        TableSchema targetSchema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.STRING_TYPE).sourceType("keyword").build())
+                .column(Column.builder("amount", BasicType.LONG_TYPE).sourceType("long").build())
+                .build();
+        CatalogTable target = CatalogTable.builder(
+                TablePath.of("orders_target"), targetSchema).build();
+        Map<TablePath, CatalogTable> targets =
+                new LinkedHashMap<TablePath, CatalogTable>();
+        targets.put(source.getTablePath(), target);
+        return new PreparedSinkMetadata(targets);
+    }
+
+    private static final class FakeBulkExecutor
+            implements Elasticsearch8SinkWriter.BulkExecutor {
+        private final List<List<Document>> executions =
+                new ArrayList<List<Document>>();
+
+        @Override
+        public void open() {
+        }
+
+        @Override
+        public int execute(List<Document> documents) {
+            executions.add(new ArrayList<Document>(documents));
+            return documents.size();
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Complete the planned Elasticsearch connector family with **Stage 4: a restrained Elasticsearch 8 bounded Sink**.

This PR is based directly on current `main` after merged Stage 3 (#111). Together with Stages 0–3, it completes bounded/offline Source + Sink support for both `elasticsearch7` and `elasticsearch8` while preserving the version-specific dependency islands.

## What is included

### Connector / preparation boundary

- register `SinkFactory` under versioned identifier `elasticsearch8`
- intentionally expose no `UPSERT`, `AUTO_CREATE_TABLE`, CDC, RowKind, or realtime capabilities
- support exactly one source table and one existing Elasticsearch target index
- allow an alias only when it resolves to exactly one concrete target index
- validate Elasticsearch server major version = 8 before task writers start
- discover the existing target mapping and validate source/target field compatibility
- reject runtime schema changes
- reject overlapping document paths such as `customer` + `customer.name`

### Elasticsearch 8 Java API Client Bulk writer

Stage 4 uses the ES8 Java API Client directly:

- `co.elastic.clients:elasticsearch-java:8.19.21`
- `RestClientTransport`
- `ElasticsearchClient`
- typed `BulkRequest`
- typed `IndexOperation<Map<String,Object>>`
- `BulkResponse.items()` / `BulkResponseItem.status()` / `error()` for item-level outcome handling

No ES7 High Level REST Client is reused by the ES8 Sink.

### Shared ES8 client resources

The Stage 3 Source and Stage 4 Sink both need the same transport setup. This PR extracts a package-local `Elasticsearch8ClientResources` inside the ES8 leaf to own:

- hosts
- Basic Auth
- connect/socket timeouts
- Jackson 2 `JacksonJsonpMapper`
- `RestClientTransport`
- `ElasticsearchClient`

This is internal reuse only. No Elasticsearch SDK type is moved into `elasticsearch-common`, and Stage 3 Source semantics are unchanged.

### Bounded write lifecycle

- buffer documents until `batch_size`
- synchronous Bulk flush at the threshold
- `prepareCommit()` flushes remaining buffered documents
- `close()` deliberately does **not** implicitly flush
- successful Bulk requests form a task-local durability boundary
- `abort()` only discards documents that have not yet been sent
- runtime schema changes are rejected

### Retry boundary

Stage 4 deliberately separates explicit item failures from ambiguous whole-request failures:

- retry only Bulk items explicitly returned with status `408`, `429`, `502`, `503`, or `504`
- retry only failed items; already confirmed successful items are not resent
- use capped exponential backoff
- do **not** automatically retry a whole `client.bulk()` call that fails before a usable item-level response is available

A whole-request exception does not prove whether Elasticsearch committed none, some, or all submitted operations. Blindly replaying the complete batch would create duplicate-write risk.

### Document identity

`document_id_field` is optional.

- without it, Elasticsearch generates `_id`; retrying a whole failed task may create duplicate documents
- with it, one source field becomes a stable Elasticsearch `_id`, improving deterministic re-indexing
- `_id` must be nonblank and no longer than 512 UTF-8 bytes
- stable `_id` does **not** expose CDC/UPSERT semantics and does not provide Job-level atomicity

### Type / mapping boundary

Target mapping validation remains conservative and aligns with the ES7 bounded Sink:

- integer types allow safe widening only; narrowing is rejected
- `float -> double` is accepted
- `unsigned_long` validates integer semantics and range `0..18446744073709551615`
- date targets accept Link-Up STRING / DATE / TIMESTAMP / TIMESTAMP_TZ values
- binary accepts BYTES / STRING
- object/nested/geo/vector/range-style targets accept bounded STRING(JSON) / ROW / ARRAY representations where safe
- dotted source fields are rebuilt into Elasticsearch JSON objects
- overlapping parent/child paths are rejected before conversion

Stage 4 also recognizes newer ES8 mapping families such as `counted_keyword`, `semantic_text`, `rank_vectors`, and `aggregate_metric_double` without expanding the Link-Up type system. Structured values remain on conservative STRING(JSON) / ROW / ARRAY boundaries.

## Configuration

```hocon
sink {
  Elasticsearch8 {
    hosts = ["http://127.0.0.1:9200"]
    index = "orders_target"

    username = "elastic"
    password = "secret"

    document_id_field = "order_id"
    batch_size = 1000
    max_retries = 3
    retry_backoff_ms = 200
    max_retry_backoff_ms = 5000
  }
}
```

The target index must already exist. Stage 4 intentionally does not auto-create indices or evolve mappings.

## Tests added

Unit coverage includes:

- Sink configuration defaults and validation
- wildcard / multi-index target rejection
- stable `document_id_field`
- exponential / capped retry backoff
- explicit retryable Bulk status classification
- `BulkResponseItem` success vs item failure classification
- safe integer widening and narrowing rejection
- dotted document reconstruction
- structured JSON conversion, including an ES8 `aggregate_metric_double` boundary
- overlapping parent/child document-path rejection
- factory identifier and absence of realtime capabilities
- batch-size flush and `prepareCommit()` flush
- `close()` does not implicitly flush

The existing ES8 dependency boundary continues to verify:

- ES8 Java API Client is present
- Jackson 2 `JacksonJsonpMapper` is present
- ES7 `RestHighLevelClient` is absent
- Jackson 3 runtime mapper classes are absent

## Scope deliberately excluded

- automatic index creation
- automatic mapping evolution
- Elasticsearch `UpdateRequest` / `DeleteRequest`
- exposed UPSERT semantics
- CDC / streaming / RowKind semantics
- two-phase commit / Job-level exactly-once claims
- PIT / `search_after`
- Elasticsearch SQL
- wildcard or comma-separated multi-index writes

## Runtime packaging boundary

This PR still does **not** add `link-up-connector-elasticsearch7` or `link-up-connector-elasticsearch8` to the current flat `link-up-launcher` / `link-up-server` runtime classpath.

ES7 and ES8 bring incompatible versions of `org.elasticsearch.client:elasticsearch-rest-client`. Stage 0's dependency-island guard remains unchanged. Runtime connector classloader isolation, shading/relocation, or an equivalent mechanism is a separate follow-up concern from bounded Source/Sink adaptation.

## Validation

- branch is based directly on current `main` after merged Stage 3 (#111)
- final compare is ahead-only, not behind
- static API review was performed against Elasticsearch Java API Client `v8.19.21` for `BulkRequest`, `BulkOperation`, `IndexOperation`, `BulkResponse`, `BulkResponseItem`, `OperationType`, and `ErrorCause`
- Link-Up `SinkFactory` / `SinkPreparer` / `SinkWriter` and `RecordBatch` signatures were checked against current `main`
- unit tests are included without requiring a live Elasticsearch cluster
- Maven and live Elasticsearch integration tests could not be executed from the current ChatGPT execution environment; this limitation is intentionally not represented as a passing build

## Elasticsearch family status

```text
Stage 0  module / dependency boundary        DONE
Stage 1  Elasticsearch 7 bounded Source      DONE
Stage 2  Elasticsearch 7 bounded Sink        DONE
Stage 3  Elasticsearch 8 bounded Source      DONE
Stage 4  Elasticsearch 8 bounded Sink        DONE
```

After this PR, the planned bounded/offline Elasticsearch 7 + 8 Source/Sink adaptation is complete. The remaining major concern is runtime dependency isolation before both versioned connectors are wired into the flattened launcher/server runtime.