### PR TITLE
feat(gbase8c): add bounded JDBC source support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -99,8 +99,8 @@ GBase is modeled as a database family, not as one generic JDBC dialect. The stab
 `gbase8a` and `gbase8s`. A generic `gbase` dialect is intentionally not defined because the three products use different
 JDBC protocols and database semantics.
 
-The family scaffold only provides stable product metadata and family-level helpers. It deliberately does **not** register
-`JdbcDialectFactory` implementations yet, so these identifiers do not advertise runtime support before their concrete
+The shared `gbase/common` layer only carries stable product metadata and family-level helpers. GBase 8c now has its first
+runtime stage; the `gbase8a` and `gbase8s` identities remain reserved without a `JdbcDialectFactory` until their concrete
 URL, driver, catalog, type-mapping and SQL behavior is implemented and tested.
 
 Shared GBase code must remain product-neutral. Driver names, JDBC URL parsing, identifier rules, catalog behavior, type
@@ -111,8 +111,38 @@ least two completed adapters prove the behavior is genuinely common. The planned
 2. GBase 8a Source, then existing-table JDBC Sink; native/high-speed MPP loading is a later stage.
 3. GBase 8s Source, then existing-table Sink.
 
-CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths are outside
-this scaffold.
+CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths stay outside
+the family scaffold.
+
+### GBase 8c bounded Source
+
+GBase 8c is exposed as the dedicated `gbase8c` JDBC dialect. The canonical Stage 1 path uses the GBase 8c JDBC protocol
+and driver instead of pretending that a PostgreSQL or MySQL URL uniquely identifies the product:
+
+```hocon
+source {
+  type = "jdbc"
+  url = "jdbc:gbase8c://gbase8c:5432/app"
+  driver = "com.gbase8c.Driver"
+  dialect = "gbase8c"
+  schema = "public"
+  table_path = "public.orders"
+}
+```
+
+Stage 1 reuses the proven PostgreSQL-compatible **read-side type contract** while keeping its own URL parser, dialect,
+row converter and read-only Catalog. Metadata discovery uses `pg_catalog` / `information_schema` semantics for databases,
+schemas, tables, columns and primary keys. The JDBC URL owns the active database; `schema.table` is the normal table
+path, and an explicit `database.schema.table` is accepted only when the database matches the one in the JDBC URL. This
+prevents metadata from one database being paired with data read through another connection URL.
+
+The source supports bounded single-table and multi-table jobs, custom query reads and the shared safe JDBC partition
+planner. Stage 1 advertises `BEST_EFFORT` consistency only. It deliberately does not implement `WritableCatalog`, Sink
+DDL, INSERT/UPSERT, automatic table creation, CDC, streaming checkpoints, coordinated database snapshots, or Oracle /
+MySQL / Teradata compatibility-mode expansion. Those remain product-specific follow-up stages.
+
+The dedicated GBase 8c JDBC driver is not guessed as a Maven dependency by this module. Deployments must place the vendor
+JDBC driver on the runtime classpath and configure `driver = "com.gbase8c.Driver"` explicitly.
 
 ## SAP HANA
 

--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -99,24 +99,24 @@ GBase is modeled as a database family, not as one generic JDBC dialect. The stab
 `gbase8a` and `gbase8s`. A generic `gbase` dialect is intentionally not defined because the three products use different
 JDBC protocols and database semantics.
 
-The shared `gbase/common` layer only carries stable product metadata and family-level helpers. GBase 8c now has its first
-runtime stage; the `gbase8a` and `gbase8s` identities remain reserved without a `JdbcDialectFactory` until their concrete
-URL, driver, catalog, type-mapping and SQL behavior is implemented and tested.
+The shared `gbase/common` layer only carries stable product metadata and family-level helpers. GBase 8c now has bounded
+Source and existing-table Sink support; the `gbase8a` and `gbase8s` identities remain reserved without a
+`JdbcDialectFactory` until their concrete URL, driver, catalog, type-mapping and SQL behavior is implemented and tested.
 
 Shared GBase code must remain product-neutral. Driver names, JDBC URL parsing, identifier rules, catalog behavior, type
 mapping, row conversion, INSERT/UPSERT SQL and distribution/MPP behavior belong to the concrete product adapter unless at
 least two completed adapters prove the behavior is genuinely common. The planned bounded/offline implementation order is:
 
-1. GBase 8c Source, then existing-table Sink.
+1. GBase 8c bounded Source and existing-table Sink.
 2. GBase 8a Source, then existing-table JDBC Sink; native/high-speed MPP loading is a later stage.
 3. GBase 8s Source, then existing-table Sink.
 
 CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths stay outside
 the family scaffold.
 
-### GBase 8c bounded Source
+### GBase 8c bounded Source and existing-table Sink
 
-GBase 8c is exposed as the dedicated `gbase8c` JDBC dialect. The canonical Stage 1 path uses the GBase 8c JDBC protocol
+GBase 8c is exposed as the dedicated `gbase8c` JDBC dialect. The canonical bounded path uses the GBase 8c JDBC protocol
 and driver instead of pretending that a PostgreSQL or MySQL URL uniquely identifies the product:
 
 ```hocon
@@ -128,18 +128,39 @@ source {
   schema = "public"
   table_path = "public.orders"
 }
+
+sink {
+  type = "jdbc"
+  url = "jdbc:gbase8c://gbase8c:5432/archive"
+  driver = "com.gbase8c.Driver"
+  dialect = "gbase8c"
+  schema = "public"
+  table = "public.orders"
+}
 ```
 
-Stage 1 reuses the proven PostgreSQL-compatible **read-side type contract** while keeping its own URL parser, dialect,
-row converter and read-only Catalog. Metadata discovery uses `pg_catalog` / `information_schema` semantics for databases,
-schemas, tables, columns and primary keys. The JDBC URL owns the active database; `schema.table` is the normal table
-path, and an explicit `database.schema.table` is accepted only when the database matches the one in the JDBC URL. This
-prevents metadata from one database being paired with data read through another connection URL.
+The bounded Source reuses the proven PostgreSQL-compatible **read-side type contract** while keeping its own URL parser,
+dialect, row converter and Catalog. Metadata discovery uses `information_schema` semantics for schemas, tables, columns
+and primary keys. The JDBC URL owns the active database; `schema.table` is the normal table path, and an explicit
+`database.schema.table` is accepted only when the database matches the one in the JDBC URL. This prevents metadata from
+one database being paired with data read through another connection URL.
 
