### PR TITLE
feat(gbase8c): add existing-table JDBC sink support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -99,24 +99,24 @@ GBase is modeled as a database family, not as one generic JDBC dialect. The stab
 `gbase8a` and `gbase8s`. A generic `gbase` dialect is intentionally not defined because the three products use different
 JDBC protocols and database semantics.
 
-The shared `gbase/common` layer only carries stable product metadata and family-level helpers. GBase 8c now has its first
-runtime stage; the `gbase8a` and `gbase8s` identities remain reserved without a `JdbcDialectFactory` until their concrete
-URL, driver, catalog, type-mapping and SQL behavior is implemented and tested.
+The shared `gbase/common` layer only carries stable product metadata and family-level helpers. GBase 8c now has bounded
+Source and existing-table Sink support; the `gbase8a` and `gbase8s` identities remain reserved without a
+`JdbcDialectFactory` until their concrete URL, driver, catalog, type-mapping and SQL behavior is implemented and tested.
 
 Shared GBase code must remain product-neutral. Driver names, JDBC URL parsing, identifier rules, catalog behavior, type
 mapping, row conversion, INSERT/UPSERT SQL and distribution/MPP behavior belong to the concrete product adapter unless at
 least two completed adapters prove the behavior is genuinely common. The planned bounded/offline implementation order is:
 
-1. GBase 8c Source, then existing-table Sink.
+1. GBase 8c bounded Source and existing-table Sink.
 2. GBase 8a Source, then existing-table JDBC Sink; native/high-speed MPP loading is a later stage.
 3. GBase 8s Source, then existing-table Sink.
 
 CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths stay outside
 the family scaffold.
 
-### GBase 8c bounded Source
+### GBase 8c bounded Source and existing-table Sink
 
-GBase 8c is exposed as the dedicated `gbase8c` JDBC dialect. The canonical Stage 1 path uses the GBase 8c JDBC protocol
+GBase 8c is exposed as the dedicated `gbase8c` JDBC dialect. The canonical bounded path uses the GBase 8c JDBC protocol
 and driver instead of pretending that a PostgreSQL or MySQL URL uniquely identifies the product:
 
 ```hocon
@@ -128,18 +128,39 @@ source {
   schema = "public"
   table_path = "public.orders"
 }
+
+sink {
+  type = "jdbc"
+  url = "jdbc:gbase8c://gbase8c:5432/archive"
+  driver = "com.gbase8c.Driver"
+  dialect = "gbase8c"
+  schema = "public"
+  table = "public.orders"
+}
 ```
 
-Stage 1 reuses the proven PostgreSQL-compatible **read-side type contract** while keeping its own URL parser, dialect,
-row converter and read-only Catalog. Metadata discovery uses `pg_catalog` / `information_schema` semantics for databases,
-schemas, tables, columns and primary keys. The JDBC URL owns the active database; `schema.table` is the normal table
-path, and an explicit `database.schema.table` is accepted only when the database matches the one in the JDBC URL. This
-prevents metadata from one database being paired with data read through another connection URL.
+The bounded Source reuses the proven PostgreSQL-compatible **read-side type contract** while keeping its own URL parser,
+dialect, row converter and Catalog. Metadata discovery uses `information_schema` semantics for schemas, tables, columns
+and primary keys. The JDBC URL owns the active database; `schema.table` is the normal table path, and an explicit
+`database.schema.table` is accepted only when the database matches the one in the JDBC URL. This prevents metadata from
+one database being paired with data read through another connection URL.
 
