### PR TITLE
feat(mongodb): add bounded insert sink

### DIFF
--- a/link-up-connectors/MONGODB.md
+++ b/link-up-connectors/MONGODB.md
@@ -2,21 +2,27 @@
 
 MongoDB follows Link-Up's bounded/offline boundary. The product goal is usability first: users select a database, collection and fields; they do not declare BSON or Link-Up field types.
 
+## Status
+
+```text
+Stage 1  Catalog + automatic schema discovery     DONE (#117)
+Stage 2  bounded MongoDB Source                   DONE (#118)
+Stage 3  bounded MongoDB Sink                     DONE in this PR
+```
+
+After Stage 3, the connector has a complete single-collection bounded Source/Sink path. CDC, multi-collection execution and generic partition splitting remain separate future work rather than being mixed into the core offline contract.
+
 ## Stage 1 — Catalog and automatic schema discovery
 
-Stage 1 established the metadata boundary:
+MongoDB has no enforced table schema. Link-Up therefore treats:
 
-- module `link-up-connector-mongodb`
-- MongoDB Java synchronous driver 4.11.5
-- database -> MongoDB database
-- table -> collection
-- automatic sampled schema discovery
-- BSON -> canonical Link-Up type inference
-- numeric widening and heterogeneous-type fallback
-- dotted nested field discovery for BSON documents
-- conservative JSON/STRING boundary for documents and arrays
-- `_id` primary-key metadata when discovered
-- synthetic `_id` metadata for an empty collection
+```text
+MongoDB database   -> Link-Up database
+MongoDB collection -> Link-Up table
+MongoDB field      -> Link-Up column
+```
+
+`MongoCatalog#getTable` samples collection documents and synthesizes a stable `TableSchema`.
 
 Default discovery limits are connector-internal:
 
@@ -27,7 +33,7 @@ schema max depth   = 8
 
 Yak Ops should not ask users to provide field types.
 
