### PR TITLE
chore(elasticsearch): package ES7 and ES8 as isolated runtime plugins

### DIFF
--- a/link-up-connectors/link-up-connector-elasticsearch7/pom.xml
+++ b/link-up-connectors/link-up-connector-elasticsearch7/pom.xml
@@ -58,4 +58,34 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                Keep the ES7 dependency graph local to this module. The distribution copies these
+                jars into plugins/elasticsearch7 instead of resolving ES7 and ES8 through one
+                flattened Maven dependency graph where version mediation would collapse the shared
+                elasticsearch-rest-client artifact to one version.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>stage-elasticsearch7-plugin-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/plugin-dependencies</outputDirectory>
+                            <excludeArtifactIds>link-up-api,slf4j-api</excludeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/link-up-connectors/link-up-connector-elasticsearch8/pom.xml
+++ b/link-up-connectors/link-up-connector-elasticsearch8/pom.xml
@@ -70,4 +70,34 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <!--
+                Resolve ES8 independently from ES7 and stage the runtime graph for its own plugin
+                directory. ConnectorClassLoader is child-first for vendor libraries, so the ES8
+                Jackson/client stack remains private while Link-Up API/logging contracts come from
+                the parent Worker classloader.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven-dependency-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>stage-elasticsearch8-plugin-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/plugin-dependencies</outputDirectory>
+                            <excludeArtifactIds>link-up-api,slf4j-api</excludeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/link-up-dist/pom.xml
+++ b/link-up-dist/pom.xml
@@ -26,6 +26,25 @@
             <artifactId>link-up-server</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!--
