### PR TITLE
feat(gbase8a): add bounded JDBC source support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -99,20 +99,54 @@ GBase is modeled as a database family, not as one generic JDBC dialect. The stab
 `gbase8a` and `gbase8s`. A generic `gbase` dialect is intentionally not defined because the three products use different
 JDBC protocols and database semantics.
 
-The family scaffold only provides stable product metadata and family-level helpers. It deliberately does **not** register
-`JdbcDialectFactory` implementations yet, so these identifiers do not advertise runtime support before their concrete
-URL, driver, catalog, type-mapping and SQL behavior is implemented and tested.
+The shared `gbase/common` layer only carries stable product metadata and family-level helpers. Runtime dialects remain
+product-specific: URL parsing, identifiers, catalog behavior, type mapping, row conversion, Sink SQL and MPP behavior
+must stay in the concrete product adapter unless completed implementations prove that behavior is genuinely common.
 
-Shared GBase code must remain product-neutral. Driver names, JDBC URL parsing, identifier rules, catalog behavior, type
-mapping, row conversion, INSERT/UPSERT SQL and distribution/MPP behavior belong to the concrete product adapter unless at
-least two completed adapters prove the behavior is genuinely common. The planned bounded/offline implementation order is:
+The planned bounded/offline implementation order is:
 
 1. GBase 8c Source, then existing-table Sink.
 2. GBase 8a Source, then existing-table JDBC Sink; native/high-speed MPP loading is a later stage.
 3. GBase 8s Source, then existing-table Sink.
 
-CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths are outside
-this scaffold.
+CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths stay outside
+this family-level contract.
+
+### GBase 8a bounded Source
+
+GBase 8a is exposed as the first-class `gbase8a` JDBC dialect. Stage 1 uses the vendor JDBC protocol and driver:
+
+```hocon
+source {
+  type = "jdbc"
+  url = "jdbc:gbase://gbase8a:5258/app"
+  driver = "com.gbase.jdbc.Driver"
+  dialect = "gbase8a"
+  table_path = "app.orders"
+}
+```
+
+GBase 8a uses `database.table` semantics with no separate schema layer in this stage. The Source owns a dedicated
+read-only Catalog built on standard JDBC `DatabaseMetaData` for database, table, column and primary-key discovery instead
+of borrowing MySQL DDL behavior. Table identifiers use backtick quoting, and both single-table and multi-table bounded
+jobs continue through the shared JDBC Source runtime.
+
+The read-side type contract covers common numeric, string/text, binary/BLOB, DATE, TIME, DATETIME and TIMESTAMP types.
+DATETIME/TIMESTAMP map to the Link-Up `TIMESTAMP` boundary. DECIMAL values above Link-Up's precision limit fall back to
+STRING instead of silently losing precision. Unknown/extension JDBC types also fall back to STRING for metadata/read
+usability. No target database type generation is exposed in this Source-only stage.
+
+GBase JDBC uses `Integer.MIN_VALUE` as the streaming-result fetch-size sentinel. A positive Link-Up `fetch_size` therefore
+selects that vendor streaming mode rather than passing the positive value through directly, keeping large bounded reads
+from relying on the driver's default full-result buffering behavior. `tinyInt1isBit=false` and `yearIsDateType=false` are
+safe dialect defaults; explicit user `properties` still override dialect defaults.
+
+Stage 1 advertises `BEST_EFFORT` read consistency only. It does not claim one MPP-wide snapshot across parallel JDBC
+readers. Sink, WritableCatalog, CREATE/ALTER/DROP DDL, UPSERT, POC/native high-speed loading, VC/topology management, CDC,
+streaming checkpoints and runtime schema evolution remain separate follow-up stages.
+
+The vendor GBase JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official
+GBase 8a JDBC driver on the runtime classpath and configure `driver = "com.gbase.jdbc.Driver"`.
 
 ## SAP HANA
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalog.java
@@ -1,0 +1,296 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8a;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Read-only GBase 8a Catalog for bounded/offline Source jobs.
+ *
+ * <p>GBase 8a exposes database/table semantics through its JDBC catalog model. Stage 1 uses the
+ * standard {@link DatabaseMetaData} contract instead of borrowing MySQL DDL/catalog code, keeping
+ * this adapter source-only and MPP-safe.</p>
+ */
+public final class GBase8aCatalog implements Catalog {
+
+    public static final String TABLE_OPTION_DIALECT = "dialect";
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String defaultDatabase;
+    private final GBase8aTypeMapper typeMapper = new GBase8aTypeMapper();
+    private volatile boolean opened;
+
+    public GBase8aCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            String defaultDatabase) {
+        if (!hasText(catalogName)) {
+            throw new IllegalArgumentException("catalogName must not be empty");
+        }
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        if (!GBase8aJdbcUrl.accepts(config.getUrl())) {
+            throw new IllegalArgumentException("非法 GBase 8a JDBC URL：" + config.getUrl());
+        }
+        if (!hasText(defaultDatabase)) {
+            throw new IllegalArgumentException("GBase 8a Stage 1 必须指定默认 database");
+        }
+        this.catalogName = catalogName.trim();
+        this.config = config;
+        this.defaultDatabase = defaultDatabase.trim();
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+        loadDriver();
+        try (Connection connection = newConnection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException("GBase 8a Catalog 连接校验失败：" + config.getUrl());
+            }
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException("GBase 8a Catalog 连接失败：" + config.getUrl(), e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.of(defaultDatabase);
+    }
+
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        checkOpened();
+        try (Connection connection = newConnection();
+             ResultSet resultSet = connection.getMetaData().getCatalogs()) {
+            Set<String> databases = new LinkedHashSet<String>();
+            while (resultSet.next()) {
+                String database = resultSet.getString(1);
+                if (hasText(database)) {
+                    databases.add(database.trim());
+                }
+            }
+            databases.add(defaultDatabase);
+            return new ArrayList<String>(databases);
+        } catch (SQLException e) {
+            throw new CatalogException("获取 GBase 8a 数据库列表失败", e);
+        }
+    }
+
+    /** GBase 8a Stage 1 models database as JDBC catalog and has no separate schema layer. */
+    @Override
+    public List<String> listSchemas(String databaseName) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String databaseName,
+            String schemaName) throws CatalogException {
+        checkOpened();
+        String database = resolveDatabase(databaseName, schemaName);
+        try (Connection connection = newConnection();
+             ResultSet resultSet = connection.getMetaData()
+                     .getTables(database, null, "%", null)) {
+            List<TablePath> tables = new ArrayList<TablePath>();
+            while (resultSet.next()) {
+                String tableType = resultSet.getString("TABLE_TYPE");
+                if (!isBaseTable(tableType)) {
+                    continue;
+                }
+                String tableName = resultSet.getString("TABLE_NAME");
+                if (hasText(tableName)) {
+                    tables.add(TablePath.of(database, tableName.trim()));
+                }
+            }
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 GBase 8a 表列表失败，database=" + database,
+                    e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        checkOpened();
+        TablePath normalized = normalizeTablePath(tablePath);
+        try (Connection connection = newConnection();
+             ResultSet resultSet = connection.getMetaData().getTables(
+                     normalized.getDatabaseName(),
+                     null,
+                     normalized.getTableName(),
+                     null)) {
+            while (resultSet.next()) {
+                if (isBaseTable(resultSet.getString("TABLE_TYPE"))
+                        && normalized.getTableName().equals(resultSet.getString("TABLE_NAME"))) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (SQLException e) {
+            throw new CatalogException("检查 GBase 8a 表是否存在失败，table=" + normalized, e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath normalized = normalizeTablePath(tablePath);
+        try (Connection connection = newConnection()) {
+            DatabaseMetaData metadata = connection.getMetaData();
+            List<Column> columns = readColumns(metadata, normalized);
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(catalogName, normalized);
+            }
+            PrimaryKey primaryKey = readPrimaryKey(metadata, normalized);
+            TableSchema schema = TableSchema.builder()
+                    .columns(columns)
+                    .primaryKey(primaryKey)
+                    .build();
+            return CatalogTable.builder(normalized, schema)
+                    .option(TABLE_OPTION_DIALECT, DatabaseIdentifier.GBASE8A)
+                    .build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 GBase 8a 表结构失败，table=" + normalized, e);
+        }
+    }
+
+    private List<Column> readColumns(
+            DatabaseMetaData metadata,
+            TablePath tablePath) throws SQLException {
+        try (ResultSet resultSet = metadata.getColumns(
+                tablePath.getDatabaseName(),
+                null,
+                tablePath.getTableName(),
+                "%")) {
+            List<Column> columns = new ArrayList<Column>();
+            while (resultSet.next()) {
+                columns.add(typeMapper.toColumn(resultSet));
+            }
+            return columns;
+        }
+    }
+
+    private PrimaryKey readPrimaryKey(
+            DatabaseMetaData metadata,
+            TablePath tablePath) throws SQLException {
+        try (ResultSet resultSet = metadata.getPrimaryKeys(
+                tablePath.getDatabaseName(),
+                null,
+                tablePath.getTableName())) {
+            String primaryKeyName = null;
+            Map<Integer, String> columnsBySequence = new TreeMap<Integer, String>();
+            while (resultSet.next()) {
+                if (primaryKeyName == null) {
+                    primaryKeyName = resultSet.getString("PK_NAME");
+                }
+                String column = resultSet.getString("COLUMN_NAME");
+                int sequence = resultSet.getInt("KEY_SEQ");
+                if (hasText(column)) {
+                    columnsBySequence.put(sequence, column.trim());
+                }
+            }
+            return columnsBySequence.isEmpty()
+                    ? null
+                    : PrimaryKey.of(
+                            primaryKeyName,
+                            new ArrayList<String>(columnsBySequence.values()));
+        }
+    }
+
+    private TablePath normalizeTablePath(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (!hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("table name must not be empty");
+        }
+        String database = resolveDatabase(
+                tablePath.getDatabaseName(),
+                tablePath.getSchemaName());
+        return TablePath.of(database, tablePath.getTableName().trim());
+    }
+
+    private String resolveDatabase(String databaseName, String schemaName) {
+        if (hasText(databaseName)) {
+            return databaseName.trim();
+        }
+        if (hasText(schemaName)) {
+            return schemaName.trim();
+        }
+        return defaultDatabase;
+    }
+
+    private Connection newConnection() throws SQLException {
+        return DriverManager.getConnection(config.getUrl(), config.toConnectionProperties());
+    }
+
+    private void loadDriver() {
+        if (!hasText(config.getDriverClass())) {
+            return;
+        }
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException("找不到 GBase 8a JDBC Driver：" + config.getDriverClass(), e);
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static boolean isBaseTable(String tableType) {
+        return tableType != null
+                && ("TABLE".equalsIgnoreCase(tableType)
+                || "BASE TABLE".equalsIgnoreCase(tableType));
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialect.java
@@ -1,0 +1,174 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.gbase.gbase8a.GBase8aCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * GBase 8a bounded/offline JDBC Source dialect.
+ *
+ * <p>Stage 1 covers the normal JDBC read path only. MPP-native loading, Sink DDL, UPSERT, CDC and
+ * streaming semantics remain separate stages.</p>
+ */
+public final class GBase8aDialect implements JdbcDialect {
+
+    private final String defaultDatabase;
+    private final GBase8aTypeMapper typeMapper;
+
+    public GBase8aDialect(JdbcConnectionConfig connectionConfig) {
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException("connectionConfig must not be null");
+        }
+        if (!GBase8aJdbcUrl.accepts(connectionConfig.getUrl())) {
+            throw new IllegalArgumentException(
+                    "非法 GBase 8a JDBC URL：" + connectionConfig.getUrl());
+        }
+
+        String database = GBase8aJdbcUrl.databaseName(connectionConfig.getUrl());
+        if (!JdbcDialect.hasText(database)) {
+            throw new IllegalArgumentException(
+                    "GBase 8a Stage 1 JDBC URL 必须指定 database");
+        }
+
+        this.defaultDatabase = database.trim();
+        this.typeMapper = new GBase8aTypeMapper();
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.GBASE8A;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+        String database = GBase8aJdbcUrl.databaseName(connectionConfig.getUrl());
+
+        return new GBase8aCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        resolveConnectionProperties(connectionConfig.getProperties()),
+                        false),
+                database);
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new GBase8aJdbcRowConverter();
+    }
+
+    /** GBase 8a uses database.table and does not expose a separate schema layer. */
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        if (!JdbcDialect.hasText(tablePath)) {
+            throw new IllegalArgumentException("tablePath must not be empty");
+        }
+        String[] parts = tablePath.trim().split("\\.", -1);
+        switch (parts.length) {
+            case 1:
+                return TablePath.of(normalizePart(parts[0]));
+            case 2:
+                return TablePath.of(
+                        normalizePart(parts[0]),
+                        normalizePart(parts[1]));
+            default:
+                throw new IllegalArgumentException(
+                        "非法 GBase 8a 表路径，仅支持 table 或 database.table：" + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        if (!JdbcDialect.hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "`" + identifier.trim().replace("`", "``") + "`";
+    }
+
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (!JdbcDialect.hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("table name must not be empty");
+        }
+
+        String database = tablePath.getDatabaseName();
+        if (!JdbcDialect.hasText(database)) {
+            database = tablePath.getSchemaName();
+        }
+        if (!JdbcDialect.hasText(database)) {
+            database = defaultDatabase;
+        }
+
+        return quoteIdentifier(database)
+                + "."
+                + quoteIdentifier(tablePath.getTableName());
+    }
+
+    /**
+     * GBase JDBC streaming reads require Integer.MIN_VALUE rather than an ordinary positive fetch
+     * size. A positive Link-Up fetch_size therefore opts into the vendor's streaming result mode.
+     */
+    @Override
+    public PreparedStatement prepareReadStatement(
+            Connection connection,
+            String sql,
+            int fetchSize) throws SQLException {
+        PreparedStatement statement = connection.prepareStatement(
+                sql,
+                ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_READ_ONLY);
+        if (fetchSize > 0) {
+            statement.setFetchSize(Integer.MIN_VALUE);
+        }
+        return statement;
+    }
+
+    @Override
+    public Map<String, String> defaultConnectionProperties() {
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put("tinyInt1isBit", "false");
+        properties.put("yearIsDateType", "false");
+        return Collections.unmodifiableMap(properties);
+    }
+
+    private static String normalizePart(String part) {
+        String value = part == null ? "" : part.trim();
+        if (value.length() >= 2
+                && value.charAt(0) == '`'
+                && value.charAt(value.length() - 1) == '`') {
+            value = value.substring(1, value.length() - 1)
+                    .replace("``", "`");
+        }
+        if (!JdbcDialect.hasText(value)) {
+            throw new IllegalArgumentException("GBase 8a table path contains an empty identifier");
+        }
+        return value;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectFactory.java
@@ -1,0 +1,27 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/** GBase 8a bounded JDBC Source dialect factory. */
+@AutoService(JdbcDialectFactory.class)
+public final class GBase8aDialectFactory implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.GBASE8A;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return GBase8aJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(JdbcConnectionConfig connectionConfig) {
+        return new GBase8aDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aJdbcRowConverter.java
@@ -1,0 +1,13 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
+
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+/** GBase 8a bounded Source row converter. */
+public final class GBase8aJdbcRowConverter extends AbstractJdbcRowConverter {
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.GBASE8A;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aJdbcUrl.java
@@ -1,0 +1,43 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
+
+import java.util.Locale;
+
+/** Dedicated GBase 8a JDBC URL helpers. */
+public final class GBase8aJdbcUrl {
+
+    private static final String PREFIX = "jdbc:gbase://";
+
+    private GBase8aJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return url != null
+                && url.trim().toLowerCase(Locale.ROOT).startsWith(PREFIX);
+    }
+
+    public static String databaseName(String url) {
+        if (!accepts(url)) {
+            return null;
+        }
+
+        String value = url.trim();
+        int queryIndex = value.indexOf('?');
+        int fragmentIndex = value.indexOf('#');
+        int end = value.length();
+        if (queryIndex >= 0) {
+            end = queryIndex;
+        }
+        if (fragmentIndex >= 0 && fragmentIndex < end) {
+            end = fragmentIndex;
+        }
+
+        String main = value.substring(0, end);
+        int databaseSeparator = main.indexOf('/', PREFIX.length());
+        if (databaseSeparator < 0 || databaseSeparator == main.length() - 1) {
+            return null;
+        }
+
+        String database = main.substring(databaseSeparator + 1).trim();
+        return database.isEmpty() ? null : database;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapper.java
@@ -1,0 +1,269 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
+
+/**
+ * GBase 8a bounded Source type mapper.
+ *
+ * <p>The mapper follows the JDBC types documented by GBase 8a and keeps the contract read-only.
+ * Unknown/extension types fall back to STRING so schema discovery stays usable without inventing
+ * GBase-specific runtime types.</p>
+ */
+public final class GBase8aTypeMapper implements JdbcTypeMapper {
+
+    private static final int MAX_DECIMAL_PRECISION = 38;
+    private static final int DEFAULT_DECIMAL_PRECISION = 38;
+    private static final int DEFAULT_DECIMAL_SCALE = 18;
+
+    @Override
+    public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+        String name = firstText(
+                metadata.getColumnLabel(columnIndex),
+                metadata.getColumnName(columnIndex));
+        int jdbcType = metadata.getColumnType(columnIndex);
+        String sourceType = metadata.getColumnTypeName(columnIndex);
+        int precision = metadata.getPrecision(columnIndex);
+        int scale = metadata.getScale(columnIndex);
+        FluxDataType<?> type = mapType(jdbcType, sourceType, precision, scale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(metadata.isNullable(columnIndex) != ResultSetMetaData.columnNoNulls)
+                .sourceType(sourceType);
+        applyProperties(builder, type.getSqlType(), precision, scale);
+        return builder.build();
+    }
+
+    /** Maps one row returned by {@link DatabaseMetaData#getColumns}. */
+    public Column toColumn(ResultSet row) throws SQLException {
+        String name = row.getString("COLUMN_NAME");
+        int jdbcType = row.getInt("DATA_TYPE");
+        String sourceType = row.getString("TYPE_NAME");
+        int precision = intValue(row, "COLUMN_SIZE");
+        int scale = intValue(row, "DECIMAL_DIGITS");
+        FluxDataType<?> type = mapType(jdbcType, sourceType, precision, scale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(row.getInt("NULLABLE") != DatabaseMetaData.columnNoNulls)
+                .defaultValue(safeObject(row, "COLUMN_DEF"))
+                .autoIncrement("YES".equalsIgnoreCase(safeString(row, "IS_AUTOINCREMENT")))
+                .comment(safeString(row, "REMARKS"))
+                .sourceType(sourceType);
+        applyProperties(builder, type.getSqlType(), precision, scale);
+        return builder.build();
+    }
+
+    @Override
+    public String toDatabaseType(Column column) {
+        throw new UnsupportedOperationException(
+                "GBase 8a Stage 1 is source-only; target type generation belongs to the Sink stage");
+    }
+
+    private static FluxDataType<?> mapType(
+            int jdbcType,
+            String sourceType,
+            int precision,
+            int scale) {
+
+        String type = normalizeType(sourceType);
+        if ("BOOL".equals(type) || "BOOLEAN".equals(type)) {
+            return BasicType.BOOLEAN_TYPE;
+        }
+        if ("TINYINT".equals(type)
+                || "SMALLINT".equals(type)
+                || "MEDIUMINT".equals(type)
+                || "INT".equals(type)
+                || "INTEGER".equals(type)
+                || "YEAR".equals(type)) {
+            return BasicType.INT_TYPE;
+        }
+        if ("BIGINT".equals(type)) {
+            return BasicType.LONG_TYPE;
+        }
+        if ("FLOAT".equals(type)) {
+            return BasicType.FLOAT_TYPE;
+        }
+        if ("REAL".equals(type) || "DOUBLE".equals(type)) {
+            return BasicType.DOUBLE_TYPE;
+        }
+        if ("DECIMAL".equals(type) || "NUMERIC".equals(type)) {
+            return decimal(precision, scale);
+        }
+        if ("DATE".equals(type)) {
+            return BasicType.DATE_TYPE;
+        }
+        if ("TIME".equals(type)) {
+            return BasicType.TIME_TYPE;
+        }
+        if ("DATETIME".equals(type) || "TIMESTAMP".equals(type)) {
+            return BasicType.TIMESTAMP_TYPE;
+        }
+        if (isBinary(type)) {
+            return BasicType.BYTES_TYPE;
+        }
+        if (isString(type)) {
+            return BasicType.STRING_TYPE;
+        }
+
+        switch (jdbcType) {
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return BasicType.BOOLEAN_TYPE;
+            case Types.TINYINT:
+            case Types.SMALLINT:
+            case Types.INTEGER:
+                return BasicType.INT_TYPE;
+            case Types.BIGINT:
+                return BasicType.LONG_TYPE;
+            case Types.FLOAT:
+            case Types.REAL:
+                return BasicType.FLOAT_TYPE;
+            case Types.DOUBLE:
+                return BasicType.DOUBLE_TYPE;
+            case Types.DECIMAL:
+            case Types.NUMERIC:
+                return decimal(precision, scale);
+            case Types.DATE:
+                return BasicType.DATE_TYPE;
+            case Types.TIME:
+                return BasicType.TIME_TYPE;
+            case Types.TIMESTAMP:
+                return BasicType.TIMESTAMP_TYPE;
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return BasicType.TIMESTAMP_TZ_TYPE;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+            case Types.BLOB:
+                return BasicType.BYTES_TYPE;
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR:
+            case Types.CLOB:
+            case Types.NCLOB:
+            case Types.SQLXML:
+            case Types.OTHER:
+            default:
+                return BasicType.STRING_TYPE;
+        }
+    }
+
+    private static FluxDataType<?> decimal(int precision, int scale) {
+        if (precision > MAX_DECIMAL_PRECISION) {
+            return BasicType.STRING_TYPE;
+        }
+        int resolvedPrecision = precision > 0
+                ? Math.max(1, precision)
+                : DEFAULT_DECIMAL_PRECISION;
+        int resolvedScale = scale >= 0
+                ? Math.min(scale, resolvedPrecision)
+                : DEFAULT_DECIMAL_SCALE;
+        return new DecimalType(resolvedPrecision, resolvedScale);
+    }
+
+    private static void applyProperties(
+            Column.Builder builder,
+            SqlType type,
+            int precision,
+            int scale) {
+        if ((type == SqlType.STRING || type == SqlType.BYTES) && precision > 0) {
+            builder.length((long) precision);
+            return;
+        }
+        if (type == SqlType.DECIMAL) {
+            if (precision > 0 && precision <= MAX_DECIMAL_PRECISION) {
+                builder.precision(precision);
+            }
+            if (scale >= 0 && precision > 0 && precision <= MAX_DECIMAL_PRECISION) {
+                builder.scale(Math.min(scale, precision));
+            }
+            return;
+        }
+        if ((type == SqlType.TIME || type == SqlType.TIMESTAMP) && scale > 0) {
+            builder.precision(scale);
+        }
+    }
+
+    private static boolean isBinary(String type) {
+        return "BINARY".equals(type)
+                || "VARBINARY".equals(type)
+                || "TINYBLOB".equals(type)
+                || "BLOB".equals(type)
+                || "MEDIUMBLOB".equals(type)
+                || "LONGBLOB".equals(type);
+    }
+
+    private static boolean isString(String type) {
+        return "CHAR".equals(type)
+                || "VARCHAR".equals(type)
+                || "TINYTEXT".equals(type)
+                || "TEXT".equals(type)
+                || "MEDIUMTEXT".equals(type)
+                || "LONGTEXT".equals(type)
+                || "CLOB".equals(type)
+                || "ENUM".equals(type)
+                || "SET".equals(type)
+                || "JSON".equals(type);
+    }
+
+    private static String normalizeType(String value) {
+        if (value == null) {
+            return "";
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        int parenthesis = normalized.indexOf('(');
+        if (parenthesis > 0) {
+            normalized = normalized.substring(0, parenthesis).trim();
+        }
+        int space = normalized.indexOf(' ');
+        if (space > 0) {
+            normalized = normalized.substring(0, space).trim();
+        }
+        return normalized;
+    }
+
+    private static String firstText(String first, String second) {
+        if (first != null && !first.trim().isEmpty()) {
+            return first.trim();
+        }
+        if (second != null && !second.trim().isEmpty()) {
+            return second.trim();
+        }
+        throw new IllegalArgumentException("column name must not be empty");
+    }
+
+    private static int intValue(ResultSet row, String column) throws SQLException {
+        Object value = row.getObject(column);
+        return value == null ? 0 : ((Number) value).intValue();
+    }
+
+    private static String safeString(ResultSet row, String column) {
+        try {
+            return row.getString(column);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static Object safeObject(ResultSet row, String column) {
+        try {
+            return row.getObject(column);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectTest.java
@@ -1,0 +1,211 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.config.ReadConsistency;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8aDialectTest {
+
+    @Test
+    public void loadsDedicatedGBase8aDialectFromJdbcUrlThroughSpi() {
+        JdbcDialect dialect = JdbcDialectLoader.load(config(baseUrl(), null, null));
+        assertEquals(DatabaseIdentifier.GBASE8A, dialect.name());
+    }
+
+    @Test
+    public void factoryOnlyAcceptsDedicatedGBase8aProtocol() {
+        GBase8aDialectFactory factory = new GBase8aDialectFactory();
+        assertTrue(factory.acceptsUrl(baseUrl()));
+        assertFalse(factory.acceptsUrl("jdbc:gbase8c://127.0.0.1:5432/app"));
+        assertFalse(factory.acceptsUrl("jdbc:gbasedbt-sqli://127.0.0.1:9088/app"));
+        assertFalse(factory.acceptsUrl("jdbc:mysql://127.0.0.1:3306/app"));
+    }
+
+    @Test
+    public void explicitDialectKeepsFirstClassIdentity() {
+        JdbcDialect dialect = JdbcDialectLoader.load(
+                config(baseUrl(), null, DatabaseIdentifier.GBASE8A));
+        assertEquals(DatabaseIdentifier.GBASE8A, dialect.name());
+    }
+
+    @Test
+    public void extractsDatabaseWithoutConnectionProperties() {
+        assertEquals("app", GBase8aJdbcUrl.databaseName(baseUrl()));
+        assertEquals(
+                "sales",
+                GBase8aJdbcUrl.databaseName(
+                        "jdbc:gbase://10.0.0.1:5258/sales?failoverEnable=true&hostList=10.0.0.2"));
+    }
+
+    @Test
+    public void usesDatabaseTablePathSemanticsAndBacktickQuoting() {
+        GBase8aDialect dialect = dialect();
+        assertEquals(TablePath.of("orders"), dialect.parseTablePath("orders"));
+        assertEquals(
+                TablePath.of("analytics", "orders"),
+                dialect.parseTablePath("analytics.orders"));
+        assertEquals(
+                TablePath.of("Sales-DB", "Order-Items"),
+                dialect.parseTablePath("`Sales-DB`.`Order-Items`"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> dialect.parseTablePath("vc.analytics.orders"));
+
+        assertEquals(
+                "`app`.`orders`",
+                dialect.tableIdentifier(TablePath.of("orders")));
+        assertEquals(
+                "`archive`.`orders`",
+                dialect.tableIdentifier(TablePath.of("archive", "orders")));
+    }
+
+    @Test
+    public void sourceCatalogIsReadOnlyAndSinkSemanticsStayDisabled() {
+        GBase8aDialect dialect = dialect();
+        Catalog catalog = dialect.createCatalog(config(baseUrl(), null, null));
+        assertFalse(catalog instanceof WritableCatalog);
+        assertFalse(dialect.buildUpsertSql(
+                TablePath.of("app", "orders"),
+                Arrays.asList("id", "name"),
+                Collections.singletonList("id")).isPresent());
+
+        Column column = Column.builder("name", BasicType.STRING_TYPE).build();
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> dialect.typeMapper().toDatabaseType(column));
+    }
+
+    @Test
+    public void sourceDefaultsRemoveTinyintAndYearAmbiguity() {
+        Map<String, String> properties = dialect().defaultConnectionProperties();
+        assertEquals("false", properties.get("tinyInt1isBit"));
+        assertEquals("false", properties.get("yearIsDateType"));
+    }
+
+    @Test
+    public void positiveFetchSizeUsesGBaseStreamingSentinel() throws Exception {
+        AtomicInteger configuredFetchSize = new AtomicInteger(0);
+        PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> {
+                    if ("setFetchSize".equals(method.getName())) {
+                        configuredFetchSize.set((Integer) args[0]);
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+        Connection connection = (Connection) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    if ("prepareStatement".equals(method.getName())) {
+                        return statement;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+
+        dialect().prepareReadStatement(connection, "SELECT 1", 1000);
+        assertEquals(Integer.MIN_VALUE, configuredFetchSize.get());
+    }
+
+    @Test
+    public void boundedSourceAdvertisesBestEffortOnly() {
+        assertEquals(
+                Collections.singleton(ReadConsistency.BEST_EFFORT),
+                dialect().supportedReadConsistencies());
+        assertEquals(
+                DatabaseIdentifier.GBASE8A,
+                dialect().rowConverter().name());
+    }
+
+    @Test
+    public void requiresDatabaseInJdbcUrlEvenWhenGenericSchemaIsPresent() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new GBase8aDialect(
+                        config("jdbc:gbase://127.0.0.1:5258", "app", null)));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new GBase8aDialect(
+                        config("jdbc:gbase://127.0.0.1:5258", null, null)));
+    }
+
+    private static GBase8aDialect dialect() {
+        return new GBase8aDialect(config(baseUrl(), null, null));
+    }
+
+    private static JdbcConnectionConfig config(
+            String url,
+            String schema,
+            String dialect) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", "com.gbase.jdbc.Driver");
+        values.put("username", "gbase");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (dialect != null) {
+            values.put("dialect", dialect);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:gbase://127.0.0.1:5258/app?characterEncoding=utf8";
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapperTest.java
@@ -1,0 +1,89 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.SqlType;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+
+public class GBase8aTypeMapperTest {
+
+    private final GBase8aTypeMapper mapper = new GBase8aTypeMapper();
+
+    @Test
+    public void mapsCommonGBase8aReadTypesWithoutMySqlTimezoneSemantics() throws Exception {
+        assertType(SqlType.INT, "TINYINT", Types.TINYINT, 3, 0);
+        assertType(SqlType.INT, "MEDIUMINT", Types.INTEGER, 8, 0);
+        assertType(SqlType.BIGINT, "BIGINT", Types.BIGINT, 19, 0);
+        assertType(SqlType.FLOAT, "FLOAT", Types.FLOAT, 12, 4);
+        assertType(SqlType.DOUBLE, "DOUBLE", Types.DOUBLE, 22, 8);
+        assertType(SqlType.DECIMAL, "DECIMAL", Types.DECIMAL, 20, 4);
+        assertType(SqlType.DATE, "DATE", Types.DATE, 10, 0);
+        assertType(SqlType.TIME, "TIME", Types.TIME, 8, 0);
+        assertType(SqlType.TIMESTAMP, "DATETIME", Types.TIMESTAMP, 26, 6);
+        assertType(SqlType.TIMESTAMP, "TIMESTAMP", Types.TIMESTAMP, 26, 6);
+        assertType(SqlType.BYTES, "BLOB", Types.BLOB, 65535, 0);
+        assertType(SqlType.STRING, "CLOB", Types.CLOB, 65535, 0);
+    }
+
+    @Test
+    public void oversizedDecimalFallsBackToStringInsteadOfLosingPrecision() throws Exception {
+        assertType(SqlType.STRING, "DECIMAL", Types.DECIMAL, 65, 30);
+    }
+
+    private void assertType(
+            SqlType expected,
+            String sourceType,
+            int jdbcType,
+            int precision,
+            int scale) throws Exception {
+        Column column = mapper.map(metadata(sourceType, jdbcType, precision, scale), 1);
+        assertEquals(expected, column.getDataType().getSqlType());
+    }
+
+    private static ResultSetMetaData metadata(
+            String sourceType,
+            int jdbcType,
+            int precision,
+            int scale) {
+        return (ResultSetMetaData) Proxy.newProxyInstance(
+                GBase8aTypeMapperTest.class.getClassLoader(),
+                new Class<?>[]{ResultSetMetaData.class},
+                (proxy, method, args) -> {
+                    String name = method.getName();
+                    if ("getColumnLabel".equals(name) || "getColumnName".equals(name)) {
+                        return "value";
+                    }
+                    if ("getColumnTypeName".equals(name)) {
+                        return sourceType;
+                    }
+                    if ("getColumnType".equals(name)) {
+                        return jdbcType;
+                    }
+                    if ("getPrecision".equals(name)) {
+                        return precision;
+                    }
+                    if ("getScale".equals(name)) {
+                        return scale;
+                    }
+                    if ("isNullable".equals(name)) {
+                        return ResultSetMetaData.columnNullable;
+                    }
+                    Class<?> type = method.getReturnType();
+                    if (type == boolean.class) {
+                        return false;
+                    }
+                    if (type == int.class) {
+                        return 0;
+                    }
+                    if (type == long.class) {
+                        return 0L;
+                    }
+                    return null;
+                });
+    }
+}


### PR DESCRIPTION
## Summary

Add the first runtime stage for GBase 8a: a bounded/offline JDBC Source.

This PR is based directly on the current `main` and keeps the scope source-only. GBase 8a is modeled as its own first-class `gbase8a` dialect; it does not reuse GBase 8c, PostgreSQL, or MySQL runtime identity.

## Canonical connection contract

```hocon
source {
  type = "jdbc"
  url = "jdbc:gbase://gbase8a:5258/app"
  driver = "com.gbase.jdbc.Driver"
  dialect = "gbase8a"
  table_path = "app.orders"
}
```

Stage 1 requires the database in the JDBC URL. The generic `schema` option is deliberately not treated as an implicit database because the shared connection runtime does not call `Connection#setCatalog`; requiring a URL-bound database keeps Catalog metadata, custom SQL, and physical reads aligned.

## Source implementation

- add `GBase8aDialectFactory` through AutoService SPI
- add dedicated `GBase8aDialect`
- add `GBase8aJdbcUrl`
  - accepts only `jdbc:gbase://`
  - extracts the URL-bound database
- add `GBase8aJdbcRowConverter` with first-class `gbase8a` identity
- add source-only `GBase8aTypeMapper`
- add dedicated read-only `GBase8aCatalog`
  - uses standard JDBC `DatabaseMetaData`
  - database/catalog discovery
  - table discovery
  - column discovery
  - primary-key discovery
  - does not implement `WritableCatalog`

## Database/table semantics

GBase 8a Stage 1 uses `database.table` paths with no separate schema layer.

- `orders` -> database from the JDBC URL
- `analytics.orders` -> explicitly qualified database
- three-part paths are rejected
- identifiers use backtick quoting

The Catalog intentionally uses JDBC metadata instead of borrowing `MySqlCatalog`, so the Source does not inherit MySQL DDL or write semantics just because parts of the SQL surface look familiar.

## Read-side type contract

Common mappings include:

- BOOLEAN -> BOOLEAN
- TINYINT / SMALLINT / MEDIUMINT / INT / INTEGER -> INT
- BIGINT -> BIGINT
- FLOAT -> FLOAT
- REAL / DOUBLE -> DOUBLE
- DECIMAL / NUMERIC -> DECIMAL up to Link-Up precision 38
- oversized DECIMAL -> STRING to avoid silent precision loss
- DATE -> DATE
- TIME -> TIME
- DATETIME / TIMESTAMP -> TIMESTAMP
- binary/BLOB -> BYTES
- character/text/CLOB/ENUM/SET/JSON -> STRING
- unknown/extension JDBC types -> STRING

Target database type generation is explicitly disabled in this Source-only stage.

## Large-result streaming

GBase JDBC uses `Integer.MIN_VALUE` as the streaming result-set fetch-size sentinel. When Link-Up is configured with a positive `fetch_size`, `GBase8aDialect` translates it to that vendor streaming mode instead of passing the positive value through directly.

Dialect defaults also set:

- `tinyInt1isBit=false`
- `yearIsDateType=false`

User-supplied JDBC properties still override dialect defaults through the existing connection provider.

## Supported Stage 1 behavior

- bounded single-table Source
- bounded multi-table Source through the shared JDBC path
- custom query reads
- database/table/column/primary-key metadata discovery
- shared safe JDBC range partition planning
- GBase 8a read-side type mapping
- `BEST_EFFORT` read consistency

## Explicit non-goals

- JDBC Sink
- `WritableCatalog`
- INSERT / UPSERT generation
- CREATE / ALTER / DROP table DDL
- automatic target-table creation
- POC/native high-speed MPP loading
- VC/topology management
- CDC / streaming job semantics
- coordinated MPP-wide snapshots
- runtime schema evolution
- GBase 8s runtime support

## Tests

Focused tests cover:

- SPI loading from `jdbc:gbase://`
- URL discrimination from GBase 8c / GBase 8s / MySQL
- explicit `dialect=gbase8a`
- database extraction from JDBC URLs with connection properties
- `database.table` path parsing
- backtick identifier quoting
- three-part path rejection
- read-only Catalog / no `WritableCatalog`
- no UPSERT advertisement
- no Sink type generation
- `tinyInt1isBit` / `yearIsDateType` defaults
- positive `fetch_size` -> `Integer.MIN_VALUE`
- `BEST_EFFORT`-only consistency
- first-class row-converter identity
- URL-bound database requirement
- common GBase 8a type mappings
- DATETIME/TIMESTAMP -> Link-Up TIMESTAMP
- oversized DECIMAL -> STRING precision-safe fallback

## Verification

- branch is based directly on current `main`
- final branch is one atomic commit
- final compare: `ahead=1`, `behind=0`
- diff is limited to 9 files: GBase 8a Source implementation, focused tests, and JDBC README documentation
- no vendor JDBC Maven coordinate is guessed or added; runtime must provide the official `com.gbase.jdbc.Driver`
- Maven execution was attempted, but this execution environment cannot resolve `github.com`, so the repository could not be cloned and the Maven suite was not executed here
- tests are added but are not claimed as executed
- a real GBase 8a environment plus the vendor JDBC driver is still required before Ready for Review to validate connection, JDBC metadata, common types, primary-key discovery, streaming fetch behavior, custom SQL, and bounded single/multi-table execution end to end

## Repository stack note

PRs #122 and #123 are marked merged, but because they were stacked onto feature branches after #121 had already been merged, their GBase 8c runtime changes are not currently present on `main`. This PR deliberately does not roll those 8c changes into the GBase 8a diff. A small GBase 8c roll-up PR to `main` should be handled separately.