### PR TITLE
feat(gbase): add database family scaffold

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -93,6 +93,27 @@ schema/table before the job; `CREATE_SCHEMA_WHEN_NOT_EXIST` remains safe for an 
 target table is absent. CDC, streaming, GoldenDB-native bulk loading and coordinated distributed snapshots are also out
 of scope for this bounded JDBC stage.
 
+## GBase family
+
+GBase is modeled as a database family, not as one generic JDBC dialect. The stable product identities are `gbase8c`,
+`gbase8a` and `gbase8s`. A generic `gbase` dialect is intentionally not defined because the three products use different
+JDBC protocols and database semantics.
+
+The family scaffold only provides stable product metadata and family-level helpers. It deliberately does **not** register
+`JdbcDialectFactory` implementations yet, so these identifiers do not advertise runtime support before their concrete
+URL, driver, catalog, type-mapping and SQL behavior is implemented and tested.
+
+Shared GBase code must remain product-neutral. Driver names, JDBC URL parsing, identifier rules, catalog behavior, type
+mapping, row conversion, INSERT/UPSERT SQL and distribution/MPP behavior belong to the concrete product adapter unless at
+least two completed adapters prove the behavior is genuinely common. The planned bounded/offline implementation order is:
+
+1. GBase 8c Source, then existing-table Sink.
+2. GBase 8a Source, then existing-table JDBC Sink; native/high-speed MPP loading is a later stage.
+3. GBase 8s Source, then existing-table Sink.
+
+CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths are outside
+this scaffold.
+
 ## SAP HANA
 
 SAP HANA is exposed as the `hana` JDBC dialect and is auto-detected from `jdbc:sap://` URLs. Stage 1 is deliberately

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/DatabaseIdentifier.java
@@ -10,6 +10,9 @@ public final class DatabaseIdentifier {
     public static final String MYSQL = "mysql";
     public static final String TIDB = "tidb";
     public static final String GOLDENDB = "goldendb";
+    public static final String GBASE8C = "gbase8c";
+    public static final String GBASE8A = "gbase8a";
+    public static final String GBASE8S = "gbase8s";
     public static final String POSTGRESQL = "postgresql";
     public static final String ORACLE = "oracle";
     public static final String SQLSERVER = "sqlserver";

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/common/GBaseDialectSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/common/GBaseDialectSupport.java
@@ -1,0 +1,30 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.common;
+
+import java.util.Optional;
+
+/**
+ * Family-level helpers shared by future GBase JDBC dialects.
+ *
+ * <p>This class must stay product-neutral. Driver names, JDBC URL parsing, SQL generation, type
+ * mapping, catalog behavior and row conversion belong to the concrete 8c/8a/8s implementations
+ * unless multiple completed adapters prove that a behavior is truly shared.</p>
+ */
+public final class GBaseDialectSupport {
+
+    public static final String FAMILY_NAME = "gbase";
+
+    private GBaseDialectSupport() {
+    }
+
+    public static boolean isGBase(
+            String identifier) {
+
+        return productOf(identifier).isPresent();
+    }
+
+    public static Optional<GBaseProduct> productOf(
+            String identifier) {
+
+        return GBaseProduct.fromIdentifier(identifier);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/common/GBaseProduct.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/common/GBaseProduct.java
@@ -1,0 +1,71 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.common;
+
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+import java.util.Locale;
+import java.util.Optional;
+
+/**
+ * Stable product identities for the GBase database family.
+ *
+ * <p>The family intentionally does not expose a generic {@code gbase} dialect. GBase 8c, 8a and
+ * 8s have different JDBC protocols and database semantics, so runtime support must be implemented
+ * per product while sharing only proven family-level metadata.</p>
+ */
+public enum GBaseProduct {
+
+    GBASE8C(
+            DatabaseIdentifier.GBASE8C,
+            "GBase 8c"),
+
+    GBASE8A(
+            DatabaseIdentifier.GBASE8A,
+            "GBase 8a"),
+
+    GBASE8S(
+            DatabaseIdentifier.GBASE8S,
+            "GBase 8s");
+
+    private final String identifier;
+    private final String displayName;
+
+    GBaseProduct(
+            String identifier,
+            String displayName) {
+
+        this.identifier = identifier;
+        this.displayName = displayName;
+    }
+
+    public String identifier() {
+        return identifier;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    public static Optional<GBaseProduct> fromIdentifier(
+            String identifier) {
+
+        if (identifier == null) {
+            return Optional.empty();
+        }
+
+        String normalized =
+                identifier.trim()
+                        .toLowerCase(Locale.ROOT);
+
+        if (normalized.isEmpty()) {
+            return Optional.empty();
+        }
+
+        for (GBaseProduct product : values()) {
+            if (product.identifier.equals(normalized)) {
+                return Optional.of(product);
+            }
+        }
+
+        return Optional.empty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/GBaseFamilyContractTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/GBaseFamilyContractTest.java
@@ -1,0 +1,84 @@
+package com.link.up.connector.jdbc.core.dialect.gbase;
+
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.common.GBaseDialectSupport;
+import com.link.up.connector.jdbc.core.dialect.gbase.common.GBaseProduct;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GBaseFamilyContractTest {
+
+    @Test
+    public void exposesThreeStableFirstClassDatabaseIdentities() {
+        assertEquals("gbase8c", DatabaseIdentifier.GBASE8C);
+        assertEquals("gbase8a", DatabaseIdentifier.GBASE8A);
+        assertEquals("gbase8s", DatabaseIdentifier.GBASE8S);
+
+        Set<String> identifiers =
+                Arrays.stream(GBaseProduct.values())
+                        .map(GBaseProduct::identifier)
+                        .collect(Collectors.toSet());
+
+        assertEquals(
+                new HashSet<String>(
+                        Arrays.asList(
+                                DatabaseIdentifier.GBASE8C,
+                                DatabaseIdentifier.GBASE8A,
+                                DatabaseIdentifier.GBASE8S)),
+                identifiers);
+    }
+
+    @Test
+    public void familyHelperRecognizesOnlyConcreteProducts() {
+        assertTrue(GBaseDialectSupport.isGBase("gbase8c"));
+        assertTrue(GBaseDialectSupport.isGBase(" GBASE8A "));
+        assertTrue(GBaseDialectSupport.isGBase("gbase8s"));
+
+        assertFalse(GBaseDialectSupport.isGBase("gbase"));
+        assertFalse(GBaseDialectSupport.isGBase("gbase8"));
+        assertFalse(GBaseDialectSupport.isGBase("mysql"));
+        assertFalse(GBaseDialectSupport.isGBase(null));
+    }
+
+    @Test
+    public void productMetadataKeepsUserFacingNamesSeparate() {
+        assertEquals(
+                "GBase 8c",
+                GBaseProduct.GBASE8C.displayName());
+        assertEquals(
+                "GBase 8a",
+                GBaseProduct.GBASE8A.displayName());
+        assertEquals(
+                "GBase 8s",
+                GBaseProduct.GBASE8S.displayName());
+
+        assertEquals(
+                GBaseProduct.GBASE8C,
+                GBaseDialectSupport.productOf("GBASE8C").get());
+    }
+
+    @Test
+    public void databaseIdentifiersDoNotIntroduceGenericGBaseDialect()
+            throws Exception {
+
+        Set<String> fieldNames =
+                Arrays.stream(
+                                DatabaseIdentifier.class
+                                        .getFields())
+                        .map(Field::getName)
+                        .collect(Collectors.toSet());
+
+        assertFalse(
+                "GBase family must keep 8c/8a/8s as separate dialect identities",
+                fieldNames.contains("GBASE"));
+    }
+}


### PR DESCRIPTION
## Summary

Introduce the GBase family scaffold for future bounded/offline JDBC support without pretending that GBase 8c, 8a and 8s are one database dialect.

This PR reserves three first-class database identities and adds only a thin family-level metadata layer. It deliberately does not register any JDBC dialect factory or runtime connector behavior yet.

## Scope

- add `gbase8c`, `gbase8a` and `gbase8s` to `DatabaseIdentifier`
- add `GBaseProduct` with stable product identifiers and user-facing names
- add `GBaseDialectSupport` for product-family recognition
- add a family contract test that keeps the three identities distinct and prevents a generic `gbase` dialect from being introduced accidentally
- document the GBase family architecture and staged implementation order in the JDBC connector README

## Architecture boundary

GBase is modeled as one product family with three independent runtime dialects:

- `gbase8c`
- `gbase8a`
- `gbase8s`

The shared `gbase/common` layer is intentionally thin. Driver names, JDBC URL parsing, catalog behavior, type mapping, row conversion, SQL generation and distribution/MPP semantics stay in the concrete product adapter unless completed implementations prove that the behavior is genuinely shared.

## Why no DialectFactory in this PR

Registering `JdbcDialectFactory` now would make `dialect=gbase8c` / `gbase8a` / `gbase8s` look executable before their drivers, URLs, catalogs and type contracts exist. This scaffold therefore reserves identity only; runtime support begins in the next product-specific stage.

## Planned follow-up

1. GBase 8c bounded Source
2. GBase 8c existing-table Sink
3. GBase 8a bounded Source
4. GBase 8a existing-table JDBC Sink
5. GBase 8s bounded Source
6. GBase 8s existing-table Sink

Native/high-speed 8a load paths, CDC, compatibility-mode expansion and automatic distributed-table design remain later stages.

## Verification

- branch is based directly on the current `main` head after GoldenDB PR #120
- final branch contains one atomic commit
- diff is limited to the family identities, two common metadata/helper classes, one contract test and README documentation
- no runtime SPI registration or connector capability is added by this scaffold
