### PR TITLE
feat(mongodb): add bounded source connector

### DIFF
--- a/link-up-connectors/MONGODB.md
+++ b/link-up-connectors/MONGODB.md
@@ -1,16 +1,13 @@
 # MongoDB Connector
 
-MongoDB connector follows Link-Up's bounded/offline boundary. The product goal is usability first: users select a database, collection and fields; they do not declare BSON or Link-Up field types.
+MongoDB follows Link-Up's bounded/offline boundary. The product goal is usability first: users select a database, collection and fields; they do not declare BSON or Link-Up field types.
 
 ## Stage 1 — Catalog and automatic schema discovery
 
-Stage 1 provides metadata discovery only. It deliberately does not register a SourceFactory or SinkFactory and does not enter launcher/server runtime composition yet.
-
-Implemented:
+Stage 1 established the metadata boundary:
 
 - module `link-up-connector-mongodb`
 - MongoDB Java synchronous driver 4.11.5
-- `MongoCatalog`
 - database -> MongoDB database
 - table -> collection
 - automatic sampled schema discovery
@@ -19,16 +16,16 @@ Implemented:
 - dotted nested field discovery for BSON documents
 - conservative JSON/STRING boundary for documents and arrays
 - `_id` primary-key metadata when discovered
-- synthetic `_id` metadata for an empty collection so metadata discovery still returns a usable schema
+- synthetic `_id` metadata for an empty collection
 
-Default discovery limits:
+Default discovery limits are connector-internal:
 
 ```text
 schema sample size = 1000 documents
 schema max depth   = 8
 ```
 
-These are connector-internal defaults. Yak Ops should not ask users to provide field types.
+Yak Ops should not ask users to provide field types.
 
 ## BSON type policy
 
@@ -51,27 +48,11 @@ Null / missing  -> nullable
 
 Physical BSON information remains in `Column.sourceType` and `Column.attributes`; Mongo-specific types do not leak into Link-Up's global `SqlType` model.
 
-## Merge policy
-
-Schema discovery observes multiple documents instead of trusting the first document.
-
-```text
-INT + BIGINT            -> BIGINT
-INT/BIGINT + DOUBLE     -> DOUBLE
-INT/BIGINT + DECIMAL    -> DECIMAL
-DECIMAL + DOUBLE        -> STRING
-NULL + T                -> nullable T
-incompatible scalar     -> STRING
-complex + incompatible  -> STRING
-```
-
-When a field is missing from part of the sample, it becomes nullable. Multiple BSON physical types are retained in the `mongodb.bsonTypes` column attribute.
+Schema discovery observes multiple documents rather than trusting the first one. Numeric values widen when safe and incompatible shapes degrade to STRING. Missing sampled fields become nullable.
 
 ## Nested documents
 
-A document field is retained as a JSON string boundary and its child fields are also discovered as dotted paths.
-
-Example:
+A document field remains a JSON string boundary and its child fields are also discovered as dotted paths.
 
 ```json
 {
@@ -83,7 +64,7 @@ Example:
 }
 ```
 
-Discovered columns include:
+Discovery exposes:
 
 ```text
 name
@@ -92,26 +73,122 @@ address.province
 address.city
 ```
 
-This lets a future Yak Ops field picker expose a tree while keeping the Link-Up row schema flat and portable to JDBC/Doris/StarRocks sinks.
+This keeps the Link-Up row schema flat while allowing a future Yak Ops field picker to render a tree.
 
-Arrays remain JSON strings in Stage 1. Strong ARRAY/ROW inference is intentionally deferred until cross-sink compatibility has a clear product requirement.
+## Stage 2 — bounded MongoDB Source
 
-## Explicit non-goals for Stage 1
-
-- bounded Source reader
-- Sink writer
-- partition/split planning
-- multi-table execution
-- CDC / Change Streams / oplog
-- realtime semantics
-- checkpoint/savepoint
-- automatic schema evolution
-- user-authored schema/type configuration
-
-## Next stages
+Stage 2 adds the finite read path:
 
 ```text
-Stage 1  Catalog + schema discovery     DONE in this PR
-Stage 2  bounded MongoDB Source
+MongoDB collection
+  -> sampled TableSchema
+  -> one bounded collection split
+  -> Mongo cursor
+  -> BSON projection/filter
+  -> MongoBsonRowConverter
+  -> FluxRow
+```
+
+The Source exposes only `TABLE_SCHEMA_DISCOVERY`. It deliberately does not advertise `PARTITION_SPLIT` or `MULTI_TABLE` yet.
+
+### Configuration
+
+Minimal configuration:
+
+```hocon
+source {
+  type = "mongodb"
+  uri = "mongodb://127.0.0.1:27017/app"
+  collection = "users"
+}
+```
+
+The database may be selected explicitly when it is not present in the URI:
+
+```hocon
+source {
+  type = "mongodb"
+  uri = "mongodb://127.0.0.1:27017"
+  database = "app"
+  collection = "users"
+}
+```
+
+Field selection requires names only, never types:
+
+```hocon
+source {
+  type = "mongodb"
+  uri = "mongodb://127.0.0.1:27017/app"
+  collection = "users"
+
+  fields = ["_id", "username", "address.city", "created_at"]
+  fetch_size = 1000
+}
+```
+
+An optional bounded `find` filter accepts MongoDB Extended JSON:
+
+```hocon
+filter = """{"status":"ACTIVE"}"""
+```
+
+### Projection
+
+Explicit `fields` are pushed down to MongoDB. Dotted paths are supported.
+
+If both a parent and one of its children are selected, for example:
+
+```text
+address
+address.city
+```
+
+only the parent path is sent in the MongoDB projection to avoid a parent/child projection collision. The row converter still derives both selected Link-Up fields from the returned document.
+
+When no fields are selected, Stage 2 reads the full document. This avoids manufacturing a projection from sampled metadata and remains robust when the collection contains fields that were not seen during discovery.
+
+### Runtime conversion and schema drift
+
+The prepared `TableSchema` remains authoritative while a bounded task is running.
+
+- ObjectId is emitted as its hex STRING form.
+- DateTime/Timestamp values become UTC `LocalDateTime` values.
+- Documents, arrays and other STRING fallback values use Extended JSON.
+- Missing fields become null.
+- Safe numeric widening follows the discovered Link-Up type.
+- A later document that conflicts with a strongly inferred scalar type fails explicitly instead of being silently coerced.
+
+This is deliberate: a sampled schema can never prove that every document in a schema-less collection has the same shape. Silent coercion would make downstream relational writes harder to reason about.
+
+### Single-split boundary
+
+Stage 2 always creates one full-collection split, even when Source reader parallelism is greater than one.
+
+This is intentional. MongoDB `_id` is not guaranteed to be an ObjectId and may be a string, integer, UUID, compound/application value, or another BSON type. Stage 2 does not pretend that a safe generic range partition exists.
+
+A later hardening stage may add explicit range/chunk planning with a conservative single-split fallback.
+
+### Bounded does not mean transactional snapshot
+
+Stage 2 executes one finite MongoDB `find` cursor. It does not claim a point-in-time multi-reader database snapshot or exactly-once snapshot semantics. Concurrent application updates may affect what MongoDB returns according to the server/read-concern configuration supplied by the connection URI.
+
+## Explicit non-goals for Stage 2
+
+- MongoDB Sink
+- multi-collection execution
+- automatic partition/range split planning
+- Change Streams / oplog / CDC
+- realtime polling
+- checkpoint/savepoint
+- automatic runtime schema evolution
+- user-authored schema/type configuration
+- job-level exactly-once snapshot claims
+
+## Next stage
+
+```text
+Stage 1  Catalog + schema discovery              DONE
+Stage 2  bounded MongoDB Source                  DONE in this PR
 Stage 3  bounded MongoDB Sink + offline hardening
 ```

