### PR TITLE
feat(goldendb): add offline JDBC source and sink support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -59,6 +59,40 @@ Stage 1 intentionally does not advertise `DATABASE_SNAPSHOT`, TiCDC, TiKV/TiFlas
 checkpoints or runtime schema evolution. Those capabilities require separate stages instead of changing the bounded JDBC
 contract.
 
+## GoldenDB
+
+GoldenDB is exposed as the separate `goldendb` JDBC dialect while Stage 1 reuses the MySQL-compatible execution path and
+MySQL Connector/J. Because MySQL, TiDB and GoldenDB can share the `jdbc:mysql://` URL scheme, GoldenDB must be selected
+explicitly with `dialect = "goldendb"` instead of being inferred from the URL:
+
+```hocon
+source {
+  type = "jdbc"
+  url = "jdbc:mysql://goldendb:3306/app"
+  driver = "com.mysql.cj.jdbc.Driver"
+  dialect = "goldendb"
+  table_path = "app.orders"
+}
+
+sink {
+  type = "jdbc"
+  url = "jdbc:mysql://goldendb:3306/archive"
+  driver = "com.mysql.cj.jdbc.Driver"
+  dialect = "goldendb"
+}
+```
+
+The Stage 1 GoldenDB adapter supports bounded single-table and multi-table reads, MySQL-compatible automatic type
+mapping, shared JDBC range/hash split planning, INSERT/UPSERT, batch writes and metadata discovery. Sink target database
+resolution prefers the database in the target JDBC URL so source database metadata does not leak into a cross-database
+write.
+
+GoldenDB Stage 1 writes existing target tables only. Automatic database/table creation, table recreation, add-column
+schema evolution and other distribution/sharding-sensitive DDL are intentionally blocked. Create the GoldenDB target
+schema/table before the job; `CREATE_SCHEMA_WHEN_NOT_EXIST` remains safe for an existing table but fails clearly when the
+target table is absent. CDC, streaming, GoldenDB-native bulk loading and coordinated distributed snapshots are also out
+of scope for this bounded JDBC stage.
+
 ## SAP HANA
 
 SAP HANA is exposed as the `hana` JDBC dialect and is auto-detected from `jdbc:sap://` URLs. Stage 1 is deliberately

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/goldendb/GoldenDbCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/goldendb/GoldenDbCatalog.java
@@ -1,0 +1,193 @@
+package com.link.up.connector.jdbc.catalog.goldendb;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.mysql.MySqlCatalog;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * GoldenDB catalog facade over MySQL-compatible JDBC metadata.
+ *
+ * <p>Stage 1 deliberately supports metadata discovery and writes to existing
+ * tables only. Schema-changing DDL is blocked until GoldenDB distribution and
+ * sharding semantics can be modeled explicitly instead of silently creating a
+ * generic MySQL-style table.</p>
+ */
+public final class GoldenDbCatalog
+        implements WritableCatalog {
+
+    public static final String DIALECT =
+            DatabaseIdentifier.GOLDENDB;
+
+    private final WritableCatalog delegate;
+
+    public GoldenDbCatalog(
+            String catalogName,
+            JdbcCatalogConfig config) {
+
+        this.delegate =
+                new MySqlCatalog(
+                        catalogName,
+                        config);
+    }
+
+    @Override
+    public String name() {
+        return delegate.name();
+    }
+
+    @Override
+    public void open() throws CatalogException {
+        delegate.open();
+    }
+
+    @Override
+    public void close() throws CatalogException {
+        delegate.close();
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase()
+            throws CatalogException {
+
+        return delegate.getDefaultDatabase();
+    }
+
+    @Override
+    public List<String> listDatabases()
+            throws CatalogException {
+
+        return delegate.listDatabases();
+    }
+
+    @Override
+    public List<String> listSchemas(
+            String databaseName)
+            throws CatalogException {
+
+        return delegate.listSchemas(databaseName);
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String databaseName,
+            String schemaName)
+            throws CatalogException {
+
+        return delegate.listTables(
+                databaseName,
+                schemaName);
+    }
+
+    @Override
+    public boolean tableExists(
+            TablePath tablePath)
+            throws CatalogException {
+
+        return delegate.tableExists(tablePath);
+    }
+
+    @Override
+    public CatalogTable getTable(
+            TablePath tablePath)
+            throws CatalogException,
+            TableNotFoundException {
+
+        CatalogTable table =
+                delegate.getTable(tablePath);
+
+        return table.toBuilder()
+                .option(
+                        MySqlCatalog.TABLE_OPTION_DIALECT,
+                        DIALECT)
+                .build();
+    }
+
+    @Override
+    public void createDatabase(
+            String databaseName,
+            boolean ignoreIfExists)
+            throws CatalogException,
+            DatabaseAlreadyExistsException {
+
+        throw unsupportedSchemaDdl(
+                "create database");
+    }
+
+    @Override
+    public void dropDatabase(
+            String databaseName,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            DatabaseNotFoundException {
+
+        throw unsupportedSchemaDdl(
+                "drop database");
+    }
+
+    @Override
+    public void createTable(
+            CatalogTable table,
+            boolean ignoreIfExists)
+            throws CatalogException,
+            DatabaseNotFoundException,
+            TableAlreadyExistsException {
+
+        throw unsupportedSchemaDdl(
+                "create table");
+    }
+
+    @Override
+    public void addColumn(
+            TablePath tablePath,
+            Column column)
+            throws CatalogException,
+            TableNotFoundException {
+
+        throw unsupportedSchemaDdl(
+                "add column");
+    }
+
+    @Override
+    public void dropTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            TableNotFoundException {
+
+        throw unsupportedSchemaDdl(
+                "drop table");
+    }
+
+    @Override
+    public void truncateTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException,
+            TableNotFoundException {
+
+        delegate.truncateTable(
+                tablePath,
+                ignoreIfNotExists);
+    }
+
+    private static CatalogException unsupportedSchemaDdl(
+            String operation) {
+
+        return new CatalogException(
+                "GoldenDB Stage 1 supports existing target tables only; "
+                        + operation
+                        + " is disabled until GoldenDB distribution/sharding DDL is modeled");
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/goldendb/GoldenDbCatalogFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/goldendb/GoldenDbCatalogFactory.java
@@ -1,0 +1,62 @@
+package com.link.up.connector.jdbc.catalog.goldendb;
+
+import com.google.auto.service.AutoService;
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.factory.Factory;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.factory.CatalogFactory;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.config.JdbcCommonOptions;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * GoldenDB catalog factory backed by MySQL Connector/J for Stage 1.
+ */
+@AutoService(Factory.class)
+public final class GoldenDbCatalogFactory
+        implements CatalogFactory {
+
+    private static final String DEFAULT_DRIVER =
+            "com.mysql.cj.jdbc.Driver";
+
+    @Override
+    public String factoryIdentifier() {
+        return DatabaseIdentifier.GOLDENDB;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            ReadonlyConfig options) {
+
+        String url = options.get(JdbcCommonOptions.URL);
+        String username =
+                options.getOptional(JdbcCommonOptions.USERNAME)
+                        .orElse(null);
+        String password =
+                options.getOptional(JdbcCommonOptions.PASSWORD)
+                        .orElse(null);
+        String driver =
+                options.getOptional(JdbcCommonOptions.DRIVER)
+                        .orElse(DEFAULT_DRIVER);
+        Map<String, String> properties =
+                options.getOptional(JdbcCommonOptions.PROPERTIES)
+                        .orElse(Collections.emptyMap());
+        boolean intTypeNarrowing =
+                options.getOptional(JdbcCommonOptions.INT_TYPE_NARROWING)
+                        .orElse(false);
+
+        return new GoldenDbCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        url,
+                        username,
+                        password,
+                        driver,
+                        properties,
+                        intTypeNarrowing));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -9,6 +9,7 @@ public final class DatabaseIdentifier {
 
     public static final String MYSQL = "mysql";
     public static final String TIDB = "tidb";
+    public static final String GOLDENDB = "goldendb";
     public static final String POSTGRESQL = "postgresql";
     public static final String ORACLE = "oracle";
     public static final String SQLSERVER = "sqlserver";

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/goldendb/GoldenDbDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/goldendb/GoldenDbDialect.java
@@ -1,0 +1,141 @@
+package com.link.up.connector.jdbc.core.dialect.goldendb;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.goldendb.GoldenDbCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.config.ReadConsistency;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+import com.link.up.connector.jdbc.core.dialect.mysql.MySqlDialect;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * GoldenDB bounded offline JDBC dialect.
+ *
+ * <p>Stage 1 keeps GoldenDB as a first-class database identity while reusing
+ * the mature MySQL-compatible JDBC execution semantics: Connector/J, type
+ * mapping, INSERT/UPSERT, cursor reads and hash splitting. GoldenDB-specific
+ * CDC, native bulk loading and distributed-table DDL are outside this stage.</p>
+ */
+public final class GoldenDbDialect
+        implements JdbcDialect {
+
+    private final MySqlDialect mysqlDelegate;
+
+    public GoldenDbDialect(
+            JdbcConnectionConfig connectionConfig) {
+
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException(
+                    "connectionConfig must not be null");
+        }
+
+        this.mysqlDelegate =
+                new MySqlDialect(connectionConfig);
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.GOLDENDB;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+
+        return new GoldenDbCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false));
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return mysqlDelegate.typeMapper();
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new GoldenDbJdbcRowConverter();
+    }
+
+    @Override
+    public Set<ReadConsistency> supportedReadConsistencies() {
+        return mysqlDelegate.supportedReadConsistencies();
+    }
+
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        return mysqlDelegate.parseTablePath(tablePath);
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        return mysqlDelegate.quoteIdentifier(identifier);
+    }
+
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        return mysqlDelegate.tableIdentifier(tablePath);
+    }
+
+    @Override
+    public Optional<String> buildUpsertSql(
+            TablePath tablePath,
+            List<String> fieldNames,
+            List<String> primaryKeys) {
+
+        return mysqlDelegate.buildUpsertSql(
+                tablePath,
+                fieldNames,
+                primaryKeys);
+    }
+
+    @Override
+    public PreparedStatement prepareReadStatement(
+            Connection connection,
+            String sql,
+            int fetchSize)
+            throws SQLException {
+
+        return mysqlDelegate.prepareReadStatement(
+                connection,
+                sql,
+                fetchSize);
+    }
+
+    @Override
+    public Map<String, String> defaultConnectionProperties() {
+        return mysqlDelegate.defaultConnectionProperties();
+    }
+
+    @Override
+    public Optional<String> buildHashPartitionPredicate(
+            Column column,
+            int bucket,
+            int bucketCount) {
+
+        return mysqlDelegate.buildHashPartitionPredicate(
+                column,
+                bucket,
+                bucketCount);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/goldendb/GoldenDbDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/goldendb/GoldenDbDialectFactory.java
@@ -1,0 +1,37 @@
+package com.link.up.connector.jdbc.core.dialect.goldendb;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/**
+ * GoldenDB JDBC dialect SPI.
+ *
+ * <p>GoldenDB can use the MySQL-compatible JDBC protocol and therefore shares
+ * the {@code jdbc:mysql://} URL scheme with MySQL and TiDB. URL-only detection
+ * is intentionally disabled; select GoldenDB explicitly with
+ * {@code dialect=goldendb}.</p>
+ */
+@AutoService(JdbcDialectFactory.class)
+public final class GoldenDbDialectFactory
+        implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.GOLDENDB;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return false;
+    }
+
+    @Override
+    public JdbcDialect create(
+            JdbcConnectionConfig connectionConfig) {
+
+        return new GoldenDbDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/goldendb/GoldenDbJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/goldendb/GoldenDbJdbcRowConverter.java
@@ -1,0 +1,37 @@
+package com.link.up.connector.jdbc.core.dialect.goldendb;
+
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * GoldenDB row converter for the MySQL-compatible JDBC protocol.
+ */
+public final class GoldenDbJdbcRowConverter
+        extends AbstractJdbcRowConverter {
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.GOLDENDB;
+    }
+
+    @Override
+    protected void writeTime(
+            PreparedStatement statement,
+            int index,
+            LocalTime value)
+            throws SQLException {
+
+        statement.setTimestamp(
+                index,
+                java.sql.Timestamp.valueOf(
+                        LocalDateTime.of(
+                                LocalDate.now(),
+                                value)));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GoldenDbSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GoldenDbSinkSupport.java
@@ -1,0 +1,122 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+/**
+ * GoldenDB-specific target normalization for the shared JDBC sink.
+ *
+ * <p>Stage 1 writes existing tables only. No CREATE TABLE SQL is generated
+ * here; the GoldenDB catalog blocks schema-changing DDL explicitly.</p>
+ */
+final class GoldenDbSinkSupport {
+
+    private GoldenDbSinkSupport() {
+    }
+
+    static boolean accepts(
+            JdbcConnectionConfig connectionConfig) {
+
+        return connectionConfig != null
+                && DatabaseIdentifier.GOLDENDB.equalsIgnoreCase(
+                        connectionConfig.getDialect());
+    }
+
+    static TablePath resolveTargetPath(
+            JdbcConnectionConfig connectionConfig,
+            TablePath tablePath) {
+
+        if (connectionConfig == null
+                || tablePath == null) {
+            return tablePath;
+        }
+
+        String database =
+                databaseFromUrl(
+                        connectionConfig.getUrl());
+
+        if (!hasText(database)) {
+            database = connectionConfig.getSchema();
+        }
+
+        if (!hasText(database)) {
+            database = tablePath.getDatabaseName();
+        }
+
+        if (!hasText(database)) {
+            database = tablePath.getSchemaName();
+        }
+
+        if (!hasText(database)) {
+            return null;
+        }
+
+        return TablePath.of(
+                database.trim(),
+                tablePath.getTableName());
+    }
+
+    private static String databaseFromUrl(
+            String url) {
+
+        if (!hasText(url)) {
+            return null;
+        }
+
+        String normalized = url.trim();
+        int protocolSeparator =
+                normalized.indexOf("://");
+
+        if (protocolSeparator < 0) {
+            return null;
+        }
+
+        int databaseStart =
+                normalized.indexOf(
+                        '/',
+                        protocolSeparator + 3);
+
+        if (databaseStart < 0
+                || databaseStart
+                == normalized.length() - 1) {
+            return null;
+        }
+
+        int databaseEnd = normalized.length();
+
+        int queryStart =
+                normalized.indexOf(
+                        '?',
+                        databaseStart + 1);
+
+        if (queryStart >= 0) {
+            databaseEnd = queryStart;
+        }
+
+        int fragmentStart =
+                normalized.indexOf(
+                        '#',
+                        databaseStart + 1);
+
+        if (fragmentStart >= 0
+                && fragmentStart < databaseEnd) {
+            databaseEnd = fragmentStart;
+        }
+
+        String database =
+                normalized.substring(
+                        databaseStart + 1,
+                        databaseEnd)
+                        .trim();
+
+        return hasText(database)
+                ? database
+                : null;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null
+                && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -137,6 +137,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return TiDbSinkSupport.resolveTargetPath(
                     config.getConnectionConfig(), tablePath);
         }
+        if (GoldenDbSinkSupport.accepts(config.getConnectionConfig())) {
+            return GoldenDbSinkSupport.resolveTargetPath(
+                    config.getConnectionConfig(), tablePath);
+        }
         return JdbcCreateTableSqlResolver.resolveTargetPath(
                 config.getConnectionConfig(), tablePath);
     }
@@ -161,6 +165,9 @@ final class JdbcSinkPreparer implements SinkPreparer {
         if (TiDbSinkSupport.accepts(config.getConnectionConfig())) {
             return TiDbSinkSupport.resolveCreateTableSql(
                     config.getConnectionConfig(), table);
+        }
+        if (GoldenDbSinkSupport.accepts(config.getConnectionConfig())) {
+            return null;
         }
         return JdbcCreateTableSqlResolver.resolve(
                 dialect,

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/goldendb/GoldenDbCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/goldendb/GoldenDbCatalogTest.java
@@ -1,0 +1,92 @@
+package com.link.up.connector.jdbc.catalog.goldendb;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class GoldenDbCatalogTest {
+
+    @Test
+    public void stageOneRejectsAutomaticTableCreation() {
+        GoldenDbCatalog catalog =
+                new GoldenDbCatalog(
+                        "goldendb",
+                        new JdbcCatalogConfig(
+                                "jdbc:mysql://127.0.0.1:3306/target_db",
+                                "user",
+                                "password",
+                                "com.mysql.cj.jdbc.Driver",
+                                Collections.emptyMap(),
+                                false));
+
+        try {
+            catalog.createTable(
+                    table(),
+                    false);
+            fail("GoldenDB Stage 1 must not auto-create target tables");
+        } catch (CatalogException expected) {
+            assertTrue(
+                    expected.getMessage()
+                            .contains(
+                                    "existing target tables only"));
+        }
+    }
+
+    @Test
+    public void stageOneRejectsDestructiveSchemaRecreationBeforeDrop() {
+        GoldenDbCatalog catalog =
+                new GoldenDbCatalog(
+                        "goldendb",
+                        new JdbcCatalogConfig(
+                                "jdbc:mysql://127.0.0.1:3306/target_db",
+                                "user",
+                                "password",
+                                "com.mysql.cj.jdbc.Driver",
+                                Collections.emptyMap(),
+                                false));
+
+        try {
+            catalog.dropTable(
+                    TablePath.of(
+                            "target_db",
+                            "orders"),
+                    false);
+            fail("GoldenDB Stage 1 must not drop target tables");
+        } catch (CatalogException expected) {
+            assertTrue(
+                    expected.getMessage()
+                            .contains(
+                                    "drop table"));
+        }
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .columns(
+                                Collections.singletonList(
+                                        Column.builder(
+                                                        "id",
+                                                        BasicType.LONG_TYPE)
+                                                .nullable(false)
+                                                .build()))
+                        .build();
+
+        return CatalogTable.builder(
+                        TablePath.of(
+                                "target_db",
+                                "orders"),
+                        schema)
+                .build();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/goldendb/GoldenDbDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/goldendb/GoldenDbDialectTest.java
@@ -1,0 +1,123 @@
+package com.link.up.connector.jdbc.core.dialect.goldendb;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.config.ReadConsistency;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import com.link.up.connector.jdbc.core.dialect.mysql.MySqlTypeMapper;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GoldenDbDialectTest {
+
+    @Test
+    public void explicitDialectLoadsGoldenDbForMysqlJdbcUrl() {
+        JdbcDialect dialect =
+                JdbcDialectLoader.load(
+                        config(
+                                "jdbc:mysql://127.0.0.1:3306/test",
+                                "goldendb"));
+
+        assertTrue(dialect instanceof GoldenDbDialect);
+        assertEquals(
+                DatabaseIdentifier.GOLDENDB,
+                dialect.name());
+    }
+
+    @Test
+    public void factoryDoesNotCompeteWithMysqlUrlDetection() {
+        assertFalse(
+                new GoldenDbDialectFactory()
+                        .acceptsUrl(
+                                "jdbc:mysql://127.0.0.1:3306/test"));
+    }
+
+    @Test
+    public void reusesMysqlOfflineTypeTableAndUpsertSemantics() {
+        GoldenDbDialect dialect =
+                new GoldenDbDialect(
+                        config(
+                                "jdbc:mysql://127.0.0.1:3306/test",
+                                "goldendb"));
+
+        assertTrue(
+                dialect.typeMapper()
+                        instanceof MySqlTypeMapper);
+        assertEquals(
+                "`test`.`orders`",
+                dialect.tableIdentifier(
+                        TablePath.of("orders")));
+
+        String upsert =
+                dialect.buildUpsertSql(
+                                TablePath.of("test", "orders"),
+                                Arrays.asList("id", "name"),
+                                Arrays.asList("id"))
+                        .get();
+
+        assertTrue(
+                upsert.contains(
+                        "ON DUPLICATE KEY UPDATE"));
+    }
+
+    @Test
+    public void rowConverterKeepsGoldenDbIdentity() {
+        GoldenDbDialect dialect =
+                new GoldenDbDialect(
+                        config(
+                                "jdbc:mysql://127.0.0.1:3306/test",
+                                "goldendb"));
+
+        assertEquals(
+                DatabaseIdentifier.GOLDENDB,
+                dialect.rowConverter().name());
+    }
+
+    @Test
+    public void stageOneDoesNotAdvertiseCoordinatedDatabaseSnapshot() {
+        GoldenDbDialect dialect =
+                new GoldenDbDialect(
+                        config(
+                                "jdbc:mysql://127.0.0.1:3306/test",
+                                "goldendb"));
+
+        assertTrue(
+                dialect.supportedReadConsistencies()
+                        .contains(ReadConsistency.BEST_EFFORT));
+        assertTrue(
+                dialect.supportedReadConsistencies()
+                        .contains(
+                                ReadConsistency.SINGLE_CONNECTION_SNAPSHOT));
+        assertFalse(
+                dialect.supportedReadConsistencies()
+                        .contains(
+                                ReadConsistency.DATABASE_SNAPSHOT));
+    }
+
+    private static JdbcConnectionConfig config(
+            String url,
+            String dialect) {
+
+        Map<String, Object> values =
+                new LinkedHashMap<String, Object>();
+
+        values.put("url", url);
+        values.put(
+                "driver",
+                "com.mysql.cj.jdbc.Driver");
+        values.put("dialect", dialect);
+
+        return JdbcConnectionConfig.of(
+                ReadonlyConfig.fromMap(values));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GoldenDbSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GoldenDbSinkSupportTest.java
@@ -1,0 +1,115 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.goldendb.GoldenDbDialect;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class GoldenDbSinkSupportTest {
+
+    @Test
+    public void sourceDatabaseDoesNotLeakIntoGoldenDbTarget() {
+        TablePath target =
+                GoldenDbSinkSupport.resolveTargetPath(
+                        config(
+                                "jdbc:mysql://127.0.0.1:3306/target_db",
+                                null),
+                        TablePath.of(
+                                "source_db",
+                                "orders"));
+
+        assertEquals(
+                TablePath.of(
+                        "target_db",
+                        "orders"),
+                target);
+    }
+
+    @Test
+    public void configuredSchemaActsAsTargetDatabaseWhenUrlIsUnqualified() {
+        TablePath target =
+                GoldenDbSinkSupport.resolveTargetPath(
+                        config(
+                                "jdbc:mysql://127.0.0.1:3306",
+                                "configured_db"),
+                        TablePath.of(
+                                "source_db",
+                                "orders"));
+
+        assertEquals(
+                TablePath.of(
+                        "configured_db",
+                        "orders"),
+                target);
+    }
+
+    @Test
+    public void stageOneDoesNotGenerateAutomaticCreateTableSql() {
+        JdbcConnectionConfig config =
+                config(
+                        "jdbc:mysql://127.0.0.1:3306/target_db",
+                        null);
+
+        assertNull(
+                JdbcCreateTableSqlResolver.resolve(
+                        new GoldenDbDialect(config),
+                        config,
+                        table()));
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .columns(
+                                Collections.singletonList(
+                                        Column.builder(
+                                                        "id",
+                                                        BasicType.LONG_TYPE)
+                                                .nullable(false)
+                                                .build()))
+                        .build();
+
+        return CatalogTable.builder(
+                        TablePath.of(
+                                "source_db",
+                                "orders"),
+                        schema)
+                .build();
+    }
+
+    private static JdbcConnectionConfig config(
+            String url,
+            String schema) {
+
+        Map<String, Object> values =
+                new LinkedHashMap<String, Object>();
+
+        values.put("url", url);
+        values.put(
+                "driver",
+                "com.mysql.cj.jdbc.Driver");
+        values.put(
+                "dialect",
+                DatabaseIdentifier.GOLDENDB);
+
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+
+        return JdbcConnectionConfig.of(
+                ReadonlyConfig.fromMap(values));
+    }
+}


### PR DESCRIPTION
## Summary

Adds GoldenDB Stage 1 as a first-class bounded JDBC dialect while reusing the mature MySQL-compatible execution path.

GoldenDB remains explicitly identifiable as `goldendb`, but Stage 1 delegates Connector/J behavior, type mapping, table quoting, INSERT/UPSERT, cursor reads and hash split predicates to the existing MySQL dialect.

## Scope

- add `goldendb` database identifier and SPI dialect/catalog factories
- add `GoldenDbDialect` and GoldenDB row-converter identity
- reuse MySQL JDBC type mapping and bounded Source semantics
- add GoldenDB metadata discovery through a MySQL-compatible catalog facade
- support existing-table offline Sink with INSERT/UPSERT and batch writes
- normalize GoldenDB Sink targets from the target JDBC URL so source database names do not leak into cross-database jobs
- explicitly disable URL auto-detection because GoldenDB can share `jdbc:mysql://` with MySQL/TiDB
- document GoldenDB configuration and Stage 1 boundaries
- add focused dialect, catalog-boundary and sink-target tests

## Stage 1 DDL boundary

GoldenDB Stage 1 intentionally writes **existing target tables only**. The GoldenDB catalog blocks schema-changing DDL (`CREATE/DROP DATABASE`, `CREATE/DROP TABLE`, `ADD COLUMN`) so save modes such as `RECREATE_SCHEMA` cannot destructively drop a table and then fail to recreate it.

`TRUNCATE` remains available for the shared JDBC `DROP_DATA` data-save mode because it changes table data rather than distributed table topology.

This keeps the first GoldenDB adapter usable without pretending generic MySQL DDL is sufficient for GoldenDB distribution/sharding design.

## Non-goals

- CDC / streaming
- GoldenDB binlog integration
- GoldenDB-native bulk loading
- automatic distributed table creation
- sharding/distribution-key management
- runtime schema evolution
- coordinated distributed snapshots

## Verification

Added unit coverage for:

- explicit `dialect=goldendb` SPI loading on `jdbc:mysql://` URLs
- avoiding URL-detection conflicts with MySQL/TiDB
- MySQL-compatible type mapper, table identifiers and UPSERT generation
- GoldenDB row-converter identity
- bounded read-consistency capabilities
- target database normalization
- no automatic CREATE TABLE SQL for GoldenDB Stage 1
- explicit blocking of automatic/destructive schema DDL

The execution environment used for this change cannot reach GitHub/Maven dependencies directly, and this repository currently has no GitHub Actions workflow under `.github/workflows`, so the Maven suite could not be executed here. The PR is intentionally Draft; a real GoldenDB environment is still required to validate JDBC metadata, common type coverage, primary-key discovery, INSERT/UPSERT and batch-write behavior end to end.

## Follow-up

A separate Stage 2 can model GoldenDB-aware automatic table creation once default table organization, sharding/distribution keys and related DDL semantics are defined instead of exposing low-level type/distribution configuration to users.