-## BSON type policy
+### BSON -> Link-Up discovery policy
 
 ```text
 ObjectId        -> STRING
@@ -50,9 +56,9 @@ Physical BSON information remains in `Column.sourceType` and `Column.attributes`
 
 Schema discovery observes multiple documents rather than trusting the first one. Numeric values widen when safe and incompatible shapes degrade to STRING. Missing sampled fields become nullable.
 
-## Nested documents
+### Nested documents
 
-A document field remains a JSON string boundary and its child fields are also discovered as dotted paths.
+A document field remains a JSON string boundary and child fields are also discovered as dotted paths.
 
 ```json
 {
@@ -73,11 +79,11 @@ address.province
 address.city
 ```
 
-This keeps the Link-Up row schema flat while allowing a future Yak Ops field picker to render a tree.
+This keeps the Link-Up row schema flat while allowing Yak Ops to render a field tree.
 
 ## Stage 2 — bounded MongoDB Source
 
-Stage 2 adds the finite read path:
+The finite read path is:
 
 ```text
 MongoDB collection
@@ -89,9 +95,9 @@ MongoDB collection
   -> FluxRow
 ```
 
-The Source exposes only `TABLE_SCHEMA_DISCOVERY`. It deliberately does not advertise `PARTITION_SPLIT` or `MULTI_TABLE` yet.
+The Source exposes only `TABLE_SCHEMA_DISCOVERY`. It does not advertise `PARTITION_SPLIT` or `MULTI_TABLE`.
 
-### Configuration
+### Source configuration
 
 Minimal configuration:
 
@@ -114,17 +120,10 @@ source {
 }
 ```
 
-Field selection requires names only, never types:
+Field selection requires names only:
 
 ```hocon
-source {
-  type = "mongodb"
-  uri = "mongodb://127.0.0.1:27017/app"
-  collection = "users"
-
-  fields = ["_id", "username", "address.city", "created_at"]
-  fetch_size = 1000
-}
+fields = ["_id", "username", "address.city", "created_at"]
 ```
 
 An optional bounded `find` filter accepts MongoDB Extended JSON:
@@ -133,62 +132,174 @@ An optional bounded `find` filter accepts MongoDB Extended JSON:
 filter = """{"status":"ACTIVE"}"""
 ```
 
-### Projection
+Explicit fields are pushed down to MongoDB. If both a parent and child are selected, only the parent is sent in the server projection, while the row converter still derives both Link-Up fields.
 
-Explicit `fields` are pushed down to MongoDB. Dotted paths are supported.
+A later document that conflicts with a strongly inferred scalar type fails explicitly instead of being silently coerced.
 
-If both a parent and one of its children are selected, for example:
+Stage 2 always uses one full-collection split. `_id` is not guaranteed to be ObjectId or generically range-partitionable, so reader parallelism does not manufacture unsafe split semantics.
+
+## Stage 3 — bounded MongoDB Sink
+
+The bounded write path is:
+
+```text
+FluxRow
+  -> prepared source TableSchema
+  -> MongoFluxRowBsonConverter
+  -> ordered local document buffer
+  -> insertMany(ordered=true)
+  -> MongoDB acknowledgement
+```
+
+Stage 3 is deliberately INSERT-only. It does not expose `UPSERT`, `AUTO_CREATE_TABLE`, `MULTI_TABLE` or two-phase-commit capabilities.
+
+### Sink configuration
+
+Minimal configuration:
+
+```hocon
+sink {
+  type = "mongodb"
+  uri = "mongodb://127.0.0.1:27017/archive"
+  collection = "users_copy"
+}
+```
+
+When the URI has no database:
+
+```hocon
+sink {
+  type = "mongodb"
+  uri = "mongodb://127.0.0.1:27017"
+  database = "archive"
+  collection = "users_copy"
+}
+```
+
+Optional batching and stable document identity:
+
+```hocon
+sink {
+  type = "mongodb"
+  uri = "mongodb://127.0.0.1:27017/archive"
+  collection = "orders"
+
+  batch_size = 1000
+  document_id_field = "order_id"
+}
+```
+
+`document_id_field` copies one existing source field to MongoDB `_id`. The original source field is still retained in the document. If the source schema already contains `_id`, configuring another `document_id_field` is rejected as ambiguous.
+
+If the source contains `_id`, Stage 3 preserves it. A null implicit `_id` is omitted so MongoDB may generate one. When Stage 1 metadata proves that a STRING originated from BSON ObjectId, Stage 3 restores the 24-hex value to a real BSON ObjectId for MongoDB-to-MongoDB round trips.
+
+### Target collection creation
+
+MongoDB naturally creates a missing collection on the first successful insert. Stage 3 allows that native behavior, but does not advertise Link-Up `AUTO_CREATE_TABLE`: the connector does not run an explicit collection-DDL contract, configure validators, or evolve target schema.
+
+### Link-Up -> BSON policy
+
+```text
+STRING          -> BsonString
+Mongo ObjectId STRING metadata -> BsonObjectId
+Mongo Extended JSON STRING metadata -> original BSON Document/Array when unambiguous
+BOOLEAN         -> BsonBoolean
+TINYINT         -> BsonInt32
+SMALLINT        -> BsonInt32
+INT             -> BsonInt32
+BIGINT          -> BsonInt64
+FLOAT           -> BsonDouble
+DOUBLE          -> BsonDouble
+DECIMAL         -> BsonDecimal128
+BYTES           -> BsonBinary
+DATE            -> ISO-8601 BsonString
+TIME            -> ISO-8601 BsonString
+TIMESTAMP       -> BsonDateTime when millisecond-exact
+TIMESTAMP_TZ    -> ISO-8601 BsonString preserving offset
+NULL            -> BsonNull
+```
+
+MongoDB BSON DateTime has millisecond precision. A Link-Up TIMESTAMP containing sub-millisecond precision is rejected instead of being silently truncated.
+
+Native Link-Up ARRAY/MAP/ROW values are not accepted in Stage 3. MongoDB-origin documents and arrays already cross the generic pipeline as STRING + Extended JSON metadata, which Stage 3 can restore when the metadata is unambiguous.
+
+### Dotted paths and Mongo round trips
+
+Relational dotted field names are interpreted as MongoDB nested paths:
+
+```text
+customer.name -> { "customer": { "name": ... } }
+```
+
+Ordinary overlapping paths such as `customer` plus `customer.name` are rejected because the result would otherwise depend on write order.
+
+MongoDB-origin parent documents are a special safe case. When Stage 1 metadata proves that `address` is an Extended-JSON Mongo Document, Stage 3 allows both:
 
 ```text
 address
 address.city
 ```
 
-only the parent path is sent in the MongoDB projection to avoid a parent/child projection collision. The row converter still derives both selected Link-Up fields from the returned document.
+The parent document is restored first and the explicit child field deterministically overwrites that nested value. This keeps the default MongoDB Source schema usable for MongoDB-to-MongoDB copy jobs.
 
-When no fields are selected, Stage 2 reads the full document. This avoids manufacturing a projection from sampled metadata and remains robust when the collection contains fields that were not seen during discovery.
+### Flush and durability boundary
 
-### Runtime conversion and schema drift
-
-The prepared `TableSchema` remains authoritative while a bounded task is running.
-
-- ObjectId is emitted as its hex STRING form.
-- DateTime/Timestamp values become UTC `LocalDateTime` values.
-- Documents, arrays and other STRING fallback values use Extended JSON.
-- Missing fields become null.
-- Safe numeric widening follows the discovered Link-Up type.
-- A later document that conflicts with a strongly inferred scalar type fails explicitly instead of being silently coerced.
-
-This is deliberate: a sampled schema can never prove that every document in a schema-less collection has the same shape. Silent coercion would make downstream relational writes harder to reason about.
-
-### Single-split boundary
-
-Stage 2 always creates one full-collection split, even when Source reader parallelism is greater than one.
-
-This is intentional. MongoDB `_id` is not guaranteed to be an ObjectId and may be a string, integer, UUID, compound/application value, or another BSON type. Stage 2 does not pretend that a safe generic range partition exists.
-
-A later hardening stage may add explicit range/chunk planning with a conservative single-split fallback.
-
-### Bounded does not mean transactional snapshot
-
-Stage 2 executes one finite MongoDB `find` cursor. It does not claim a point-in-time multi-reader database snapshot or exactly-once snapshot semantics. Concurrent application updates may affect what MongoDB returns according to the server/read-concern configuration supplied by the connection URI.
-
-## Explicit non-goals for Stage 2
-
-- MongoDB Sink
-- multi-collection execution
-- automatic partition/range split planning
-- Change Streams / oplog / CDC
-- realtime polling
-- checkpoint/savepoint
-- automatic runtime schema evolution
-- user-authored schema/type configuration
-- job-level exactly-once snapshot claims
-
-## Next stage
+`batch_size` defaults to 1000 documents.
 
 ```text
-Stage 1  Catalog + schema discovery              DONE
-Stage 2  bounded MongoDB Source                  DONE in this PR
-Stage 3  bounded MongoDB Sink + offline hardening
+write()
+  -> buffer documents
+  -> threshold reached
+  -> ordered insertMany
+
+prepareCommit()
+  -> flush remaining documents
+
+commit()
+  -> task lifecycle boundary only
+
+abort()
+  -> discard only unsent local buffer
+
+close()
+  -> never implicitly flush
 ```
+
+Every successful `insertMany` is already a remote write and cannot be rolled back by a later task abort. The writer therefore reports `TASK_LOCAL` commit scope and makes no Job-level atomicity or exactly-once claim.
+
+The target write concern must be acknowledged. Stronger write concerns configured in the MongoDB URI remain valid; an unacknowledged write concern is rejected.
+
+### Failure and retry boundary
+
+Stage 3 does not automatically replay a failed `insertMany` request.
+
+Even with `ordered=true`, MongoDB may have committed a prefix of the batch before returning an error such as a duplicate key. A network failure may also leave the exact remote outcome unclear. After one insert failure, the writer enters a failed state and refuses additional writes or `prepareCommit` replay.
+
+Whole-task retry therefore requires target verification. Stable `_id` values can make duplicate detection easier, but they do not turn this INSERT Sink into an UPSERT or exactly-once connector.
+
+## Explicit non-goals
+
+The completed bounded connector still deliberately excludes:
+
+- Change Streams / oplog / CDC
+- realtime polling or streaming semantics
+- automatic runtime schema evolution
+- update / replace / delete operations
+- exposed UPSERT semantics
+- multi-collection execution / `MULTI_TABLE`
+- generic automatic range/chunk Source splitting / `PARTITION_SPLIT`
+- checkpoint/savepoint recovery
+- job-level exactly-once or point-in-time snapshot claims
+- MongoDB transactions spanning Link-Up SinkTasks
+
+## Future optional hardening
+
+Future work should only be added when the semantics are explicit:
+
+```text
+safe Source range/chunk planning with single-split fallback
+multi-collection source/sink routing with explicit target mapping
+optional collection validators / explicit create semantics
+```
+
+These are intentionally not required for the core usability goal: select a MongoDB database/collection/fields and run a bounded offline synchronization job without manually declaring types.

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoSinkConfig.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoSinkConfig.java
@@ -1,0 +1,114 @@
+package com.link.up.connector.mongodb.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+import com.mongodb.ConnectionString;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** Immutable bounded MongoDB Sink configuration. */
+public final class MongoSinkConfig implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String uri;
+    private final String database;
+    private final String collection;
+    private final String documentIdField;
+    private final int batchSize;
+
+    private MongoSinkConfig(
+            String uri,
+            String database,
+            String collection,
+            String documentIdField,
+            int batchSize) {
+        this.uri = uri;
+        this.database = database;
+        this.collection = collection;
+        this.documentIdField = documentIdField;
+        this.batchSize = batchSize;
+    }
+
+    public static MongoSinkConfig of(ReadonlyConfig config) {
+        Objects.requireNonNull(config, "config must not be null");
+
+        String uri = requireText(config.get(MongoSinkOptions.URI), "uri");
+        ConnectionString connectionString = parseConnectionString(uri);
+        String configuredDatabase =
+                normalize(config.getOptional(MongoSinkOptions.DATABASE).orElse(null));
+        String database = configuredDatabase == null
+                ? normalize(connectionString.getDatabase())
+                : configuredDatabase;
+        if (database == null) {
+            throw new IllegalArgumentException(
+                    "database must be configured when the MongoDB URI has no default database");
+        }
+
+        String collection = requireText(
+                config.get(MongoSinkOptions.COLLECTION),
+                "collection");
+        String documentIdField = normalize(
+                config.getOptional(MongoSinkOptions.DOCUMENT_ID_FIELD).orElse(null));
+        int batchSize = config.get(MongoSinkOptions.BATCH_SIZE);
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batch_size must be greater than 0");
+        }
+
+        return new MongoSinkConfig(
+                uri,
+                database,
+                collection,
+                documentIdField,
+                batchSize);
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public String getDocumentIdField() {
+        return documentIdField;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public TablePath getTargetPath() {
+        return TablePath.of(database, collection);
+    }
+
+    private static ConnectionString parseConnectionString(String uri) {
+        try {
+            return new ConnectionString(uri);
+        } catch (IllegalArgumentException failure) {
+            throw new IllegalArgumentException("Invalid MongoDB connection URI", failure);
+        }
+    }
+
+    private static String requireText(String value, String fieldName) {
+        String normalized = normalize(value);
+        if (normalized == null) {
+            throw new IllegalArgumentException(fieldName + " must not be empty");
+        }
+        return normalized;
+    }
+
+    private static String normalize(String value) {
+        if (value == null) {
+            return null;
+        }
+        String normalized = value.trim();
+        return normalized.isEmpty() ? null : normalized;
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoSinkOptions.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/config/MongoSinkOptions.java
@@ -1,0 +1,53 @@
+package com.link.up.connector.mongodb.config;
+
+import com.link.up.api.configuration.Option;
+import com.link.up.api.configuration.Options;
+import com.link.up.api.connector.schema.ConnectorOptionScope;
+
+/** User-facing options for the bounded MongoDB Sink. */
+public final class MongoSinkOptions {
+
+    private MongoSinkOptions() {
+    }
+
+    public static final Option<String> URI =
+            Options.key("uri")
+                    .stringType()
+                    .noDefaultValue()
+                    .sensitive()
+                    .withDescription("MongoDB connection URI")
+                    .withSemanticType("MONGODB_URI")
+                    .withScope(ConnectorOptionScope.DATASOURCE);
+
+    public static final Option<String> DATABASE =
+            Options.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("MongoDB database; optional when the URI already contains one")
+                    .withSemanticType("DATABASE")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> COLLECTION =
+            Options.key("collection")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("One MongoDB target collection")
+                    .withSemanticType("COLLECTION")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<String> DOCUMENT_ID_FIELD =
+            Options.key("document_id_field")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Optional source field copied to MongoDB _id")
+                    .withSemanticType("DOCUMENT_ID_FIELD")
+                    .withScope(ConnectorOptionScope.TASK);
+
+    public static final Option<Integer> BATCH_SIZE =
+            Options.key("batch_size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("Documents per ordered MongoDB insertMany flush")
+                    .withSemanticType("BATCH_ROWS")
+                    .withScope(ConnectorOptionScope.RUNTIME);
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/converter/MongoFluxRowBsonConverter.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/converter/MongoFluxRowBsonConverter.java
@@ -1,0 +1,315 @@
+package com.link.up.connector.mongodb.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.api.table.type.SqlType;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonNull;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.BsonType;
+import org.bson.BsonValue;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Converts one prepared FluxRow into a MongoDB BSON document. */
+public final class MongoFluxRowBsonConverter {
+
+    private final List<FieldConversion> fields;
+    private final FieldConversion documentIdField;
+
+    public MongoFluxRowBsonConverter(
+            TableSchema schema,
+            String documentIdFieldName) {
+        Objects.requireNonNull(schema, "schema must not be null");
+
+        List<FieldConversion> prepared = new ArrayList<FieldConversion>(schema.getColumnCount());
+        FieldConversion idField = null;
+        for (int i = 0; i < schema.getColumnCount(); i++) {
+            Column column = schema.getColumn(i);
+            FieldConversion field = new FieldConversion(column, i);
+            prepared.add(field);
+            if (documentIdFieldName != null
+                    && documentIdFieldName.equals(column.getName())) {
+                idField = field;
+            }
+        }
+
+        Collections.sort(
+                prepared,
+                new Comparator<FieldConversion>() {
+                    @Override
+                    public int compare(FieldConversion left, FieldConversion right) {
+                        int depth = Integer.compare(left.pathSegments.length, right.pathSegments.length);
+                        return depth != 0 ? depth : Integer.compare(left.rowIndex, right.rowIndex);
+                    }
+                });
+
+        if (documentIdFieldName != null && idField == null) {
+            throw new IllegalArgumentException(
+                    "document_id_field does not exist in source schema: " + documentIdFieldName);
+        }
+        this.fields = Collections.unmodifiableList(prepared);
+        this.documentIdField = idField;
+    }
+
+    public BsonDocument convert(FluxRow row) {
+        Objects.requireNonNull(row, "row must not be null");
+        if (row.getArity() != fields.size()) {
+            throw new IllegalArgumentException(
+                    "MongoDB Sink row arity does not match prepared schema: expected="
+                            + fields.size()
+                            + ", actual="
+                            + row.getArity());
+        }
+
+        BsonDocument document = new BsonDocument();
+        for (FieldConversion field : fields) {
+            Object raw = row.getField(field.rowIndex);
+            BsonValue value = convertValue(field, raw);
+
+            if (field.isMongoId() && value.getBsonType() == BsonType.NULL) {
+                if (documentIdField == field) {
+                    throw new IllegalArgumentException(
+                            "document_id_field must not be null: " + field.column.getName());
+                }
+                continue;
+            }
+            putPath(document, field.pathSegments, value, field.column.getName());
+        }
+
+        if (documentIdField != null && !documentIdField.isMongoId()) {
+            BsonValue idValue = convertValue(
+                    documentIdField,
+                    row.getField(documentIdField.rowIndex));
+            validateDocumentId(idValue, documentIdField.column.getName());
+            document.put("_id", idValue);
+        } else if (documentIdField != null) {
+            validateDocumentId(document.get("_id"), documentIdField.column.getName());
+        } else if (document.containsKey("_id")) {
+            validateDocumentId(document.get("_id"), "_id");
+        }
+
+        return document;
+    }
+
+    private static BsonValue convertValue(FieldConversion field, Object raw) {
+        if (raw == null) {
+            return BsonNull.VALUE;
+        }
+
+        switch (field.sqlType) {
+            case STRING:
+                return convertString(field, raw);
+            case BOOLEAN:
+                return new BsonBoolean(require(Boolean.class, raw, field));
+            case TINYINT:
+                return new BsonInt32(require(Byte.class, raw, field).intValue());
+            case SMALLINT:
+                return new BsonInt32(require(Short.class, raw, field).intValue());
+            case INT:
+                return new BsonInt32(require(Integer.class, raw, field));
+            case BIGINT:
+                return new BsonInt64(require(Long.class, raw, field));
+            case FLOAT:
+                return new BsonDouble(require(Float.class, raw, field).doubleValue());
+            case DOUBLE:
+                return new BsonDouble(require(Double.class, raw, field));
+            case DECIMAL:
+                return toDecimal128(raw, field);
+            case BYTES:
+                return new BsonBinary(require(byte[].class, raw, field));
+            case DATE:
+                return new BsonString(require(LocalDate.class, raw, field).toString());
+            case TIME:
+                return new BsonString(require(LocalTime.class, raw, field).toString());
+            case TIMESTAMP:
+                return toDateTime(raw, field);
+            case TIMESTAMP_TZ:
+                return new BsonString(require(OffsetDateTime.class, raw, field).toString());
+            case NULL:
+                throw new IllegalArgumentException(
+                        "MongoDB Sink received a non-null value for NULL field "
+                                + field.column.getName());
+            default:
+                throw new IllegalArgumentException(
+                        "MongoDB Sink does not support Link-Up type "
+                                + field.sqlType
+                                + " for field "
+                                + field.column.getName());
+        }
+    }
+
+    private static BsonValue convertString(FieldConversion field, Object raw) {
+        String value = require(String.class, raw, field);
+        if (field.restoreObjectId) {
+            if (!ObjectId.isValid(value)) {
+                throw new IllegalArgumentException(
+                        "MongoDB ObjectId source field is not a valid 24-hex value: field="
+                                + field.column.getName());
+            }
+            return new BsonObjectId(new ObjectId(value));
+        }
+        if (field.restoreExtendedJson) {
+            try {
+                BsonDocument wrapper = BsonDocument.parse("{\"_value\":" + value + "}");
+                return wrapper.get("_value");
+            } catch (RuntimeException failure) {
+                throw new IllegalArgumentException(
+                        "MongoDB Extended JSON source field cannot be restored: field="
+                                + field.column.getName(),
+                        failure);
+            }
+        }
+        return new BsonString(value);
+    }
+
+    private static BsonValue toDecimal128(Object raw, FieldConversion field) {
+        BigDecimal decimal = require(BigDecimal.class, raw, field);
+        try {
+            return new BsonDecimal128(new Decimal128(decimal));
+        } catch (RuntimeException failure) {
+            throw new IllegalArgumentException(
+                    "Decimal value cannot be represented by MongoDB Decimal128: field="
+                            + field.column.getName()
+                            + ", value="
+                            + decimal,
+                    failure);
+        }
+    }
+
+    private static BsonValue toDateTime(Object raw, FieldConversion field) {
+        LocalDateTime timestamp = require(LocalDateTime.class, raw, field);
+        if (timestamp.getNano() % 1_000_000 != 0) {
+            throw new IllegalArgumentException(
+                    "MongoDB DateTime has millisecond precision; refusing lossy TIMESTAMP write: field="
+                            + field.column.getName()
+                            + ", value="
+                            + timestamp);
+        }
+        long epochMillis = timestamp.toInstant(ZoneOffset.UTC).toEpochMilli();
+        return new BsonDateTime(epochMillis);
+    }
+
+    private static <T> T require(
+            Class<T> expected,
+            Object raw,
+            FieldConversion field) {
+        if (!expected.isInstance(raw)) {
+            throw typeMismatch(field, raw, expected.getName());
+        }
+        return expected.cast(raw);
+    }
+
+    private static IllegalArgumentException typeMismatch(
+            FieldConversion field,
+            Object raw,
+            String expected) {
+        return new IllegalArgumentException(
+                "MongoDB Sink row value does not match prepared schema: field="
+                        + field.column.getName()
+                        + ", expected="
+                        + expected
+                        + ", actual="
+                        + raw.getClass().getName());
+    }
+
+    private static void putPath(
+            BsonDocument root,
+            String[] path,
+            BsonValue value,
+            String fieldName) {
+        BsonDocument current = root;
+        for (int i = 0; i < path.length - 1; i++) {
+            String segment = path[i];
+            BsonValue existing = current.get(segment);
+            if (existing == null || existing.getBsonType() == BsonType.NULL) {
+                BsonDocument child = new BsonDocument();
+                current.put(segment, child);
+                current = child;
+                continue;
+            }
+            if (existing.getBsonType() != BsonType.DOCUMENT) {
+                throw new IllegalArgumentException(
+                        "MongoDB target path conflicts with a non-document parent: field=" + fieldName);
+            }
+            current = existing.asDocument();
+        }
+        current.put(path[path.length - 1], value);
+    }
+
+    private static void validateDocumentId(BsonValue value, String fieldName) {
+        if (value == null || value.getBsonType() == BsonType.NULL) {
+            throw new IllegalArgumentException("MongoDB _id must not be null: field=" + fieldName);
+        }
+        if (value.getBsonType() == BsonType.ARRAY
+                || value.getBsonType() == BsonType.DOCUMENT) {
+            throw new IllegalArgumentException(
+                    "MongoDB Sink keeps document identity scalar; complex _id is not supported: field="
+                            + fieldName);
+        }
+    }
+
+    private static final class FieldConversion {
+
+        private final Column column;
+        private final int rowIndex;
+        private final String[] pathSegments;
+        private final SqlType sqlType;
+        private final boolean restoreObjectId;
+        private final boolean restoreExtendedJson;
+
+        private FieldConversion(Column column, int rowIndex) {
+            this.column = Objects.requireNonNull(column, "column must not be null");
+            this.rowIndex = rowIndex;
+            this.pathSegments = column.getName().split("\\.");
+            this.sqlType = column.getDataType().getSqlType();
+
+            Map<String, String> attributes = column.getAttributes();
+            String bsonTypes = normalize(attributes.get("mongodb.bsonTypes"));
+            String sourceType = normalize(column.getSourceType());
+            this.restoreObjectId =
+                    "OBJECT_ID".equals(bsonTypes)
+                            || "OBJECTID".equals(sourceType);
+
+            String encoding = normalize(attributes.get("mongodb.encoding"));
+            String heterogeneous = normalize(attributes.get("mongodb.heterogeneous"));
+            this.restoreExtendedJson =
+                    "EXTENDED-JSON".equals(encoding)
+                            && !"TRUE".equals(heterogeneous);
+        }
+
+        private boolean isMongoId() {
+            return pathSegments.length == 1 && "_id".equals(pathSegments[0]);
+        }
+
+        private static String normalize(String value) {
+            if (value == null) {
+                return null;
+            }
+            String normalized = value.trim();
+            return normalized.isEmpty() ? null : normalized.toUpperCase(java.util.Locale.ROOT);
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/sink/MongoSinkFactory.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/sink/MongoSinkFactory.java
@@ -1,0 +1,59 @@
+package com.link.up.connector.mongodb.sink;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.configuration.util.OptionRule;
+import com.link.up.api.connector.schema.ConnectorCapability;
+import com.link.up.api.factory.SinkFactory;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.mongodb.MongoConnectorIdentity;
+import com.link.up.connector.mongodb.config.MongoSinkConfig;
+import com.link.up.connector.mongodb.config.MongoSinkOptions;
+
+import java.util.Collections;
+import java.util.Set;
+
+/** SPI factory for the bounded MongoDB insert Sink. */
+@AutoService(SinkFactory.class)
+public final class MongoSinkFactory implements SinkFactory {
+
+    @Override
+    public String factoryIdentifier() {
+        return MongoConnectorIdentity.IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConnectorCapability> capabilities() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public OptionRule optionRule() {
+        return OptionRule.builder()
+                .required(
+                        MongoSinkOptions.URI,
+                        MongoSinkOptions.COLLECTION)
+                .optional(
+                        MongoSinkOptions.DATABASE,
+                        MongoSinkOptions.DOCUMENT_ID_FIELD,
+                        MongoSinkOptions.BATCH_SIZE)
+                .build();
+    }
+
+    @Override
+    public SinkPreparer createPreparer(ReadonlyConfig config) {
+        return new MongoSinkPreparer(MongoSinkConfig.of(config));
+    }
+
+    @Override
+    public SinkWriter<FluxRow> createSink(
+            ReadonlyConfig config,
+            PreparedSinkMetadata metadata) {
+        return new MongoSinkWriter(
+                MongoSinkConfig.of(config),
+                metadata);
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/sink/MongoSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/sink/MongoSinkPreparer.java
@@ -1,0 +1,162 @@
+package com.link.up.connector.mongodb.sink;
+
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPrepareContext;
+import com.link.up.api.sink.SinkPreparer;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.mongodb.config.MongoSinkConfig;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Prepares one bounded MongoDB target collection. */
+final class MongoSinkPreparer implements SinkPreparer {
+
+    private final MongoSinkConfig config;
+
+    MongoSinkPreparer(MongoSinkConfig config) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+    }
+
+    @Override
+    public PreparedSinkMetadata prepare(SinkPrepareContext context) {
+        Objects.requireNonNull(context, "context must not be null");
+        if (context.getSourceTables().size() != 1) {
+            throw new IllegalArgumentException(
+                    "MongoDB bounded Sink supports exactly one source table");
+        }
+
+        Map<TablePath, CatalogTable> targets = new LinkedHashMap<TablePath, CatalogTable>();
+        for (Map.Entry<TablePath, CatalogTable> entry : context.getSourceTables().entrySet()) {
+            CatalogTable sourceTable = Objects.requireNonNull(
+                    entry.getValue(),
+                    "source table must not be null");
+            TableSchema schema = Objects.requireNonNull(
+                    sourceTable.getTableSchema(),
+                    "MongoDB Sink requires source table schema");
+
+            validateSchema(schema);
+            CatalogTable targetTable = CatalogTable.builder(config.getTargetPath(), schema)
+                    .options(sourceTable.getOptions())
+                    .option("mongodb.collection", config.getCollection())
+                    .build();
+            targets.put(entry.getKey(), targetTable);
+        }
+        return new PreparedSinkMetadata(targets);
+    }
+
+    private void validateSchema(TableSchema schema) {
+        String documentIdField = config.getDocumentIdField();
+        if (documentIdField != null && !schema.contains(documentIdField)) {
+            throw new IllegalArgumentException(
+                    "document_id_field does not exist in source schema: " + documentIdField);
+        }
+        if (documentIdField != null
+                && !"_id".equals(documentIdField)
+                && schema.contains("_id")) {
+            throw new IllegalArgumentException(
+                    "Source schema already contains _id; document_id_field would create ambiguous MongoDB identity");
+        }
+
+        for (Column column : schema.getColumns()) {
+            validateType(column);
+        }
+        validatePathOverlaps(schema);
+    }
+
+    private static void validateType(Column column) {
+        SqlType type = column.getDataType().getSqlType();
+        switch (type) {
+            case STRING:
+            case BOOLEAN:
+            case TINYINT:
+            case SMALLINT:
+            case INT:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+            case DECIMAL:
+            case BYTES:
+            case DATE:
+            case TIME:
+            case TIMESTAMP:
+            case TIMESTAMP_TZ:
+            case NULL:
+                return;
+            case ARRAY:
+            case MAP:
+            case ROW:
+            default:
+                throw new IllegalArgumentException(
+                        "MongoDB bounded Sink does not support Link-Up type "
+                                + type
+                                + " for field "
+                                + column.getName()
+                                + "; MongoDB-origin complex values should use the Stage 1 STRING/Extended JSON boundary");
+        }
+    }
+
+    private static void validatePathOverlaps(TableSchema schema) {
+        List<Column> columns = new ArrayList<Column>(schema.getColumns());
+        Collections.sort(
+                columns,
+                new Comparator<Column>() {
+                    @Override
+                    public int compare(Column left, Column right) {
+                        return left.getName().compareTo(right.getName());
+                    }
+                });
+
+        for (int i = 0; i < columns.size(); i++) {
+            Column parent = columns.get(i);
+            String prefix = parent.getName() + ".";
+            for (int j = i + 1; j < columns.size(); j++) {
+                Column child = columns.get(j);
+                if (!child.getName().startsWith(prefix)) {
+                    if (child.getName().compareTo(prefix) > 0) {
+                        break;
+                    }
+                    continue;
+                }
+                if (!isRestorableMongoDocument(parent)) {
+                    throw new IllegalArgumentException(
+                            "MongoDB target field paths overlap but the parent is not a MongoDB document: parent="
+                                    + parent.getName()
+                                    + ", child="
+                                    + child.getName());
+                }
+            }
+        }
+    }
+
+    private static boolean isRestorableMongoDocument(Column column) {
+        Map<String, String> attributes = column.getAttributes();
+        String encoding = attributes.get("mongodb.encoding");
+        String heterogeneous = attributes.get("mongodb.heterogeneous");
+        String bsonTypes = attributes.get("mongodb.bsonTypes");
+        return "extended-json".equalsIgnoreCase(encoding)
+                && !"true".equalsIgnoreCase(heterogeneous)
+                && containsType(bsonTypes, "DOCUMENT");
+    }
+
+    private static boolean containsType(String values, String expected) {
+        if (values == null) {
+            return false;
+        }
+        for (String value : values.split(",")) {
+            if (expected.equalsIgnoreCase(value.trim())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/sink/MongoSinkWriter.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/sink/MongoSinkWriter.java
@@ -21,7 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-/** Ordered bounded MongoDB insert writer with task-local durability. */
+/** Ordered bounded MongoDB insert writer with task-local acknowledged writes. */
 public final class MongoSinkWriter implements SinkWriter<FluxRow> {
 
     private final MongoSinkConfig config;
@@ -122,7 +122,7 @@ public final class MongoSinkWriter implements SinkWriter<FluxRow> {
 
     @Override
     public String getRetryAdvice() {
-        return "MongoDB insertMany makes each successful flush durable before task commit. "
+        return "MongoDB insertMany makes each successful flush an acknowledged remote write before task commit. "
                 + "A failed insert request may have inserted a prefix of the ordered batch; "
                 + "verify target documents before retrying the whole task.";
     }

--- a/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/sink/MongoSinkWriter.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/main/java/com/link/up/connector/mongodb/sink/MongoSinkWriter.java
@@ -1,0 +1,276 @@
+package com.link.up.connector.mongodb.sink;
+
+import com.link.up.api.sink.CommitScope;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkWriter;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.mongodb.config.MongoSinkConfig;
+import com.link.up.connector.mongodb.converter.MongoFluxRowBsonConverter;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.InsertManyOptions;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/** Ordered bounded MongoDB insert writer with task-local durability. */
+public final class MongoSinkWriter implements SinkWriter<FluxRow> {
+
+    private final MongoSinkConfig config;
+    private final PreparedSinkMetadata metadata;
+    private final BatchInsertExecutor insertExecutor;
+    private final List<BsonDocument> bufferedDocuments = new ArrayList<BsonDocument>();
+
+    private TableSchema schema;
+    private MongoFluxRowBsonConverter converter;
+    private long totalWrittenRows;
+    private long totalInsertRequests;
+    private boolean opened;
+    private boolean failed;
+    private boolean closed;
+
+    public MongoSinkWriter(
+            MongoSinkConfig config,
+            PreparedSinkMetadata metadata) {
+        this(
+                config,
+                metadata,
+                new MongoClientBatchInsertExecutor(
+                        Objects.requireNonNull(config, "config must not be null")));
+    }
+
+    MongoSinkWriter(
+            MongoSinkConfig config,
+            PreparedSinkMetadata metadata,
+            BatchInsertExecutor insertExecutor) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
+        this.insertExecutor = Objects.requireNonNull(
+                insertExecutor,
+                "insertExecutor must not be null");
+    }
+
+    @Override
+    public void open() throws Exception {
+        if (opened || closed) {
+            throw new IllegalStateException("MongoDB SinkWriter has already been opened or closed");
+        }
+
+        boolean success = false;
+        try {
+            insertExecutor.open();
+            opened = true;
+            success = true;
+        } finally {
+            if (!success) {
+                try {
+                    insertExecutor.close();
+                } catch (Exception ignored) {
+                    // Preserve the original open failure.
+                }
+            }
+        }
+    }
+
+    @Override
+    public void write(
+            RecordBatch<FluxRow> batch,
+            CatalogTable sourceTable)
+            throws Exception {
+        checkUsable();
+        if (batch == null || batch.isEndOfInput() || batch.getRecords().isEmpty()) {
+            return;
+        }
+
+        initializeSchema(sourceTable);
+        for (FluxRow row : batch.getRecords()) {
+            bufferedDocuments.add(converter.convert(row));
+            if (bufferedDocuments.size() >= config.getBatchSize()) {
+                flush();
+            }
+        }
+    }
+
+    @Override
+    public void prepareCommit() throws Exception {
+        checkUsable();
+        flush();
+    }
+
+    @Override
+    public void commit() {
+        checkUsable();
+    }
+
+    @Override
+    public void abort() {
+        bufferedDocuments.clear();
+    }
+
+    @Override
+    public CommitScope getCommitScope() {
+        return CommitScope.TASK_LOCAL;
+    }
+
+    @Override
+    public String getRetryAdvice() {
+        return "MongoDB insertMany makes each successful flush durable before task commit. "
+                + "A failed insert request may have inserted a prefix of the ordered batch; "
+                + "verify target documents before retrying the whole task.";
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (closed) {
+            return;
+        }
+        bufferedDocuments.clear();
+        opened = false;
+        closed = true;
+        insertExecutor.close();
+    }
+
+    private void initializeSchema(CatalogTable sourceTable) {
+        if (sourceTable == null || sourceTable.getTableSchema() == null) {
+            throw new IllegalArgumentException(
+                    "MongoDB bounded Sink requires CatalogTable schema on write");
+        }
+        if (metadata.getTargetTable(sourceTable.getTablePath()) == null) {
+            throw new IllegalArgumentException(
+                    "MongoDB bounded Sink has no prepared target for source table: "
+                            + sourceTable.getTablePath());
+        }
+
+        TableSchema incoming = sourceTable.getTableSchema();
+        if (schema == null) {
+            schema = incoming;
+            converter = new MongoFluxRowBsonConverter(
+                    schema,
+                    config.getDocumentIdField());
+            return;
+        }
+        if (!schema.equals(incoming)) {
+            throw new IllegalArgumentException(
+                    "MongoDB bounded Sink does not support runtime schema changes");
+        }
+    }
+
+    private void flush() throws Exception {
+        if (bufferedDocuments.isEmpty()) {
+            return;
+        }
+        if (converter == null || schema == null) {
+            throw new IllegalStateException(
+                    "Cannot flush MongoDB Sink before source schema is initialized");
+        }
+
+        List<BsonDocument> request = Collections.unmodifiableList(
+                new ArrayList<BsonDocument>(bufferedDocuments));
+        try {
+            insertExecutor.insert(request);
+        } catch (Exception failure) {
+            failed = true;
+            throw failure;
+        }
+
+        totalWrittenRows += request.size();
+        totalInsertRequests++;
+        bufferedDocuments.clear();
+    }
+
+    private void checkUsable() {
+        if (!opened || closed) {
+            throw new IllegalStateException("MongoDB SinkWriter is not open");
+        }
+        if (failed) {
+            throw new IllegalStateException(
+                    "MongoDB SinkWriter cannot continue after an ambiguous insert failure");
+        }
+    }
+
+    long getTotalWrittenRows() {
+        return totalWrittenRows;
+    }
+
+    long getTotalInsertRequests() {
+        return totalInsertRequests;
+    }
+
+    int getBufferedDocuments() {
+        return bufferedDocuments.size();
+    }
+
+    interface BatchInsertExecutor extends AutoCloseable {
+
+        void open() throws Exception;
+
+        void insert(List<BsonDocument> documents) throws Exception;
+
+        @Override
+        void close() throws Exception;
+    }
+
+    private static final class MongoClientBatchInsertExecutor
+            implements BatchInsertExecutor {
+
+        private final MongoSinkConfig config;
+
+        private MongoClient client;
+        private MongoCollection<BsonDocument> collection;
+
+        private MongoClientBatchInsertExecutor(MongoSinkConfig config) {
+            this.config = config;
+        }
+
+        @Override
+        public void open() {
+            MongoClient openedClient = MongoClients.create(config.getUri());
+            boolean success = false;
+            try {
+                openedClient.getDatabase(config.getDatabase())
+                        .runCommand(new BsonDocument("ping", new BsonInt32(1)));
+                MongoCollection<BsonDocument> openedCollection = openedClient
+                        .getDatabase(config.getDatabase())
+                        .getCollection(config.getCollection(), BsonDocument.class);
+                if (!openedCollection.getWriteConcern().isAcknowledged()) {
+                    throw new IllegalArgumentException(
+                            "MongoDB bounded Sink requires an acknowledged write concern");
+                }
+                client = openedClient;
+                collection = openedCollection;
+                success = true;
+            } finally {
+                if (!success) {
+                    openedClient.close();
+                }
+            }
+        }
+
+        @Override
+        public void insert(List<BsonDocument> documents) {
+            if (collection == null) {
+                throw new IllegalStateException("MongoDB batch insert executor is not open");
+            }
+            collection.insertMany(
+                    new ArrayList<BsonDocument>(documents),
+                    new InsertManyOptions().ordered(true));
+        }
+
+        @Override
+        public void close() {
+            collection = null;
+            if (client != null) {
+                client.close();
+                client = null;
+            }
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/config/MongoSinkConfigTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/config/MongoSinkConfigTest.java
@@ -1,0 +1,67 @@
+package com.link.up.connector.mongodb.config;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class MongoSinkConfigTest {
+
+    @Test
+    public void usesDatabaseFromUriAndBoundedDefaults() {
+        MongoSinkConfig config = MongoSinkConfig.of(
+                ReadonlyConfig.fromMap(base("mongodb://localhost:27017/app")));
+
+        assertEquals("app", config.getDatabase());
+        assertEquals("archive", config.getCollection());
+        assertEquals(1000, config.getBatchSize());
+        assertNull(config.getDocumentIdField());
+    }
+
+    @Test
+    public void explicitDatabaseAndDocumentIdOverrideDefaults() {
+        Map<String, Object> values = base("mongodb://localhost:27017/from_uri");
+        values.put("database", "target_db");
+        values.put("document_id_field", "order_id");
+        values.put("batch_size", 256);
+
+        MongoSinkConfig config = MongoSinkConfig.of(ReadonlyConfig.fromMap(values));
+
+        assertEquals("target_db", config.getDatabase());
+        assertEquals("order_id", config.getDocumentIdField());
+        assertEquals(256, config.getBatchSize());
+    }
+
+    @Test
+    public void requiresDatabaseWhenUriHasNone() {
+        assertInvalid(base("mongodb://localhost:27017"));
+    }
+
+    @Test
+    public void rejectsNonPositiveBatchSize() {
+        Map<String, Object> values = base("mongodb://localhost:27017/app");
+        values.put("batch_size", 0);
+        assertInvalid(values);
+    }
+
+    private static Map<String, Object> base(String uri) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("uri", uri);
+        values.put("collection", "archive");
+        return values;
+    }
+
+    private static void assertInvalid(Map<String, Object> values) {
+        try {
+            MongoSinkConfig.of(ReadonlyConfig.fromMap(values));
+            fail("Expected invalid MongoDB Sink configuration");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/converter/MongoFluxRowBsonConverterTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/converter/MongoFluxRowBsonConverterTest.java
@@ -1,0 +1,117 @@
+package com.link.up.connector.mongodb.converter;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import org.bson.BsonDocument;
+import org.bson.BsonType;
+import org.bson.types.ObjectId;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class MongoFluxRowBsonConverterTest {
+
+    @Test
+    public void restoresMongoObjectIdAndNestedDocument() {
+        Column id = Column.builder("_id", BasicType.STRING_TYPE)
+                .sourceType("ObjectId")
+                .attribute("mongodb.bsonTypes", "OBJECT_ID")
+                .build();
+        Column address = Column.builder("address", BasicType.STRING_TYPE)
+                .sourceType("Document")
+                .attribute("mongodb.bsonTypes", "DOCUMENT")
+                .attribute("mongodb.encoding", "extended-json")
+                .attribute("mongodb.complex", "true")
+                .build();
+        Column city = Column.builder("address.city", BasicType.STRING_TYPE)
+                .attribute("mongodb.path", "address.city")
+                .build();
+        Column createdAt = Column.builder("created_at", BasicType.TIMESTAMP_TYPE)
+                .build();
+        TableSchema schema = TableSchema.builder()
+                .column(id)
+                .column(address)
+                .column(city)
+                .column(createdAt)
+                .build();
+
+        String idValue = "64b7abdecf2160b649ab6085";
+        FluxRow row = FluxRow.of(
+                idValue,
+                "{\"city\":\"Old\",\"province\":\"Sichuan\"}",
+                "Chengdu",
+                LocalDateTime.of(2026, 9, 6, 12, 30, 0, 123_000_000));
+
+        BsonDocument document = new MongoFluxRowBsonConverter(schema, null).convert(row);
+
+        assertEquals(new ObjectId(idValue), document.getObjectId("_id").getValue());
+        assertEquals("Chengdu", document.getDocument("address").getString("city").getValue());
+        assertEquals("Sichuan", document.getDocument("address").getString("province").getValue());
+        assertEquals(BsonType.DATE_TIME, document.get("created_at").getBsonType());
+    }
+
+    @Test
+    public void documentIdFieldCreatesScalarIdAndKeepsSourceField() {
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("order_id", BasicType.STRING_TYPE).build())
+                .column(Column.builder("amount", BasicType.LONG_TYPE).build())
+                .build();
+
+        BsonDocument document = new MongoFluxRowBsonConverter(schema, "order_id")
+                .convert(FluxRow.of("order-1", Long.valueOf(42L)));
+
+        assertEquals("order-1", document.getString("_id").getValue());
+        assertEquals("order-1", document.getString("order_id").getValue());
+        assertEquals(42L, document.getInt64("amount").getValue());
+    }
+
+    @Test
+    public void nullImplicitIdIsOmittedSoMongoCanGenerateOne() {
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("_id", BasicType.STRING_TYPE).nullable(true).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .build();
+
+        BsonDocument document = new MongoFluxRowBsonConverter(schema, null)
+                .convert(FluxRow.of(null, "Yak"));
+
+        assertFalse(document.containsKey("_id"));
+        assertEquals("Yak", document.getString("name").getValue());
+    }
+
+    @Test
+    public void rejectsLossySubMillisecondTimestamp() {
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("created_at", BasicType.TIMESTAMP_TYPE).build())
+                .build();
+
+        try {
+            new MongoFluxRowBsonConverter(schema, null)
+                    .convert(FluxRow.of(LocalDateTime.of(2026, 9, 6, 12, 30, 0, 123_456_000)));
+            fail("Expected sub-millisecond timestamp rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    @Test
+    public void explicitDocumentIdMustNotBeNull() {
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("order_id", BasicType.STRING_TYPE).nullable(true).build())
+                .build();
+
+        try {
+            new MongoFluxRowBsonConverter(schema, "order_id")
+                    .convert(FluxRow.of((Object) null));
+            fail("Expected null document id rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/sink/MongoSinkFactoryTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/sink/MongoSinkFactoryTest.java
@@ -1,0 +1,22 @@
+package com.link.up.connector.mongodb.sink;
+
+import com.link.up.api.connector.schema.ConnectorCapability;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class MongoSinkFactoryTest {
+
+    @Test
+    public void exposesInsertOnlyBoundedSinkBoundary() {
+        MongoSinkFactory factory = new MongoSinkFactory();
+
+        assertEquals("mongodb", factory.factoryIdentifier());
+        assertTrue(factory.capabilities().isEmpty());
+        assertFalse(factory.capabilities().contains(ConnectorCapability.UPSERT));
+        assertFalse(factory.capabilities().contains(ConnectorCapability.AUTO_CREATE_TABLE));
+        assertFalse(factory.capabilities().contains(ConnectorCapability.MULTI_TABLE));
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/sink/MongoSinkPreparerTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/sink/MongoSinkPreparerTest.java
@@ -1,0 +1,127 @@
+package com.link.up.connector.mongodb.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.sink.SinkPrepareContext;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.mongodb.config.MongoSinkConfig;
+import org.junit.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class MongoSinkPreparerTest {
+
+    @Test
+    public void mapsOneSourceTableToConfiguredTarget() {
+        CatalogTable source = sourceTable(
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                        .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                        .build());
+
+        PreparedSinkMetadata metadata = new MongoSinkPreparer(config(null))
+                .prepare(context(source));
+
+        CatalogTable target = metadata.getTargetTable(source.getTablePath());
+        assertEquals(TablePath.of("archive", "orders_copy"), target.getTablePath());
+        assertEquals(source.getTableSchema(), target.getTableSchema());
+    }
+
+    @Test
+    public void acceptsMongoDocumentParentAndDottedChild() {
+        Column parent = Column.builder("address", BasicType.STRING_TYPE)
+                .attribute("mongodb.bsonTypes", "DOCUMENT")
+                .attribute("mongodb.encoding", "extended-json")
+                .build();
+        Column child = Column.builder("address.city", BasicType.STRING_TYPE).build();
+        CatalogTable source = sourceTable(
+                TableSchema.builder().column(parent).column(child).build());
+
+        new MongoSinkPreparer(config(null)).prepare(context(source));
+    }
+
+    @Test
+    public void rejectsOrdinaryParentAndDottedChild() {
+        CatalogTable source = sourceTable(
+                TableSchema.builder()
+                        .column(Column.builder("address", BasicType.STRING_TYPE).build())
+                        .column(Column.builder("address.city", BasicType.STRING_TYPE).build())
+                        .build());
+
+        assertPrepareFails(source, config(null));
+    }
+
+    @Test
+    public void rejectsDocumentIdOverrideWhenSourceAlreadyHasId() {
+        CatalogTable source = sourceTable(
+                TableSchema.builder()
+                        .column(Column.builder("_id", BasicType.STRING_TYPE).build())
+                        .column(Column.builder("order_id", BasicType.STRING_TYPE).build())
+                        .build());
+
+        assertPrepareFails(source, config("order_id"));
+    }
+
+    @Test
+    public void rejectsMultipleSourceTables() {
+        CatalogTable source = sourceTable(
+                TableSchema.builder()
+                        .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                        .build());
+        Map<TablePath, CatalogTable> tables = new LinkedHashMap<TablePath, CatalogTable>();
+        tables.put(source.getTablePath(), source);
+        CatalogTable second = CatalogTable.builder(
+                TablePath.of("source", "orders_2"),
+                source.getTableSchema()).build();
+        tables.put(second.getTablePath(), second);
+
+        try {
+            new MongoSinkPreparer(config(null))
+                    .prepare(new SinkPrepareContext(ReadonlyConfig.fromMap(new LinkedHashMap<String, Object>()), tables));
+            fail("Expected multi-table rejection");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    private static void assertPrepareFails(
+            CatalogTable source,
+            MongoSinkConfig config) {
+        try {
+            new MongoSinkPreparer(config).prepare(context(source));
+            fail("Expected MongoDB Sink preparation failure");
+        } catch (IllegalArgumentException expected) {
+            // expected
+        }
+    }
+
+    private static SinkPrepareContext context(CatalogTable source) {
+        Map<TablePath, CatalogTable> tables = new LinkedHashMap<TablePath, CatalogTable>();
+        tables.put(source.getTablePath(), source);
+        return new SinkPrepareContext(
+                ReadonlyConfig.fromMap(new LinkedHashMap<String, Object>()),
+                tables);
+    }
+
+    private static CatalogTable sourceTable(TableSchema schema) {
+        return CatalogTable.builder(TablePath.of("source", "orders"), schema).build();
+    }
+
+    private static MongoSinkConfig config(String documentIdField) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("uri", "mongodb://localhost:27017/archive");
+        values.put("collection", "orders_copy");
+        if (documentIdField != null) {
+            values.put("document_id_field", documentIdField);
+        }
+        return MongoSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}

--- a/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/sink/MongoSinkWriterTest.java
+++ b/link-up-connectors/link-up-connector-mongodb/src/test/java/com/link/up/connector/mongodb/sink/MongoSinkWriterTest.java
@@ -1,0 +1,172 @@
+package com.link.up.connector.mongodb.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.sink.CommitScope;
+import com.link.up.api.sink.PreparedSinkMetadata;
+import com.link.up.api.source.RecordBatch;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.FluxRow;
+import com.link.up.connector.mongodb.config.MongoSinkConfig;
+import org.bson.BsonDocument;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class MongoSinkWriterTest {
+
+    @Test
+    public void flushesAtBatchThresholdAndPrepareCommitFlushesTail() throws Exception {
+        CatalogTable source = sourceTable();
+        FakeInsertExecutor executor = new FakeInsertExecutor();
+        MongoSinkWriter writer = writer(source, executor, 2);
+
+        writer.open();
+        writer.write(batch(FluxRow.of(Long.valueOf(1L), "one"), FluxRow.of(Long.valueOf(2L), "two")), source);
+        assertEquals(1, executor.requests.size());
+        assertEquals(2, executor.requests.get(0).size());
+        assertEquals(0, writer.getBufferedDocuments());
+
+        writer.write(batch(FluxRow.of(Long.valueOf(3L), "three")), source);
+        assertEquals(1, writer.getBufferedDocuments());
+        writer.prepareCommit();
+
+        assertEquals(2, executor.requests.size());
+        assertEquals(1, executor.requests.get(1).size());
+        assertEquals(3L, writer.getTotalWrittenRows());
+        assertEquals(2L, writer.getTotalInsertRequests());
+        assertEquals(CommitScope.TASK_LOCAL, writer.getCommitScope());
+        writer.close();
+    }
+
+    @Test
+    public void closeDoesNotImplicitlyFlush() throws Exception {
+        CatalogTable source = sourceTable();
+        FakeInsertExecutor executor = new FakeInsertExecutor();
+        MongoSinkWriter writer = writer(source, executor, 10);
+
+        writer.open();
+        writer.write(batch(FluxRow.of(Long.valueOf(1L), "one")), source);
+        writer.close();
+
+        assertTrue(executor.requests.isEmpty());
+        assertEquals(1, executor.closeCount);
+    }
+
+    @Test
+    public void abortDiscardsOnlyUnsentBuffer() throws Exception {
+        CatalogTable source = sourceTable();
+        FakeInsertExecutor executor = new FakeInsertExecutor();
+        MongoSinkWriter writer = writer(source, executor, 10);
+
+        writer.open();
+        writer.write(batch(FluxRow.of(Long.valueOf(1L), "one")), source);
+        writer.abort();
+
+        assertEquals(0, writer.getBufferedDocuments());
+        assertTrue(executor.requests.isEmpty());
+        writer.close();
+    }
+
+    @Test
+    public void insertFailureStopsWriterInsteadOfReplaying() throws Exception {
+        CatalogTable source = sourceTable();
+        FakeInsertExecutor executor = new FakeInsertExecutor();
+        executor.failInsert = true;
+        MongoSinkWriter writer = writer(source, executor, 2);
+
+        writer.open();
+        try {
+            writer.write(batch(FluxRow.of(Long.valueOf(1L), "one"), FluxRow.of(Long.valueOf(2L), "two")), source);
+            fail("Expected MongoDB insert failure");
+        } catch (IllegalStateException expected) {
+            // expected
+        }
+
+        executor.failInsert = false;
+        try {
+            writer.prepareCommit();
+            fail("Writer must remain failed after ambiguous insert outcome");
+        } catch (IllegalStateException expected) {
+            // expected
+        }
+        assertTrue(executor.requests.isEmpty());
+        writer.abort();
+        writer.close();
+    }
+
+    private static MongoSinkWriter writer(
+            CatalogTable source,
+            FakeInsertExecutor executor,
+            int batchSize) {
+        MongoSinkConfig config = config(batchSize);
+        Map<TablePath, CatalogTable> targets = new LinkedHashMap<TablePath, CatalogTable>();
+        targets.put(
+                source.getTablePath(),
+                CatalogTable.builder(config.getTargetPath(), source.getTableSchema()).build());
+        return new MongoSinkWriter(
+                config,
+                new PreparedSinkMetadata(targets),
+                executor);
+    }
+
+    private static CatalogTable sourceTable() {
+        TableSchema schema = TableSchema.builder()
+                .column(Column.builder("id", BasicType.LONG_TYPE).build())
+                .column(Column.builder("name", BasicType.STRING_TYPE).build())
+                .build();
+        return CatalogTable.builder(TablePath.of("source", "orders"), schema).build();
+    }
+
+    private static RecordBatch<FluxRow> batch(FluxRow... rows) {
+        List<FluxRow> values = new ArrayList<FluxRow>();
+        for (FluxRow row : rows) {
+            values.add(row);
+        }
+        return RecordBatch.of("source.orders", "split-0", values);
+    }
+
+    private static MongoSinkConfig config(int batchSize) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("uri", "mongodb://localhost:27017/archive");
+        values.put("collection", "orders_copy");
+        values.put("batch_size", batchSize);
+        return MongoSinkConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static final class FakeInsertExecutor
+            implements MongoSinkWriter.BatchInsertExecutor {
+
+        private final List<List<BsonDocument>> requests =
+                new ArrayList<List<BsonDocument>>();
+        private int closeCount;
+        private boolean failInsert;
+
+        @Override
+        public void open() {
+        }
+
+        @Override
+        public void insert(List<BsonDocument> documents) {
+            if (failInsert) {
+                throw new IllegalStateException("ambiguous insert failure");
+            }
+            requests.add(new ArrayList<BsonDocument>(documents));
+        }
+
+        @Override
+        public void close() {
+            closeCount++;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Stage 3 completes the core bounded/offline MongoDB Source + Sink path after merged #117 and #118.

This PR adds a restrained INSERT-only MongoDB Sink. It keeps the same usability-first product rule as the Source: users select a MongoDB database/collection and optional document identity field; they do not author BSON or Link-Up field types.

## What changed

### Sink factory and configuration

- register `SinkFactory` under the existing `mongodb` connector identifier
- add user-facing Sink options:
  - `uri` (required)
  - `database` (optional when present in URI)
  - `collection` (required)
  - `document_id_field` (optional)
  - `batch_size` (default 1000)
- deliberately expose no `UPSERT`, `AUTO_CREATE_TABLE`, `MULTI_TABLE` or 2PC capability
- no user-authored schema/type option

### Preparation boundary

- support exactly one source table and one MongoDB target collection
- preserve the prepared source `TableSchema` as the write contract
- reject unsupported native Link-Up `ARRAY/MAP/ROW` values
- reject ambiguous `_id` configuration when the source already contains `_id`
- reject ordinary overlapping target paths such as `customer` + `customer.name`
- allow MongoDB-origin parent Document + dotted child when Stage 1 metadata proves that the parent is restorable Extended JSON

### FluxRow -> BSON

Add `MongoFluxRowBsonConverter` with the bounded target policy:

```text
STRING          -> BsonString
Mongo ObjectId STRING metadata -> BsonObjectId
Mongo Extended JSON metadata   -> original BSON Document/Array when unambiguous
BOOLEAN         -> BsonBoolean
TINYINT/SMALLINT/INT -> BsonInt32
BIGINT          -> BsonInt64
FLOAT/DOUBLE    -> BsonDouble
DECIMAL         -> Decimal128
BYTES           -> BsonBinary
DATE            -> ISO STRING
TIME            -> ISO STRING
TIMESTAMP       -> BSON DateTime when millisecond-exact
TIMESTAMP_TZ    -> ISO STRING preserving offset
NULL            -> BsonNull
```

MongoDB BSON DateTime only has millisecond precision. Sub-millisecond Link-Up TIMESTAMP values fail explicitly instead of being silently truncated.

### Nested document usability

Dotted fields are rebuilt into BSON documents.

For a MongoDB-origin document schema containing both:

```text
address
address.city
```

Stage 3 restores the parent Extended JSON document first, then deterministically applies the explicit child value. This keeps default MongoDB-to-MongoDB copy jobs usable without forcing users to manually strip every discovered parent document field.

For ordinary relational schemas, overlapping parent/child fields remain fail-fast because there is no metadata proving that the parent is a document.

### `_id` policy

- existing source `_id` is preserved
- MongoDB-origin ObjectId metadata restores a 24-hex STRING back to BSON ObjectId
- null implicit `_id` is omitted so MongoDB may generate one
- optional `document_id_field` copies one existing source field to `_id`
- the original `document_id_field` remains in the document
- explicit document identity must be non-null and scalar
- stable `_id` does **not** expose UPSERT semantics

### Ordered batch writer

`MongoSinkWriter` uses one task-local Mongo client and ordered `insertMany` flushes:

```text
write()         -> buffer -> threshold insertMany
prepareCommit() -> flush remaining buffer
commit()        -> task lifecycle boundary only
abort()         -> discard unsent buffer only
close()         -> never implicitly flush
```

- default `batch_size=1000`
- `ordered=true`
- requires acknowledged write concern; stronger URI write concerns remain valid
- successful flushes are remote writes and cannot be rolled back
- reports `TASK_LOCAL` commit scope
- no connector-level automatic replay of failed insert requests
- after one ambiguous insert failure, the writer enters a failed state and refuses additional writes/prepareCommit replay

MongoDB may have inserted a prefix of an ordered batch before a duplicate-key or other write error. A whole-task retry therefore requires target verification. Driver-level retryable-write behavior still follows the MongoDB URI/driver contract; this PR does not add another Link-Up replay loop on top of it.

### Collection creation

MongoDB naturally creates a missing collection on first successful insert. Stage 3 permits that native behavior but intentionally does not advertise Link-Up `AUTO_CREATE_TABLE`: no explicit collection DDL, validator creation or schema-evolution contract is implemented.

### Tests

Added focused coverage for:

- Sink URI/default database and batch defaults
- explicit target database and `document_id_field`
- ObjectId restoration
- Extended JSON document restoration
- parent document + dotted child deterministic overwrite
- scalar document identity and null identity rejection
- implicit null `_id` omission
- sub-millisecond TIMESTAMP fail-fast behavior
- single-target preparation
- ordinary path-overlap rejection
- Mongo-origin document overlap acceptance
- `_id` / `document_id_field` ambiguity rejection
- batch threshold flush
- `prepareCommit()` tail flush
- `abort()` unsent-buffer discard
- `close()` no implicit flush
- failed insert prevents automatic replay
- factory capability boundary

## Scope deliberately excluded

- update / replace / delete operations
- exposed UPSERT semantics
- Change Streams / oplog / CDC
- realtime polling / streaming
- automatic runtime schema evolution
- multi-collection execution / `MULTI_TABLE`
- generic automatic Source range/chunk splitting / `PARTITION_SPLIT`
- checkpoint/savepoint recovery
- MongoDB transactions spanning SinkTasks
- Job-level exactly-once or point-in-time snapshot claims

`MULTI_TABLE` and `PARTITION_SPLIT` remain undeclared because Stage 3 does not have a safe generic routing/split contract for them. Core single-collection bounded Source + Sink support is complete without pretending those advanced semantics already exist.

## Validation

The implementation was statically checked against current Link-Up Sink SPI contracts and MongoDB Java Driver 4.11 APIs for BSON conversion, write concern and ordered `insertMany`.

Focused unit tests are committed and do not require a live MongoDB server. The current ChatGPT execution environment does not provide a reliable repository-side Maven run, so a successful Maven build is **not** claimed here.

Suggested merge gate:

```bash
mvn --batch-mode -pl link-up-connectors/link-up-connector-mongodb -am test
mvn --batch-mode clean verify
```

Then run one real MongoDB smoke test covering:

- JDBC/MySQL -> MongoDB INSERT
- MongoDB -> MongoDB ObjectId + nested document round trip
- at least two batches plus one `prepareCommit()` tail flush
- duplicate `_id` failure with verification that no automatic whole-batch replay occurs