-The source supports bounded single-table and multi-table jobs, custom query reads and the shared safe JDBC partition
-planner. Stage 1 advertises `BEST_EFFORT` consistency only. It deliberately does not implement `WritableCatalog`, Sink
-DDL, INSERT/UPSERT, automatic table creation, CDC, streaming checkpoints, coordinated database snapshots, or Oracle /
-MySQL / Teradata compatibility-mode expansion. Those remain product-specific follow-up stages.
+The existing-table Sink reuses the shared transactional JDBC writer: standard parameterized `INSERT`, configured batch
+size, `PreparedStatement.addBatch()/executeBatch()`, task-local commit/rollback, retry/savepoint handling and dirty-data
+behavior all remain in the common JDBC path. No GBase-specific writer is introduced. The target database always comes
+from the Sink JDBC URL. An explicit `schema.table` target mapping is preserved; otherwise target connection settings are
+preferred so a source database/schema cannot silently leak into a different GBase 8c target.
+
+GBase 8c target tables must already exist. The Catalog implements `WritableCatalog` only so the common Sink save-mode
+lifecycle can validate existing tables and support `DROP_DATA` through `TRUNCATE TABLE`. Automatic database/table
+creation, table recreation, `ADD COLUMN`, `DROP TABLE` and target DDL type generation are blocked explicitly.
+`CREATE_SCHEMA_WHEN_NOT_EXIST` therefore works when the target already exists and fails clearly when it does not;
+`RECREATE_SCHEMA` is rejected before a destructive drop can occur.
+
+The current GBase 8c Sink intentionally does not advertise UPSERT. `write_mode = UPSERT` fails during Sink preparation
+instead of guessing PostgreSQL/MySQL/compatibility-mode conflict semantics. CDC, streaming checkpoints, coordinated
+database snapshots, automatic distributed-table design, Oracle/MySQL/Teradata compatibility-mode expansion and native
+bulk-loading paths remain separate stages.
 
 The dedicated GBase 8c JDBC driver is not guessed as a Maven dependency by this module. Deployments must place the vendor
 JDBC driver on the runtime classpath and configure `driver = "com.gbase8c.Driver"` explicitly.

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
@@ -1,0 +1,322 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Read-only GBase 8c Catalog for the bounded Source stage.
+ *
+ * <p>Metadata follows the PG-compatible information_schema contract, while the JDBC connection
+ * remains the dedicated GBase 8c protocol. One Source connection owns exactly one database; other
+ * databases are intentionally not exposed as selectable targets. This class does not implement
+ * WritableCatalog so the generic JDBC Sink rejects it during preparation.</p>
+ */
+public final class GBase8cCatalog implements Catalog {
+
+    public static final String TABLE_OPTION_DIALECT = "dialect";
+
+    private static final String DEFAULT_SCHEMA = "public";
+
+    private static final String LIST_SCHEMAS_SQL =
+            "SELECT schema_name FROM information_schema.schemata ORDER BY schema_name";
+
+    private static final String LIST_TABLES_SQL =
+            "SELECT table_name FROM information_schema.tables "
+                    + "WHERE table_schema = ? AND table_type = 'BASE TABLE' ORDER BY table_name";
+
+    private static final String TABLE_EXISTS_SQL =
+            "SELECT 1 FROM information_schema.tables "
+                    + "WHERE table_schema = ? AND table_name = ? AND table_type = 'BASE TABLE'";
+
+    private static final String SELECT_COLUMNS_SQL =
+            "SELECT "
+                    + "c.column_name AS COLUMN_NAME, "
+                    + "c.data_type AS DATA_TYPE, "
+                    + "c.udt_name AS UDT_NAME, "
+                    + "c.character_maximum_length AS CHARACTER_MAXIMUM_LENGTH, "
+                    + "c.numeric_precision AS NUMERIC_PRECISION, "
+                    + "c.numeric_scale AS NUMERIC_SCALE, "
+                    + "c.datetime_precision AS DATETIME_PRECISION, "
+                    + "c.is_nullable AS IS_NULLABLE, "
+                    + "c.column_default AS COLUMN_DEFAULT, "
+                    + "NULL AS IS_IDENTITY, "
+                    + "NULL AS COLUMN_COMMENT "
+                    + "FROM information_schema.columns c "
+                    + "WHERE c.table_schema = ? AND c.table_name = ? "
+                    + "ORDER BY c.ordinal_position";
+
+    private static final String SELECT_PRIMARY_KEY_SQL =
+            "SELECT tc.constraint_name AS CONSTRAINT_NAME, "
+                    + "kcu.column_name AS COLUMN_NAME "
+                    + "FROM information_schema.table_constraints tc "
+                    + "JOIN information_schema.key_column_usage kcu "
+                    + "ON tc.constraint_schema = kcu.constraint_schema "
+                    + "AND tc.constraint_name = kcu.constraint_name "
+                    + "WHERE tc.table_schema = ? AND tc.table_name = ? "
+                    + "AND tc.constraint_type = 'PRIMARY KEY' "
+                    + "ORDER BY kcu.ordinal_position";
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String defaultDatabase;
+    private final String defaultSchema;
+    private final GBase8cTypeMapper typeMapper = new GBase8cTypeMapper();
+    private volatile boolean opened;
+
+    public GBase8cCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            String defaultSchema) {
+        if (catalogName == null || catalogName.trim().isEmpty()) {
+            throw new IllegalArgumentException("catalogName must not be empty");
+        }
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        if (!GBase8cJdbcUrl.accepts(config.getUrl())) {
+            throw new IllegalArgumentException("非法 GBase 8c JDBC URL：" + config.getUrl());
+        }
+        String database = GBase8cJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(database)) {
+            throw new IllegalArgumentException("GBase 8c JDBC URL 必须指定数据库");
+        }
+        this.catalogName = catalogName.trim();
+        this.config = config;
+        this.defaultDatabase = database;
+        this.defaultSchema = hasText(defaultSchema) ? defaultSchema.trim() : DEFAULT_SCHEMA;
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+        loadDriver();
+        try (Connection connection = newConnection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException("GBase 8c Catalog 连接校验失败：" + config.getUrl());
+            }
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException("GBase 8c Catalog 连接失败：" + config.getUrl(), e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.of(defaultDatabase);
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        checkOpened();
+        return Collections.singletonList(defaultDatabase);
+    }
+
+    @Override
+    public List<String> listSchemas(String databaseName) throws CatalogException {
+        checkOpened();
+        requireCurrentDatabase(databaseName);
+        try (Connection connection = newConnection();
+             PreparedStatement statement = connection.prepareStatement(LIST_SCHEMAS_SQL);
+             ResultSet resultSet = statement.executeQuery()) {
+            List<String> schemas = new ArrayList<String>();
+            while (resultSet.next()) {
+                schemas.add(resultSet.getString(1));
+            }
+            return schemas;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 GBase 8c Schema 列表失败，database=" + defaultDatabase,
+                    e);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String databaseName,
+            String schemaName) throws CatalogException {
+        checkOpened();
+        requireCurrentDatabase(databaseName);
+        String schema = resolveSchemaName(schemaName);
+        try (Connection connection = newConnection();
+             PreparedStatement statement = connection.prepareStatement(LIST_TABLES_SQL)) {
+            statement.setString(1, schema);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<TablePath> tables = new ArrayList<TablePath>();
+                while (resultSet.next()) {
+                    tables.add(TablePath.of(
+                            defaultDatabase,
+                            schema,
+                            resultSet.getString("table_name")));
+                }
+                return tables;
+            }
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 GBase 8c 表列表失败，database="
+                            + defaultDatabase
+                            + ", schema="
+                            + schema,
+                    e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        checkOpened();
+        TablePath normalized = normalizeTablePath(tablePath);
+        try (Connection connection = newConnection();
+             PreparedStatement statement = connection.prepareStatement(TABLE_EXISTS_SQL)) {
+            statement.setString(1, normalized.getSchemaName());
+            statement.setString(2, normalized.getTableName());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next();
+            }
+        } catch (SQLException e) {
+            throw new CatalogException("检查 GBase 8c 表是否存在失败，table=" + normalized, e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath normalized = normalizeTablePath(tablePath);
+        try (Connection connection = newConnection()) {
+            List<Column> columns = readColumns(connection, normalized);
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(catalogName, normalized);
+            }
+            PrimaryKey primaryKey = readPrimaryKey(connection, normalized);
+            TableSchema schema = TableSchema.builder()
+                    .columns(columns)
+                    .primaryKey(primaryKey)
+                    .build();
+            return CatalogTable.builder(normalized, schema)
+                    .option(TABLE_OPTION_DIALECT, DatabaseIdentifier.GBASE8C)
+                    .build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 GBase 8c 表结构失败，table=" + normalized, e);
+        }
+    }
+
+    private List<Column> readColumns(Connection connection, TablePath tablePath)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_COLUMNS_SQL)) {
+            statement.setString(1, tablePath.getSchemaName());
+            statement.setString(2, tablePath.getTableName());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                List<Column> columns = new ArrayList<Column>();
+                while (resultSet.next()) {
+                    columns.add(typeMapper.toColumn(resultSet));
+                }
+                return columns;
+            }
+        }
+    }
+
+    private PrimaryKey readPrimaryKey(Connection connection, TablePath tablePath)
+            throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(SELECT_PRIMARY_KEY_SQL)) {
+            statement.setString(1, tablePath.getSchemaName());
+            statement.setString(2, tablePath.getTableName());
+            try (ResultSet resultSet = statement.executeQuery()) {
+                String primaryKeyName = null;
+                List<String> columns = new ArrayList<String>();
+                while (resultSet.next()) {
+                    if (primaryKeyName == null) {
+                        primaryKeyName = resultSet.getString("CONSTRAINT_NAME");
+                    }
+                    columns.add(resultSet.getString("COLUMN_NAME"));
+                }
+                return columns.isEmpty() ? null : PrimaryKey.of(primaryKeyName, columns);
+            }
+        }
+    }
+
+    private TablePath normalizeTablePath(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        requireCurrentDatabase(tablePath.getDatabaseName());
+        if (!hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("table name must not be empty");
+        }
+        return TablePath.of(
+                defaultDatabase,
+                resolveSchemaName(tablePath.getSchemaName()),
+                tablePath.getTableName().trim());
+    }
+
+    private void requireCurrentDatabase(String databaseName) {
+        if (hasText(databaseName) && !defaultDatabase.equals(databaseName.trim())) {
+            throw new IllegalArgumentException(
+                    "GBase 8c Stage 1 连接固定到 database="
+                            + defaultDatabase
+                            + "，不支持请求 database="
+                            + databaseName);
+        }
+    }
+
+    private String resolveSchemaName(String schemaName) {
+        return hasText(schemaName) ? schemaName.trim() : defaultSchema;
+    }
+
+    private Connection newConnection() throws SQLException {
+        return DriverManager.getConnection(config.getUrl(), config.toConnectionProperties());
+    }
+
+    private void loadDriver() {
+        if (!hasText(config.getDriverClass())) {
+            return;
+        }
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException("找不到 GBase 8c JDBC Driver：" + config.getDriverClass(), e);
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
@@ -1,12 +1,15 @@
 package com.link.up.connector.jdbc.catalog.gbase.gbase8c;
 
-import com.link.up.api.table.catalog.Catalog;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.Column;
 import com.link.up.api.table.catalog.PrimaryKey;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
 import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
 import com.link.up.api.table.catalog.exception.TableNotFoundException;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
@@ -18,20 +21,21 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * Read-only GBase 8c Catalog for the bounded Source stage.
+ * GBase 8c Catalog for bounded Source and existing-table Sink jobs.
  *
  * <p>Metadata follows the PG-compatible information_schema contract, while the JDBC connection
- * remains the dedicated GBase 8c protocol. One Source connection owns exactly one database; other
- * databases are intentionally not exposed as selectable targets. This class does not implement
- * WritableCatalog so the generic JDBC Sink rejects it during preparation.</p>
+ * remains bound to one GBase 8c database. Sink preparation may validate and truncate an existing
+ * target table, but all structure-changing DDL stays blocked until GBase 8c distribution and
+ * compatibility-mode semantics are modeled explicitly.</p>
  */
-public final class GBase8cCatalog implements Catalog {
+public final class GBase8cCatalog implements WritableCatalog {
 
     public static final String TABLE_OPTION_DIALECT = "dialect";
 
@@ -233,6 +237,72 @@ public final class GBase8cCatalog implements Catalog {
         }
     }
 
+    @Override
+    public void createDatabase(
+            String databaseName,
+            boolean ignoreIfExists)
+            throws CatalogException, DatabaseAlreadyExistsException {
+        throw unsupportedSchemaDdl("create database");
+    }
+
+    @Override
+    public void dropDatabase(
+            String databaseName,
+            boolean ignoreIfNotExists)
+            throws CatalogException, DatabaseNotFoundException {
+        throw unsupportedSchemaDdl("drop database");
+    }
+
+    @Override
+    public void createTable(
+            CatalogTable table,
+            boolean ignoreIfExists)
+            throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+        throw unsupportedSchemaDdl("create table");
+    }
+
+    @Override
+    public void addColumn(
+            TablePath tablePath,
+            Column column)
+            throws CatalogException, TableNotFoundException {
+        throw unsupportedSchemaDdl("add column");
+    }
+
+    @Override
+    public void dropTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        throw unsupportedSchemaDdl("drop table");
+    }
+
+    @Override
+    public void truncateTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath normalized = normalizeTablePath(tablePath);
+        if (!tableExists(normalized)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotFoundException(catalogName, normalized);
+        }
+
+        String sql = "TRUNCATE TABLE "
+                + quoteIdentifier(normalized.getSchemaName())
+                + "."
+                + quoteIdentifier(normalized.getTableName());
+        try (Connection connection = newConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        } catch (SQLException e) {
+            throw new CatalogException("清空 GBase 8c 表失败，table=" + normalized, e);
+        }
+    }
+
     private List<Column> readColumns(Connection connection, TablePath tablePath)
             throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(SELECT_COLUMNS_SQL)) {
@@ -284,9 +354,9 @@ public final class GBase8cCatalog implements Catalog {
     private void requireCurrentDatabase(String databaseName) {
         if (hasText(databaseName) && !defaultDatabase.equals(databaseName.trim())) {
             throw new IllegalArgumentException(
-                    "GBase 8c Stage 1 连接固定到 database="
+                    "GBase 8c bounded JDBC adapter is fixed to database="
                             + defaultDatabase
-                            + "，不支持请求 database="
+                            + " and does not support database="
                             + databaseName);
         }
     }
@@ -314,6 +384,20 @@ public final class GBase8cCatalog implements Catalog {
         if (!opened) {
             throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
         }
+    }
+
+    private static String quoteIdentifier(String identifier) {
+        if (!hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + identifier.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static CatalogException unsupportedSchemaDdl(String operation) {
+        return new CatalogException(
+                "GBase 8c existing-table Sink supports target-table DML only; "
+                        + operation
+                        + " is disabled until distribution and compatibility-mode DDL is modeled");
     }
 
     private static boolean hasText(String value) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialect.java
@@ -11,10 +11,11 @@ import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
 
 /**
- * GBase 8c bounded/offline JDBC Source dialect.
+ * GBase 8c bounded/offline JDBC dialect.
  *
- * <p>Stage 1 targets the dedicated GBase 8c JDBC protocol and PG-compatible metadata/read
- * semantics. Sink DDL, INSERT/UPSERT, CDC and compatibility-mode expansion are separate stages.</p>
+ * <p>The adapter targets the dedicated GBase 8c JDBC protocol and PG-compatible metadata/read
+ * semantics. The existing-table Sink stage reuses the portable INSERT/batch path only; UPSERT,
+ * structure-changing DDL, CDC and compatibility-mode expansion remain separate stages.</p>
  */
 public final class GBase8cDialect implements JdbcDialect {
 
@@ -72,7 +73,7 @@ public final class GBase8cDialect implements JdbcDialect {
         return new GBase8cJdbcRowConverter();
     }
 
-    /** GBase 8c Stage 1 follows PG-compatible schema.table path semantics. */
+    /** GBase 8c follows PG-compatible schema.table path semantics. */
     @Override
     public TablePath parseTablePath(String tablePath) {
         if (!JdbcDialect.hasText(tablePath)) {
@@ -127,9 +128,10 @@ public final class GBase8cDialect implements JdbcDialect {
         if (!JdbcDialect.hasText(requestedDatabase)
                 || !databaseName.equals(requestedDatabase.trim())) {
             throw new IllegalArgumentException(
-                    "GBase 8c Stage 1 不支持跨 database table_path；当前 JDBC 数据库="
+                    "GBase 8c bounded JDBC adapter does not support cross-database table_path; "
+                            + "current database="
                             + databaseName
-                            + "，请求数据库="
+                            + ", requested database="
                             + requestedDatabase);
         }
     }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialect.java
@@ -1,0 +1,136 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.gbase.gbase8c.GBase8cCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+/**
+ * GBase 8c bounded/offline JDBC Source dialect.
+ *
+ * <p>Stage 1 targets the dedicated GBase 8c JDBC protocol and PG-compatible metadata/read
+ * semantics. Sink DDL, INSERT/UPSERT, CDC and compatibility-mode expansion are separate stages.</p>
+ */
+public final class GBase8cDialect implements JdbcDialect {
+
+    private static final String DEFAULT_SCHEMA = "public";
+
+    private final JdbcConnectionConfig connectionConfig;
+    private final String databaseName;
+    private final GBase8cTypeMapper typeMapper;
+
+    public GBase8cDialect(JdbcConnectionConfig connectionConfig) {
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException("connectionConfig must not be null");
+        }
+        if (!GBase8cJdbcUrl.accepts(connectionConfig.getUrl())) {
+            throw new IllegalArgumentException(
+                    "非法 GBase 8c JDBC URL：" + connectionConfig.getUrl());
+        }
+        String database = GBase8cJdbcUrl.databaseName(connectionConfig.getUrl());
+        if (!JdbcDialect.hasText(database)) {
+            throw new IllegalArgumentException("GBase 8c JDBC URL 必须指定数据库");
+        }
+        this.connectionConfig = connectionConfig;
+        this.databaseName = database;
+        this.typeMapper = new GBase8cTypeMapper();
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.GBASE8C;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+        return new GBase8cCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false),
+                connectionConfig.getSchema());
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new GBase8cJdbcRowConverter();
+    }
+
+    /** GBase 8c Stage 1 follows PG-compatible schema.table path semantics. */
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        if (!JdbcDialect.hasText(tablePath)) {
+            throw new IllegalArgumentException("tablePath must not be empty");
+        }
+        String[] parts = tablePath.trim().split("\\.");
+        switch (parts.length) {
+            case 1:
+                return TablePath.of(parts[0]);
+            case 2:
+                return TablePath.of(null, parts[0], parts[1]);
+            case 3:
+                requireCurrentDatabase(parts[0]);
+                return TablePath.of(databaseName, parts[1], parts[2]);
+            default:
+                throw new IllegalArgumentException(
+                        "非法 GBase 8c 表路径：" + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        if (!JdbcDialect.hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + identifier.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    /** Database is selected by the JDBC URL; SQL identifiers use schema.table. */
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (JdbcDialect.hasText(tablePath.getDatabaseName())) {
+            requireCurrentDatabase(tablePath.getDatabaseName());
+        }
+        if (!JdbcDialect.hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("table name must not be empty");
+        }
+        String schema = tablePath.getSchemaName();
+        if (!JdbcDialect.hasText(schema)) {
+            schema = connectionConfig.getSchema();
+        }
+        if (!JdbcDialect.hasText(schema)) {
+            schema = DEFAULT_SCHEMA;
+        }
+        return quoteIdentifier(schema) + "." + quoteIdentifier(tablePath.getTableName());
+    }
+
+    private void requireCurrentDatabase(String requestedDatabase) {
+        if (!JdbcDialect.hasText(requestedDatabase)
+                || !databaseName.equals(requestedDatabase.trim())) {
+            throw new IllegalArgumentException(
+                    "GBase 8c Stage 1 不支持跨 database table_path；当前 JDBC 数据库="
+                            + databaseName
+                            + "，请求数据库="
+                            + requestedDatabase);
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectFactory.java
@@ -1,0 +1,27 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/** GBase 8c bounded JDBC Source dialect factory. */
+@AutoService(JdbcDialectFactory.class)
+public final class GBase8cDialectFactory implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.GBASE8C;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return GBase8cJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(JdbcConnectionConfig connectionConfig) {
+        return new GBase8cDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectFactory.java
@@ -6,7 +6,7 @@ import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
 
-/** GBase 8c bounded JDBC Source dialect factory. */
+/** GBase 8c bounded Source and existing-table Sink dialect factory. */
 @AutoService(JdbcDialectFactory.class)
 public final class GBase8cDialectFactory implements JdbcDialectFactory {
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cJdbcRowConverter.java
@@ -1,0 +1,13 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+/** GBase 8c bounded Source row converter. */
+public final class GBase8cJdbcRowConverter extends AbstractJdbcRowConverter {
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.GBASE8C;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cJdbcRowConverter.java
@@ -3,7 +3,7 @@ package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
 import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 
-/** GBase 8c bounded Source row converter. */
+/** GBase 8c bounded Source and existing-table Sink row converter. */
 public final class GBase8cJdbcRowConverter extends AbstractJdbcRowConverter {
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cJdbcUrl.java
@@ -1,0 +1,34 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import java.util.Locale;
+
+/** Dedicated GBase 8c JDBC URL helpers for bounded/offline reads. */
+public final class GBase8cJdbcUrl {
+
+    private static final String PREFIX = "jdbc:gbase8c://";
+
+    private GBase8cJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return url != null
+                && url.trim().toLowerCase(Locale.ROOT).startsWith(PREFIX);
+    }
+
+    public static String databaseName(String url) {
+        if (!accepts(url)) {
+            return null;
+        }
+
+        String value = url.trim();
+        int queryIndex = value.indexOf('?');
+        String main = queryIndex >= 0 ? value.substring(0, queryIndex) : value;
+        int databaseSeparator = main.indexOf('/', PREFIX.length());
+        if (databaseSeparator < 0 || databaseSeparator == main.length() - 1) {
+            return null;
+        }
+
+        String database = main.substring(databaseSeparator + 1).trim();
+        return database.isEmpty() ? null : database;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTypeMapper.java
@@ -9,10 +9,11 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 /**
- * GBase 8c Stage 1 type mapper.
+ * GBase 8c type mapper for bounded Source and existing-table Sink jobs.
  *
- * <p>The bounded Source targets PG-compatible databases and reuses the mature PostgreSQL read-side
- * type contract. Sink DDL mapping stays disabled until the dedicated GBase 8c Sink stage.</p>
+ * <p>The adapter reuses the mature PostgreSQL-compatible read-side type contract. The current Sink
+ * writes only to pre-created tables, so target DDL type generation stays disabled until a later
+ * GBase 8c table-creation stage models distribution and compatibility-mode semantics.</p>
  */
 public final class GBase8cTypeMapper implements JdbcTypeMapper {
 
@@ -31,6 +32,6 @@ public final class GBase8cTypeMapper implements JdbcTypeMapper {
     @Override
     public String toDatabaseType(Column column) {
         throw new UnsupportedOperationException(
-                "GBase 8c Stage 1 is source-only; target type generation belongs to the Sink stage");
+                "GBase 8c existing-table Sink does not generate target DDL types");
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTypeMapper.java
@@ -1,0 +1,36 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+import com.link.up.connector.jdbc.core.dialect.postgres.PostgresTypeMapper;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/**
+ * GBase 8c Stage 1 type mapper.
+ *
+ * <p>The bounded Source targets PG-compatible databases and reuses the mature PostgreSQL read-side
+ * type contract. Sink DDL mapping stays disabled until the dedicated GBase 8c Sink stage.</p>
+ */
+public final class GBase8cTypeMapper implements JdbcTypeMapper {
+
+    private final PostgresTypeMapper delegate = new PostgresTypeMapper();
+
+    @Override
+    public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+        return delegate.map(metadata, columnIndex);
+    }
+
+    /** Maps one information_schema.columns row using the PG-compatible read contract. */
+    public Column toColumn(ResultSet row) throws SQLException {
+        return delegate.toColumn(row);
+    }
+
+    @Override
+    public String toDatabaseType(Column column) {
+        throw new UnsupportedOperationException(
+                "GBase 8c Stage 1 is source-only; target type generation belongs to the Sink stage");
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupport.java
@@ -1,0 +1,66 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cJdbcUrl;
+
+/** Target-path normalization for the GBase 8c existing-table Sink stage. */
+final class GBase8cSinkSupport {
+
+    private static final String DEFAULT_SCHEMA = "public";
+
+    private GBase8cSinkSupport() {
+    }
+
+    static boolean accepts(JdbcConnectionConfig config) {
+        if (config == null) {
+            return false;
+        }
+        if (hasText(config.getDialect())) {
+            return DatabaseIdentifier.GBASE8C.equalsIgnoreCase(config.getDialect());
+        }
+        return GBase8cJdbcUrl.accepts(config.getUrl());
+    }
+
+    static TablePath resolveTargetPath(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+        if (config == null || tablePath == null) {
+            return tablePath;
+        }
+
+        String database = GBase8cJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(database)) {
+            return null;
+        }
+
+        String pathDatabase = tablePath.getDatabaseName();
+        String pathSchema = tablePath.getSchemaName();
+        String schema;
+
+        /*
+         * Keep schema.table from an explicit target mapping. A three-part source path is safe to
+         * reuse only when its database is already the target database; otherwise prefer target
+         * connection settings so source database/schema metadata cannot leak into the Sink.
+         */
+        if (hasText(pathSchema)
+                && (!hasText(pathDatabase)
+                || database.equals(pathDatabase.trim()))) {
+            schema = pathSchema.trim();
+        } else if (hasText(config.getSchema())) {
+            schema = config.getSchema().trim();
+        } else {
+            schema = DEFAULT_SCHEMA;
+        }
+
+        return TablePath.of(
+                database,
+                schema,
+                tablePath.getTableName());
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -141,6 +141,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return GoldenDbSinkSupport.resolveTargetPath(
                     config.getConnectionConfig(), tablePath);
         }
+        if (GBase8cSinkSupport.accepts(config.getConnectionConfig())) {
+            return GBase8cSinkSupport.resolveTargetPath(
+                    config.getConnectionConfig(), tablePath);
+        }
         return JdbcCreateTableSqlResolver.resolveTargetPath(
                 config.getConnectionConfig(), tablePath);
     }
@@ -167,6 +171,9 @@ final class JdbcSinkPreparer implements SinkPreparer {
                     config.getConnectionConfig(), table);
         }
         if (GoldenDbSinkSupport.accepts(config.getConnectionConfig())) {
+            return null;
+        }
+        if (GBase8cSinkSupport.accepts(config.getConnectionConfig())) {
             return null;
         }
         return JdbcCreateTableSqlResolver.resolve(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalogTest.java
@@ -1,0 +1,88 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class GBase8cCatalogTest {
+
+    @Test
+    public void existingTableSinkRejectsAutomaticTableCreation() {
+        GBase8cCatalog catalog = catalog();
+
+        try {
+            catalog.createTable(table(), false);
+            fail("GBase 8c existing-table Sink must not auto-create target tables");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("existing-table Sink"));
+            assertTrue(expected.getMessage().contains("create table"));
+        }
+    }
+
+    @Test
+    public void existingTableSinkRejectsDestructiveSchemaRecreationBeforeDrop() {
+        GBase8cCatalog catalog = catalog();
+
+        try {
+            catalog.dropTable(
+                    TablePath.of("app", "public", "orders"),
+                    false);
+            fail("GBase 8c existing-table Sink must not drop target tables");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("drop table"));
+        }
+    }
+
+    @Test
+    public void existingTableSinkRejectsSchemaEvolution() {
+        GBase8cCatalog catalog = catalog();
+
+        try {
+            catalog.addColumn(
+                    TablePath.of("app", "public", "orders"),
+                    Column.builder("extra", BasicType.STRING_TYPE).build());
+            fail("GBase 8c existing-table Sink must not add target columns");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("add column"));
+        }
+    }
+
+    private static GBase8cCatalog catalog() {
+        return new GBase8cCatalog(
+                "gbase8c",
+                new JdbcCatalogConfig(
+                        "jdbc:gbase8c://127.0.0.1:5432/app",
+                        "gbase",
+                        "password",
+                        "com.gbase8c.Driver",
+                        Collections.emptyMap(),
+                        false),
+                "public");
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .columns(
+                                Collections.singletonList(
+                                        Column.builder("id", BasicType.LONG_TYPE)
+                                                .nullable(false)
+                                                .build()))
+                        .build();
+
+        return CatalogTable.builder(
+                        TablePath.of("app", "public", "orders"),
+                        schema)
+                .build();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectTest.java
@@ -1,0 +1,165 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.config.ReadConsistency;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cDialectTest {
+
+    @Test
+    public void loadsDedicatedGBase8cDialectFromJdbcUrlThroughSpi() {
+        JdbcDialect dialect = JdbcDialectLoader.load(config(null, baseUrl(), null, null));
+        assertEquals(DatabaseIdentifier.GBASE8C, dialect.name());
+    }
+
+    @Test
+    public void factoryOnlyAcceptsDedicatedGBase8cProtocol() {
+        GBase8cDialectFactory factory = new GBase8cDialectFactory();
+        assertTrue(factory.acceptsUrl(baseUrl()));
+        assertFalse(factory.acceptsUrl("jdbc:postgresql://127.0.0.1:5432/app"));
+        assertFalse(factory.acceptsUrl("jdbc:gbase://127.0.0.1:5258/app"));
+        assertFalse(factory.acceptsUrl("jdbc:mysql://127.0.0.1:3306/app"));
+    }
+
+    @Test
+    public void explicitDialectLoadsDedicatedGBase8cIdentity() {
+        JdbcDialect dialect = JdbcDialectLoader.load(
+                config(null, baseUrl(), null, DatabaseIdentifier.GBASE8C));
+        assertEquals(DatabaseIdentifier.GBASE8C, dialect.name());
+    }
+
+    @Test
+    public void jdbcUrlHelperExtractsDatabaseWithoutQueryProperties() {
+        assertEquals("app", GBase8cJdbcUrl.databaseName(baseUrl()));
+        assertEquals(
+                "archive",
+                GBase8cJdbcUrl.databaseName(
+                        "jdbc:gbase8c://127.0.0.1:5432/archive?loggerLevel=warning"));
+    }
+
+    @Test
+    public void parsesPgCompatibleSchemaTablePaths() {
+        GBase8cDialect dialect = dialect(null);
+        assertEquals(
+                TablePath.of(null, "sales", "orders"),
+                dialect.parseTablePath("sales.orders"));
+        assertEquals(
+                TablePath.of("app", "sales", "orders"),
+                dialect.parseTablePath("app.sales.orders"));
+    }
+
+    @Test
+    public void rejectsCrossDatabaseTablePaths() {
+        GBase8cDialect dialect = dialect(null);
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> dialect.parseTablePath("archive.sales.orders"));
+        assertTrue(error.getMessage().contains("不支持跨 database"));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> dialect.tableIdentifier(TablePath.of("archive", "sales", "orders")));
+    }
+
+    @Test
+    public void configuredSchemaAndPublicFallbackQualifyTables() {
+        assertEquals(
+                "\"sales\".\"orders\"",
+                dialect("sales").tableIdentifier(TablePath.of("orders")));
+        assertEquals(
+                "\"public\".\"orders\"",
+                dialect(null).tableIdentifier(TablePath.of("orders")));
+        assertEquals(
+                "\"archive\".\"orders\"",
+                dialect("sales").tableIdentifier(TablePath.of(null, "archive", "orders")));
+    }
+
+    @Test
+    public void stageOneCatalogIsReadOnlyAndUpsertIsNotAdvertised() {
+        GBase8cDialect dialect = dialect("public");
+        Catalog catalog = dialect.createCatalog(config("public", baseUrl(), null, null));
+        assertFalse(catalog instanceof WritableCatalog);
+        assertFalse(dialect.buildUpsertSql(
+                TablePath.of(null, "public", "orders"),
+                Arrays.asList("id", "name"),
+                Collections.singletonList("id")).isPresent());
+    }
+
+    @Test
+    public void stageOneTypeMapperDoesNotGenerateSinkTypes() {
+        Column column = Column.builder("name", BasicType.STRING_TYPE).build();
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> dialect("public").typeMapper().toDatabaseType(column));
+    }
+
+    @Test
+    public void stageOneAdvertisesBestEffortReadConsistencyOnly() {
+        assertEquals(
+                Collections.singleton(ReadConsistency.BEST_EFFORT),
+                dialect("public").supportedReadConsistencies());
+    }
+
+    @Test
+    public void rowConverterKeepsFirstClassDatabaseIdentity() {
+        assertEquals(
+                DatabaseIdentifier.GBASE8C,
+                dialect("public").rowConverter().name());
+    }
+
+    @Test
+    public void requiresDatabaseInDedicatedJdbcUrl() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new GBase8cDialect(
+                        config(null, "jdbc:gbase8c://127.0.0.1:5432", null, null)));
+    }
+
+    private static GBase8cDialect dialect(String schema) {
+        return new GBase8cDialect(config(schema, baseUrl(), null, null));
+    }
+
+    private static JdbcConnectionConfig config(
+            String schema,
+            String url,
+            Map<String, String> properties,
+            String dialect) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", "com.gbase8c.Driver");
+        values.put("username", "gbase");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (properties != null) {
+            values.put("properties", properties);
+        }
+        if (dialect != null) {
+            values.put("dialect", dialect);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:gbase8c://127.0.0.1:5432/app?loggerLevel=warning";
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectTest.java
@@ -73,7 +73,7 @@ public class GBase8cDialectTest {
         IllegalArgumentException error = assertThrows(
                 IllegalArgumentException.class,
                 () -> dialect.parseTablePath("archive.sales.orders"));
-        assertTrue(error.getMessage().contains("不支持跨 database"));
+        assertTrue(error.getMessage().contains("cross-database"));
 
         assertThrows(
                 IllegalArgumentException.class,
@@ -94,10 +94,15 @@ public class GBase8cDialectTest {
     }
 
     @Test
-    public void stageOneCatalogIsReadOnlyAndUpsertIsNotAdvertised() {
+    public void existingTableSinkUsesPortableInsertAndStillRejectsUpsert() {
         GBase8cDialect dialect = dialect("public");
         Catalog catalog = dialect.createCatalog(config("public", baseUrl(), null, null));
-        assertFalse(catalog instanceof WritableCatalog);
+        assertTrue(catalog instanceof WritableCatalog);
+        assertEquals(
+                "INSERT INTO \"public\".\"orders\" (\"id\", \"name\") VALUES (?, ?)",
+                dialect.buildInsertSql(
+                        TablePath.of("app", "public", "orders"),
+                        Arrays.asList("id", "name")));
         assertFalse(dialect.buildUpsertSql(
                 TablePath.of(null, "public", "orders"),
                 Arrays.asList("id", "name"),
@@ -105,7 +110,7 @@ public class GBase8cDialectTest {
     }
 
     @Test
-    public void stageOneTypeMapperDoesNotGenerateSinkTypes() {
+    public void existingTableSinkDoesNotGenerateDdlTypes() {
         Column column = Column.builder("name", BasicType.STRING_TYPE).build();
         assertThrows(
                 UnsupportedOperationException.class,
@@ -113,7 +118,7 @@ public class GBase8cDialectTest {
     }
 
     @Test
-    public void stageOneAdvertisesBestEffortReadConsistencyOnly() {
+    public void boundedSourceStillAdvertisesBestEffortReadConsistencyOnly() {
         assertEquals(
                 Collections.singleton(ReadConsistency.BEST_EFFORT),
                 dialect("public").supportedReadConsistencies());

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupportTest.java
@@ -1,0 +1,126 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cDialect;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cSinkSupportTest {
+
+    @Test
+    public void sourceDatabaseAndSchemaDoNotLeakIntoGBase8cTarget() {
+        TablePath target =
+                GBase8cSinkSupport.resolveTargetPath(
+                        config("target_db", "landing", DatabaseIdentifier.GBASE8C),
+                        TablePath.of("source_db", "source_schema", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "landing", "orders"),
+                target);
+    }
+
+    @Test
+    public void foreignSourceSchemaFallsBackToPublicWithoutTargetSchema() {
+        TablePath target =
+                GBase8cSinkSupport.resolveTargetPath(
+                        config("target_db", null, DatabaseIdentifier.GBASE8C),
+                        TablePath.of("source_db", "source_schema", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "public", "orders"),
+                target);
+    }
+
+    @Test
+    public void explicitSchemaTableMappingWinsOverConfiguredDefaultSchema() {
+        TablePath target =
+                GBase8cSinkSupport.resolveTargetPath(
+                        config("target_db", "public", DatabaseIdentifier.GBASE8C),
+                        TablePath.of(null, "archive", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "archive", "orders"),
+                target);
+    }
+
+    @Test
+    public void schemaCanBePreservedWhenPathAlreadyTargetsSameDatabase() {
+        TablePath target =
+                GBase8cSinkSupport.resolveTargetPath(
+                        config("target_db", "public", DatabaseIdentifier.GBASE8C),
+                        TablePath.of("target_db", "sales", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "sales", "orders"),
+                target);
+    }
+
+    @Test
+    public void dedicatedUrlCanSelectSinkSupportWithoutExplicitDialect() {
+        assertTrue(GBase8cSinkSupport.accepts(config("target_db", null, null)));
+        assertTrue(GBase8cSinkSupport.accepts(
+                config("target_db", null, DatabaseIdentifier.GBASE8C)));
+        assertFalse(GBase8cSinkSupport.accepts(
+                config("target_db", null, DatabaseIdentifier.POSTGRESQL)));
+    }
+
+    @Test
+    public void existingTableSinkDoesNotGenerateAutomaticCreateTableSql() {
+        JdbcConnectionConfig config =
+                config("target_db", "public", DatabaseIdentifier.GBASE8C);
+
+        assertNull(
+                JdbcCreateTableSqlResolver.resolve(
+                        new GBase8cDialect(config),
+                        config,
+                        table()));
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .columns(
+                                Collections.singletonList(
+                                        Column.builder("id", BasicType.LONG_TYPE)
+                                                .nullable(false)
+                                                .build()))
+                        .build();
+
+        return CatalogTable.builder(
+                        TablePath.of("source_db", "source_schema", "orders"),
+                        schema)
+                .build();
+    }
+
+    private static JdbcConnectionConfig config(
+            String database,
+            String schema,
+            String dialect) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", "jdbc:gbase8c://127.0.0.1:5432/" + database);
+        values.put("driver", "com.gbase8c.Driver");
+        values.put("username", "gbase");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (dialect != null) {
+            values.put("dialect", dialect);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}


### PR DESCRIPTION
## Summary

Add the first runtime stage for the GBase family: a bounded/offline **GBase 8c JDBC Source**.

This is intentionally a stacked PR on top of #121 (`feat/gbase-family-scaffold`). The diff contains only GBase 8c Source behavior; GBase 8a/8s remain identity-only scaffolds until their own stages.

## Dependency

- depends on #121
- PR base: `feat/gbase-family-scaffold`
- follow-up: GBase 8c existing-table Sink

## Canonical connection contract

Stage 1 uses the dedicated GBase 8c JDBC protocol and driver:

```hocon
source {
  type = "jdbc"
  url = "jdbc:gbase8c://gbase8c:5432/app"
  driver = "com.gbase8c.Driver"
  dialect = "gbase8c"
  schema = "public"
  table_path = "public.orders"
}
```

The dedicated protocol is auto-detectable because `jdbc:gbase8c://` is product-specific. Explicit `dialect=gbase8c` is also supported. MySQL / generic `jdbc:gbase://` / PostgreSQL URLs are deliberately not auto-classified as GBase 8c.

The repository does not guess or bundle an unofficial Maven coordinate for the vendor JDBC driver. Deployments must make the official GBase 8c JDBC driver available on the runtime classpath.

## Source implementation

- add `GBase8cDialectFactory` through AutoService SPI
- add a dedicated `GBase8cDialect`
- add `GBase8cJdbcUrl` for the product-specific URL contract
- add `GBase8cJdbcRowConverter` with first-class `gbase8c` identity
- add `GBase8cTypeMapper`
  - reuses the mature PostgreSQL-compatible **read-side** type contract
  - deliberately refuses target database type generation in this Source-only stage
- add a dedicated read-only `GBase8cCatalog`
  - database identity comes from the JDBC URL
  - schema/table/column discovery uses PG-compatible `information_schema` metadata
  - primary-key discovery uses `information_schema.table_constraints` / `key_column_usage`
  - table metadata records `dialect=gbase8c`
  - does **not** implement `WritableCatalog`

## Database/table-path boundary

One GBase 8c Source connection is bound to exactly one database from its JDBC URL.

- `table` -> uses configured schema or `public`
- `schema.table` -> normal Stage 1 path
- `database.schema.table` -> accepted only when `database` equals the database in the JDBC URL
- other databases are not exposed as selectable Source databases by this Catalog

This prevents metadata from one database from being paired with rows read through another JDBC connection URL. Cross-database jobs should use separate datasource connections instead of implicit URL rebinding.

## Supported Stage 1 behavior

- bounded single-table Source
- bounded multi-table Source through the shared JDBC path
- schema/table/column/primary-key metadata discovery
- custom query reads through the shared JDBC Source
- shared safe JDBC range partition planning
- PostgreSQL-compatible read-side type mapping
- `BEST_EFFORT` read consistency

## Explicit non-goals

- JDBC Sink
- `WritableCatalog`
- CREATE/ALTER/DROP table DDL
- INSERT / UPSERT generation
- automatic target-table creation
- CDC / streaming semantics
- coordinated distributed snapshots
- compatibility-mode expansion for Oracle / MySQL / Teradata modes
- GBase 8a / GBase 8s runtime support

## Tests

Focused tests cover:

- SPI loading from `jdbc:gbase8c://`
- explicit `dialect=gbase8c`
- URL discrimination from PostgreSQL / generic GBase / MySQL URLs
- JDBC database extraction
- PG-compatible `schema.table` parsing and identifier quoting
- rejection of cross-database table paths
- configured-schema and `public` fallback behavior
- read-only Catalog / no `WritableCatalog`
- no UPSERT advertisement
- no Sink type generation from the Source-only type mapper
- `BEST_EFFORT`-only consistency
- first-class row-converter identity
- database-required URL validation

## Verification

- final branch is one atomic commit on top of #121
- final diff is limited to the GBase 8c Source implementation, focused tests and JDBC README documentation
- repository currently has no GitHub Actions workflow, so no CI run is available for this PR
- the execution environment cannot perform a reliable Maven build against this repository in this session; tests are added but not claimed as executed
- a real GBase 8c environment and vendor JDBC driver are still required before Ready for Review to verify connection, metadata, common type reads, primary-key discovery, custom query reads and bounded single/multi-table execution end to end