+            Reactor ordering only. These must never become runtime dependencies of link-up-dist,
+            otherwise Maven would resolve ES7 and ES8 through one flattened dependency graph and
+            mediate the incompatible elasticsearch-rest-client versions before classloader isolation.
+        -->
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-connector-elasticsearch7</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-connector-elasticsearch8</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/link-up-dist/src/main/assembly/distribution.xml
+++ b/link-up-dist/src/main/assembly/distribution.xml
@@ -31,5 +31,40 @@
                 <exclude>bin/*.sh</exclude>
             </excludes>
         </fileSet>
+
+        <!-- Elasticsearch 7 and 8 must stay in separate directories: one directory == one ConnectorClassLoader. -->
+        <fileSet>
+            <directory>../link-up-connectors/link-up-connector-elasticsearch7/target</directory>
+            <outputDirectory>plugins/elasticsearch7</outputDirectory>
+            <fileMode>0644</fileMode>
+            <includes>
+                <include>link-up-connector-elasticsearch7-${project.version}.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>../link-up-connectors/link-up-connector-elasticsearch7/target/plugin-dependencies</directory>
+            <outputDirectory>plugins/elasticsearch7</outputDirectory>
+            <fileMode>0644</fileMode>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
+
+        <fileSet>
+            <directory>../link-up-connectors/link-up-connector-elasticsearch8/target</directory>
+            <outputDirectory>plugins/elasticsearch8</outputDirectory>
+            <fileMode>0644</fileMode>
+            <includes>
+                <include>link-up-connector-elasticsearch8-${project.version}.jar</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <directory>../link-up-connectors/link-up-connector-elasticsearch8/target/plugin-dependencies</directory>
+            <outputDirectory>plugins/elasticsearch8</outputDirectory>
+            <fileMode>0644</fileMode>
+            <includes>
+                <include>*.jar</include>
+            </includes>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/link-up-dist/src/main/dist/bin/link-up-server.sh
+++ b/link-up-dist/src/main/dist/bin/link-up-server.sh
@@ -8,6 +8,7 @@ CONF_DIR="${LINK_UP_CONF_DIR:-${LINK_UP_HOME}/config}"
 LOG_DIR="${LINK_UP_LOG_DIR:-${LINK_UP_HOME}/logs}"
 LOGFILE="${LOGFILE:-${LOG_DIR}/link-up-server.log}"
 JOB_LOG_DIR="${LINK_UP_JOB_LOG_DIR:-${LOG_DIR}/jobs}"
+PLUGIN_ROOT="${LINK_UP_PLUGIN_ROOT:-${LINK_UP_HOME}/plugins}"
 JAVA_BIN="${JAVA_HOME:+${JAVA_HOME}/bin/}java"
 
 if ! command -v "${JAVA_BIN}" >/dev/null 2>&1; then
@@ -33,8 +34,33 @@ if [[ -n "${LINK_UP_JAVA_OPTS:-}" ]]; then
   JAVA_OPTS+=( ${LINK_UP_JAVA_OPTS} )
 fi
 
+PLUGIN_ARGS=()
+
+# Each plugin directory is intentionally passed separately. FactoryRegistry creates one
+# ConnectorClassLoader per --plugin-dir, which is required for mutually incompatible SDK versions
+# such as Elasticsearch 7 and Elasticsearch 8.
+if [[ -n "${LINK_UP_PLUGIN_DIRS:-}" ]]; then
+  IFS=',' read -r -a configured_plugin_dirs <<< "${LINK_UP_PLUGIN_DIRS}"
+  for plugin_dir in "${configured_plugin_dirs[@]}"; do
+    plugin_dir="${plugin_dir#${plugin_dir%%[![:space:]]*}}"
+    plugin_dir="${plugin_dir%${plugin_dir##*[![:space:]]}}"
+    if [[ -n "${plugin_dir}" ]]; then
+      PLUGIN_ARGS+=( --plugin-dir "${plugin_dir}" )
+    fi
+  done
+elif [[ -d "${PLUGIN_ROOT}" ]]; then
+  shopt -s nullglob
+  for plugin_dir in "${PLUGIN_ROOT}"/*; do
+    if [[ -d "${plugin_dir}" ]]; then
+      PLUGIN_ARGS+=( --plugin-dir "${plugin_dir}" )
+    fi
+  done
+  shopt -u nullglob
+fi
+
 exec "${JAVA_BIN}" \
   "${JAVA_OPTS[@]}" \
   -cp "${LINK_UP_HOME}/lib/*" \
   com.link.up.server.FluxServer \
+  "${PLUGIN_ARGS[@]}" \
   "$@"

--- a/link-up-dist/src/main/dist/plugins/README.md
+++ b/link-up-dist/src/main/dist/plugins/README.md
@@ -1,0 +1,36 @@
+# Link-Up isolated connector plugins
+
+The standalone distribution keeps mutually incompatible connector SDKs outside `lib/`.
+
+Each immediate subdirectory under `plugins/` is loaded through its own `ConnectorClassLoader`:
+
+```text
+plugins/
+  elasticsearch7/
+    link-up-connector-elasticsearch7-*.jar
+    elasticsearch-rest-high-level-client-7.*.jar
+    elasticsearch-rest-client-7.*.jar
+    ...
+
+  elasticsearch8/
+    link-up-connector-elasticsearch8-*.jar
+    elasticsearch-java-8.*.jar
+    elasticsearch-rest-client-8.*.jar
+    ...
+```
+
+`bin/link-up-server.sh` discovers immediate plugin subdirectories automatically. Override the root with:
+
+```bash
+export LINK_UP_PLUGIN_ROOT=/opt/link-up/plugins
+```
+
+Or provide an explicit comma-separated directory list:
+
+```bash
+export LINK_UP_PLUGIN_DIRS=/opt/plugins/elasticsearch7,/opt/plugins/elasticsearch8
+```
+
+Do **not** merge the Elasticsearch 7 and Elasticsearch 8 jars into one plugin directory and do not add them to `lib/`. The two connector families intentionally depend on incompatible versions of `org.elasticsearch.client:elasticsearch-rest-client`.
+
+The Worker connector inventory endpoints remain the runtime source of truth. A control plane should enable Elasticsearch execution only when `elasticsearch7` / `elasticsearch8` SOURCE and SINK schemas are actually reported by the configured Worker.

--- a/link-up-framework/src/main/java/com/link/up/framework/classloading/ConnectorClassLoader.java
+++ b/link-up-framework/src/main/java/com/link/up/framework/classloading/ConnectorClassLoader.java
@@ -1,12 +1,19 @@
 package com.link.up.framework.classloading;
 
+import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Enumeration;
 
 /**
  * Isolated connector loader: framework/API contracts come from the parent, connector libraries do not.
  */
 public final class ConnectorClassLoader extends URLClassLoader {
+    private static final String SOURCE_FACTORY_SERVICE =
+            "META-INF/services/com.link.up.api.table.factory.TableSourceFactory";
+    private static final String SINK_FACTORY_SERVICE =
+            "META-INF/services/com.link.up.api.factory.SinkFactory";
+
     static {
         registerAsParallelCapable();
     }
@@ -19,6 +26,27 @@ public final class ConnectorClassLoader extends URLClassLoader {
         return name.startsWith("java.") || name.startsWith("javax.") || name.startsWith("jdk.")
                 || name.startsWith("sun.") || name.startsWith("com.link.up.api.")
                 || name.startsWith("org.slf4j.") || name.startsWith("org.apache.logging.");
+    }
+
+    private static boolean connectorFactoryService(String resourceName) {
+        return SOURCE_FACTORY_SERVICE.equals(resourceName)
+                || SINK_FACTORY_SERVICE.equals(resourceName);
+    }
+
+    /**
+     * ServiceLoader normally inherits parent META-INF/services resources. For connector factory
+     * discovery that would make every plugin directory rediscover built-in factories such as JDBC,
+     * producing duplicate identifiers before the plugin's own factories can be registered.
+     *
+     * <p>Only Link-Up connector factory service descriptors are child-only. Other resources and
+     * other ServiceLoader contracts retain normal URLClassLoader behavior.</p>
+     */
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        if (connectorFactoryService(name)) {
+            return findResources(name);
+        }
+        return super.getResources(name);
     }
 
     @Override

