### PR TITLE
feat(mongodb): add catalog and automatic schema discovery

### DIFF
--- a/link-up-connectors/MONGODB.md
+++ b/link-up-connectors/MONGODB.md
@@ -1,0 +1,117 @@
+# MongoDB Connector
+
+MongoDB connector follows Link-Up's bounded/offline boundary. The product goal is usability first: users select a database, collection and fields; they do not declare BSON or Link-Up field types.
+
+## Stage 1 — Catalog and automatic schema discovery
+
+Stage 1 provides metadata discovery only. It deliberately does not register a SourceFactory or SinkFactory and does not enter launcher/server runtime composition yet.
+
+Implemented:
+
+- module `link-up-connector-mongodb`
+- MongoDB Java synchronous driver 4.11.5
+- `MongoCatalog`
+- database -> MongoDB database
+- table -> collection
+- automatic sampled schema discovery
+- BSON -> canonical Link-Up type inference
+- numeric widening and heterogeneous-type fallback
+- dotted nested field discovery for BSON documents
+- conservative JSON/STRING boundary for documents and arrays
+- `_id` primary-key metadata when discovered
+- synthetic `_id` metadata for an empty collection so metadata discovery still returns a usable schema
+
+Default discovery limits:
+
+```text
+schema sample size = 1000 documents
+schema max depth   = 8
+```
+
+These are connector-internal defaults. Yak Ops should not ask users to provide field types.
+
+## BSON type policy
+
+```text
+ObjectId        -> STRING
+String          -> STRING
+Boolean         -> BOOLEAN
+Int32           -> INT
+Int64           -> BIGINT
+Double          -> DOUBLE
+Decimal128      -> DECIMAL(34,18)
+DateTime        -> TIMESTAMP
+Timestamp       -> TIMESTAMP
+Binary          -> BYTES
+Document        -> STRING (Extended JSON boundary)
+Array           -> STRING (Extended JSON boundary)
+other BSON      -> STRING
+Null / missing  -> nullable
+```
+
+Physical BSON information remains in `Column.sourceType` and `Column.attributes`; Mongo-specific types do not leak into Link-Up's global `SqlType` model.
+
+## Merge policy
+
+Schema discovery observes multiple documents instead of trusting the first document.
+
+```text
+INT + BIGINT            -> BIGINT
+INT/BIGINT + DOUBLE     -> DOUBLE
+INT/BIGINT + DECIMAL    -> DECIMAL
+DECIMAL + DOUBLE        -> STRING
+NULL + T                -> nullable T
+incompatible scalar     -> STRING
+complex + incompatible  -> STRING
+```
+
+When a field is missing from part of the sample, it becomes nullable. Multiple BSON physical types are retained in the `mongodb.bsonTypes` column attribute.
+
+## Nested documents
+
+A document field is retained as a JSON string boundary and its child fields are also discovered as dotted paths.
+
+Example:
+
+```json
+{
+  "name": "Yak",
+  "address": {
+    "province": "Sichuan",
+    "city": "Chengdu"
+  }
+}
+```
+
+Discovered columns include:
+
+```text
+name
+address
+address.province
+address.city
+```
+
+This lets a future Yak Ops field picker expose a tree while keeping the Link-Up row schema flat and portable to JDBC/Doris/StarRocks sinks.
+
+Arrays remain JSON strings in Stage 1. Strong ARRAY/ROW inference is intentionally deferred until cross-sink compatibility has a clear product requirement.
+
+## Explicit non-goals for Stage 1
+
+- bounded Source reader
+- Sink writer
+- partition/split planning
+- multi-table execution
+- CDC / Change Streams / oplog
+- realtime semantics
+- checkpoint/savepoint
+- automatic schema evolution
+- user-authored schema/type configuration
+
+## Next stages
+
+```text
+Stage 1  Catalog + schema discovery     DONE in this PR
+Stage 2  bounded MongoDB Source
+Stage 3  bounded MongoDB Sink + offline hardening
+```