-The source supports bounded single-table and multi-table jobs, custom query reads and the shared safe JDBC partition
-planner. Stage 1 advertises `BEST_EFFORT` consistency only. It deliberately does not implement `WritableCatalog`, Sink
-DDL, INSERT/UPSERT, automatic table creation, CDC, streaming checkpoints, coordinated database snapshots, or Oracle /
-MySQL / Teradata compatibility-mode expansion. Those remain product-specific follow-up stages.
+The existing-table Sink reuses the shared transactional JDBC writer: standard parameterized `INSERT`, configured batch
+size, `PreparedStatement.addBatch()/executeBatch()`, task-local commit/rollback, retry/savepoint handling and dirty-data
+behavior all remain in the common JDBC path. No GBase-specific writer is introduced. The target database always comes
+from the Sink JDBC URL. An explicit `schema.table` target mapping is preserved; otherwise target connection settings are
+preferred so a source database/schema cannot silently leak into a different GBase 8c target.
+
+GBase 8c target tables must already exist. The Catalog implements `WritableCatalog` only so the common Sink save-mode
+lifecycle can validate existing tables and support `DROP_DATA` through `TRUNCATE TABLE`. Automatic database/table
+creation, table recreation, `ADD COLUMN`, `DROP TABLE` and target DDL type generation are blocked explicitly.
+`CREATE_SCHEMA_WHEN_NOT_EXIST` therefore works when the target already exists and fails clearly when it does not;
+`RECREATE_SCHEMA` is rejected before a destructive drop can occur.
+
+The current GBase 8c Sink intentionally does not advertise UPSERT. `write_mode = UPSERT` fails during Sink preparation
+instead of guessing PostgreSQL/MySQL/compatibility-mode conflict semantics. CDC, streaming checkpoints, coordinated
+database snapshots, automatic distributed-table design, Oracle/MySQL/Teradata compatibility-mode expansion and native
+bulk-loading paths remain separate stages.
 
 The dedicated GBase 8c JDBC driver is not guessed as a Maven dependency by this module. Deployments must place the vendor
 JDBC driver on the runtime classpath and configure `driver = "com.gbase8c.Driver"` explicitly.

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
@@ -1,12 +1,15 @@
 package com.link.up.connector.jdbc.catalog.gbase.gbase8c;
 
-import com.link.up.api.table.catalog.Catalog;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.Column;
 import com.link.up.api.table.catalog.PrimaryKey;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
 import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
 import com.link.up.api.table.catalog.exception.TableNotFoundException;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
@@ -18,20 +21,21 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 /**
- * Read-only GBase 8c Catalog for the bounded Source stage.
+ * GBase 8c Catalog for bounded Source and existing-table Sink jobs.
  *
  * <p>Metadata follows the PG-compatible information_schema contract, while the JDBC connection
- * remains the dedicated GBase 8c protocol. One Source connection owns exactly one database; other
- * databases are intentionally not exposed as selectable targets. This class does not implement
- * WritableCatalog so the generic JDBC Sink rejects it during preparation.</p>
+ * remains bound to one GBase 8c database. Sink preparation may validate and truncate an existing
+ * target table, but all structure-changing DDL stays blocked until GBase 8c distribution and
+ * compatibility-mode semantics are modeled explicitly.</p>
  */