--- a/link-up-framework/src/test/java/com/link/up/framework/classloading/ConnectorClassLoaderTest.java
+++ b/link-up-framework/src/test/java/com/link/up/framework/classloading/ConnectorClassLoaderTest.java
@@ -1,0 +1,81 @@
+package com.link.up.framework.classloading;
+
+import org.junit.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ConnectorClassLoaderTest {
+
+    private static final String SOURCE_FACTORY_SERVICE =
+            "META-INF/services/com.link.up.api.table.factory.TableSourceFactory";
+
+    @Test
+    public void connectorFactoryServiceDescriptorsAreChildOnly() throws Exception {
+        Path parentRoot = Files.createTempDirectory("link-up-parent-services");
+        Path childRoot = Files.createTempDirectory("link-up-child-services");
+        writeService(parentRoot, SOURCE_FACTORY_SERVICE, "parent.Factory");
+        writeService(childRoot, SOURCE_FACTORY_SERVICE, "child.Factory");
+
+        URLClassLoader parent = new URLClassLoader(
+                new URL[]{parentRoot.toUri().toURL()},
+                getClass().getClassLoader());
+        ConnectorClassLoader child = new ConnectorClassLoader(
+                new URL[]{childRoot.toUri().toURL()},
+                parent);
+        try {
+            List<URL> resources = list(child.getResources(SOURCE_FACTORY_SERVICE));
+            assertEquals(1, resources.size());
+            assertTrue(resources.get(0).toString().contains(childRoot.getFileName().toString()));
+        } finally {
+            child.close();
+            parent.close();
+        }
+    }
+
+    @Test
+    public void ordinaryResourcesStillUseParentAndChildLookup() throws Exception {
+        Path parentRoot = Files.createTempDirectory("link-up-parent-resource");
+        Path childRoot = Files.createTempDirectory("link-up-child-resource");
+        String resourceName = "connector-test-resource.txt";
+        Files.write(parentRoot.resolve(resourceName), "parent".getBytes(StandardCharsets.UTF_8));
+        Files.write(childRoot.resolve(resourceName), "child".getBytes(StandardCharsets.UTF_8));
+
+        URLClassLoader parent = new URLClassLoader(
+                new URL[]{parentRoot.toUri().toURL()},
+                getClass().getClassLoader());
+        ConnectorClassLoader child = new ConnectorClassLoader(
+                new URL[]{childRoot.toUri().toURL()},
+                parent);
+        try {
+            List<URL> resources = list(child.getResources(resourceName));
+            assertEquals(2, resources.size());
+        } finally {
+            child.close();
+            parent.close();
+        }
+    }
+
+    private void writeService(Path root, String resourceName, String provider) throws Exception {
+        Path file = root.resolve(resourceName);
+        Files.createDirectories(file.getParent());
+        Files.write(file, (provider + "\n").getBytes(StandardCharsets.UTF_8));
+    }
+
+    private List<URL> list(Enumeration<URL> resources) {
+        List<URL> result = new ArrayList<URL>();
+        while (resources.hasMoreElements()) {
+            result.add(resources.nextElement());
+        }
+        return result;
+    }
+}