--- a/link-up-connectors/link-up-connector-mongodb/pom.xml
+++ b/link-up-connectors/link-up-connector-mongodb/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/link-up-connectors/link-up-connector-mongodb/pom.xml
+++ b/link-up-connectors/link-up-connector-mongodb/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.link.up</groupId>
+        <artifactId>link-up-connectors</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>link-up-connector-mongodb</artifactId>
+    <version>1.0.0</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>${mongodb.driver.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/catalog/MongoCatalog.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/catalog/MongoCatalog.java
@@ -1,0 +1,246 @@
+package com.link.up.connector.mongodb.catalog;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.mongodb.config.MongoCatalogConfig;
+import com.link.up.connector.mongodb.schema.MongoSchemaInference;
+import com.mongodb.MongoException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import com.mongodb.client.MongoDatabase;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * MongoDB metadata catalog.
+ *
+ * <p>MongoDB has no enforced table schema, so {@link #getTable(TablePath)} samples collection
+ * documents and synthesizes a stable Link-Up {@link TableSchema}. The BSON details remain inside
+ * column metadata and are not exposed as global Link-Up types.
+ */
+public final class MongoCatalog implements Catalog {
+
+    public static final String IDENTIFIER = "mongodb";
+
+    private final String catalogName;
+    private final MongoCatalogConfig config;
+
+    private volatile MongoClient client;
+
+    public MongoCatalog(MongoCatalogConfig config) {
+        this(IDENTIFIER, config);
+    }
+
+    public MongoCatalog(String catalogName, MongoCatalogConfig config) {
+        this.catalogName = requireText(catalogName, "catalogName");
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.ofNullable(config.getDefaultDatabase());
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (client != null) {
+            return;
+        }
+
+        MongoClient openedClient = null;
+        try {
+            openedClient = MongoClients.create(config.getUri());
+            String pingDatabase = config.getDefaultDatabase() == null
+                    ? "admin"
+                    : config.getDefaultDatabase();
+            openedClient.getDatabase(pingDatabase)
+                    .runCommand(new BsonDocument("ping", new BsonInt32(1)));
+            client = openedClient;
+        } catch (RuntimeException failure) {
+            if (openedClient != null) {
+                openedClient.close();
+            }
+            throw new CatalogException(
+                    "MongoDB Catalog connection failed, catalog=" + catalogName,
+                    failure);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        MongoClient current = client;
+        client = null;
+        if (current != null) {
+            current.close();
+        }
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        try {
+            List<String> databases = new ArrayList<String>();
+            for (String databaseName : currentClient().listDatabaseNames()) {
+                databases.add(databaseName);
+            }
+            Collections.sort(databases);
+            return databases;
+        } catch (MongoException failure) {
+            throw new CatalogException(
+                    "Could not list MongoDB databases, catalog=" + catalogName,
+                    failure);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(String databaseName, String schemaName)
+            throws CatalogException {
+        rejectSchema(schemaName);
+        String resolvedDatabase = resolveDatabase(databaseName);
+
+        try {
+            List<String> collectionNames = new ArrayList<String>();
+            for (String collectionName : currentClient()
+                    .getDatabase(resolvedDatabase)
+                    .listCollectionNames()) {
+                collectionNames.add(collectionName);
+            }
+            Collections.sort(collectionNames);
+
+            List<TablePath> tables = new ArrayList<TablePath>(collectionNames.size());
+            for (String collectionName : collectionNames) {
+                tables.add(TablePath.of(resolvedDatabase, collectionName));
+            }
+            return tables;
+        } catch (MongoException failure) {
+            throw new CatalogException(
+                    "Could not list MongoDB collections, database=" + resolvedDatabase,
+                    failure);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        TablePath resolvedPath = resolveTablePath(tablePath);
+        try {
+            MongoDatabase database = currentClient().getDatabase(resolvedPath.getDatabaseName());
+            for (String collectionName : database.listCollectionNames()) {
+                if (resolvedPath.getTableName().equals(collectionName)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (MongoException failure) {
+            throw new CatalogException(
+                    "Could not check MongoDB collection, table=" + resolvedPath,
+                    failure);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+        TablePath resolvedPath = resolveTablePath(tablePath);
+        if (!tableExists(resolvedPath)) {
+            throw new TableNotFoundException(catalogName, resolvedPath);
+        }
+
+        try {
+            MongoCollection<BsonDocument> collection = currentClient()
+                    .getDatabase(resolvedPath.getDatabaseName())
+                    .getCollection(resolvedPath.getTableName(), BsonDocument.class);
+
+            MongoSchemaInference inference = new MongoSchemaInference(config.getSchemaMaxDepth());
+            try (MongoCursor<BsonDocument> cursor = collection.find()
+                    .limit(config.getSchemaSampleSize())
+                    .iterator()) {
+                while (cursor.hasNext()) {
+                    inference.observe(cursor.next());
+                }
+            }
+
+            TableSchema schema = inference.build();
+            String discoveryMode = inference.getSampledDocuments() == 0
+                    ? "synthetic-empty"
+                    : "sampled";
+
+            return CatalogTable.builder(resolvedPath, schema)
+                    .option("mongodb.collection", resolvedPath.getTableName())
+                    .option("mongodb.schema.discovery", discoveryMode)
+                    .option("mongodb.schema.sampleSize", String.valueOf(config.getSchemaSampleSize()))
+                    .option("mongodb.schema.sampledDocuments", String.valueOf(inference.getSampledDocuments()))
+                    .option("mongodb.schema.maxDepth", String.valueOf(config.getSchemaMaxDepth()))
+                    .build();
+        } catch (MongoException failure) {
+            throw new CatalogException(
+                    "Could not discover MongoDB collection schema, table=" + resolvedPath,
+                    failure);
+        }
+    }
+
+    private MongoClient currentClient() throws CatalogException {
+        MongoClient current = client;
+        if (current == null) {
+            throw new CatalogException("MongoDB Catalog is not open, catalog=" + catalogName);
+        }
+        return current;
+    }
+
+    private TablePath resolveTablePath(TablePath tablePath) throws CatalogException {
+        Objects.requireNonNull(tablePath, "tablePath must not be null");
+        rejectSchema(tablePath.getSchemaName());
+        return TablePath.of(
+                resolveDatabase(tablePath.getDatabaseName()),
+                tablePath.getTableName());
+    }
+
+    private String resolveDatabase(String databaseName) throws CatalogException {
+        String normalized = normalize(databaseName);
+        if (normalized != null) {
+            return normalized;
+        }
+        if (config.getDefaultDatabase() != null) {
+            return config.getDefaultDatabase();
+        }
+        throw new CatalogException(
+                "MongoDB database must be specified when the connection URI has no default database");
+    }
+
+    private static void rejectSchema(String schemaName) throws CatalogException {
+        if (normalize(schemaName) != null) {
+            throw new CatalogException("MongoDB does not have an independent schema namespace");
+        }
+    }
+
+    private static String requireText(String value, String fieldName) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(fieldName + " must not be empty");
+        }
+        return normalized;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoCatalogConfig.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoCatalogConfig.java
@@ -1,0 +1,109 @@
+package com.link.up.connector.mongodb.config;
+
+import com.mongodb.ConnectionString;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * MongoDB Catalog configuration.
+ *
+ * <p>Stage 1 intentionally keeps schema controls internal to the connector. Users only need a
+ * MongoDB URI; field types are discovered from collection documents.
+ */
+public final class MongoCatalogConfig implements Serializable {
+
+    public static final int DEFAULT_SCHEMA_SAMPLE_SIZE = 1000;
+    public static final int DEFAULT_SCHEMA_MAX_DEPTH = 8;
+
+    private static final long serialVersionUID = 1L;
+    private static final int MAX_SCHEMA_MAX_DEPTH = 32;
+
+    private final String uri;
+    private final String defaultDatabase;
+    private final int schemaSampleSize;
+    private final int schemaMaxDepth;
+
+    public MongoCatalogConfig(String uri, int schemaSampleSize, int schemaMaxDepth) {
+        this.uri = requireText(uri, "uri");
+        this.defaultDatabase = parseDefaultDatabase(this.uri);
+
+        if (schemaSampleSize <= 0) {
+            throw new IllegalArgumentException("schemaSampleSize must be greater than 0");
+        }
+        if (schemaMaxDepth < 0 || schemaMaxDepth > MAX_SCHEMA_MAX_DEPTH) {
+            throw new IllegalArgumentException(
+                    "schemaMaxDepth must be between 0 and " + MAX_SCHEMA_MAX_DEPTH);
+        }
+
+        this.schemaSampleSize = schemaSampleSize;
+        this.schemaMaxDepth = schemaMaxDepth;
+    }
+
+    public static MongoCatalogConfig of(String uri) {
+        return new MongoCatalogConfig(
+                uri,
+                DEFAULT_SCHEMA_SAMPLE_SIZE,
+                DEFAULT_SCHEMA_MAX_DEPTH);
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getDefaultDatabase() {
+        return defaultDatabase;
+    }
+
+    public int getSchemaSampleSize() {
+        return schemaSampleSize;
+    }
+
+    public int getSchemaMaxDepth() {
+        return schemaMaxDepth;
+    }
+
+    private static String parseDefaultDatabase(String uri) {
+        try {
+            return normalize(new ConnectionString(uri).getDatabase());
+        } catch (IllegalArgumentException failure) {
+            throw new IllegalArgumentException("Invalid MongoDB connection URI", failure);
+        }
+    }
+
+    private static String requireText(String value, String fieldName) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(fieldName + " must not be empty");
+        }
+        return normalized;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof MongoCatalogConfig)) {
+            return false;
+        }
+        MongoCatalogConfig that = (MongoCatalogConfig) obj;
+        return schemaSampleSize == that.schemaSampleSize
+                && schemaMaxDepth == that.schemaMaxDepth
+                && Objects.equals(uri, that.uri)
+                && Objects.equals(defaultDatabase, that.defaultDatabase);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri, defaultDatabase, schemaSampleSize, schemaMaxDepth);
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/schema/MongoSchemaInference.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/schema/MongoSchemaInference.java
@@ -1,0 +1,322 @@
+package com.link.up.connector.mongodb.schema;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Infers a portable Link-Up schema from sampled BSON documents.
+ *
+ * <p>The inference is intentionally conservative. Stable scalar values keep strong canonical
+ * types; incompatible values and complex containers fall back to STRING so downstream relational
+ * sinks do not need MongoDB-specific types.
+ */
+public final class MongoSchemaInference {
+
+    private static final int DECIMAL_PRECISION = 34;
+    private static final int DECIMAL_SCALE = 18;
+
+    private final int maxDepth;
+    private final Map<String, FieldState> fields = new LinkedHashMap<String, FieldState>();
+
+    private int sampledDocuments;
+
+    public MongoSchemaInference(int maxDepth) {
+        if (maxDepth < 0) {
+            throw new IllegalArgumentException("maxDepth must not be negative");
+        }
+        this.maxDepth = maxDepth;
+    }
+
+    public void observe(BsonDocument document) {
+        Objects.requireNonNull(document, "document must not be null");
+        sampledDocuments++;
+        observeDocument(null, document, 0);
+    }
+
+    public int getSampledDocuments() {
+        return sampledDocuments;
+    }
+
+    public TableSchema build() {
+        if (fields.isEmpty()) {
+            return syntheticEmptySchema();
+        }
+
+        TableSchema.Builder schema = TableSchema.builder();
+        for (Map.Entry<String, FieldState> entry : fields.entrySet()) {
+            schema.column(entry.getValue().toColumn(entry.getKey(), sampledDocuments));
+        }
+
+        if (fields.containsKey("_id")) {
+            schema.primaryKey(PrimaryKey.of("_id_", Collections.singletonList("_id")));
+        }
+        return schema.build();
+    }
+
+    private void observeDocument(String parentPath, BsonDocument document, int depth) {
+        for (Map.Entry<String, BsonValue> entry : document.entrySet()) {
+            String path = parentPath == null
+                    ? entry.getKey()
+                    : parentPath + "." + entry.getKey();
+            BsonValue value = entry.getValue();
+
+            FieldState state = fields.get(path);
+            if (state == null) {
+                state = new FieldState();
+                fields.put(path, state);
+            }
+            state.observe(value);
+
+            if (value != null
+                    && value.getBsonType() == BsonType.DOCUMENT
+                    && depth < maxDepth) {
+                observeDocument(path, value.asDocument(), depth + 1);
+            }
+        }
+    }
+
+    private static TableSchema syntheticEmptySchema() {
+        Column id = Column.builder("_id", BasicType.STRING_TYPE)
+                .nullable(false)
+                .sourceType("ObjectId")
+                .attribute("mongodb.path", "_id")
+                .attribute("mongodb.synthetic", "true")
+                .build();
+
+        return TableSchema.builder()
+                .column(id)
+                .primaryKey(PrimaryKey.of("_id_", Collections.singletonList("_id")))
+                .build();
+    }
+
+    private static final class FieldState {
+
+        private final Set<BsonType> bsonTypes = new LinkedHashSet<BsonType>();
+
+        private InferredKind kind = InferredKind.NULL;
+        private int observedDocuments;
+        private boolean sawNull;
+        private boolean sawComplex;
+
+        private void observe(BsonValue value) {
+            observedDocuments++;
+            BsonType bsonType = value == null ? BsonType.NULL : value.getBsonType();
+            bsonTypes.add(bsonType);
+
+            if (bsonType == BsonType.NULL) {
+                sawNull = true;
+            }
+            if (bsonType == BsonType.DOCUMENT || bsonType == BsonType.ARRAY) {
+                sawComplex = true;
+            }
+
+            kind = InferredKind.merge(kind, InferredKind.from(bsonType));
+        }
+
+        private Column toColumn(String path, int totalDocuments) {
+            FluxDataType<?> dataType = kind.toDataType();
+            boolean nullable = sawNull || observedDocuments < totalDocuments;
+
+            Column.Builder builder = Column.builder(path, dataType)
+                    .nullable(nullable)
+                    .sourceType(sourceType())
+                    .attribute("mongodb.path", path)
+                    .attribute("mongodb.bsonTypes", bsonTypeList());
+
+            if (path.indexOf('.') >= 0) {
+                builder.attribute("mongodb.nested", "true");
+            }
+            if (sawComplex) {
+                builder.attribute("mongodb.complex", "true")
+                        .attribute("mongodb.encoding", "extended-json");
+            }
+            if (nonNullTypeCount() > 1) {
+                builder.attribute("mongodb.heterogeneous", "true");
+            }
+            if (kind == InferredKind.DECIMAL) {
+                builder.precision(DECIMAL_PRECISION).scale(DECIMAL_SCALE);
+            }
+            return builder.build();
+        }
+
+        private String sourceType() {
+            StringBuilder result = new StringBuilder();
+            for (BsonType bsonType : bsonTypes) {
+                if (result.length() > 0) {
+                    result.append('|');
+                }
+                result.append(displayName(bsonType));
+            }
+            return result.length() == 0 ? "Unknown" : result.toString();
+        }
+
+        private String bsonTypeList() {
+            StringBuilder result = new StringBuilder();
+            for (BsonType bsonType : bsonTypes) {
+                if (result.length() > 0) {
+                    result.append(',');
+                }
+                result.append(bsonType.name());
+            }
+            return result.toString();
+        }
+
+        private int nonNullTypeCount() {
+            int count = 0;
+            for (BsonType bsonType : bsonTypes) {
+                if (bsonType != BsonType.NULL) {
+                    count++;
+                }
+            }
+            return count;
+        }
+
+        private static String displayName(BsonType bsonType) {
+            switch (bsonType) {
+                case OBJECT_ID:
+                    return "ObjectId";
+                case INT32:
+                    return "Int32";
+                case INT64:
+                    return "Int64";
+                case DECIMAL128:
+                    return "Decimal128";
+                case DATE_TIME:
+                    return "DateTime";
+                case TIMESTAMP:
+                    return "Timestamp";
+                case BINARY:
+                    return "Binary";
+                case DOCUMENT:
+                    return "Document";
+                case ARRAY:
+                    return "Array";
+                case STRING:
+                    return "String";
+                case BOOLEAN:
+                    return "Boolean";
+                case DOUBLE:
+                    return "Double";
+                case NULL:
+                    return "Null";
+                default:
+                    return bsonType.name();
+            }
+        }
+    }
+
+    private enum InferredKind {
+        NULL,
+        BOOLEAN,
+        INT,
+        LONG,
+        DOUBLE,
+        DECIMAL,
+        TIMESTAMP,
+        BYTES,
+        JSON,
+        STRING;
+
+        private static InferredKind from(BsonType bsonType) {
+            switch (bsonType) {
+                case NULL:
+                    return NULL;
+                case BOOLEAN:
+                    return BOOLEAN;
+                case INT32:
+                    return INT;
+                case INT64:
+                    return LONG;
+                case DOUBLE:
+                    return DOUBLE;
+                case DECIMAL128:
+                    return DECIMAL;
+                case DATE_TIME:
+                case TIMESTAMP:
+                    return TIMESTAMP;
+                case BINARY:
+                    return BYTES;
+                case DOCUMENT:
+                case ARRAY:
+                    return JSON;
+                default:
+                    return STRING;
+            }
+        }
+
+        private static InferredKind merge(InferredKind left, InferredKind right) {
+            if (left == NULL) {
+                return right;
+            }
+            if (right == NULL) {
+                return left;
+            }
+            if (left == right) {
+                return left;
+            }
+            if (isNumeric(left) && isNumeric(right)) {
+                return mergeNumeric(left, right);
+            }
+            return STRING;
+        }
+
+        private static InferredKind mergeNumeric(InferredKind left, InferredKind right) {
+            if ((left == DECIMAL && right == DOUBLE)
+                    || (left == DOUBLE && right == DECIMAL)) {
+                return STRING;
+            }
+            if (left == DECIMAL || right == DECIMAL) {
+                return DECIMAL;
+            }
+            if (left == DOUBLE || right == DOUBLE) {
+                return DOUBLE;
+            }
+            if (left == LONG || right == LONG) {
+                return LONG;
+            }
+            return INT;
+        }
+
+        private static boolean isNumeric(InferredKind kind) {
+            return kind == INT || kind == LONG || kind == DOUBLE || kind == DECIMAL;
+        }
+
+        private FluxDataType<?> toDataType() {
+            switch (this) {
+                case BOOLEAN:
+                    return BasicType.BOOLEAN_TYPE;
+                case INT:
+                    return BasicType.INT_TYPE;
+                case LONG:
+                    return BasicType.LONG_TYPE;
+                case DOUBLE:
+                    return BasicType.DOUBLE_TYPE;
+                case DECIMAL:
+                    return new DecimalType(DECIMAL_PRECISION, DECIMAL_SCALE);
+                case TIMESTAMP:
+                    return BasicType.TIMESTAMP_TYPE;
+                case BYTES:
+                    return BasicType.BYTES_TYPE;
+                case NULL:
+                case JSON:
+                case STRING:
+                default:
+                    return BasicType.STRING_TYPE;
+            }
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/config/MongoCatalogConfigTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/config/MongoCatalogConfigTest.java
@@ -1,0 +1,33 @@
+package com.link.up.connector.mongodb.config;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MongoCatalogConfigTest {
+
+    @Test
+    public void parsesDefaultDatabaseFromUri() {
+        MongoCatalogConfig config = MongoCatalogConfig.of(
+                "mongodb://user:password@localhost:27017/business?authSource=admin");
+
+        Assert.assertEquals("business", config.getDefaultDatabase());
+        Assert.assertEquals(MongoCatalogConfig.DEFAULT_SCHEMA_SAMPLE_SIZE, config.getSchemaSampleSize());
+        Assert.assertEquals(MongoCatalogConfig.DEFAULT_SCHEMA_MAX_DEPTH, config.getSchemaMaxDepth());
+    }
+
+    @Test
+    public void allowsUriWithoutDefaultDatabase() {
+        MongoCatalogConfig config = MongoCatalogConfig.of("mongodb://localhost:27017");
+        Assert.assertNull(config.getDefaultDatabase());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsInvalidSampleSize() {
+        new MongoCatalogConfig("mongodb://localhost:27017/test", 0, 8);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void rejectsExcessiveDepth() {
+        new MongoCatalogConfig("mongodb://localhost:27017/test", 10, 33);
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/schema/MongoSchemaInferenceTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/schema/MongoSchemaInferenceTest.java
@@ -1,0 +1,112 @@
+package com.link.up.connector.mongodb.schema;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.SqlType;
+import org.bson.BsonArray;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+
+public class MongoSchemaInferenceTest {
+
+    @Test
+    public void infersPortableTypesAndNestedPaths() {
+        MongoSchemaInference inference = new MongoSchemaInference(8);
+
+        BsonDocument first = new BsonDocument()
+                .append("_id", new BsonObjectId(new ObjectId("64b64c8f0000000000000001")))
+                .append("name", new BsonString("Yak"))
+                .append("age", new BsonInt32(18))
+                .append("score", new BsonDouble(9.5D))
+                .append("created_at", new BsonDateTime(1700000000000L))
+                .append("address", new BsonDocument("city", new BsonString("Chengdu")))
+                .append("tags", new BsonArray(Arrays.<BsonValue>asList(new BsonString("data"))));
+
+        BsonDocument second = new BsonDocument()
+                .append("_id", new BsonObjectId(new ObjectId("64b64c8f0000000000000002")))
+                .append("name", new BsonString("Link-Up"))
+                .append("age", new BsonInt64(20L))
+                .append("score", new BsonDouble(9.8D))
+                .append("created_at", new BsonDateTime(1700000100000L))
+                .append("address", new BsonDocument("province", new BsonString("Sichuan")))
+                .append("tags", new BsonArray(Arrays.<BsonValue>asList(new BsonString("sync"))));
+
+        inference.observe(first);
+        inference.observe(second);
+        TableSchema schema = inference.build();
+
+        Assert.assertEquals(SqlType.STRING, schema.getColumn("_id").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.STRING, schema.getColumn("name").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.BIGINT, schema.getColumn("age").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.DOUBLE, schema.getColumn("score").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.TIMESTAMP, schema.getColumn("created_at").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.STRING, schema.getColumn("address").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.STRING, schema.getColumn("address.city").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.STRING, schema.getColumn("address.province").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.STRING, schema.getColumn("tags").getDataType().getSqlType());
+
+        Assert.assertFalse(schema.getColumn("_id").isNullable());
+        Assert.assertTrue(schema.getColumn("address.city").isNullable());
+        Assert.assertTrue(schema.getColumn("address.province").isNullable());
+        Assert.assertEquals("ObjectId", schema.getColumn("_id").getSourceType());
+        Assert.assertEquals("true", schema.getColumn("address").getAttributes().get("mongodb.complex"));
+        Assert.assertEquals("true", schema.getColumn("address.city").getAttributes().get("mongodb.nested"));
+        Assert.assertEquals(Arrays.asList("_id"), schema.getPrimaryKey().getColumnNames());
+    }
+
+    @Test
+    public void widensNumbersAndFallsBackOnIncompatibleValues() {
+        MongoSchemaInference inference = new MongoSchemaInference(8);
+
+        inference.observe(new BsonDocument()
+                .append("count", new BsonInt32(1))
+                .append("price", new BsonDecimal128(new Decimal128(new BigDecimal("12.34"))))
+                .append("mixed", new BsonInt32(1)));
+        inference.observe(new BsonDocument()
+                .append("count", new BsonDouble(2.5D))
+                .append("price", new BsonInt64(15L))
+                .append("mixed", new BsonString("unknown")));
+
+        TableSchema schema = inference.build();
+        Assert.assertEquals(SqlType.DOUBLE, schema.getColumn("count").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.DECIMAL, schema.getColumn("price").getDataType().getSqlType());
+        Assert.assertEquals(SqlType.STRING, schema.getColumn("mixed").getDataType().getSqlType());
+        Assert.assertEquals("true", schema.getColumn("mixed").getAttributes().get("mongodb.heterogeneous"));
+    }
+
+    @Test
+    public void marksMissingFieldsNullable() {
+        MongoSchemaInference inference = new MongoSchemaInference(8);
+        inference.observe(new BsonDocument("name", new BsonString("Yak")));
+        inference.observe(new BsonDocument("other", new BsonString("value")));
+
+        TableSchema schema = inference.build();
+        Assert.assertTrue(schema.getColumn("name").isNullable());
+        Assert.assertTrue(schema.getColumn("other").isNullable());
+    }
+
+    @Test
+    public void keepsMetadataUsableForEmptyCollection() {
+        TableSchema schema = new MongoSchemaInference(8).build();
+        Column id = schema.getColumn("_id");
+
+        Assert.assertEquals(SqlType.STRING, id.getDataType().getSqlType());
+        Assert.assertFalse(id.isNullable());
+        Assert.assertEquals("true", id.getAttributes().get("mongodb.synthetic"));
+        Assert.assertEquals(Arrays.asList("_id"), schema.getPrimaryKey().getColumnNames());
+    }
+}

--- a/link-up-connectors/pom.xml
+++ b/link-up-connectors/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>

--- a/link-up-connectors/pom.xml
+++ b/link-up-connectors/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -23,6 +23,7 @@
         <module>link-up-connector-elasticsearch-common</module>
         <module>link-up-connector-elasticsearch7</module>
         <module>link-up-connector-elasticsearch8</module>
+        <module>link-up-connector-mongodb</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
 
@@ -41,6 +41,7 @@
         <elasticsearch7.client.version>7.17.29</elasticsearch7.client.version>
         <elasticsearch8.client.version>8.19.21</elasticsearch8.client.version>
         <elasticsearch8.jackson2.version>2.18.8</elasticsearch8.jackson2.version>
+        <mongodb.driver.version>4.11.5</mongodb.driver.version>
 
 
     </properties>


### PR DESCRIPTION
## Summary

Stage 1 of the bounded/offline MongoDB connector.

This PR intentionally solves MongoDB's schema-less metadata problem before adding any reader/writer runtime. The product boundary is usability-first: users should select a database, collection and fields; they should not author BSON or Link-Up field types.

## What changed

- add `link-up-connector-mongodb` module
- pin MongoDB Java Sync Driver `4.11.5` for the Java 8 runtime boundary and broad server compatibility
- add `MongoCatalogConfig`
- add `MongoCatalog`
  - list databases
  - list collections as `TablePath`
  - collection existence checks
  - automatic `CatalogTable` / `TableSchema` discovery
- add sampled `MongoSchemaInference`
  - default sample size: 1000 documents
  - default nested depth: 8
  - preserve BSON physical types in `Column.sourceType` / `Column.attributes`
  - keep Mongo-specific types out of the global `SqlType` model
- discover nested BSON documents as dotted fields while retaining the parent document as a JSON/STRING boundary
- keep arrays conservative as JSON/STRING in Stage 1
- synthesize `_id` metadata for empty collections so metadata discovery remains usable
- add unit coverage for config parsing, scalar mapping, numeric widening, heterogeneous fallback, nested field discovery, nullable/missing fields and empty collections
- add `link-up-connectors/MONGODB.md` documenting the connector boundary and follow-up stages

## Type policy

```text
ObjectId        -> STRING
String          -> STRING
Boolean         -> BOOLEAN
Int32           -> INT
Int64           -> BIGINT
Double          -> DOUBLE
Decimal128      -> DECIMAL(34,18)
DateTime        -> TIMESTAMP
Timestamp       -> TIMESTAMP
Binary          -> BYTES
Document        -> STRING(JSON) + dotted child discovery
Array           -> STRING(JSON)
other BSON      -> STRING
Null / missing  -> nullable
```

Merge examples:

```text
INT + BIGINT         -> BIGINT
INT/BIGINT + DOUBLE  -> DOUBLE
INT/BIGINT + DECIMAL -> DECIMAL
DECIMAL + DOUBLE     -> STRING
NULL + T             -> nullable T
incompatible values  -> STRING
```

## Product boundary

There is deliberately **no user-authored schema/type option** in this stage.

There is also deliberately no:

- SourceFactory / SourceReader
- SinkFactory / SinkWriter
- split/partition runtime
- CDC / Change Streams / oplog
- realtime semantics
- checkpoint/savepoint
- schema evolution

The MongoDB module is aggregated for compilation, but is not added to launcher/server runtime composition yet because it does not expose a runnable connector factory in Stage 1.

## Follow-up

```text
Stage 1  Catalog + schema discovery                  <- this PR
Stage 2  bounded MongoDB Source
Stage 3  bounded MongoDB Sink + offline hardening
```

## Verification

Unit tests are included for the pure schema-discovery layer. This environment cannot run the repository Maven build against downloaded external dependencies, so the branch should still be verified with:

```bash
mvn --batch-mode clean verify
```
