### PR TITLE
feat(jdbc): add SAP HANA offline source support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -59,6 +59,31 @@ Stage 1 intentionally does not advertise `DATABASE_SNAPSHOT`, TiCDC, TiKV/TiFlas
 checkpoints or runtime schema evolution. Those capabilities require separate stages instead of changing the bounded JDBC
 contract.
 
+## SAP HANA
+
+SAP HANA is exposed as the `hana` JDBC dialect and is auto-detected from `jdbc:sap://` URLs. Stage 1 is deliberately
+source-only: it provides bounded reads, schema/table metadata discovery, custom SQL projection, common HANA type mapping
+and the shared safe JDBC split planner. It does not enable HANA sink DDL, INSERT/UPSERT, CDC, SLT or streaming semantics.
+
+```hocon
+source {
+  type = "jdbc"
+  url = "jdbc:sap://hana:30013/?databaseName=HXE"
+  driver = "com.sap.db.jdbc.Driver"
+  schema = "SALES"
+  table_path = "SALES.ORDERS"
+}
+```
+
+HANA SQL identifiers use `schema.table`; the database/tenant is selected by the JDBC connection. Unquoted `table_path`
+parts are normalized to HANA's uppercase identifier semantics, while quoted identifiers preserve case. The connector
+`schema` option is applied as the JDBC `currentSchema` default unless the URL or explicit JDBC properties already set
+`currentSchema`.
+
+The Stage 1 type contract covers BOOLEAN, integer types, SMALLDECIMAL/DECIMAL, REAL/DOUBLE, VARCHAR/NVARCHAR and common
+text/LOB types, DATE/TIME/SECONDDATE/TIMESTAMP, and binary/BLOB types. ARRAY and spatial `ST_POINT`/`ST_GEOMETRY` are
+rejected explicitly instead of being silently coerced.
+
 ## Options
 
 | Option | Required | Default | Description |

--- a/link-up-connectors/link-up-connector-jdbc/pom.xml
+++ b/link-up-connectors/link-up-connector-jdbc/pom.xml
@@ -79,6 +79,11 @@
             <version>11.5.9.0</version>
         </dependency>
         <dependency>
