### PR TITLE
feat(tidb): add JDBC offline source and sink support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -28,6 +28,37 @@ uses the source schema; for MySQL's `database.table` paths it uses the database 
 as `public.sink_table`, writes all input to that target. If `table`/`table_path` is configured, Flux generates the
 INSERT/UPSERT SQL for the resolved target and ignores `custom_sql`/`query`.
 
+## TiDB
+
+TiDB reuses MySQL Connector/J and the MySQL-compatible JDBC execution path, but it is exposed as a separate database
+dialect. Because both MySQL and TiDB use the `jdbc:mysql://` URL scheme, TiDB must be selected explicitly instead of
+being guessed from the URL:
+
+```hocon
+source {
+  type = "jdbc"
+  url = "jdbc:mysql://tidb:4000/app"
+  driver = "com.mysql.cj.jdbc.Driver"
+  dialect = "tidb"
+  table_path = "app.orders"
+}
+
+sink {
+  type = "jdbc"
+  url = "jdbc:mysql://tidb:4000/archive"
+  driver = "com.mysql.cj.jdbc.Driver"
+  dialect = "tidb"
+}
+```
+
+The Stage 1 TiDB adapter supports bounded single-table and multi-table reads, shared JDBC range/hash split planning,
+INSERT/UPSERT and offline sink DDL. Target database resolution prefers the database bound in the TiDB JDBC URL so a
+source database name is not accidentally reused by a cross-database sink.
+
+Stage 1 intentionally does not advertise `DATABASE_SNAPSHOT`, TiCDC, TiKV/TiFlash native access, CDC, streaming
+checkpoints or runtime schema evolution. Those capabilities require separate stages instead of changing the bounded JDBC
+contract.
+
 ## Options
 
 | Option | Required | Default | Description |

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/tidb/TiDbCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/tidb/TiDbCatalog.java
@@ -1,0 +1,205 @@
+package com.link.up.connector.jdbc.catalog.tidb;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlCatalog;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * TiDB Catalog facade over the MySQL-compatible metadata protocol.
+ *
+ * <p>The facade keeps TiDB as a first-class database identity while reusing
+ * the mature MySQL INFORMATION_SCHEMA and DDL implementation.</p>
+ */
+public final class TiDbCatalog
+        implements WritableCatalog {
+
+    public static final String DIALECT =
+            DatabaseIdentifier.TIDB;
+
+    private final WritableCatalog delegate;
+
+    public TiDbCatalog(
+            String catalogName,
+            JdbcCatalogConfig config) {
+
+        this.delegate =
+                new MySqlCatalog(
+                        catalogName,
+                        config);
+    }
+
+    @Override
+    public String name() {
+        return delegate.name();
+    }
+
+    @Override
+    public void open() throws CatalogException {
+        delegate.open();
+    }
+
+    @Override
+    public void close() throws CatalogException {
+        delegate.close();
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase()
+            throws CatalogException {
+
+        return delegate.getDefaultDatabase();
+    }
+
+    @Override
+    public List<String> listDatabases()
+            throws CatalogException {
+
+        return delegate.listDatabases();
+    }
+
+    @Override
+    public List<String> listSchemas(
+            String databaseName)
+            throws CatalogException {
+
+        return delegate.listSchemas(databaseName);
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String databaseName,
+            String schemaName)
+            throws CatalogException {
+
+        return delegate.listTables(
+                databaseName,
+                schemaName);
+    }
+
+    @Override
+    public boolean tableExists(
+            TablePath tablePath)
+            throws CatalogException {
+
+        return delegate.tableExists(tablePath);
+    }
+
+    @Override
+    public CatalogTable getTable(
+            TablePath tablePath)
+            throws CatalogException,
+            TableNotFoundException {
+
+        CatalogTable table =
+                delegate.getTable(tablePath);
+
+        return table.toBuilder()
+                .option(
+                        MySqlCatalog.TABLE_OPTION_DIALECT,
+                        DIALECT)
+                .build();
+    }
+
+    @Override
+    public void createDatabase(
+            String databaseName,
+            boolean ignoreIfExists)
+            throws CatalogException,
+            DatabaseAlreadyExistsException {
+
+        delegate.createDatabase(
+                databaseName,
+                ignoreIfExists);
+    }
+
+    @Override
+    public void dropDatabase(
+            String databaseName,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            DatabaseNotFoundException {
+
+        delegate.dropDatabase(
+                databaseName,
+                ignoreIfNotExists);
+    }
+
+    @Override
+    public void createTable(
+            CatalogTable table,
+            boolean ignoreIfExists)
+            throws CatalogException,
+            DatabaseNotFoundException,
+            TableAlreadyExistsException {
+
+        delegate.createTable(
+                asMySqlCompatibleSource(table),
+                ignoreIfExists);
+    }
+
+    @Override
+    public void addColumn(
+            TablePath tablePath,
+            Column column)
+            throws CatalogException,
+            TableNotFoundException {
+
+        delegate.addColumn(
+                tablePath,
+                column);
+    }
+
+    @Override
+    public void dropTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            TableNotFoundException {
+
+        delegate.dropTable(
+                tablePath,
+                ignoreIfNotExists);
+    }
+
+    @Override
+    public void truncateTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            TableNotFoundException {
+
+        delegate.truncateTable(
+                tablePath,
+                ignoreIfNotExists);
+    }
+
+    private static CatalogTable asMySqlCompatibleSource(
+            CatalogTable table) {
+
+        String sourceDialect =
+                table.getOptions()
+                        .get(MySqlCatalog.TABLE_OPTION_DIALECT);
+
+        if (!DIALECT.equalsIgnoreCase(sourceDialect)) {
+            return table;
+        }
+
+        return table.toBuilder()
+                .option(
+                        MySqlCatalog.TABLE_OPTION_DIALECT,
+                        DatabaseIdentifier.MYSQL)
+                .build();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/tidb/TiDbCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/tidb/TiDbCatalogFactory.java
@@ -1,0 +1,62 @@
+package com.link.up.connector.jdbc.catalog.tidb;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.factory.Factory;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.config.JdbcCommonOptions;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * TiDB Catalog factory backed by MySQL Connector/J.
+ */
+@AutoService(Factory.class)
+public final class TiDbCatalogFactory
+        implements CatalogFactory {
+
+    private static final String DEFAULT_DRIVER =
+            "com.mysql.cj.jdbc.Driver";
+
+    @Override
+    public String factoryIdentifier() {
+        return DatabaseIdentifier.TIDB;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            ReadonlyConfig options) {
+
+        String url = options.get(JdbcCommonOptions.URL);
+        String username =
+                options.getOptional(JdbcCommonOptions.USERNAME)
+                        .orElse(null);
+        String password =
+                options.getOptional(JdbcCommonOptions.PASSWORD)
+                        .orElse(null);
+        String driver =
+                options.getOptional(JdbcCommonOptions.DRIVER)
+                        .orElse(DEFAULT_DRIVER);
+        Map<String, String> properties =
+                options.getOptional(JdbcCommonOptions.PROPERTIES)
+                        .orElse(Collections.emptyMap());
+        boolean intTypeNarrowing =
+                options.getOptional(JdbcCommonOptions.INT_TYPE_NARROWING)
+                        .orElse(false);
+
+        return new TiDbCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        url,
+                        username,
+                        password,
+                        driver,
+                        properties,
+                        intTypeNarrowing));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -8,6 +8,7 @@ package com.link.up.connector.jdbc.core.dialect;
 public final class DatabaseIdentifier {
 
     public static final String MYSQL = "mysql";
+    public static final String TIDB = "tidb";
     public static final String POSTGRESQL = "postgresql";
     public static final String ORACLE = "oracle";
     public static final String SQLSERVER = "sqlserver";

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/tidb/TiDbDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/tidb/TiDbDialect.java
@@ -1,0 +1,143 @@
+package com.link.up.connector.jdbc.core.dialect.tidb;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.tidb.TiDbCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.config.ReadConsistency;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+import com.link.up.connector.jdbc.core.dialect.mysql.MySqlDialect;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * TiDB bounded offline JDBC dialect.
+ *
+ * <p>Stage 1 intentionally reuses the mature MySQL JDBC execution semantics:
+ * Connector/J, type mapping, INSERT/UPSERT, cursor reads and hash splitting.
+ * TiDB-specific CDC, TiKV/TiFlash access and coordinated database snapshots
+ * are outside this stage.</p>
+ */
+public final class TiDbDialect
+        implements JdbcDialect {
+
+    private final JdbcConnectionConfig connectionConfig;
+    private final MySqlDialect mysqlDelegate;
+
+    public TiDbDialect(
+            JdbcConnectionConfig connectionConfig) {
+
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException(
+                    "connectionConfig must not be null");
+        }
+
+        this.connectionConfig = connectionConfig;
+        this.mysqlDelegate =
+                new MySqlDialect(connectionConfig);
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.TIDB;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+
+        return new TiDbCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false));
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return mysqlDelegate.typeMapper();
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new TiDbJdbcRowConverter();
+    }
+
+    @Override
+    public Set<ReadConsistency> supportedReadConsistencies() {
+        return mysqlDelegate.supportedReadConsistencies();
+    }
+
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        return mysqlDelegate.parseTablePath(tablePath);
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        return mysqlDelegate.quoteIdentifier(identifier);
+    }
+
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        return mysqlDelegate.tableIdentifier(tablePath);
+    }
+
+    @Override
+    public Optional<String> buildUpsertSql(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+
+        return mysqlDelegate.buildUpsertSql(
+                tablePath,
+                fieldNames,
+                primaryKeys);
+    }
+
+    @Override
+    public PreparedStatement prepareReadStatement(
+            Connection connection,
+            String sql,
+            int fetchSize)
+            throws SQLException {
+
+        return mysqlDelegate.prepareReadStatement(
+                connection,
+                sql,
+                fetchSize);
+    }
+
+    @Override
+    public Map<String, String> defaultConnectionProperties() {
+        return mysqlDelegate.defaultConnectionProperties();
+    }
+
+    @Override
+    public Optional<String> buildHashPartitionPredicate(
+            Column column,
+            int bucket,
+            int bucketCount) {
+
+        return mysqlDelegate.buildHashPartitionPredicate(
+                column,
+                bucket,
+                bucketCount);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/tidb/TiDbDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/tidb/TiDbDialectFactory.java
@@ -1,0 +1,36 @@
+package com.link.up.connector.jdbc.core.dialect.tidb;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/**
+ * TiDB JDBC dialect SPI.
+ *
+ * <p>TiDB speaks the MySQL protocol and therefore uses the same jdbc:mysql URL
+ * scheme as MySQL. URL-only detection would make both factories match, so TiDB
+ * must be selected explicitly with {@code dialect=tidb}.</p>
+ */
+@AutoService(JdbcDialectFactory.class)
+public final class TiDbDialectFactory
+        implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.TIDB;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return false;
+    }
+
+    @Override
+    public JdbcDialect create(
+            JdbcConnectionConfig connectionConfig) {
+
+        return new TiDbDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/tidb/TiDbJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/tidb/TiDbJdbcRowConverter.java
@@ -1,0 +1,37 @@
+package com.link.up.connector.jdbc.core.dialect.tidb;
+
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * TiDB row converter for the MySQL-compatible JDBC protocol.
+ */
+public final class TiDbJdbcRowConverter
+        extends AbstractJdbcRowConverter {
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.TIDB;
+    }
+
+    @Override
+    protected void writeTime(
+            PreparedStatement statement,
+            int index,
+            LocalTime value)
+            throws SQLException {
+
+        statement.setTimestamp(
+                index,
+                java.sql.Timestamp.valueOf(
+                        LocalDateTime.of(
+                                LocalDate.now(),
+                                value)));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -133,6 +133,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return XuguSinkSupport.resolveTargetPath(
                     config.getConnectionConfig(), tablePath);
         }
+        if (TiDbSinkSupport.accepts(config.getConnectionConfig())) {
+            return TiDbSinkSupport.resolveTargetPath(
+                    config.getConnectionConfig(), tablePath);
+        }
         return JdbcCreateTableSqlResolver.resolveTargetPath(
                 config.getConnectionConfig(), tablePath);
     }
@@ -152,6 +156,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
         }
         if (XuguSinkSupport.accepts(config.getConnectionConfig())) {
             return XuguSinkSupport.resolveCreateTableSql(
+                    config.getConnectionConfig(), table);
+        }
+        if (TiDbSinkSupport.accepts(config.getConnectionConfig())) {
+            return TiDbSinkSupport.resolveCreateTableSql(
                     config.getConnectionConfig(), table);
         }
         return JdbcCreateTableSqlResolver.resolve(

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/TiDbSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/TiDbSinkSupport.java
@@ -1,0 +1,167 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlCatalog;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlCreateTableSqlBuilder;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlTypeMapper;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+/**
+ * TiDB-specific target normalization for the shared JDBC sink.
+ */
+final class TiDbSinkSupport {
+
+    private TiDbSinkSupport() {
+    }
+
+    static boolean accepts(
+            JdbcConnectionConfig connectionConfig) {
+
+        return connectionConfig != null
+                && DatabaseIdentifier.TIDB.equalsIgnoreCase(
+                        connectionConfig.getDialect());
+    }
+
+    static TablePath resolveTargetPath(
+            JdbcConnectionConfig connectionConfig,
+            TablePath tablePath) {
+
+        if (connectionConfig == null
+                || tablePath == null) {
+            return tablePath;
+        }
+
+        String database =
+                databaseFromUrl(
+                        connectionConfig.getUrl());
+
+        if (!hasText(database)) {
+            database = connectionConfig.getSchema();
+        }
+
+        if (!hasText(database)) {
+            database = tablePath.getDatabaseName();
+        }
+
+        if (!hasText(database)) {
+            database = tablePath.getSchemaName();
+        }
+
+        if (!hasText(database)) {
+            return null;
+        }
+
+        return TablePath.of(
+                database.trim(),
+                tablePath.getTableName());
+    }
+
+    static String resolveCreateTableSql(
+            JdbcConnectionConfig connectionConfig,
+            CatalogTable table) {
+
+        if (connectionConfig == null
+                || table == null) {
+            return null;
+        }
+
+        TablePath targetPath =
+                resolveTargetPath(
+                        connectionConfig,
+                        table.getTablePath());
+
+        if (targetPath == null) {
+            return null;
+        }
+
+        CatalogTable ddlTable =
+                table.getTablePath().equals(targetPath)
+                        ? table
+                        : table.withPath(targetPath);
+
+        String sourceDialect =
+                ddlTable.getOptions()
+                        .get(MySqlCatalog.TABLE_OPTION_DIALECT);
+
+        if (DatabaseIdentifier.TIDB
+                .equalsIgnoreCase(sourceDialect)) {
+
+            ddlTable = ddlTable.toBuilder()
+                    .option(
+                            MySqlCatalog.TABLE_OPTION_DIALECT,
+                            DatabaseIdentifier.MYSQL)
+                    .build();
+        }
+
+        return new MySqlCreateTableSqlBuilder(
+                targetPath,
+                ddlTable,
+                new MySqlTypeMapper(false))
+                .build();
+    }
+
+    private static String databaseFromUrl(
+            String url) {
+
+        if (!hasText(url)) {
+            return null;
+        }
+
+        String normalized = url.trim();
+        int protocolSeparator =
+                normalized.indexOf("://");
+
+        if (protocolSeparator < 0) {
+            return null;
+        }
+
+        int databaseStart =
+                normalized.indexOf(
+                        '/',
+                        protocolSeparator + 3);
+
+        if (databaseStart < 0
+                || databaseStart
+                == normalized.length() - 1) {
+            return null;
+        }
+
+        int databaseEnd = normalized.length();
+
+        int queryStart =
+                normalized.indexOf(
+                        '?',
+                        databaseStart + 1);
+
+        if (queryStart >= 0) {
+            databaseEnd = queryStart;
+        }
+
+        int fragmentStart =
+                normalized.indexOf(
+                        '#',
+                        databaseStart + 1);
+
+        if (fragmentStart >= 0
+                && fragmentStart < databaseEnd) {
+            databaseEnd = fragmentStart;
+        }
+
+        String database =
+                normalized.substring(
+                        databaseStart + 1,
+                        databaseEnd)
+                        .trim();
+
+        return hasText(database)
+                ? database
+                : null;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null
+                && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/tidb/TiDbDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/tidb/TiDbDialectTest.java
@@ -1,0 +1,106 @@
+package com.link.up.connector.jdbc.core.dialect.tidb;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.config.ReadConsistency;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TiDbDialectTest {
+
+    @Test
+    public void explicitDialectLoadsTiDbForMysqlJdbcUrl() {
+        JdbcDialect dialect =
+                JdbcDialectLoader.load(
+                        config(
+                                "jdbc:mysql://127.0.0.1:4000/test",
+                                "tidb"));
+
+        assertTrue(dialect instanceof TiDbDialect);
+        assertEquals(
+                DatabaseIdentifier.TIDB,
+                dialect.name());
+    }
+
+    @Test
+    public void factoryDoesNotCompeteWithMysqlUrlDetection() {
+        assertFalse(
+                new TiDbDialectFactory()
+                        .acceptsUrl(
+                                "jdbc:mysql://127.0.0.1:4000/test"));
+    }
+
+    @Test
+    public void reusesMysqlOfflineTableAndUpsertSemantics() {
+        TiDbDialect dialect =
+                new TiDbDialect(
+                        config(
+                                "jdbc:mysql://127.0.0.1:4000/test",
+                                "tidb"));
+
+        assertEquals(
+                "`test`.`orders`",
+                dialect.tableIdentifier(
+                        TablePath.of("orders")));
+
+        String upsert =
+                dialect.buildUpsertSql(
+                                TablePath.of("test", "orders"),
+                                Arrays.asList("id", "name"),
+                                Arrays.asList("id"))
+                        .get();
+
+        assertTrue(
+                upsert.contains(
+                        "ON DUPLICATE KEY UPDATE"));
+    }
+
+    @Test
+    public void stageOneDoesNotAdvertiseCoordinatedDatabaseSnapshot() {
+        TiDbDialect dialect =
+                new TiDbDialect(
+                        config(
+                                "jdbc:mysql://127.0.0.1:4000/test",
+                                "tidb"));
+
+        assertTrue(
+                dialect.supportedReadConsistencies()
+                        .contains(ReadConsistency.BEST_EFFORT));
+        assertTrue(
+                dialect.supportedReadConsistencies()
+                        .contains(
+                                ReadConsistency.SINGLE_CONNECTION_SNAPSHOT));
+        assertFalse(
+                dialect.supportedReadConsistencies()
+                        .contains(
+                                ReadConsistency.DATABASE_SNAPSHOT));
+    }
+
+    private static JdbcConnectionConfig config(
+            String url,
+            String dialect) {
+
+        Map<String, Object> values =
+                new LinkedHashMap<String, Object>();
+
+        values.put("url", url);
+        values.put(
+                "driver",
+                "com.mysql.cj.jdbc.Driver");
+        values.put("dialect", dialect);
+
+        return JdbcConnectionConfig.of(
+                ReadonlyConfig.fromMap(values));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/TiDbSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/TiDbSinkSupportTest.java
@@ -1,0 +1,120 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class TiDbSinkSupportTest {
+
+    @Test
+    public void sourceDatabaseDoesNotLeakIntoTidbTarget() {
+        TablePath target =
+                TiDbSinkSupport.resolveTargetPath(
+                        config(
+                                "jdbc:mysql://127.0.0.1:4000/target_db",
+                                null),
+                        TablePath.of(
+                                "source_db",
+                                "orders"));
+
+        assertEquals(
+                TablePath.of(
+                        "target_db",
+                        "orders"),
+                target);
+    }
+
+    @Test
+    public void configuredSchemaActsAsTargetDatabaseWhenUrlIsUnqualified() {
+        TablePath target =
+                TiDbSinkSupport.resolveTargetPath(
+                        config(
+                                "jdbc:mysql://127.0.0.1:4000",
+                                "configured_db"),
+                        TablePath.of(
+                                "source_db",
+                                "orders"));
+
+        assertEquals(
+                TablePath.of(
+                        "configured_db",
+                        "orders"),
+                target);
+    }
+
+    @Test
+    public void createTableSqlUsesMysqlCompatibleDdl() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .columns(
+                                Collections.singletonList(
+                                        Column.builder(
+                                                        "id",
+                                                        BasicType.LONG_TYPE)
+                                                .nullable(false)
+                                                .sourceType(
+                                                        "bigint unsigned")
+                                                .build()))
+                        .build();
+
+        CatalogTable table =
+                CatalogTable.builder(
+                                TablePath.of(
+                                        "source_db",
+                                        "orders"),
+                                schema)
+                        .option(
+                                MySqlCatalog.TABLE_OPTION_DIALECT,
+                                DatabaseIdentifier.TIDB)
+                        .build();
+
+        String sql =
+                TiDbSinkSupport.resolveCreateTableSql(
+                        config(
+                                "jdbc:mysql://127.0.0.1:4000/target_db",
+                                null),
+                        table);
+
+        assertTrue(
+                sql.startsWith(
+                        "CREATE TABLE `target_db`.`orders`"));
+        assertTrue(sql.contains("bigint unsigned"));
+    }
+
+    private static JdbcConnectionConfig config(
+            String url,
+            String schema) {
+
+        Map<String, Object> values =
+                new LinkedHashMap<String, Object>();
+
+        values.put("url", url);
+        values.put(
+                "driver",
+                "com.mysql.cj.jdbc.Driver");
+        values.put(
+                "dialect",
+                DatabaseIdentifier.TIDB);
+
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+
+        return JdbcConnectionConfig.of(
+                ReadonlyConfig.fromMap(values));
+    }
+}


### PR DESCRIPTION
## Summary

Add Stage 1 TiDB support to the existing JDBC connector without introducing a separate TiDB Maven module or any CDC/runtime streaming semantics.

### What changed

- add first-class `tidb` JDBC dialect identity and SPI factory
- require explicit `dialect=tidb` because TiDB and MySQL share the `jdbc:mysql://` URL scheme
- reuse MySQL Connector/J, MySQL-compatible type mapping, cursor reads, INSERT/UPSERT and hash split semantics
- add a TiDB Catalog facade that reuses the mature MySQL INFORMATION_SCHEMA/DDL implementation while preserving `dialect=tidb` metadata identity
- normalize TiDB sink target paths from the target JDBC URL so source database names do not leak into cross-database writes
- reuse MySQL-compatible offline CREATE TABLE generation for TiDB sink preparation
- document bounded TiDB source/sink configuration

### Tests added

- explicit TiDB dialect loading over a `jdbc:mysql://` URL
- no TiDB URL auto-detection conflict with MySQL
- MySQL-compatible table identifier and UPSERT behavior
- Stage 1 does not advertise coordinated `DATABASE_SNAPSHOT`
- TiDB sink target database isolation
- TiDB-compatible CREATE TABLE generation and source type preservation

## Scope boundary

This PR intentionally stays bounded/offline only. It does **not** add:

- TiCDC
- TiKV/TiFlash native reads
- PD/TSO coordination
- coordinated multi-reader `DATABASE_SNAPSHOT`
- streaming checkpoints
- runtime schema evolution
- CDC or real-time synchronization semantics

Those capabilities should remain separate follow-up stages rather than changing the shared JDBC offline execution model.

## Configuration example

```hocon
source {
  type = "jdbc"
  url = "jdbc:mysql://tidb:4000/app"
  driver = "com.mysql.cj.jdbc.Driver"
  dialect = "tidb"
  table_path = "app.orders"
}

sink {
  type = "jdbc"
  url = "jdbc:mysql://tidb:4000/archive"
  driver = "com.mysql.cj.jdbc.Driver"
  dialect = "tidb"
}
```