--- a/link-up-connectors/link-up-connector-mongodb/pom.xml
+++ b/link-up-connectors/link-up-connector-mongodb/pom.xml
@@ -21,6 +21,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>${auto-service.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mongodb</groupId>
             <artifactId>mongodb-driver-sync</artifactId>
             <version>${mongodb.driver.version}</version>

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/MongoConnectorIdentity.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/MongoConnectorIdentity.java
@@ -1,0 +1,10 @@
+package com.link.up.connector.mongodb;
+
+/** Stable MongoDB connector identity shared by metadata and runtime roles. */
+public final class MongoConnectorIdentity {
+
+    public static final String IDENTIFIER = "mongodb";
+
+    private MongoConnectorIdentity() {
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoSourceConfig.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoSourceConfig.java
@@ -1,0 +1,171 @@
+package com.link.up.connector.mongodb.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+import com.mongodb.ConnectionString;
+import org.bson.BsonDocument;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** Immutable bounded MongoDB Source configuration. */
+public final class MongoSourceConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String uri;
+    private final String database;
+    private final String collection;
+    private final List<String> fields;
+    private final String filter;
+    private final int fetchSize;
+
+    private MongoSourceConfig(
+            String uri,
+            String database,
+            String collection,
+            List<String> fields,
+            String filter,
+            int fetchSize) {
+        this.uri = uri;
+        this.database = database;
+        this.collection = collection;
+        this.fields = Collections.unmodifiableList(new ArrayList<String>(fields));
+        this.filter = filter;
+        this.fetchSize = fetchSize;
+    }
+
+    public static MongoSourceConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        String uri = requireText(config.get(MongoSourceOptions.URI), "uri");
+        ConnectionString connectionString = parseConnectionString(uri);
+        String configuredDatabase =
+                normalize(config.getOptional(MongoSourceOptions.DATABASE).orElse(null));
+        String database = configuredDatabase == null
+                ? normalize(connectionString.getDatabase())
+                : configuredDatabase;
+        if (database == null) {
+            throw new IllegalArgumentException(
+                    "database must be configured when the MongoDB URI has no default database");
+        }
+
+        String collection = requireText(
+                config.get(MongoSourceOptions.COLLECTION),
+                "collection");
+        List<String> fields = normalizeFields(
+                config.getOptional(MongoSourceOptions.FIELDS)
+                        .orElse(Collections.<String>emptyList()));
+        String filter = normalize(config.get(MongoSourceOptions.FILTER));
+        validateFilter(filter);
+
+        int fetchSize = config.get(MongoSourceOptions.FETCH_SIZE);
+        if (fetchSize <= 0) {
+            throw new IllegalArgumentException("fetch_size must be greater than 0");
+        }
+
+        return new MongoSourceConfig(
+                uri,
+                database,
+                collection,
+                fields,
+                filter,
+                fetchSize);
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public List<String> getFields() {
+        return fields;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    public int getFetchSize() {
+        return fetchSize;
+    }
+
+    public boolean hasProjection() {
+        return !fields.isEmpty();
+    }
+
+    public BsonDocument createFilter() {
+        return filter == null ? new BsonDocument() : BsonDocument.parse(filter);
+    }
+
+    public TablePath getTablePath() {
+        return TablePath.of(database, collection);
+    }
+
+    private static ConnectionString parseConnectionString(String uri) {
+        try {
+            return new ConnectionString(uri);
+        } catch (IllegalArgumentException failure) {
+            throw new IllegalArgumentException("Invalid MongoDB connection URI", failure);
+        }
+    }
+
+    private static List<String> normalizeFields(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        Set<String> unique = new LinkedHashSet<String>();
+        for (String value : values) {
+            String field = normalize(value);
+            if (field == null) {
+                throw new IllegalArgumentException("fields values must not be blank");
+            }
+            if (!unique.add(field)) {
+                throw new IllegalArgumentException("Duplicate MongoDB field: " + field);
+            }
+        }
+        return new ArrayList<String>(unique);
+    }
+
+    private static void validateFilter(String filter) {
+        if (filter == null) {
+            return;
+        }
+        try {
+            BsonDocument.parse(filter);
+        } catch (RuntimeException failure) {
+            throw new IllegalArgumentException(
+                    "filter must be a valid MongoDB Extended JSON document",
+                    failure);
+        }
+    }
+
+    private static String requireText(String value, String fieldName) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(fieldName + " must not be empty");
+        }
+        return normalized;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoSourceOptions.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoSourceOptions.java
@@ -1,0 +1,63 @@
+package com.link.up.connector.mongodb.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+import java.util.List;
+
+/** User-facing options for the bounded MongoDB Source. */
+public final class MongoSourceOptions {
+
+    private MongoSourceOptions() {
+    }
+
+    public static final Option<String> URI =
+            Options.key("uri")
+                    .stringType()
+                    .noDefaultValue()
+                    .sensitive()
+                    .withDescription("MongoDB connection URI")
+                    .withSemanticType("MONGODB_URI")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> DATABASE =
+            Options.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("MongoDB database; optional when the URI already contains one")
+                    .withSemanticType("DATABASE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> COLLECTION =
+            Options.key("collection")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("One MongoDB collection")
+                    .withSemanticType("COLLECTION")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<List<String>> FIELDS =
+            Options.key("fields")
+                    .listType()
+                    .noDefaultValue()
+                    .withDescription("Optional field projection; dotted nested paths are supported")
+                    .withSemanticType("SOURCE_FIELDS")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> FILTER =
+            Options.key("filter")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Optional MongoDB find filter as Extended JSON")
+                    .withSemanticType("QUERY")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> FETCH_SIZE =
+            Options.key("fetch_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("Documents requested from MongoDB per cursor batch")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/converter/MongoBsonRowConverter.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/converter/MongoBsonRowConverter.java
@@ -1,0 +1,251 @@
+package com.link.up.connector.mongodb.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.SqlType;
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/** Converts one BSON document to a FluxRow using the prepared discovered schema. */
+public final class MongoBsonRowConverter {
+
+    private final List<FieldConversion> fields;
+
+    public MongoBsonRowConverter(TableSchema schema) {
+        Objects.requireNonNull(schema, "schema must not be null");
+        List<FieldConversion> prepared = new ArrayList<FieldConversion>(schema.getColumnCount());
+        for (Column column : schema.getColumns()) {
+            prepared.add(new FieldConversion(column));
+        }
+        this.fields = prepared;
+    }
+
+    public FluxRow convert(BsonDocument document) {
+        Objects.requireNonNull(document, "document must not be null");
+        FluxRow row = new FluxRow(fields.size());
+        for (int i = 0; i < fields.size(); i++) {
+            FieldConversion field = fields.get(i);
+            BsonValue value = extract(document, field.pathSegments);
+            row.setField(i, convertValue(field, value));
+        }
+        return row;
+    }
+
+    private static BsonValue extract(BsonDocument document, String[] pathSegments) {
+        BsonDocument current = document;
+        for (int i = 0; i < pathSegments.length; i++) {
+            BsonValue value = current.get(pathSegments[i]);
+            if (value == null) {
+                return null;
+            }
+            if (i == pathSegments.length - 1) {
+                return value;
+            }
+            if (value.getBsonType() != BsonType.DOCUMENT) {
+                return null;
+            }
+            current = value.asDocument();
+        }
+        return null;
+    }
+
+    private static Object convertValue(FieldConversion field, BsonValue value) {
+        if (value == null || value.getBsonType() == BsonType.NULL) {
+            return null;
+        }
+
+        switch (field.sqlType) {
+            case STRING:
+                return toPortableString(value);
+            case BOOLEAN:
+                requireType(field, value, BsonType.BOOLEAN);
+                return value.asBoolean().getValue();
+            case TINYINT:
+                return toByte(field, value);
+            case SMALLINT:
+                return toShort(field, value);
+            case INT:
+                requireType(field, value, BsonType.INT32);
+                return value.asInt32().getValue();
+            case BIGINT:
+                return toLong(field, value);
+            case FLOAT:
+                return toFloat(field, value);
+            case DOUBLE:
+                return toDouble(field, value);
+            case DECIMAL:
+                return toDecimal(field, value);
+            case BYTES:
+                requireType(field, value, BsonType.BINARY);
+                byte[] bytes = value.asBinary().getData();
+                return Arrays.copyOf(bytes, bytes.length);
+            case TIMESTAMP:
+                return toTimestamp(field, value);
+            default:
+                throw unsupported(field, value);
+        }
+    }
+
+    private static Byte toByte(FieldConversion field, BsonValue value) {
+        requireType(field, value, BsonType.INT32);
+        int number = value.asInt32().getValue();
+        if (number < Byte.MIN_VALUE || number > Byte.MAX_VALUE) {
+            throw typeMismatch(field, value, "value is outside TINYINT range");
+        }
+        return (byte) number;
+    }
+
+    private static Short toShort(FieldConversion field, BsonValue value) {
+        requireType(field, value, BsonType.INT32);
+        int number = value.asInt32().getValue();
+        if (number < Short.MIN_VALUE || number > Short.MAX_VALUE) {
+            throw typeMismatch(field, value, "value is outside SMALLINT range");
+        }
+        return (short) number;
+    }
+
+    private static Long toLong(FieldConversion field, BsonValue value) {
+        if (value.getBsonType() == BsonType.INT32) {
+            return (long) value.asInt32().getValue();
+        }
+        if (value.getBsonType() == BsonType.INT64) {
+            return value.asInt64().getValue();
+        }
+        throw typeMismatch(field, value, "expected Int32 or Int64");
+    }
+
+    private static Float toFloat(FieldConversion field, BsonValue value) {
+        switch (value.getBsonType()) {
+            case INT32:
+                return (float) value.asInt32().getValue();
+            case INT64:
+                return (float) value.asInt64().getValue();
+            case DOUBLE:
+                return (float) value.asDouble().getValue();
+            default:
+                throw typeMismatch(field, value, "expected a BSON numeric value");
+        }
+    }
+
+    private static Double toDouble(FieldConversion field, BsonValue value) {
+        switch (value.getBsonType()) {
+            case INT32:
+                return (double) value.asInt32().getValue();
+            case INT64:
+                return (double) value.asInt64().getValue();
+            case DOUBLE:
+                return value.asDouble().getValue();
+            default:
+                throw typeMismatch(field, value, "expected Int32, Int64, or Double");
+        }
+    }
+
+    private static BigDecimal toDecimal(FieldConversion field, BsonValue value) {
+        switch (value.getBsonType()) {
+            case INT32:
+                return BigDecimal.valueOf(value.asInt32().getValue());
+            case INT64:
+                return BigDecimal.valueOf(value.asInt64().getValue());
+            case DECIMAL128:
+                try {
+                    return value.asDecimal128().getValue().bigDecimalValue();
+                } catch (ArithmeticException failure) {
+                    throw typeMismatch(field, value, "Decimal128 value is not a finite BigDecimal");
+                }
+            default:
+                throw typeMismatch(field, value, "expected Int32, Int64, or Decimal128");
+        }
+    }
+
+    private static LocalDateTime toTimestamp(FieldConversion field, BsonValue value) {
+        final Instant instant;
+        if (value.getBsonType() == BsonType.DATE_TIME) {
+            instant = Instant.ofEpochMilli(value.asDateTime().getValue());
+        } else if (value.getBsonType() == BsonType.TIMESTAMP) {
+            instant = Instant.ofEpochSecond(value.asTimestamp().getTime());
+        } else {
+            throw typeMismatch(field, value, "expected DateTime or Timestamp");
+        }
+        return LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+    }
+
+    private static String toPortableString(BsonValue value) {
+        if (value.getBsonType() == BsonType.STRING) {
+            return value.asString().getValue();
+        }
+        if (value.getBsonType() == BsonType.OBJECT_ID) {
+            return value.asObjectId().getValue().toHexString();
+        }
+        return toExtendedJsonValue(value);
+    }
+
+    private static String toExtendedJsonValue(BsonValue value) {
+        String wrapped = new BsonDocument("_value", value).toJson();
+        int separator = wrapped.indexOf(':');
+        if (separator < 0 || wrapped.length() < separator + 2) {
+            return value.toString();
+        }
+        return wrapped.substring(separator + 1, wrapped.length() - 1).trim();
+    }
+
+    private static void requireType(
+            FieldConversion field,
+            BsonValue value,
+            BsonType expected) {
+        if (value.getBsonType() != expected) {
+            throw typeMismatch(field, value, "expected " + expected);
+        }
+    }
+
+    private static IllegalArgumentException unsupported(
+            FieldConversion field,
+            BsonValue value) {
+        return typeMismatch(
+                field,
+                value,
+                "Link-Up type " + field.sqlType + " is not supported by the MongoDB Source converter");
+    }
+
+    private static IllegalArgumentException typeMismatch(
+            FieldConversion field,
+            BsonValue value,
+            String detail) {
+        return new IllegalArgumentException(
+                "MongoDB field type changed after schema discovery, field="
+                        + field.name
+                        + ", expected="
+                        + field.sqlType
+                        + ", actual="
+                        + value.getBsonType()
+                        + ", detail="
+                        + detail);
+    }
+
+    private static final class FieldConversion {
+
+        private final String name;
+        private final String[] pathSegments;
+        private final SqlType sqlType;
+
+        private FieldConversion(Column column) {
+            this.name = column.getName();
+            String physicalPath = column.getAttributes().get("mongodb.path");
+            if (physicalPath == null || physicalPath.trim().isEmpty()) {
+                physicalPath = column.getName();
+            }
+            this.pathSegments = physicalPath.split("\\.");
+            this.sqlType = column.getDataType().getSqlType();
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoFieldProjection.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoFieldProjection.java
@@ -1,0 +1,55 @@
+package com.link.up.connector.mongodb.source;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/** Builds an inclusion projection without MongoDB parent/child path collisions. */
+final class MongoFieldProjection {
+
+    private MongoFieldProjection() {
+    }
+
+    static BsonDocument build(List<String> fields) {
+        if (fields == null || fields.isEmpty()) {
+            return new BsonDocument();
+        }
+
+        Set<String> selected = new LinkedHashSet<String>(fields);
+        BsonDocument projection = new BsonDocument();
+        for (String field : selected) {
+            if (!hasSelectedAncestor(field, selected)) {
+                projection.put(field, new BsonInt32(1));
+            }
+        }
+
+        if (!selectsId(selected)) {
+            projection.put("_id", new BsonInt32(0));
+        }
+        return projection;
+    }
+
+    private static boolean hasSelectedAncestor(String field, Set<String> selected) {
+        int separator = field.lastIndexOf('.');
+        while (separator > 0) {
+            String ancestor = field.substring(0, separator);
+            if (selected.contains(ancestor)) {
+                return true;
+            }
+            separator = ancestor.lastIndexOf('.');
+        }
+        return false;
+    }
+
+    private static boolean selectsId(Set<String> selected) {
+        for (String field : selected) {
+            if ("_id".equals(field) || field.startsWith("_id.")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSource.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSource.java
@@ -1,0 +1,53 @@
+package com.link.up.connector.mongodb.source;
+
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceEnumeratorContext;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.mongodb.config.MongoSourceConfig;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Bounded MongoDB Source using one finite collection cursor. */
+public final class MongoSource implements Source<MongoSourceSplit> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final MongoSourceConfig config;
+
+    public MongoSource(MongoSourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public SourceSplitEnumerator<MongoSourceSplit> createEnumerator(
+            Map<TablePath, CatalogTable> tables,
+            SourceEnumeratorContext context) {
+        Objects.requireNonNull(tables, "tables must not be null");
+        Objects.requireNonNull(context, "context must not be null");
+        return new MongoSourceSplitEnumerator(config);
+    }
+
+    @Override
+    @Deprecated
+    public List<MongoSourceSplit> createSplits(Map<TablePath, CatalogTable> tables) {
+        Objects.requireNonNull(tables, "tables must not be null");
+        return new MongoSourceSplitEnumerator(config).enumerateSplits();
+    }
+
+    @Override
+    public SourceReader<FluxRow, MongoSourceSplit> createReader(
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        return new MongoSourceReader(config, tables, batchSize);
+    }
+
+    public MongoSourceConfig getConfig() {
+        return config;
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceFactory.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceFactory.java
@@ -1,0 +1,95 @@
+package com.link.up.connector.mongodb.source;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.source.Source;
+import com.link.up.api.source.SourceFactoryContext;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.factory.TableSourceFactory;
+import com.link.up.connector.mongodb.MongoConnectorIdentity;
+import com.link.up.connector.mongodb.catalog.MongoCatalog;
+import com.link.up.connector.mongodb.config.MongoCatalogConfig;
+import com.link.up.connector.mongodb.config.MongoSourceConfig;
+import com.link.up.connector.mongodb.config.MongoSourceOptions;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/** SPI factory for the bounded MongoDB Source. */
+@AutoService(TableSourceFactory.class)
+public final class MongoSourceFactory implements TableSourceFactory<MongoSourceSplit> {
+
+    @Override
+    public String factoryIdentifier() {
+        return MongoConnectorIdentity.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.unmodifiableSet(
+                EnumSet.of(ConnectorCapability.TABLE_SCHEMA_DISCOVERY));
+    }
+
+    @Override
+    public Source<MongoSourceSplit> createSource(SourceFactoryContext context) {
+        return new MongoSource(createConfig(context));
+    }
+
+    @Override
+    public List<CatalogTable> discoverTableSchemas(SourceFactoryContext context)
+            throws Exception {
+        MongoSourceConfig config = createConfig(context);
+        MongoCatalogConfig catalogConfig = MongoCatalogConfig.of(config.getUri());
+        try (MongoCatalog catalog = new MongoCatalog(catalogConfig)) {
+            catalog.open();
+            CatalogTable table = catalog.getTable(config.getTablePath());
+            table = projectSelectedFields(table, config.getFields());
+            return Collections.singletonList(table);
+        }
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        MongoSourceOptions.URI,
+                        MongoSourceOptions.COLLECTION)
+                .optional(
+                        MongoSourceOptions.DATABASE,
+                        MongoSourceOptions.FIELDS,
+                        MongoSourceOptions.FILTER,
+                        MongoSourceOptions.FETCH_SIZE)
+                .build();
+    }
+
+    private static CatalogTable projectSelectedFields(
+            CatalogTable table,
+            List<String> fields) {
+        if (fields == null || fields.isEmpty()) {
+            return table;
+        }
+
+        TableSchema schema = table.getTableSchema();
+        for (String field : fields) {
+            if (!schema.contains(field)) {
+                throw new IllegalArgumentException(
+                        "Selected MongoDB field was not discovered in the collection sample: " + field);
+            }
+        }
+        return table.withSchema(schema.project(fields));
+    }
+
+    private static MongoSourceConfig createConfig(SourceFactoryContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        ReadonlyConfig options = Objects.requireNonNull(
+                context.getOptions(),
+                "source options must not be null");
+        return MongoSourceConfig.of(options);
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceReader.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceReader.java
@@ -124,6 +124,8 @@ public final class MongoSourceReader implements SourceReader<FluxRow, MongoSourc
                     "No prepared schema found for MongoDB collection: " + split.getTablePath());
         }
 
+        MongoBsonRowConverter preparedConverter =
+                new MongoBsonRowConverter(table.getTableSchema());
         MongoCollection<BsonDocument> collection = client
                 .getDatabase(config.getDatabase())
                 .getCollection(config.getCollection(), BsonDocument.class);
@@ -135,7 +137,7 @@ public final class MongoSourceReader implements SourceReader<FluxRow, MongoSourc
         }
 
         MongoCursor<BsonDocument> openedCursor = find.iterator();
-        this.rowConverter = new MongoBsonRowConverter(table.getTableSchema());
+        this.rowConverter = preparedConverter;
         this.currentSplit = split;
         this.cursor = openedCursor;
     }

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceReader.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceReader.java
@@ -1,0 +1,198 @@
+package com.link.up.connector.mongodb.source;
+
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.source.SourceReader;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.mongodb.config.MongoSourceConfig;
+import com.link.up.connector.mongodb.converter.MongoBsonRowConverter;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Bounded reader with one active MongoDB cursor per split. */
+public final class MongoSourceReader implements SourceReader<FluxRow, MongoSourceSplit> {
+
+    private final MongoSourceConfig config;
+    private final Map<TablePath, CatalogTable> tables;
+    private final int batchSize;
+
+    private MongoClient client;
+    private List<MongoSourceSplit> assignedSplits = Collections.emptyList();
+    private int nextSplitIndex;
+    private MongoSourceSplit currentSplit;
+    private MongoCursor<BsonDocument> cursor;
+    private MongoBsonRowConverter rowConverter;
+    private boolean opened;
+    private boolean closed;
+
+    public MongoSourceReader(
+            MongoSourceConfig config,
+            Map<TablePath, CatalogTable> tables,
+            int batchSize) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        Objects.requireNonNull(tables, "tables must not be null");
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than 0");
+        }
+        this.tables = Collections.unmodifiableMap(
+                new LinkedHashMap<TablePath, CatalogTable>(tables));
+        this.batchSize = batchSize;
+    }
+
+    @Override
+    public void open(List<MongoSourceSplit> splits) {
+        ensureNotOpened();
+        this.assignedSplits = splits == null
+                ? Collections.<MongoSourceSplit>emptyList()
+                : Collections.unmodifiableList(new ArrayList<MongoSourceSplit>(splits));
+        initializeClient();
+    }
+
+    @Override
+    public void open() {
+        open(Collections.<MongoSourceSplit>emptyList());
+    }
+
+    @Override
+    public void openSplit(MongoSourceSplit split) {
+        Objects.requireNonNull(split, "split must not be null");
+        if (!opened) {
+            open();
+        }
+        ensureUsable();
+        if (currentSplit != null) {
+            throw new IllegalStateException("A MongoDB split is already open: " + currentSplit.splitId());
+        }
+        openCurrentSplit(split);
+    }
+
+    @Override
+    public RecordBatch<FluxRow> readBatch() {
+        ensureUsable();
+
+        while (true) {
+            if (currentSplit == null && !openNextAssignedSplit()) {
+                return RecordBatch.endOfInput();
+            }
+
+            MongoSourceSplit batchSplit = currentSplit;
+            List<FluxRow> rows = new ArrayList<FluxRow>(batchSize);
+            while (rows.size() < batchSize && currentSplit == batchSplit) {
+                if (cursor.hasNext()) {
+                    rows.add(rowConverter.convert(cursor.next()));
+                    continue;
+                }
+                closeSplit();
+            }
+
+            if (!rows.isEmpty()) {
+                return RecordBatch.of(batchSplit, rows);
+            }
+        }
+    }
+
+    private boolean openNextAssignedSplit() {
+        if (nextSplitIndex >= assignedSplits.size()) {
+            return false;
+        }
+        openCurrentSplit(assignedSplits.get(nextSplitIndex++));
+        return true;
+    }
+
+    private void openCurrentSplit(MongoSourceSplit split) {
+        if (!config.getTablePath().equals(split.getTablePath())) {
+            throw new IllegalArgumentException(
+                    "MongoDB split does not belong to the configured collection: " + split.getTablePath());
+        }
+
+        CatalogTable table = tables.get(split.getTablePath());
+        if (table == null) {
+            throw new IllegalArgumentException(
+                    "No prepared schema found for MongoDB collection: " + split.getTablePath());
+        }
+
+        MongoCollection<BsonDocument> collection = client
+                .getDatabase(config.getDatabase())
+                .getCollection(config.getCollection(), BsonDocument.class);
+        FindIterable<BsonDocument> find = collection
+                .find(config.createFilter())
+                .batchSize(config.getFetchSize());
+        if (config.hasProjection()) {
+            find = find.projection(MongoFieldProjection.build(config.getFields()));
+        }
+
+        MongoCursor<BsonDocument> openedCursor = find.iterator();
+        this.rowConverter = new MongoBsonRowConverter(table.getTableSchema());
+        this.currentSplit = split;
+        this.cursor = openedCursor;
+    }
+
+    @Override
+    public void closeSplit() {
+        MongoCursor<BsonDocument> currentCursor = cursor;
+        cursor = null;
+        currentSplit = null;
+        rowConverter = null;
+        if (currentCursor != null) {
+            currentCursor.close();
+        }
+    }
+
+    private void initializeClient() {
+        MongoClient openedClient = MongoClients.create(config.getUri());
+        boolean success = false;
+        try {
+            openedClient.getDatabase(config.getDatabase())
+                    .runCommand(new BsonDocument("ping", new BsonInt32(1)));
+            this.client = openedClient;
+            this.opened = true;
+            success = true;
+        } finally {
+            if (!success) {
+                openedClient.close();
+            }
+        }
+    }
+
+    private void ensureNotOpened() {
+        if (opened || closed) {
+            throw new IllegalStateException("MongoSourceReader has already been opened or closed");
+        }
+    }
+
+    private void ensureUsable() {
+        if (!opened || closed || client == null) {
+            throw new IllegalStateException("MongoSourceReader is not open");
+        }
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        try {
+            closeSplit();
+        } finally {
+            if (client != null) {
+                client.close();
+            }
+            client = null;
+            opened = false;
+            closed = true;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceSplit.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceSplit.java
@@ -1,0 +1,39 @@
+package com.link.up.connector.mongodb.source;
+
+import com.link.up.api.source.SourceSplit;
+import com.link.up.api.table.catalog.TablePath;
+
+import java.util.Objects;
+
+/** One bounded full-collection scan unit. */
+public final class MongoSourceSplit implements SourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final TablePath tablePath;
+    private final String splitId;
+
+    public MongoSourceSplit(TablePath tablePath) {
+        this.tablePath = Objects.requireNonNull(tablePath, "tablePath must not be null");
+        this.splitId = tablePath.toString() + ":full-scan";
+    }
+
+    @Override
+    public String splitId() {
+        return splitId;
+    }
+
+    @Override
+    public String dataSetId() {
+        return tablePath.toString();
+    }
+
+    public TablePath getTablePath() {
+        return tablePath;
+    }
+
+    @Override
+    public String toString() {
+        return "MongoSourceSplit{tablePath=" + tablePath + '}';
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceSplitEnumerator.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/source/MongoSourceSplitEnumerator.java
@@ -1,0 +1,24 @@
+package com.link.up.connector.mongodb.source;
+
+import com.link.up.api.source.SourceSplitEnumerator;
+import com.link.up.connector.mongodb.config.MongoSourceConfig;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Stage 2 intentionally emits exactly one bounded collection split. */
+public final class MongoSourceSplitEnumerator
+        implements SourceSplitEnumerator<MongoSourceSplit> {
+
+    private final MongoSourceConfig config;
+
+    public MongoSourceSplitEnumerator(MongoSourceConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public List<MongoSourceSplit> enumerateSplits() {
+        return Collections.singletonList(new MongoSourceSplit(config.getTablePath()));
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/config/MongoSourceConfigTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/config/MongoSourceConfigTest.java
@@ -1,0 +1,77 @@
+package com.link.up.connector.mongodb.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MongoSourceConfigTest {
+
+    @Test
+    public void usesDatabaseFromUriByDefault() {
+        MongoSourceConfig config = MongoSourceConfig.of(
+                ReadonlyConfig.fromMap(base("mongodb://localhost:27017/app")));
+
+        assertEquals("app", config.getDatabase());
+        assertEquals("users", config.getCollection());
+        assertEquals(1000, config.getFetchSize());
+        assertTrue(config.getFields().isEmpty());
+    }
+
+    @Test
+    public void explicitDatabaseOverridesUriDatabase() {
+        Map<String, Object> values = base("mongodb://localhost:27017/from_uri");
+        values.put("database", "selected_db");
+        values.put("fields", Arrays.asList("_id", "address.city"));
+        values.put("filter", "{\"active\": true}");
+        values.put("fetch_size", 256);
+
+        MongoSourceConfig config = MongoSourceConfig.of(ReadonlyConfig.fromMap(values));
+
+        assertEquals("selected_db", config.getDatabase());
+        assertEquals(Arrays.asList("_id", "address.city"), config.getFields());
+        assertEquals(256, config.getFetchSize());
+        assertEquals(true, config.createFilter().getBoolean("active").getValue());
+    }
+
+    @Test
+    public void requiresDatabaseWhenUriHasNone() {
+        assertInvalid(base("mongodb://localhost:27017"));
+    }
+
+    @Test
+    public void rejectsDuplicateFields() {
+        Map<String, Object> values = base("mongodb://localhost:27017/app");
+        values.put("fields", Arrays.asList("name", "name"));
+        assertInvalid(values);
+    }
+
+    @Test
+    public void rejectsInvalidFilter() {
+        Map<String, Object> values = base("mongodb://localhost:27017/app");
+        values.put("filter", "{not-json}");
+        assertInvalid(values);
+    }
+
+    private static Map<String, Object> base(String uri) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("uri", uri);
+        values.put("collection", "users");
+        return values;
+    }
+
+    private static void assertInvalid(Map<String, Object> values) {
+        try {
+            MongoSourceConfig.of(ReadonlyConfig.fromMap(values));
+            fail("Expected invalid MongoDB Source configuration");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/converter/MongoBsonRowConverterTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/converter/MongoBsonRowConverterTest.java
@@ -1,0 +1,116 @@
+package com.link.up.connector.mongodb.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MongoBsonRowConverterTest {
+
+    @Test
+    public void convertsPortableScalarAndNestedValues() {
+        TableSchema schema = TableSchema.builder()
+                .column(column("_id", BasicType.STRING_TYPE, "_id"))
+                .column(column("age", BasicType.LONG_TYPE, "age"))
+                .column(column("score", BasicType.DOUBLE_TYPE, "score"))
+                .column(column("created_at", BasicType.TIMESTAMP_TYPE, "created_at"))
+                .column(column("address.city", BasicType.STRING_TYPE, "address.city"))
+                .column(column("payload", BasicType.STRING_TYPE, "payload"))
+                .column(column("binary", BasicType.BYTES_TYPE, "binary"))
+                .build();
+
+        ObjectId id = new ObjectId("64b7abdecf2160b649ab6085");
+        BsonDocument document = new BsonDocument()
+                .append("_id", new BsonObjectId(id))
+                .append("age", new BsonInt32(18))
+                .append("score", new BsonDouble(9.5D))
+                .append("created_at", new BsonDateTime(0L))
+                .append(
+                        "address",
+                        new BsonDocument("city", new BsonString("Chengdu")))
+                .append(
+                        "payload",
+                        new BsonArray(Arrays.<BsonValue>asList(
+                                new BsonInt32(1),
+                                new BsonString("x"))))
+                .append("binary", new BsonBinary(new byte[]{1, 2, 3}));
+
+        FluxRow row = new MongoBsonRowConverter(schema).convert(document);
+
+        assertEquals(id.toHexString(), row.getField(0));
+        assertEquals(Long.valueOf(18L), row.getField(1));
+        assertEquals(Double.valueOf(9.5D), row.getField(2));
+        assertEquals(LocalDateTime.of(1970, 1, 1, 0, 0), row.getField(3));
+        assertEquals("Chengdu", row.getField(4));
+        assertTrue(((String) row.getField(5)).startsWith("["));
+        assertArrayEquals(new byte[]{1, 2, 3}, (byte[]) row.getField(6));
+    }
+
+    @Test
+    public void missingNestedFieldBecomesNull() {
+        TableSchema schema = TableSchema.builder()
+                .column(column("address.city", BasicType.STRING_TYPE, "address.city"))
+                .build();
+
+        FluxRow row = new MongoBsonRowConverter(schema)
+                .convert(new BsonDocument("address", new BsonDocument()));
+
+        assertEquals(null, row.getField(0));
+    }
+
+    @Test
+    public void stringFallbackCarriesHeterogeneousScalarAsText() {
+        TableSchema schema = TableSchema.builder()
+                .column(column("value", BasicType.STRING_TYPE, "value"))
+                .build();
+
+        FluxRow row = new MongoBsonRowConverter(schema)
+                .convert(new BsonDocument("value", new BsonInt32(42)));
+
+        assertEquals("42", row.getField(0));
+    }
+
+    @Test
+    public void typedSchemaDriftFailsInsteadOfSilentlyCoercing() {
+        TableSchema schema = TableSchema.builder()
+                .column(column("age", BasicType.INT_TYPE, "age"))
+                .build();
+
+        try {
+            new MongoBsonRowConverter(schema)
+                    .convert(new BsonDocument("age", new BsonString("unknown")));
+            fail("Expected runtime schema drift to fail");
+        } catch (IllegalArgumentException expected) {
+            assertTrue(expected.getMessage().contains("field=age"));
+            assertTrue(expected.getMessage().contains("actual=STRING"));
+        }
+    }
+
+    private static Column column(
+            String name,
+            com.link.up.api.table.type.FluxDataType<?> type,
+            String path) {
+        return Column.builder(name, type)
+                .attribute("mongodb.path", path)
+                .build();
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/source/MongoFieldProjectionTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/source/MongoFieldProjectionTest.java
@@ -1,0 +1,39 @@
+package com.link.up.connector.mongodb.source;
+
+import org.bson.BsonDocument;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MongoFieldProjectionTest {
+
+    @Test
+    public void parentSelectionSuppressesChildProjectionCollision() {
+        BsonDocument projection = MongoFieldProjection.build(
+                Arrays.asList("address.city", "address", "name"));
+
+        assertEquals(1, projection.getInt32("address").getValue());
+        assertEquals(1, projection.getInt32("name").getValue());
+        assertFalse(projection.containsKey("address.city"));
+        assertEquals(0, projection.getInt32("_id").getValue());
+    }
+
+    @Test
+    public void selectedIdIsNotExcluded() {
+        BsonDocument projection = MongoFieldProjection.build(
+                Arrays.asList("_id", "address.city"));
+
+        assertEquals(1, projection.getInt32("_id").getValue());
+        assertEquals(1, projection.getInt32("address.city").getValue());
+    }
+
+    @Test
+    public void emptyFieldListMeansNoProjection() {
+        assertTrue(MongoFieldProjection.build(Collections.<String>emptyList()).isEmpty());
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/source/MongoSourceFactoryTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/source/MongoSourceFactoryTest.java
@@ -1,0 +1,21 @@
+package com.link.up.connector.mongodb.source;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MongoSourceFactoryTest {
+
+    @Test
+    public void exposesOnlyCapabilitiesImplementedInStage2() {
+        MongoSourceFactory factory = new MongoSourceFactory();
+
+        assertEquals("mongodb", factory.factoryIdentifier());
+        assertTrue(factory.capabilities().contains(ConnectorCapability.TABLE_SCHEMA_DISCOVERY));
+        assertFalse(factory.capabilities().contains(ConnectorCapability.PARTITION_SPLIT));
+        assertFalse(factory.capabilities().contains(ConnectorCapability.MULTI_TABLE));
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/source/MongoSourceSplitEnumeratorTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/source/MongoSourceSplitEnumeratorTest.java
@@ -1,0 +1,28 @@
+package com.link.up.connector.mongodb.source;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.connector.mongodb.config.MongoSourceConfig;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class MongoSourceSplitEnumeratorTest {
+
+    @Test
+    public void stage2UsesOneBoundedCollectionSplit() {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("uri", "mongodb://localhost:27017/app");
+        values.put("collection", "users");
+
+        MongoSourceConfig config = MongoSourceConfig.of(ReadonlyConfig.fromMap(values));
+        List<MongoSourceSplit> splits = new MongoSourceSplitEnumerator(config).enumerateSplits();
+
+        assertEquals(1, splits.size());
+        assertEquals("app.users", splits.get(0).dataSetId());
+        assertEquals("app.users:full-scan", splits.get(0).splitId());
+    }
+}

--- a/link-up-launcher/pom.xml
+++ b/link-up-launcher/pom.xml
@@ -50,6 +50,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.link.up</groupId>
+            <artifactId>link-up-connector-mongodb</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
             <version>${log4j2.version}</version>


### PR DESCRIPTION
## Summary

Stage 2 of the bounded/offline MongoDB connector.

PR #117 established automatic collection schema discovery. This PR turns that metadata boundary into a runnable bounded Source while preserving the usability-first product rule: users select a database, collection and fields; they do not author BSON or Link-Up field types.

## What changed

### Source factory and configuration

- register `TableSourceFactory` under connector identifier `mongodb`
- expose only `TABLE_SCHEMA_DISCOVERY`
- add user-facing options:
  - `uri` (required)
  - `database` (optional when present in the URI)
  - `collection` (required)
  - `fields` (optional)
  - `filter` (optional MongoDB Extended JSON find filter)
  - `fetch_size` (default 1000)
- deliberately add no schema/type option

### Bounded read runtime

- `MongoSource`
- `MongoSourceSplit`
- `MongoSourceSplitEnumerator`
- `MongoSourceReader`
- one finite collection cursor per split
- one full-collection split in Stage 2
- task-local `MongoClient` lifecycle
- split-local `MongoCursor` lifecycle
- MongoDB cursor `batchSize` support
- explicit connection ping before reading

Stage 2 intentionally does **not** advertise `PARTITION_SPLIT`: MongoDB `_id` is not guaranteed to be ObjectId or even range-partitionable, so the connector does not manufacture unsafe generic split semantics merely because runtime parallelism is greater than one.

### Projection and field selection

Explicit `fields` are pushed down to MongoDB.

Dotted paths are supported. If both a parent and child are selected, for example:

```text
address
address.city
```

only the parent is sent in the server-side Mongo projection to avoid parent/child projection collisions. The row converter still derives both selected Link-Up fields from the returned BSON document.

When no fields are selected, the Source reads the full document instead of building a projection from sampled metadata.

### BSON -> FluxRow

`MongoBsonRowConverter` consumes the prepared `TableSchema` from Stage 1:

```text
ObjectId        -> STRING hex
String          -> STRING
Boolean         -> BOOLEAN
Int32           -> INT / safe numeric widening
Int64           -> BIGINT / safe numeric widening
Double          -> DOUBLE
Decimal128      -> BigDecimal
DateTime        -> UTC LocalDateTime
Timestamp       -> UTC LocalDateTime
Binary          -> byte[]
Document/Array  -> Extended JSON STRING boundary
missing/null    -> null
```

A later document that conflicts with a strongly inferred scalar type fails explicitly instead of being silently coerced. This keeps schema drift visible before downstream relational writes can silently corrupt semantics.

### Runtime composition

- add AutoService support to the MongoDB module
- add the MongoDB connector to `link-up-launcher` runtime composition
- keep the standalone server's current direct-runtime connector policy unchanged

### Tests and docs

Added unit coverage for:

- URI/default database resolution
- explicit database override
- field/filter validation
- BSON scalar/nested conversion
- heterogeneous STRING fallback
- runtime schema drift failure
- parent/child projection collision avoidance
- `_id` projection behavior
- single-split Stage 2 contract
- factory identifier/capability boundary

Updated `MONGODB.md` with Stage 2 configuration, projection, schema-drift, single-split and bounded-snapshot semantics.

## Product boundary

There is still deliberately no user-authored schema/type configuration.

Minimal source configuration remains:

```hocon
source {
  type = "mongodb"
  uri = "mongodb://127.0.0.1:27017/app"
  collection = "users"
}
```

Field selection is names only:

```hocon
fields = ["_id", "username", "address.city", "created_at"]
```

## Explicit non-goals

- MongoDB Sink
- multi-collection execution / `MULTI_TABLE`
- automatic range/chunk split planning / `PARTITION_SPLIT`
- Change Streams / oplog / CDC
- realtime polling
- checkpoint/savepoint
- automatic runtime schema evolution
- job-level exactly-once or point-in-time snapshot claims

A bounded Source here means one finite MongoDB `find` cursor, not a transactionally frozen database snapshot.

## Follow-up

```text
Stage 1  Catalog + schema discovery              DONE (#117)
Stage 2  bounded MongoDB Source                  <- this PR
Stage 3  bounded MongoDB Sink + offline hardening
```

## Verification

The branch includes unit tests for pure config/projection/conversion/factory/split behavior. The current ChatGPT execution container cannot resolve `github.com`, so Maven dependencies cannot be fetched and a successful local Maven build is **not** claimed.

Please verify with the normal reactor before marking ready:

```bash
mvn --batch-mode clean verify
```