+            <groupId>com.sap.cloud.db.jdbc</groupId>
+            <artifactId>ngdbc</artifactId>
+            <version>2.29.7</version>
+        </dependency>
+        <dependency>
             <groupId>com.dameng</groupId>
             <artifactId>DmJdbcDriver18</artifactId>
             <version>8.1.3.140</version>

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/hana/HanaCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/hana/HanaCatalog.java
@@ -1,0 +1,390 @@
+package com.link.up.connector.jdbc.catalog.hana;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.hana.HanaJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.hana.HanaTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+/** Read-only SAP HANA Catalog used by Stage 1 bounded JDBC Source. */
+public final class HanaCatalog implements Catalog {
+
+    public static final String DIALECT = "hana";
+    public static final String TABLE_OPTION_DIALECT = "dialect";
+
+    private static final String CURRENT_SCHEMA_SQL =
+            "SELECT CURRENT_SCHEMA FROM DUMMY";
+    private static final String CURRENT_DATABASE_SQL =
+            "SELECT DATABASE_NAME FROM SYS.M_DATABASE";
+    private static final String[] TABLE_TYPES = new String[]{"TABLE", "VIEW"};
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String configuredDefaultSchema;
+    private final String configuredDatabaseName;
+    private final HanaTypeMapper typeMapper = new HanaTypeMapper();
+    private volatile boolean opened;
+
+    public HanaCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            String defaultSchema,
+            String databaseName) {
+        if (!hasText(catalogName)) {
+            throw new IllegalArgumentException("catalogName must not be empty");
+        }
+        this.catalogName = catalogName.trim();
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        if (!HanaJdbcUrl.accepts(config.getUrl())) {
+            throw new IllegalArgumentException(
+                    "非法 SAP HANA JDBC URL：" + config.getUrl());
+        }
+        this.configuredDefaultSchema = normalize(defaultSchema);
+        this.configuredDatabaseName = normalize(databaseName);
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.ofNullable(configuredDatabaseName);
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+        loadDriver();
+        try (Connection connection = connection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException(
+                        "SAP HANA Catalog 连接校验失败：" + config.getUrl());
+            }
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "SAP HANA Catalog 连接失败：" + config.getUrl(), e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        checkOpened();
+        try (Connection connection = connection()) {
+            String database = resolveDatabaseName(connection, null);
+            return database == null
+                    ? Collections.<String>emptyList()
+                    : Collections.singletonList(database);
+        } catch (SQLException e) {
+            throw new CatalogException("获取 SAP HANA database 失败", e);
+        }
+    }
+
+    @Override
+    public List<String> listSchemas(String databaseName) throws CatalogException {
+        checkOpened();
+        try (Connection connection = connection()) {
+            resolveDatabaseName(connection, databaseName);
+            DatabaseMetaData metadata = connection.getMetaData();
+            List<String> schemas = new ArrayList<String>();
+            try (ResultSet rs = metadata.getSchemas()) {
+                while (rs.next()) {
+                    String schema = normalize(rs.getString("TABLE_SCHEM"));
+                    if (schema != null && !isSystemSchema(schema)) {
+                        schemas.add(schema);
+                    }
+                }
+            }
+            Collections.sort(schemas);
+            return schemas;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 SAP HANA Schema 列表失败", e);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String databaseName,
+            String schemaName) throws CatalogException {
+        checkOpened();
+        try (Connection connection = connection()) {
+            String database = resolveDatabaseName(connection, databaseName);
+            String schema = resolveSchema(connection, schemaName);
+            DatabaseMetaData metadata = connection.getMetaData();
+            List<TablePath> tables = new ArrayList<TablePath>();
+            try (ResultSet rs = metadata.getTables(null, schema, "%", TABLE_TYPES)) {
+                while (rs.next()) {
+                    String table = normalize(rs.getString("TABLE_NAME"));
+                    if (table != null) {
+                        tables.add(TablePath.of(database, schema, table));
+                    }
+                }
+            }
+            tables.sort(Comparator.comparing(TablePath::getTableName));
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 SAP HANA 表列表失败，schema=" + schemaName, e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        checkOpened();
+        try (Connection connection = connection()) {
+            TablePath path = normalizePath(connection, tablePath);
+            try (ResultSet rs = connection.getMetaData().getTables(
+                    null,
+                    path.getSchemaName(),
+                    path.getTableName(),
+                    TABLE_TYPES)) {
+                return rs.next();
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "检查 SAP HANA 表是否存在失败，table=" + tablePath, e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        try (Connection connection = connection()) {
+            TablePath path = normalizePath(connection, tablePath);
+            DatabaseMetaData metadata = connection.getMetaData();
+            List<Column> columns = columns(metadata, path);
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(catalogName, path);
+            }
+
+            TableSchema schema = TableSchema.builder()
+                    .columns(columns)
+                    .primaryKey(primaryKey(metadata, path))
+                    .build();
+
+            CatalogTable.Builder table = CatalogTable.builder(path, schema)
+                    .option(TABLE_OPTION_DIALECT, DIALECT);
+            String comment = tableComment(metadata, path);
+            if (hasText(comment)) {
+                table.comment(comment);
+            }
+            return table.build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 SAP HANA 表结构失败，table=" + tablePath, e);
+        }
+    }
+
+    private List<Column> columns(DatabaseMetaData metadata, TablePath path)
+            throws SQLException {
+        try (ResultSet rs = metadata.getColumns(
+                null,
+                path.getSchemaName(),
+                path.getTableName(),
+                "%")) {
+            List<Column> columns = new ArrayList<Column>();
+            while (rs.next()) {
+                columns.add(typeMapper.toColumn(rs));
+            }
+            return columns;
+        }
+    }
+
+    private PrimaryKey primaryKey(DatabaseMetaData metadata, TablePath path)
+            throws SQLException {
+        try (ResultSet rs = metadata.getPrimaryKeys(
+                null,
+                path.getSchemaName(),
+                path.getTableName())) {
+            String name = null;
+            List<KeyColumn> keys = new ArrayList<KeyColumn>();
+            while (rs.next()) {
+                if (name == null) {
+                    name = normalize(rs.getString("PK_NAME"));
+                }
+                keys.add(new KeyColumn(
+                        rs.getShort("KEY_SEQ"),
+                        rs.getString("COLUMN_NAME")));
+            }
+            if (keys.isEmpty()) {
+                return null;
+            }
+            keys.sort(Comparator.comparingInt(KeyColumn::position));
+            List<String> columns = new ArrayList<String>(keys.size());
+            for (KeyColumn key : keys) {
+                columns.add(key.name);
+            }
+            return PrimaryKey.of(name, columns);
+        }
+    }
+
+    private String tableComment(DatabaseMetaData metadata, TablePath path)
+            throws SQLException {
+        try (ResultSet rs = metadata.getTables(
+                null,
+                path.getSchemaName(),
+                path.getTableName(),
+                TABLE_TYPES)) {
+            return rs.next() ? normalize(rs.getString("REMARKS")) : null;
+        }
+    }
+
+    private TablePath normalizePath(Connection connection, TablePath tablePath)
+            throws SQLException {
+        Objects.requireNonNull(tablePath, "tablePath must not be null");
+        String database = resolveDatabaseName(connection, tablePath.getDatabaseName());
+        String schema = resolveSchema(connection, tablePath.getSchemaName());
+        return TablePath.of(database, schema, tablePath.getTableName());
+    }
+
+    private String resolveSchema(Connection connection, String requestedSchema)
+            throws SQLException {
+        if (hasText(requestedSchema)) {
+            return requestedSchema.trim();
+        }
+        if (hasText(configuredDefaultSchema)) {
+            return configuredDefaultSchema;
+        }
+        try (PreparedStatement statement = connection.prepareStatement(CURRENT_SCHEMA_SQL);
+             ResultSet rs = statement.executeQuery()) {
+            if (rs.next()) {
+                String schema = normalize(rs.getString(1));
+                if (schema != null) {
+                    return schema;
+                }
+            }
+        }
+        throw new CatalogException(
+                "无法解析 SAP HANA 当前 schema，请显式配置 schema/currentSchema");
+    }
+
+    private String resolveDatabaseName(Connection connection, String requestedDatabase)
+            throws SQLException {
+        String discovered = configuredDatabaseName;
+
+        if (discovered == null) {
+            try (PreparedStatement statement = connection.prepareStatement(CURRENT_DATABASE_SQL);
+                 ResultSet rs = statement.executeQuery()) {
+                if (rs.next()) {
+                    discovered = normalize(rs.getString(1));
+                }
+            } catch (SQLException ignored) {
+                discovered = normalize(connection.getCatalog());
+            }
+        }
+
+        if (hasText(requestedDatabase)
+                && hasText(discovered)
+                && !requestedDatabase.trim().equalsIgnoreCase(discovered)) {
+            throw new IllegalArgumentException(
+                    "SAP HANA 表路径中的 database 与当前 JDBC 连接不一致，current="
+                            + discovered + "，requested=" + requestedDatabase);
+        }
+        if (hasText(discovered)) {
+            return discovered;
+        }
+        return hasText(requestedDatabase) ? requestedDatabase.trim() : null;
+    }
+
+    private Connection connection() throws SQLException {
+        Properties properties = config.toConnectionProperties();
+        if (configuredDefaultSchema != null
+                && !containsKeyIgnoreCase(properties, "currentSchema")) {
+            properties.setProperty("currentSchema", configuredDefaultSchema);
+        }
+        return DriverManager.getConnection(config.getUrl(), properties);
+    }
+
+    private void loadDriver() {
+        if (!hasText(config.getDriverClass())) {
+            return;
+        }
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException(
+                    "找不到 SAP HANA JDBC Driver：" + config.getDriverClass(), e);
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static boolean isSystemSchema(String schema) {
+        String normalized = schema.toUpperCase(Locale.ROOT);
+        return "SYS".equals(normalized)
+                || normalized.startsWith("_SYS_")
+                || "SAP_HANA_INTERNAL".equals(normalized);
+    }
+
+    private static boolean containsKeyIgnoreCase(Properties properties, String key) {
+        for (Object propertyKey : properties.keySet()) {
+            if (propertyKey != null && key.equalsIgnoreCase(propertyKey.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasText(String value) {
+        return normalize(value) != null;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static final class KeyColumn {
+        private final int position;
+        private final String name;
+
+        private KeyColumn(int position, String name) {
+            this.position = position;
+            this.name = name;
+        }
+
+        private int position() {
+            return position;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/hana/HanaCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/hana/HanaCatalogFactory.java
@@ -1,0 +1,49 @@
+package com.link.up.connector.jdbc.catalog.hana;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.factory.Factory;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.config.JdbcCommonOptions;
+import com.link.up.connector.jdbc.core.dialect.hana.HanaJdbcUrl;
+
+import java.util.Collections;
+import java.util.Map;
+
+/** Read-only SAP HANA Catalog factory for Stage 1. */
+@AutoService(Factory.class)
+public final class HanaCatalogFactory implements CatalogFactory {
+
+    private static final String DEFAULT_DRIVER = "com.sap.db.jdbc.Driver";
+
+    @Override
+    public String factoryIdentifier() {
+        return HanaCatalog.DIALECT;
+    }
+
+    @Override
+    public Catalog createCatalog(String catalogName, ReadonlyConfig options) {
+        String url = options.get(JdbcCommonOptions.URL);
+        String username = options.getOptional(JdbcCommonOptions.USERNAME).orElse(null);
+        String password = options.getOptional(JdbcCommonOptions.PASSWORD).orElse(null);
+        String driver = options.getOptional(JdbcCommonOptions.DRIVER).orElse(DEFAULT_DRIVER);
+        String schema = options.getOptional(JdbcCommonOptions.SCHEMA).orElse(null);
+        Map<String, String> properties = options.getOptional(JdbcCommonOptions.PROPERTIES)
+                .orElse(Collections.<String, String>emptyMap());
+
+        JdbcCatalogConfig config = new JdbcCatalogConfig(
+                url,
+                username,
+                password,
+                driver,
+                properties,
+                false);
+        return new HanaCatalog(
+                catalogName,
+                config,
+                HanaJdbcUrl.currentSchema(url, properties, schema),
+                HanaJdbcUrl.databaseName(url, properties));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -14,6 +14,7 @@ public final class DatabaseIdentifier {
     public static final String SQLSERVER = "sqlserver";
     public static final String OCEANBASE = "oceanbase";
     public static final String DB2 = "db2";
+    public static final String HANA = "hana";
     public static final String DAMENG = "dameng";
     public static final String OPENGAUSS = "opengauss";
     public static final String KINGBASE = "kingbase";

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaDialect.java
@@ -1,0 +1,222 @@
+package com.link.up.connector.jdbc.core.dialect.hana;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.hana.HanaCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * SAP HANA bounded JDBC Source dialect.
+ *
+ * <p>Stage 1 intentionally contains no Sink DDL, UPSERT, CDC, SLT or streaming semantics.</p>
+ */
+public final class HanaDialect implements JdbcDialect {
+
+    private final JdbcConnectionConfig connectionConfig;
+    private final HanaTypeMapper typeMapper;
+    private final String databaseName;
+    private final String defaultSchema;
+
+    public HanaDialect(JdbcConnectionConfig connectionConfig) {
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException("connectionConfig must not be null");
+        }
+        if (!HanaJdbcUrl.accepts(connectionConfig.getUrl())) {
+            throw new IllegalArgumentException(
+                    "非法 SAP HANA JDBC URL：" + connectionConfig.getUrl());
+        }
+        this.connectionConfig = connectionConfig;
+        this.typeMapper = new HanaTypeMapper();
+        this.databaseName = HanaJdbcUrl.databaseName(
+                connectionConfig.getUrl(),
+                connectionConfig.getProperties());
+        this.defaultSchema = HanaJdbcUrl.currentSchema(
+                connectionConfig.getUrl(),
+                connectionConfig.getProperties(),
+                connectionConfig.getSchema());
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.HANA;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+        String resolvedDatabase = HanaJdbcUrl.databaseName(
+                connectionConfig.getUrl(),
+                connectionConfig.getProperties());
+        String resolvedSchema = HanaJdbcUrl.currentSchema(
+                connectionConfig.getUrl(),
+                connectionConfig.getProperties(),
+                connectionConfig.getSchema());
+        return new HanaCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false),
+                resolvedSchema,
+                resolvedDatabase);
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new HanaJdbcRowConverter();
+    }
+
+    /** HANA SQL uses schema.table; the database/tenant is selected by the JDBC connection. */
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        if (!JdbcDialect.hasText(tablePath)) {
+            throw new IllegalArgumentException("tablePath must not be empty");
+        }
+
+        List<String> parts = splitIdentifierPath(tablePath.trim());
+        switch (parts.size()) {
+            case 1:
+                return TablePath.of(normalizePathPart(parts.get(0)));
+            case 2:
+                return TablePath.of(
+                        null,
+                        normalizePathPart(parts.get(0)),
+                        normalizePathPart(parts.get(1)));
+            case 3:
+                String database = normalizePathPart(parts.get(0));
+                if (!JdbcDialect.hasText(databaseName)) {
+                    throw new IllegalArgumentException(
+                            "三段式 SAP HANA 表路径需要 JDBC URL/properties 显式配置 databaseName："
+                                    + tablePath);
+                }
+                if (!databaseName.equalsIgnoreCase(database)) {
+                    throw new IllegalArgumentException(
+                            "SAP HANA 表路径中的 database 与 JDBC 连接不一致，urlDatabase="
+                                    + databaseName + "，pathDatabase=" + database);
+                }
+                return TablePath.of(
+                        databaseName,
+                        normalizePathPart(parts.get(1)),
+                        normalizePathPart(parts.get(2)));
+            default:
+                throw new IllegalArgumentException(
+                        "非法 SAP HANA 表路径：" + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        if (!JdbcDialect.hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + identifier.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (JdbcDialect.hasText(tablePath.getDatabaseName())
+                && JdbcDialect.hasText(databaseName)
+                && !databaseName.equalsIgnoreCase(tablePath.getDatabaseName())) {
+            throw new IllegalArgumentException(
+                    "SAP HANA 表路径中的 database 与 JDBC 连接不一致，urlDatabase="
+                            + databaseName + "，pathDatabase=" + tablePath.getDatabaseName());
+        }
+
+        String schema = JdbcDialect.hasText(tablePath.getSchemaName())
+                ? tablePath.getSchemaName().trim()
+                : defaultSchema;
+        if (JdbcDialect.hasText(schema)) {
+            return quoteIdentifier(schema)
+                    + "."
+                    + quoteIdentifier(tablePath.getTableName());
+        }
+        return quoteIdentifier(tablePath.getTableName());
+    }
+
+    /**
+     * Keep custom queries and unqualified source tables aligned with the connector-level schema option.
+     * Explicit URL/properties still override this default in the JDBC driver.
+     */
+    @Override
+    public Map<String, String> defaultConnectionProperties() {
+        if (!JdbcDialect.hasText(connectionConfig.getSchema())
+                || HanaJdbcUrl.hasCurrentSchemaProperty(
+                connectionConfig.getUrl(),
+                connectionConfig.getProperties())) {
+            return Collections.emptyMap();
+        }
+        Map<String, String> result = new LinkedHashMap<String, String>();
+        result.put("currentSchema", connectionConfig.getSchema().trim());
+        return Collections.unmodifiableMap(result);
+    }
+
+    private static List<String> splitIdentifierPath(String path) {
+        List<String> parts = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < path.length(); i++) {
+            char c = path.charAt(i);
+            if (c == '"') {
+                current.append(c);
+                if (quoted && i + 1 < path.length() && path.charAt(i + 1) == '"') {
+                    current.append('"');
+                    i++;
+                } else {
+                    quoted = !quoted;
+                }
+                continue;
+            }
+            if (c == '.' && !quoted) {
+                if (current.length() == 0) {
+                    throw new IllegalArgumentException(
+                            "非法 SAP HANA 表路径：" + path);
+                }
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(c);
+            }
+        }
+        if (quoted || current.length() == 0) {
+            throw new IllegalArgumentException(
+                    "非法 SAP HANA 表路径：" + path);
+        }
+        parts.add(current.toString());
+        return parts;
+    }
+
+    private static String normalizePathPart(String part) {
+        String value = part.trim();
+        if (value.length() >= 2
+                && value.charAt(0) == '"'
+                && value.charAt(value.length() - 1) == '"') {
+            return value.substring(1, value.length() - 1)
+                    .replace("\"\"", "\"");
+        }
+        return value.toUpperCase(Locale.ROOT);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaDialectFactory.java
@@ -1,0 +1,27 @@
+package com.link.up.connector.jdbc.core.dialect.hana;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/** SAP HANA dialect factory. */
+@AutoService(JdbcDialectFactory.class)
+public final class HanaDialectFactory implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.HANA;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return HanaJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(JdbcConnectionConfig connectionConfig) {
+        return new HanaDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaJdbcRowConverter.java
@@ -1,0 +1,13 @@
+package com.link.up.connector.jdbc.core.dialect.hana;
+
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+/** SAP HANA JDBC row converter for bounded/offline reads. */
+public final class HanaJdbcRowConverter extends AbstractJdbcRowConverter {
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.HANA;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaJdbcUrl.java
@@ -1,0 +1,114 @@
+package com.link.up.connector.jdbc.core.dialect.hana;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+import java.util.Map;
+
+/** SAP HANA JDBC URL helpers for the bounded JDBC connector. */
+public final class HanaJdbcUrl {
+
+    private static final String PREFIX = "jdbc:sap://";
+
+    private HanaJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return url != null
+                && url.trim().toLowerCase(Locale.ROOT).startsWith(PREFIX);
+    }
+
+    public static String databaseName(String url) {
+        return databaseName(url, null);
+    }
+
+    /** URL properties take precedence over Properties, matching JDBC semantics. */
+    public static String databaseName(String url, Map<String, String> properties) {
+        String fromUrl = queryValue(url, "databaseName");
+        if (hasText(fromUrl)) {
+            return fromUrl.trim();
+        }
+        String property = propertyIgnoreCase(properties, "databaseName");
+        return hasText(property) ? property.trim() : null;
+    }
+
+    /**
+     * Resolves the effective current schema used for unqualified identifiers.
+     * URL properties win, then explicit JDBC properties, then the connector-level schema option.
+     */
+    public static String currentSchema(
+            String url,
+            Map<String, String> properties,
+            String configuredSchema) {
+
+        String fromUrl = queryValue(url, "currentSchema");
+        if (hasText(fromUrl)) {
+            return fromUrl.trim();
+        }
+        String property = propertyIgnoreCase(properties, "currentSchema");
+        if (hasText(property)) {
+            return property.trim();
+        }
+        return hasText(configuredSchema) ? configuredSchema.trim() : null;
+    }
+
+    static boolean hasCurrentSchemaProperty(
+            String url,
+            Map<String, String> properties) {
+        return hasText(queryValue(url, "currentSchema"))
+                || hasText(propertyIgnoreCase(properties, "currentSchema"));
+    }
+
+    private static String queryValue(String url, String key) {
+        if (!accepts(url)) {
+            return null;
+        }
+        int query = url.indexOf('?');
+        if (query < 0 || query == url.length() - 1) {
+            return null;
+        }
+        String queryString = url.substring(query + 1);
+        if (queryString.startsWith("/")) {
+            queryString = queryString.substring(1);
+        }
+        for (String item : queryString.split("&")) {
+            int equals = item.indexOf('=');
+            if (equals <= 0) {
+                continue;
+            }
+            String itemKey = decode(item.substring(0, equals)).trim();
+            if (key.equalsIgnoreCase(itemKey)) {
+                String value = decode(item.substring(equals + 1)).trim();
+                return value.isEmpty() ? null : value;
+            }
+        }
+        return null;
+    }
+
+    private static String propertyIgnoreCase(
+            Map<String, String> properties,
+            String key) {
+        if (properties == null || properties.isEmpty()) {
+            return null;
+        }
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (entry.getKey() != null
+                    && key.equalsIgnoreCase(entry.getKey().trim())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static String decode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (Exception ignored) {
+            return value;
+        }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/hana/HanaTypeMapper.java
@@ -1,0 +1,330 @@
+package com.link.up.connector.jdbc.core.dialect.hana;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
+
+/** SAP HANA JDBC type mapper for bounded/offline source jobs. */
+public final class HanaTypeMapper implements JdbcTypeMapper {
+
+    static final int MAX_DECIMAL_PRECISION = 38;
+    static final int DEFAULT_DECIMAL_PRECISION = 38;
+    static final int DEFAULT_DECIMAL_SCALE = 0;
+    static final int MAX_TIMESTAMP_PRECISION = 7;
+    static final String NATIVE_ATTRIBUTE = "hana_native";
+
+    @Override
+    public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+        String name = firstText(
+                metadata.getColumnLabel(columnIndex),
+                metadata.getColumnName(columnIndex));
+        String sourceType = metadata.getColumnTypeName(columnIndex);
+        int precision = metadata.getPrecision(columnIndex);
+        int scale = metadata.getScale(columnIndex);
+        int jdbcType = metadata.getColumnType(columnIndex);
+
+        FluxDataType<?> type = mapType(jdbcType, sourceType, precision, scale);
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(metadata.isNullable(columnIndex)
+                        != ResultSetMetaData.columnNoNulls)
+                .sourceType(buildSourceType(sourceType, precision, scale))
+                .attribute(NATIVE_ATTRIBUTE, "true");
+        applyProperties(builder, type, sourceType, precision, scale);
+        return builder.build();
+    }
+
+    /** Maps one JDBC DatabaseMetaData#getColumns row. */
+    public Column toColumn(ResultSet row) throws SQLException {
+        String name = row.getString("COLUMN_NAME");
+        String typeName = row.getString("TYPE_NAME");
+        Integer size = integer(row, "COLUMN_SIZE");
+        Integer digits = integer(row, "DECIMAL_DIGITS");
+        Integer nullable = integer(row, "NULLABLE");
+        int jdbcType = value(integer(row, "DATA_TYPE"));
+        int precision = value(size);
+        int scale = value(digits);
+
+        FluxDataType<?> type = mapType(jdbcType, typeName, precision, scale);
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(nullable == null
+                        || nullable != ResultSetMetaData.columnNoNulls)
+                .defaultValue(safeObject(row, "COLUMN_DEF"))
+                .comment(safeString(row, "REMARKS"))
+                .sourceType(buildSourceType(typeName, precision, scale))
+                .attribute(NATIVE_ATTRIBUTE, "true");
+
+        String auto = safeString(row, "IS_AUTOINCREMENT");
+        builder.autoIncrement("YES".equalsIgnoreCase(auto));
+        applyProperties(builder, type, typeName, precision, scale);
+        return builder.build();
+    }
+
+    /** Stage 1 is deliberately source-only. */
+    @Override
+    public String toDatabaseType(Column column) {
+        throw new UnsupportedOperationException(
+                "SAP HANA Stage 1 only supports bounded JDBC Source; Sink type conversion is not enabled");
+    }
+
+    /** Package-visible for focused type contract tests. */
+    FluxDataType<?> mapType(
+            int jdbcType,
+            String sourceType,
+            int precision,
+            int scale) {
+
+        String normalized = normalizeType(sourceType);
+        String base = baseType(normalized);
+
+        if (normalized.endsWith(" ARRAY") || "ARRAY".equals(base)) {
+            throw unsupported(sourceType, jdbcType);
+        }
+        if ("ST_POINT".equals(base) || "ST_GEOMETRY".equals(base)) {
+            throw unsupported(sourceType, jdbcType);
+        }
+
+        switch (base) {
+            case "BOOLEAN":
+                return BasicType.BOOLEAN_TYPE;
+            case "TINYINT":
+            case "SMALLINT":
+                // HANA TINYINT is unsigned (0..255), so Byte would overflow.
+                return BasicType.SHORT_TYPE;
+            case "INTEGER":
+            case "INT":
+                return BasicType.INT_TYPE;
+            case "BIGINT":
+                return BasicType.LONG_TYPE;
+            case "REAL":
+                return BasicType.FLOAT_TYPE;
+            case "DOUBLE":
+            case "DOUBLE PRECISION":
+                return BasicType.DOUBLE_TYPE;
+            case "SMALLDECIMAL":
+            case "DECIMAL":
+                return decimal(precision, scale);
+            case "DATE":
+                return BasicType.DATE_TYPE;
+            case "TIME":
+                return BasicType.TIME_TYPE;
+            case "SECONDDATE":
+            case "TIMESTAMP":
+                return BasicType.TIMESTAMP_TYPE;
+            case "BINARY":
+            case "VARBINARY":
+            case "BLOB":
+                return BasicType.BYTES_TYPE;
+            case "VARCHAR":
+            case "NVARCHAR":
+            case "ALPHANUM":
+            case "SHORTTEXT":
+            case "CLOB":
+            case "NCLOB":
+            case "TEXT":
+            case "BINTEXT":
+                return BasicType.STRING_TYPE;
+            default:
+                break;
+        }
+
+        switch (jdbcType) {
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return BasicType.BOOLEAN_TYPE;
+            case Types.TINYINT:
+            case Types.SMALLINT:
+                return BasicType.SHORT_TYPE;
+            case Types.INTEGER:
+                return BasicType.INT_TYPE;
+            case Types.BIGINT:
+                return BasicType.LONG_TYPE;
+            case Types.REAL:
+            case Types.FLOAT:
+                return BasicType.FLOAT_TYPE;
+            case Types.DOUBLE:
+                return BasicType.DOUBLE_TYPE;
+            case Types.NUMERIC:
+            case Types.DECIMAL:
+                return decimal(precision, scale);
+            case Types.DATE:
+                return BasicType.DATE_TYPE;
+            case Types.TIME:
+                return BasicType.TIME_TYPE;
+            case Types.TIMESTAMP:
+                return BasicType.TIMESTAMP_TYPE;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+            case Types.BLOB:
+                return BasicType.BYTES_TYPE;
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.CLOB:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR:
+            case Types.NCLOB:
+                return BasicType.STRING_TYPE;
+            default:
+                throw unsupported(sourceType, jdbcType);
+        }
+    }
+
+    private static DecimalType decimal(int precision, int scale) {
+        int safePrecision = precision <= 0
+                ? DEFAULT_DECIMAL_PRECISION
+                : precision;
+        int safeScale = scale < 0 ? DEFAULT_DECIMAL_SCALE : scale;
+
+        if (safePrecision > MAX_DECIMAL_PRECISION) {
+            throw new IllegalArgumentException(
+                    "SAP HANA DECIMAL precision 最大为 38，actual=" + safePrecision);
+        }
+        if (safeScale > safePrecision) {
+            throw new IllegalArgumentException(
+                    "SAP HANA DECIMAL scale 不能大于 precision，precision="
+                            + safePrecision + "，scale=" + safeScale);
+        }
+        return new DecimalType(safePrecision, safeScale);
+    }
+
+    private static void applyProperties(
+            Column.Builder builder,
+            FluxDataType<?> type,
+            String sourceType,
+            int precision,
+            int scale) {
+
+        SqlType sqlType = type.getSqlType();
+        String base = baseType(normalizeType(sourceType));
+
+        if (sqlType == SqlType.STRING || sqlType == SqlType.BYTES) {
+            if (precision > 0
+                    && !"CLOB".equals(base)
+                    && !"NCLOB".equals(base)
+                    && !"TEXT".equals(base)
+                    && !"BINTEXT".equals(base)
+                    && !"BLOB".equals(base)) {
+                builder.length((long) precision);
+            }
+            return;
+        }
+        if (sqlType == SqlType.DECIMAL && type instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) type;
+            builder.precision(decimal.getPrecision());
+            builder.scale(decimal.getScale());
+            return;
+        }
+        if (sqlType == SqlType.TIMESTAMP && "TIMESTAMP".equals(base)) {
+            int p = Math.max(0, Math.min(scale, MAX_TIMESTAMP_PRECISION));
+            if (p > 0) {
+                builder.precision(p);
+            }
+        }
+    }
+
+    private static String buildSourceType(String sourceType, int precision, int scale) {
+        String raw = sourceType == null ? "" : sourceType.trim();
+        if (raw.isEmpty() || raw.indexOf('(') >= 0) {
+            return raw;
+        }
+        String base = baseType(normalizeType(raw));
+        if ("DECIMAL".equals(base) || "SMALLDECIMAL".equals(base)) {
+            if (precision > 0) {
+                return raw + "(" + precision + "," + Math.max(0, scale) + ")";
+            }
+            return raw;
+        }
+        if (isLengthType(base) && precision > 0) {
+            return raw + "(" + precision + ")";
+        }
+        return raw;
+    }
+
+    private static boolean isLengthType(String base) {
+        return "BINARY".equals(base)
+                || "VARBINARY".equals(base)
+                || "VARCHAR".equals(base)
+                || "NVARCHAR".equals(base)
+                || "ALPHANUM".equals(base)
+                || "SHORTTEXT".equals(base);
+    }
+
+    private static String normalizeType(String sourceType) {
+        return sourceType == null
+                ? ""
+                : sourceType.trim().replaceAll("\\s+", " ").toUpperCase(Locale.ROOT);
+    }
+
+    private static String baseType(String sourceType) {
+        if (sourceType == null || sourceType.isEmpty()) {
+            return "";
+        }
+        String value = sourceType;
+        int paren = value.indexOf('(');
+        if (paren >= 0) {
+            value = value.substring(0, paren).trim();
+        }
+        return value;
+    }
+
+    private static IllegalArgumentException unsupported(String sourceType, int jdbcType) {
+        return new IllegalArgumentException(
+                "暂不支持 SAP HANA 字段类型：" + sourceType + "，jdbcType=" + jdbcType);
+    }
+
+    private static String firstText(String first, String second) {
+        if (first != null && !first.trim().isEmpty()) {
+            return first.trim();
+        }
+        if (second != null && !second.trim().isEmpty()) {
+            return second.trim();
+        }
+        throw new IllegalArgumentException("JDBC column name must not be empty");
+    }
+
+    private static Integer integer(ResultSet row, String column) {
+        try {
+            Object value = row.getObject(column);
+            if (value == null) {
+                return null;
+            }
+            if (value instanceof Number) {
+                return ((Number) value).intValue();
+            }
+            return Integer.valueOf(value.toString());
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+    private static String safeString(ResultSet row, String column) {
+        try {
+            return row.getString(column);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static Object safeObject(ResultSet row, String column) {
+        try {
+            return row.getObject(column);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static int value(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/hana/HanaDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/hana/HanaDialectTest.java
@@ -1,0 +1,129 @@
+package com.link.up.connector.jdbc.core.dialect.hana;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HanaDialectTest {
+
+    @Test
+    public void loadsHanaDialectFromJdbcUrlThroughSpi() {
+        JdbcDialect dialect = JdbcDialectLoader.load(config(null, baseUrl(), null));
+        assertEquals(DatabaseIdentifier.HANA, dialect.name());
+    }
+
+    @Test
+    public void parsesSchemaTableAndPreservesQuotedCase() {
+        HanaDialect dialect = dialect("SALES");
+        assertEquals(
+                TablePath.of(null, "SALES", "ORDERS"),
+                dialect.parseTablePath("sales.orders"));
+        assertEquals(
+                TablePath.of(null, "Sales", "Order.Items"),
+                dialect.parseTablePath("\"Sales\".\"Order.Items\""));
+    }
+
+    @Test
+    public void parsesThreePartPathWhenDatabaseNameIsKnown() {
+        HanaDialect dialect = dialect("SALES");
+        assertEquals(
+                TablePath.of("HXE", "SALES", "ORDERS"),
+                dialect.parseTablePath("hxe.sales.orders"));
+    }
+
+    @Test
+    public void configuredSchemaQualifiesUnqualifiedTable() {
+        assertEquals(
+                "\"SALES\".\"ORDERS\"",
+                dialect("SALES").tableIdentifier(TablePath.of("ORDERS")));
+    }
+
+    @Test
+    public void explicitSchemaWinsOverDefaultSchema() {
+        assertEquals(
+                "\"ARCHIVE\".\"ORDERS\"",
+                dialect("SALES").tableIdentifier(
+                        TablePath.of(null, "ARCHIVE", "ORDERS")));
+    }
+
+    @Test
+    public void currentSchemaUrlPropertyWinsOverConnectorSchema() {
+        HanaDialect dialect = new HanaDialect(config(
+                "SALES",
+                baseUrl() + "&currentSchema=ARCHIVE",
+                null));
+        assertEquals(
+                "\"ARCHIVE\".\"ORDERS\"",
+                dialect.tableIdentifier(TablePath.of("ORDERS")));
+        assertTrue(dialect.defaultConnectionProperties().isEmpty());
+    }
+
+    @Test
+    public void connectorSchemaBecomesDefaultCurrentSchemaProperty() {
+        HanaDialect dialect = dialect("SALES");
+        assertEquals(
+                "SALES",
+                dialect.defaultConnectionProperties().get("currentSchema"));
+    }
+
+    @Test
+    public void stageOneCatalogIsReadOnlyAndUpsertIsNotAdvertised() {
+        HanaDialect dialect = dialect("SALES");
+        Catalog catalog = dialect.createCatalog(config("SALES", baseUrl(), null));
+        assertFalse(catalog instanceof WritableCatalog);
+        assertFalse(dialect.buildUpsertSql(
+                TablePath.of(null, "SALES", "ORDERS"),
+                Arrays.asList("ID", "NAME"),
+                Arrays.asList("ID")).isPresent());
+    }
+
+    @Test
+    public void parsesDatabaseNameAndCurrentSchemaFromUrl() {
+        assertEquals("HXE", HanaJdbcUrl.databaseName(baseUrl()));
+        assertEquals(
+                "Sales Space",
+                HanaJdbcUrl.currentSchema(
+                        baseUrl() + "&currentSchema=Sales%20Space",
+                        null,
+                        null));
+    }
+
+    private static HanaDialect dialect(String schema) {
+        return new HanaDialect(config(schema, baseUrl(), null));
+    }
+
+    private static JdbcConnectionConfig config(
+            String schema,
+            String url,
+            Map<String, String> properties) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", "com.sap.db.jdbc.Driver");
+        values.put("username", "SYSTEM");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (properties != null) {
+            values.put("properties", properties);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:sap://127.0.0.1:30013/?databaseName=HXE";
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/hana/HanaTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/hana/HanaTypeMapperTest.java
@@ -1,0 +1,89 @@
+package com.link.up.connector.jdbc.core.dialect.hana;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import org.junit.Test;
+
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+public class HanaTypeMapperTest {
+
+    private final HanaTypeMapper mapper = new HanaTypeMapper();
+
+    @Test
+    public void mapsCommonHanaTypesForOfflineSource() {
+        assertSame(BasicType.BOOLEAN_TYPE,
+                mapper.mapType(Types.BOOLEAN, "BOOLEAN", 1, 0));
+        assertSame(BasicType.SHORT_TYPE,
+                mapper.mapType(Types.TINYINT, "TINYINT", 3, 0));
+        assertSame(BasicType.SHORT_TYPE,
+                mapper.mapType(Types.SMALLINT, "SMALLINT", 5, 0));
+        assertSame(BasicType.INT_TYPE,
+                mapper.mapType(Types.INTEGER, "INTEGER", 10, 0));
+        assertSame(BasicType.LONG_TYPE,
+                mapper.mapType(Types.BIGINT, "BIGINT", 19, 0));
+        assertSame(BasicType.FLOAT_TYPE,
+                mapper.mapType(Types.REAL, "REAL", 7, 0));
+        assertSame(BasicType.DOUBLE_TYPE,
+                mapper.mapType(Types.DOUBLE, "DOUBLE", 15, 0));
+        assertSame(BasicType.STRING_TYPE,
+                mapper.mapType(Types.NVARCHAR, "NVARCHAR", 500, 0));
+        assertSame(BasicType.STRING_TYPE,
+                mapper.mapType(Types.CLOB, "NCLOB", 0, 0));
+        assertSame(BasicType.BYTES_TYPE,
+                mapper.mapType(Types.BLOB, "BLOB", 0, 0));
+        assertSame(BasicType.DATE_TYPE,
+                mapper.mapType(Types.DATE, "DATE", 10, 0));
+        assertSame(BasicType.TIME_TYPE,
+                mapper.mapType(Types.TIME, "TIME", 8, 0));
+        assertSame(BasicType.TIMESTAMP_TYPE,
+                mapper.mapType(Types.TIMESTAMP, "SECONDDATE", 19, 0));
+        assertSame(BasicType.TIMESTAMP_TYPE,
+                mapper.mapType(Types.TIMESTAMP, "TIMESTAMP", 27, 7));
+    }
+
+    @Test
+    public void mapsDecimalWithinHanaPrecisionLimit() {
+        DecimalType decimal = (DecimalType)
+                mapper.mapType(Types.DECIMAL, "DECIMAL", 20, 4);
+        assertEquals(20, decimal.getPrecision());
+        assertEquals(4, decimal.getScale());
+
+        DecimalType smallDecimal = (DecimalType)
+                mapper.mapType(Types.DECIMAL, "SMALLDECIMAL", 16, 3);
+        assertEquals(16, smallDecimal.getPrecision());
+        assertEquals(3, smallDecimal.getScale());
+    }
+
+    @Test
+    public void rejectsSpatialAndArrayTypesInsteadOfSilentlyCoercingThem() {
+        assertUnsupported("ST_GEOMETRY");
+        assertUnsupported("ST_POINT");
+        assertUnsupported("INTEGER ARRAY");
+    }
+
+    @Test
+    public void stageOneDoesNotExposeSinkTypeConversion() {
+        try {
+            mapper.toDatabaseType(
+                    Column.builder("NAME", BasicType.STRING_TYPE).build());
+            fail("Expected source-only HANA type mapper to reject sink conversion");
+        } catch (UnsupportedOperationException expected) {
+            // expected
+        }
+    }
+
+    private void assertUnsupported(String typeName) {
+        try {
+            mapper.mapType(Types.OTHER, typeName, 0, 0);
+            fail("Expected unsupported HANA type: " + typeName);
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Add Stage 1 SAP HANA support to the existing JDBC connector as a bounded/offline Source.

### Included
- add `hana` JDBC dialect and `jdbc:sap://` auto-detection
- add SAP HANA JDBC URL handling for `databaseName` and `currentSchema`
- add HANA identifier quoting and `schema.table` path semantics
- add read-only HANA Catalog for schema/table/view/column/primary-key discovery
- add common HANA Source type mapping, including `SMALLDECIMAL`, `SECONDDATE`, LOB and binary types
- map unsigned HANA `TINYINT` to Flux `SMALLINT` to avoid byte overflow
- explicitly reject ARRAY and spatial `ST_POINT` / `ST_GEOMETRY` in Stage 1 instead of silently coercing them
- add SAP `ngdbc` 2.29.7 to the JDBC module
- add focused dialect/type tests and JDBC connector documentation

### Deliberately out of scope
- HANA Sink
- DDL / create-table support
- INSERT / UPSERT / MERGE
- CDC / SAP SLT / streaming semantics
- ARRAY and spatial type support

The HANA Catalog intentionally implements read-only `Catalog`, not `WritableCatalog`, so the existing JDBC Sink preparation path rejects HANA before write/DDL execution.

## Validation
- branch is based directly on current `main` and contains one Stage 1 commit
- focused Java source/test signatures were checked against the current JDBC/API contracts
- no live SAP HANA environment is available in this session, so database integration behavior still needs an environment-backed verification before marking this PR ready