--- a/link-up-server/src/test/java/com/link/up/server/ElasticsearchPluginPackagingBoundaryTest.java
+++ b/link-up-server/src/test/java/com/link/up/server/ElasticsearchPluginPackagingBoundaryTest.java
@@ -1,0 +1,92 @@
+package com.link.up.server;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Guards the runtime packaging boundary required to load Elasticsearch 7 and 8 together. */
+public class ElasticsearchPluginPackagingBoundaryTest {
+
+    @Test
+    public void distributionKeepsVersionedConnectorsOutOfFlatRuntimeScope() throws Exception {
+        String pom = read(repositoryRoot().resolve("link-up-dist/pom.xml"));
+
+        assertProvidedDependency(pom, "link-up-connector-elasticsearch7");
+        assertProvidedDependency(pom, "link-up-connector-elasticsearch8");
+    }
+
+    @Test
+    public void distributionUsesOneDirectoryPerElasticsearchClassLoader() throws Exception {
+        String assembly = read(repositoryRoot().resolve(
+                "link-up-dist/src/main/assembly/distribution.xml"));
+
+        assertTrue(assembly.contains("<outputDirectory>plugins/elasticsearch7</outputDirectory>"));
+        assertTrue(assembly.contains("<outputDirectory>plugins/elasticsearch8</outputDirectory>"));
+        assertTrue(assembly.contains(
+                "link-up-connector-elasticsearch7/target/plugin-dependencies"));
+        assertTrue(assembly.contains(
+                "link-up-connector-elasticsearch8/target/plugin-dependencies"));
+        assertFalse(assembly.contains("<outputDirectory>plugins/elasticsearch</outputDirectory>"));
+    }
+
+    @Test
+    public void eachVersionResolvesItsRuntimeGraphInsideItsOwnModule() throws Exception {
+        String es7 = read(repositoryRoot().resolve(
+                "link-up-connectors/link-up-connector-elasticsearch7/pom.xml"));
+        String es8 = read(repositoryRoot().resolve(
+                "link-up-connectors/link-up-connector-elasticsearch8/pom.xml"));
+
+        assertTrue(es7.contains("stage-elasticsearch7-plugin-dependencies"));
+        assertTrue(es8.contains("stage-elasticsearch8-plugin-dependencies"));
+        assertTrue(es7.contains("${project.build.directory}/plugin-dependencies"));
+        assertTrue(es8.contains("${project.build.directory}/plugin-dependencies"));
+    }
+
+    @Test
+    public void distributionLauncherPassesSubdirectoriesAsSeparatePluginDirs() throws Exception {
+        String script = read(repositoryRoot().resolve(
+                "link-up-dist/src/main/dist/bin/link-up-server.sh"));
+
+        assertTrue(script.contains("LINK_UP_PLUGIN_ROOT"));
+        assertTrue(script.contains("LINK_UP_PLUGIN_DIRS"));
+        assertTrue(script.contains("PLUGIN_ARGS+=( --plugin-dir"));
+        assertTrue(script.contains("\"${PLUGIN_ROOT}\"/*"));
+        assertFalse(script.contains("-cp \"${LINK_UP_HOME}/lib/*:${LINK_UP_HOME}/plugins"));
+    }
+
+    private void assertProvidedDependency(String pom, String artifactId) {
+        String marker = "<artifactId>" + artifactId + "</artifactId>";
+        int start = pom.indexOf(marker);
+        assertTrue("missing dependency " + artifactId, start >= 0);
+
+        int end = pom.indexOf("</dependency>", start);
+        assertTrue("unterminated dependency " + artifactId, end > start);
+        String dependency = pom.substring(start, end);
+        assertTrue(
+                artifactId + " must remain reactor-only/provided",
+                dependency.contains("<scope>provided</scope>"));
+    }
+
+    private Path repositoryRoot() {
+        Path current = Paths.get("").toAbsolutePath().normalize();
+        if (Files.exists(current.resolve("link-up-dist/pom.xml"))) {
+            return current;
+        }
+        Path parent = current.getParent();
+        if (parent != null && Files.exists(parent.resolve("link-up-dist/pom.xml"))) {
+            return parent;
+        }
+        throw new IllegalStateException("Could not locate Link-Up repository root from " + current);
+    }
+
+    private String read(Path path) throws IOException {
+        return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+    }
+}