-public final class GBase8cCatalog implements Catalog {
+public final class GBase8cCatalog implements WritableCatalog {
 
     public static final String TABLE_OPTION_DIALECT = "dialect";
 
@@ -233,6 +237,72 @@ public final class GBase8cCatalog implements Catalog {
         }
     }
 
+    @Override
+    public void createDatabase(
+            String databaseName,
+            boolean ignoreIfExists)
+            throws CatalogException, DatabaseAlreadyExistsException {
+        throw unsupportedSchemaDdl("create database");
+    }
+
+    @Override
+    public void dropDatabase(
+            String databaseName,
+            boolean ignoreIfNotExists)
+            throws CatalogException, DatabaseNotFoundException {
+        throw unsupportedSchemaDdl("drop database");
+    }
+
+    @Override
+    public void createTable(
+            CatalogTable table,
+            boolean ignoreIfExists)
+            throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+        throw unsupportedSchemaDdl("create table");
+    }
+
+    @Override
+    public void addColumn(
+            TablePath tablePath,
+            Column column)
+            throws CatalogException, TableNotFoundException {
+        throw unsupportedSchemaDdl("add column");
+    }
+
+    @Override
+    public void dropTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        throw unsupportedSchemaDdl("drop table");
+    }
+
+    @Override
+    public void truncateTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath normalized = normalizeTablePath(tablePath);
+        if (!tableExists(normalized)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotFoundException(catalogName, normalized);
+        }
+
+        String sql = "TRUNCATE TABLE "
+                + quoteIdentifier(normalized.getSchemaName())
+                + "."
+                + quoteIdentifier(normalized.getTableName());
+        try (Connection connection = newConnection();
+             Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        } catch (SQLException e) {
+            throw new CatalogException("清空 GBase 8c 表失败，table=" + normalized, e);
+        }
+    }
+
     private List<Column> readColumns(Connection connection, TablePath tablePath)
             throws SQLException {
         try (PreparedStatement statement = connection.prepareStatement(SELECT_COLUMNS_SQL)) {
@@ -284,9 +354,9 @@ public final class GBase8cCatalog implements Catalog {
     private void requireCurrentDatabase(String databaseName) {
         if (hasText(databaseName) && !defaultDatabase.equals(databaseName.trim())) {
             throw new IllegalArgumentException(
-                    "GBase 8c Stage 1 连接固定到 database="
+                    "GBase 8c bounded JDBC adapter is fixed to database="
                             + defaultDatabase
-                            + "，不支持请求 database="
+                            + " and does not support database="
                             + databaseName);
         }
     }
@@ -314,6 +384,20 @@ public final class GBase8cCatalog implements Catalog {
         if (!opened) {
             throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
         }
+    }
+
+    private static String quoteIdentifier(String identifier) {
+        if (!hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + identifier.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static CatalogException unsupportedSchemaDdl(String operation) {
+        return new CatalogException(
+                "GBase 8c existing-table Sink supports target-table DML only; "
+                        + operation
+                        + " is disabled until distribution and compatibility-mode DDL is modeled");
     }
 
     private static boolean hasText(String value) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialect.java
@@ -11,10 +11,11 @@ import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
 
 /**
- * GBase 8c bounded/offline JDBC Source dialect.
+ * GBase 8c bounded/offline JDBC dialect.
  *
- * <p>Stage 1 targets the dedicated GBase 8c JDBC protocol and PG-compatible metadata/read
- * semantics. Sink DDL, INSERT/UPSERT, CDC and compatibility-mode expansion are separate stages.</p>
+ * <p>The adapter targets the dedicated GBase 8c JDBC protocol and PG-compatible metadata/read
+ * semantics. The existing-table Sink stage reuses the portable INSERT/batch path only; UPSERT,
+ * structure-changing DDL, CDC and compatibility-mode expansion remain separate stages.</p>
  */
 public final class GBase8cDialect implements JdbcDialect {
 
@@ -72,7 +73,7 @@ public final class GBase8cDialect implements JdbcDialect {
         return new GBase8cJdbcRowConverter();
     }
 
-    /** GBase 8c Stage 1 follows PG-compatible schema.table path semantics. */
+    /** GBase 8c follows PG-compatible schema.table path semantics. */
     @Override
     public TablePath parseTablePath(String tablePath) {
         if (!JdbcDialect.hasText(tablePath)) {
@@ -127,9 +128,10 @@ public final class GBase8cDialect implements JdbcDialect {
         if (!JdbcDialect.hasText(requestedDatabase)
                 || !databaseName.equals(requestedDatabase.trim())) {
             throw new IllegalArgumentException(
-                    "GBase 8c Stage 1 不支持跨 database table_path；当前 JDBC 数据库="
+                    "GBase 8c bounded JDBC adapter does not support cross-database table_path; "
+                            + "current database="
                             + databaseName
-                            + "，请求数据库="
+                            + ", requested database="
                             + requestedDatabase);
         }
     }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectFactory.java
@@ -6,7 +6,7 @@ import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
 
-/** GBase 8c bounded JDBC Source dialect factory. */
+/** GBase 8c bounded Source and existing-table Sink dialect factory. */
 @AutoService(JdbcDialectFactory.class)
 public final class GBase8cDialectFactory implements JdbcDialectFactory {
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cJdbcRowConverter.java
@@ -3,7 +3,7 @@ package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
 import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 
-/** GBase 8c bounded Source row converter. */
+/** GBase 8c bounded Source and existing-table Sink row converter. */
 public final class GBase8cJdbcRowConverter extends AbstractJdbcRowConverter {
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTypeMapper.java
@@ -9,10 +9,11 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 /**
- * GBase 8c Stage 1 type mapper.
+ * GBase 8c type mapper for bounded Source and existing-table Sink jobs.
  *
- * <p>The bounded Source targets PG-compatible databases and reuses the mature PostgreSQL read-side
- * type contract. Sink DDL mapping stays disabled until the dedicated GBase 8c Sink stage.</p>
+ * <p>The adapter reuses the mature PostgreSQL-compatible read-side type contract. The current Sink
+ * writes only to pre-created tables, so target DDL type generation stays disabled until a later
+ * GBase 8c table-creation stage models distribution and compatibility-mode semantics.</p>
  */
 public final class GBase8cTypeMapper implements JdbcTypeMapper {
 
@@ -31,6 +32,6 @@ public final class GBase8cTypeMapper implements JdbcTypeMapper {
     @Override
     public String toDatabaseType(Column column) {
         throw new UnsupportedOperationException(
-                "GBase 8c Stage 1 is source-only; target type generation belongs to the Sink stage");
+                "GBase 8c existing-table Sink does not generate target DDL types");
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupport.java
@@ -1,0 +1,66 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cJdbcUrl;
+
+/** Target-path normalization for the GBase 8c existing-table Sink stage. */
+final class GBase8cSinkSupport {
+
+    private static final String DEFAULT_SCHEMA = "public";
+
+    private GBase8cSinkSupport() {
+    }
+
+    static boolean accepts(JdbcConnectionConfig config) {
+        if (config == null) {
+            return false;
+        }
+        if (hasText(config.getDialect())) {
+            return DatabaseIdentifier.GBASE8C.equalsIgnoreCase(config.getDialect());
+        }
+        return GBase8cJdbcUrl.accepts(config.getUrl());
+    }
+
+    static TablePath resolveTargetPath(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+        if (config == null || tablePath == null) {
+            return tablePath;
+        }
+
+        String database = GBase8cJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(database)) {
+            return null;
+        }
+
+        String pathDatabase = tablePath.getDatabaseName();
+        String pathSchema = tablePath.getSchemaName();
+        String schema;
+
+        /*
+         * Keep schema.table from an explicit target mapping. A three-part source path is safe to
+         * reuse only when its database is already the target database; otherwise prefer target
+         * connection settings so source database/schema metadata cannot leak into the Sink.
+         */
+        if (hasText(pathSchema)
+                && (!hasText(pathDatabase)
+                || database.equals(pathDatabase.trim()))) {
+            schema = pathSchema.trim();
+        } else if (hasText(config.getSchema())) {
+            schema = config.getSchema().trim();
+        } else {
+            schema = DEFAULT_SCHEMA;
+        }
+
+        return TablePath.of(
+                database,
+                schema,
+                tablePath.getTableName());
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -141,6 +141,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return GoldenDbSinkSupport.resolveTargetPath(
                     config.getConnectionConfig(), tablePath);
         }
+        if (GBase8cSinkSupport.accepts(config.getConnectionConfig())) {
+            return GBase8cSinkSupport.resolveTargetPath(
+                    config.getConnectionConfig(), tablePath);
+        }
         return JdbcCreateTableSqlResolver.resolveTargetPath(
                 config.getConnectionConfig(), tablePath);
     }
@@ -167,6 +171,9 @@ final class JdbcSinkPreparer implements SinkPreparer {
                     config.getConnectionConfig(), table);
         }
         if (GoldenDbSinkSupport.accepts(config.getConnectionConfig())) {
+            return null;
+        }
+        if (GBase8cSinkSupport.accepts(config.getConnectionConfig())) {
             return null;
         }
         return JdbcCreateTableSqlResolver.resolve(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalogTest.java
@@ -1,0 +1,88 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class GBase8cCatalogTest {
+
+    @Test
+    public void existingTableSinkRejectsAutomaticTableCreation() {
+        GBase8cCatalog catalog = catalog();
+
+        try {
+            catalog.createTable(table(), false);
+            fail("GBase 8c existing-table Sink must not auto-create target tables");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("existing-table Sink"));
+            assertTrue(expected.getMessage().contains("create table"));
+        }
+    }
+
+    @Test
+    public void existingTableSinkRejectsDestructiveSchemaRecreationBeforeDrop() {
+        GBase8cCatalog catalog = catalog();
+
+        try {
+            catalog.dropTable(
+                    TablePath.of("app", "public", "orders"),
+                    false);
+            fail("GBase 8c existing-table Sink must not drop target tables");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("drop table"));
+        }
+    }
+
+    @Test
+    public void existingTableSinkRejectsSchemaEvolution() {
+        GBase8cCatalog catalog = catalog();
+
+        try {
+            catalog.addColumn(
+                    TablePath.of("app", "public", "orders"),
+                    Column.builder("extra", BasicType.STRING_TYPE).build());
+            fail("GBase 8c existing-table Sink must not add target columns");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("add column"));
+        }
+    }
+
+    private static GBase8cCatalog catalog() {
+        return new GBase8cCatalog(
+                "gbase8c",
+                new JdbcCatalogConfig(
+                        "jdbc:gbase8c://127.0.0.1:5432/app",
+                        "gbase",
+                        "password",
+                        "com.gbase8c.Driver",
+                        Collections.emptyMap(),
+                        false),
+                "public");
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .columns(
+                                Collections.singletonList(
+                                        Column.builder("id", BasicType.LONG_TYPE)
+                                                .nullable(false)
+                                                .build()))
+                        .build();
+
+        return CatalogTable.builder(
+                        TablePath.of("app", "public", "orders"),
+                        schema)
+                .build();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialectTest.java
@@ -73,7 +73,7 @@ public class GBase8cDialectTest {
         IllegalArgumentException error = assertThrows(
                 IllegalArgumentException.class,
                 () -> dialect.parseTablePath("archive.sales.orders"));
-        assertTrue(error.getMessage().contains("不支持跨 database"));
+        assertTrue(error.getMessage().contains("cross-database"));
 
         assertThrows(
                 IllegalArgumentException.class,
@@ -94,10 +94,15 @@ public class GBase8cDialectTest {
     }
 
     @Test
-    public void stageOneCatalogIsReadOnlyAndUpsertIsNotAdvertised() {
+    public void existingTableSinkUsesPortableInsertAndStillRejectsUpsert() {
         GBase8cDialect dialect = dialect("public");
         Catalog catalog = dialect.createCatalog(config("public", baseUrl(), null, null));
-        assertFalse(catalog instanceof WritableCatalog);
+        assertTrue(catalog instanceof WritableCatalog);
+        assertEquals(
+                "INSERT INTO \"public\".\"orders\" (\"id\", \"name\") VALUES (?, ?)",
+                dialect.buildInsertSql(
+                        TablePath.of("app", "public", "orders"),
+                        Arrays.asList("id", "name")));
         assertFalse(dialect.buildUpsertSql(
                 TablePath.of(null, "public", "orders"),
                 Arrays.asList("id", "name"),
@@ -105,7 +110,7 @@ public class GBase8cDialectTest {
     }
 
     @Test
-    public void stageOneTypeMapperDoesNotGenerateSinkTypes() {
+    public void existingTableSinkDoesNotGenerateDdlTypes() {
         Column column = Column.builder("name", BasicType.STRING_TYPE).build();
         assertThrows(
                 UnsupportedOperationException.class,
@@ -113,7 +118,7 @@ public class GBase8cDialectTest {
     }
 
     @Test
-    public void stageOneAdvertisesBestEffortReadConsistencyOnly() {
+    public void boundedSourceStillAdvertisesBestEffortReadConsistencyOnly() {
         assertEquals(
                 Collections.singleton(ReadConsistency.BEST_EFFORT),
                 dialect("public").supportedReadConsistencies());

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupportTest.java
@@ -1,0 +1,126 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cDialect;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cSinkSupportTest {
+
+    @Test
+    public void sourceDatabaseAndSchemaDoNotLeakIntoGBase8cTarget() {
+        TablePath target =
+                GBase8cSinkSupport.resolveTargetPath(
+                        config("target_db", "landing", DatabaseIdentifier.GBASE8C),
+                        TablePath.of("source_db", "source_schema", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "landing", "orders"),
+                target);
+    }
+
+    @Test
+    public void foreignSourceSchemaFallsBackToPublicWithoutTargetSchema() {
+        TablePath target =
+                GBase8cSinkSupport.resolveTargetPath(
+                        config("target_db", null, DatabaseIdentifier.GBASE8C),
+                        TablePath.of("source_db", "source_schema", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "public", "orders"),
+                target);
+    }
+
+    @Test
+    public void explicitSchemaTableMappingWinsOverConfiguredDefaultSchema() {
+        TablePath target =
+                GBase8cSinkSupport.resolveTargetPath(
+                        config("target_db", "public", DatabaseIdentifier.GBASE8C),
+                        TablePath.of(null, "archive", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "archive", "orders"),
+                target);
+    }
+
+    @Test
+    public void schemaCanBePreservedWhenPathAlreadyTargetsSameDatabase() {
+        TablePath target =
+                GBase8cSinkSupport.resolveTargetPath(
+                        config("target_db", "public", DatabaseIdentifier.GBASE8C),
+                        TablePath.of("target_db", "sales", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "sales", "orders"),
+                target);
+    }
+
+    @Test
+    public void dedicatedUrlCanSelectSinkSupportWithoutExplicitDialect() {
+        assertTrue(GBase8cSinkSupport.accepts(config("target_db", null, null)));
+        assertTrue(GBase8cSinkSupport.accepts(
+                config("target_db", null, DatabaseIdentifier.GBASE8C)));
+        assertFalse(GBase8cSinkSupport.accepts(
+                config("target_db", null, DatabaseIdentifier.POSTGRESQL)));
+    }
+
+    @Test
+    public void existingTableSinkDoesNotGenerateAutomaticCreateTableSql() {
+        JdbcConnectionConfig config =
+                config("target_db", "public", DatabaseIdentifier.GBASE8C);
+
+        assertNull(
+                JdbcCreateTableSqlResolver.resolve(
+                        new GBase8cDialect(config),
+                        config,
+                        table()));
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema =
+                TableSchema.builder()
+                        .columns(
+                                Collections.singletonList(
+                                        Column.builder("id", BasicType.LONG_TYPE)
+                                                .nullable(false)
+                                                .build()))
+                        .build();
+
+        return CatalogTable.builder(
+                        TablePath.of("source_db", "source_schema", "orders"),
+                        schema)
+                .build();
+    }
+
+    private static JdbcConnectionConfig config(
+            String database,
+            String schema,
+            String dialect) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", "jdbc:gbase8c://127.0.0.1:5432/" + database);
+        values.put("driver", "com.gbase8c.Driver");
+        values.put("username", "gbase");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (dialect != null) {
+            values.put("dialect", dialect);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}


### PR DESCRIPTION
## Summary

Add the second GBase 8c runtime stage: a bounded/offline **existing-table JDBC Sink**.

This is intentionally a stacked PR on top of #122 (`feat/gbase8c-jdbc-source`). The diff contains only GBase 8c Sink behavior and the small Source-boundary updates required to expose the shared INSERT path.

## Dependency

- depends on #122
- PR base: `feat/gbase8c-jdbc-source`
- #122 itself depends on #121
- follow-up after this stack: GBase 8a bounded Source

## Sink contract

The target table must already exist:

```hocon
sink {
  type = "jdbc"
  url = "jdbc:gbase8c://gbase8c:5432/archive"
  driver = "com.gbase8c.Driver"
  dialect = "gbase8c"
  schema = "public"
  table = "public.orders"
}
```

The Sink reuses the shared JDBC execution path:

- parameterized `INSERT`
- configured JDBC batch size
- `PreparedStatement.addBatch()/executeBatch()`
- one task-local JDBC transaction
- commit / rollback
- existing retry + savepoint behavior
- existing dirty-data handling

No GBase-specific writer is introduced.

## Existing-table safety boundary

`GBase8cCatalog` now implements `WritableCatalog` so the common Sink save-mode lifecycle can validate existing targets and support `DROP_DATA`, but structure-changing DDL remains blocked explicitly.

Allowed:

- metadata discovery
- target schema compatibility validation
- INSERT / batch write
- `TRUNCATE TABLE` for `DROP_DATA`

Blocked:

- CREATE DATABASE
- DROP DATABASE
- CREATE TABLE
- DROP TABLE
- ADD COLUMN
- automatic target DDL type generation

This keeps `CREATE_SCHEMA_WHEN_NOT_EXIST` safe for a pre-created table while failing clearly when the table is absent. `RECREATE_SCHEMA` is rejected before a destructive drop can happen. `CREATE_OR_ADD_COLUMNS` may validate a compatible table, but a missing target column fails instead of mutating schema.

## Target routing

Add `GBase8cSinkSupport` and wire it into `JdbcSinkPreparer`.

- target database always comes from the Sink JDBC URL
- `schema.table` mappings are preserved
- a three-part path may preserve its schema only when its database already matches the target database
- otherwise the configured target schema is used
- if no target schema is configured, fall back to `public`

This prevents source database/schema metadata from leaking into a different GBase 8c target connection.

## UPSERT boundary

This stage intentionally does **not** advertise UPSERT.

`write_mode = UPSERT` fails during Sink preparation because the adapter does not guess PostgreSQL/MySQL/compatibility-mode conflict semantics. Ordinary INSERT remains the stable bounded Sink contract for this PR.

## Tests

Focused tests cover:

- portable quoted INSERT SQL
- `WritableCatalog` availability for existing-table Sink preparation
- UPSERT remains unsupported
- target DDL type generation remains disabled
- automatic table creation rejected
- destructive DROP rejected before recreation
- ADD COLUMN rejected
- source database/schema do not leak into the target
- `public` schema fallback when no target schema is configured
- explicit `schema.table` target mapping is preserved
- same-database schema preservation
- dedicated URL auto-detection for Sink support
- no automatic CREATE TABLE SQL

## Explicit non-goals

- UPSERT
- automatic table/database creation
- runtime schema evolution
- distributed-table / distribution-key design
- Oracle / MySQL / Teradata compatibility-mode expansion
- CDC / streaming
- coordinated distributed snapshots
- native/bulk loading
- GBase 8a / GBase 8s runtime support

## Verification

- final branch is one atomic commit on top of #122
- final compare: `ahead=1`, `behind=0`
- diff is limited to 11 files: GBase 8c Sink/catalog integration, focused tests and JDBC README documentation
- Maven execution was attempted, but this execution environment cannot resolve `github.com`, so the repository could not be cloned and the Maven suite could not be run here
- tests are added but are not claimed as executed
- a real GBase 8c environment plus the vendor JDBC driver is still required before Ready for Review to validate INSERT, batch execution, transaction commit/rollback, target metadata compatibility and `DROP_DATA` end to end