### PR DESCRIPTION
## Summary

Elasticsearch Stage 5: make the already-implemented `elasticsearch7` and `elasticsearch8` bounded connectors deployable together without flattening their incompatible client stacks onto the Worker classpath.

This PR does **not** change Elasticsearch Source/Sink semantics. It uses the existing Link-Up plugin/classloader boundary and finishes the distribution/runtime packaging around it.

## Runtime shape

```text
lib/
  link-up-server + framework + built-ins

plugins/
  elasticsearch7/
    link-up-connector-elasticsearch7-*.jar
    ES7 dependency graph...

  elasticsearch8/
    link-up-connector-elasticsearch8-*.jar
    ES8 dependency graph...
```

Each immediate plugin directory is passed to `FluxServer` as a separate `--plugin-dir`. `FactoryRegistry` creates one `ConnectorClassLoader` per directory, so ES7 and ES8 can keep different versions of `org.elasticsearch.client:elasticsearch-rest-client`.

## What changed

- each versioned Elasticsearch module stages its own runtime dependencies during `package`
- `link-up-dist` references ES7/ES8 only as `provided` reactor-order dependencies; they never enter the flattened `lib/` runtime dependency set
- assembly copies the two connector artifacts and their independently resolved dependency graphs into separate plugin directories
- `link-up-server.sh` auto-discovers immediate plugin subdirectories, with `LINK_UP_PLUGIN_ROOT` and explicit `LINK_UP_PLUGIN_DIRS` overrides
- add distribution documentation for the one-directory/one-classloader rule
- fix connector factory ServiceLoader discovery so a child plugin loader does not inherit the parent Worker’s Link-Up factory service descriptors (which would otherwise rediscover built-in JDBC and create duplicate identifiers)

## ClassLoader boundary

`ConnectorClassLoader` remains child-first for connector/vendor libraries and parent-first for Java, Link-Up API, SLF4J and Log4j contracts.

Only the two Link-Up connector factory service descriptor resources are now child-only:

- `META-INF/services/com.link.up.api.table.factory.TableSourceFactory`
- `META-INF/services/com.link.up.api.factory.SinkFactory`

Other resources and other ServiceLoader contracts keep normal URLClassLoader behavior.

## Tests

Added guards for:

- parent Link-Up factory service descriptors are not inherited by a plugin loader
- ordinary resource lookup still sees parent + child resources
- ES7/ES8 remain `provided` from the distribution’s dependency graph
- ES7 and ES8 dependencies are resolved/staged independently inside their own connector modules
- assembly keeps `plugins/elasticsearch7` and `plugins/elasticsearch8` separate
- server startup passes plugin subdirectories as separate `--plugin-dir` arguments

## Non-goals

- no shading/relocation
- no second Worker or multi-worker routing
- no change to ES7/ES8 bounded Source/Sink behavior from #109–#112
- no CDC/realtime semantics
- no Elasticsearch SDK added to `link-up-server` or `link-up-launcher`
- local `link-up.sh` / `link-up.cmd` single-job launcher plugin wiring is not changed; this stage is for the control-plane Worker (`FluxServer`) path used by Yak Ops

## Validation

- based on current `main` after Elasticsearch Source/Sink stages
- branch squashed to one focused commit
- repository currently has no GitHub Actions workflow for this branch, so no CI/Maven success is claimed here
- tests are committed and should be run with the normal Maven reactor before marking ready

## Follow-up

With this packaging boundary in place, Yak Ops PR 8 can safely expose separate Elasticsearch 7 and Elasticsearch 8 datasource/control-plane profiles while still treating Worker connector discovery as runtime truth.