### PR TITLE
feat(gbase8a): add existing-table JDBC sink support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -112,9 +112,9 @@ The planned bounded/offline implementation order is:
 CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths stay outside
 this family-level contract.
 
-### GBase 8a bounded Source
+### GBase 8a bounded Source + existing-table JDBC Sink
 
-GBase 8a is exposed as the first-class `gbase8a` JDBC dialect. Stage 1 uses the vendor JDBC protocol and driver:
+GBase 8a is exposed as the first-class `gbase8a` JDBC dialect and uses the vendor JDBC protocol/driver:
 
 ```hocon
 source {
@@ -124,26 +124,56 @@ source {
   dialect = "gbase8a"
   table_path = "app.orders"
 }
+
+sink {
+  type = "jdbc"
+  url = "jdbc:gbase://gbase8a:5258/archive"
+  driver = "com.gbase.jdbc.Driver"
+  dialect = "gbase8a"
+  table = "orders"
+  schema_save_mode = "ERROR_WHEN_SCHEMA_NOT_EXIST"
+  data_save_mode = "APPEND_DATA"
+}
 ```
 
-GBase 8a uses `database.table` semantics with no separate schema layer in this stage. The Source owns a dedicated
-read-only Catalog built on standard JDBC `DatabaseMetaData` for database, table, column and primary-key discovery instead
-of borrowing MySQL DDL behavior. Table identifiers use backtick quoting, and both single-table and multi-table bounded
-jobs continue through the shared JDBC Source runtime.
+GBase 8a uses `database.table` semantics with no separate schema layer in this bounded JDBC stage. The JDBC URL owns the
+active database. Source metadata may come from another database/schema, but an unqualified Sink target is always rebound
+to the Sink URL database so source routing metadata cannot leak into the target. An explicit target may be `orders` or
+repeat the URL database as `archive.orders`; an explicit different database fails during Sink preparation instead of
+silently redirecting one connection to another database.
+
+Metadata discovery remains based on standard JDBC `DatabaseMetaData` for databases, tables, columns and primary keys.
+The Catalog now implements `WritableCatalog` only to participate in the shared JDBC Sink save-mode lifecycle. The stage
+supports metadata validation and `TRUNCATE TABLE` for `DROP_DATA`, while structure-changing DDL remains blocked:
+
+- no CREATE/DROP DATABASE
+- no CREATE/DROP TABLE
+- no ADD COLUMN or runtime schema evolution
+- no automatic target-table creation
+
+Create the target table before running the job. `CREATE_SCHEMA_WHEN_NOT_EXIST` is safe for an existing compatible table
+but fails clearly when the table is absent. `RECREATE_SCHEMA` cannot destructively drop a table because DROP TABLE is
+blocked before recreation. `CREATE_OR_ADD_COLUMNS` may validate an already compatible target, but a missing column fails
+instead of mutating MPP table structure.
+
+The Sink reuses the shared JDBC writer: parameterized `INSERT`, configured batch size, `PreparedStatement.addBatch()` /
+`executeBatch()`, one task-local transaction and the existing commit/rollback, retry/savepoint and dirty-data behavior.
+`rewriteBatchedStatements=true` is a GBase 8a dialect default because the vendor JDBC driver can rewrite batched INSERTs
+into multi-value INSERT statements; explicit user `properties` may override it.
+
+UPSERT/MERGE is intentionally not advertised. GBase 8a MERGE has distribution-specific constraints, so this generic
+existing-table stage does not guess HASH distribution keys or business-key semantics. POC/native high-speed loading is
+also a later stage; this PR keeps JDBC batch INSERT as the usable baseline before introducing a separate MPP-native load
+path.
 
 The read-side type contract covers common numeric, string/text, binary/BLOB, DATE, TIME, DATETIME and TIMESTAMP types.
 DATETIME/TIMESTAMP map to the Link-Up `TIMESTAMP` boundary. DECIMAL values above Link-Up's precision limit fall back to
-STRING instead of silently losing precision. Unknown/extension JDBC types also fall back to STRING for metadata/read
-usability. No target database type generation is exposed in this Source-only stage.
+STRING instead of silently losing precision. Target database type generation remains disabled because this stage never
+auto-creates GBase 8a tables.
 
-GBase JDBC uses `Integer.MIN_VALUE` as the streaming-result fetch-size sentinel. A positive Link-Up `fetch_size` therefore
-selects that vendor streaming mode rather than passing the positive value through directly, keeping large bounded reads
-from relying on the driver's default full-result buffering behavior. `tinyInt1isBit=false` and `yearIsDateType=false` are
-safe dialect defaults; explicit user `properties` still override dialect defaults.
-
-Stage 1 advertises `BEST_EFFORT` read consistency only. It does not claim one MPP-wide snapshot across parallel JDBC
-readers. Sink, WritableCatalog, CREATE/ALTER/DROP DDL, UPSERT, POC/native high-speed loading, VC/topology management, CDC,
-streaming checkpoints and runtime schema evolution remain separate follow-up stages.
+For large bounded reads, a positive Link-Up `fetch_size` selects the GBase JDBC streaming-result sentinel
+`Integer.MIN_VALUE`. `tinyInt1isBit=false` and `yearIsDateType=false` remain safe type defaults. The Source advertises
+`BEST_EFFORT` read consistency only and does not claim one MPP-wide snapshot across parallel JDBC readers.
 
 The vendor GBase JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official
 GBase 8a JDBC driver on the runtime classpath and configure `driver = "com.gbase.jdbc.Driver"`.

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalog.java
@@ -1,12 +1,15 @@
 package com.link.up.connector.jdbc.catalog.gbase.gbase8a;
 
-import com.link.up.api.table.catalog.Catalog;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.Column;
 import com.link.up.api.table.catalog.PrimaryKey;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
 import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
 import com.link.up.api.table.catalog.exception.TableNotFoundException;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
@@ -16,6 +19,7 @@ import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aTypeMapper;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -28,13 +32,14 @@ import java.util.Set;
 import java.util.TreeMap;
 
 /**
- * Read-only GBase 8a Catalog for bounded/offline Source jobs.
+ * GBase 8a Catalog for bounded/offline Source and existing-table JDBC Sink jobs.
  *
- * <p>GBase 8a exposes database/table semantics through its JDBC catalog model. Stage 1 uses the
- * standard {@link DatabaseMetaData} contract instead of borrowing MySQL DDL/catalog code, keeping
- * this adapter source-only and MPP-safe.</p>
+ * <p>Metadata uses the standard JDBC {@link DatabaseMetaData} contract. The Sink stage deliberately
+ * exposes {@link WritableCatalog} only so the shared save-mode lifecycle can validate existing
+ * targets and optionally truncate their data. Structure-changing DDL stays disabled until GBase 8a
+ * distribution/MPP table design is modeled explicitly.</p>
  */
-public final class GBase8aCatalog implements Catalog {
+public final class GBase8aCatalog implements WritableCatalog {
 
     public static final String TABLE_OPTION_DIALECT = "dialect";
 
@@ -58,7 +63,7 @@ public final class GBase8aCatalog implements Catalog {
             throw new IllegalArgumentException("非法 GBase 8a JDBC URL：" + config.getUrl());
         }
         if (!hasText(defaultDatabase)) {
-            throw new IllegalArgumentException("GBase 8a Stage 1 必须指定默认 database");
+            throw new IllegalArgumentException("GBase 8a JDBC URL 必须指定默认 database");
         }
         this.catalogName = catalogName.trim();
         this.config = config;
@@ -115,7 +120,7 @@ public final class GBase8aCatalog implements Catalog {
         }
     }
 
-    /** GBase 8a Stage 1 models database as JDBC catalog and has no separate schema layer. */
+    /** GBase 8a models database as JDBC catalog and has no separate schema layer. */
     @Override
     public List<String> listSchemas(String databaseName) {
         return Collections.emptyList();
@@ -197,6 +202,69 @@ public final class GBase8aCatalog implements Catalog {
         }
     }
 
+    @Override
+    public void createDatabase(
+            String databaseName,
+            boolean ignoreIfExists)
+            throws CatalogException, DatabaseAlreadyExistsException {
+        throw unsupportedSchemaDdl("create database");
+    }
+
+    @Override
+    public void dropDatabase(
+            String databaseName,
+            boolean ignoreIfNotExists)
+            throws CatalogException, DatabaseNotFoundException {
+        throw unsupportedSchemaDdl("drop database");
+    }
+
+    @Override
+    public void createTable(
+            CatalogTable table,
+            boolean ignoreIfExists)
+            throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+        throw unsupportedSchemaDdl("create table");
+    }
+
+    @Override
+    public void addColumn(
+            TablePath tablePath,
+            Column column)
+            throws CatalogException, TableNotFoundException {
+        throw unsupportedSchemaDdl("add column");
+    }
+
+    @Override
+    public void dropTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        throw unsupportedSchemaDdl("drop table");
+    }
+
+    @Override
+    public void truncateTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        TablePath normalized = normalizeTablePath(tablePath);
+        if (!tableExists(normalized)) {
+            if (ignoreIfNotExists) {
+                return;
+            }
+            throw new TableNotFoundException(catalogName, normalized);
+        }
+
+        String sql = "TRUNCATE TABLE " + quoteTable(normalized);
+        try (Connection connection = newConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new CatalogException("清空 GBase 8a 表失败，table=" + normalized, e);
+        }
+    }
+
     private List<Column> readColumns(
             DatabaseMetaData metadata,
             TablePath tablePath) throws SQLException {
@@ -263,6 +331,19 @@ public final class GBase8aCatalog implements Catalog {
         return defaultDatabase;
     }
 
+    private String quoteTable(TablePath tablePath) {
+        return quoteIdentifier(tablePath.getDatabaseName())
+                + "."
+                + quoteIdentifier(tablePath.getTableName());
+    }
+
+    private static String quoteIdentifier(String identifier) {
+        if (!hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "`" + identifier.trim().replace("`", "``") + "`";
+    }
+
     private Connection newConnection() throws SQLException {
         return DriverManager.getConnection(config.getUrl(), config.toConnectionProperties());
     }
@@ -282,6 +363,13 @@ public final class GBase8aCatalog implements Catalog {
         if (!opened) {
             throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
         }
+    }
+
+    private static CatalogException unsupportedSchemaDdl(String operation) {
+        return new CatalogException(
+                "GBase 8a existing-table JDBC Sink does not support "
+                        + operation
+                        + "; pre-create the target table and keep MPP distribution DDL outside this stage");
     }
 
     private static boolean isBaseTable(String tableType) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialect.java
@@ -19,10 +19,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * GBase 8a bounded/offline JDBC Source dialect.
+ * GBase 8a bounded/offline JDBC dialect.
  *
- * <p>Stage 1 covers the normal JDBC read path only. MPP-native loading, Sink DDL, UPSERT, CDC and
- * streaming semantics remain separate stages.</p>
+ * <p>The adapter supports bounded reads and an existing-table INSERT/batch Sink. MPP-native loading,
+ * structure-changing Sink DDL, UPSERT/MERGE, CDC and streaming job semantics remain separate stages.</p>
  */
 public final class GBase8aDialect implements JdbcDialect {
 
@@ -41,7 +41,7 @@ public final class GBase8aDialect implements JdbcDialect {
         String database = GBase8aJdbcUrl.databaseName(connectionConfig.getUrl());
         if (!JdbcDialect.hasText(database)) {
             throw new IllegalArgumentException(
-                    "GBase 8a Stage 1 JDBC URL 必须指定 database");
+                    "GBase 8a JDBC URL 必须指定 database");
         }
 
         this.defaultDatabase = database.trim();
@@ -155,6 +155,7 @@ public final class GBase8aDialect implements JdbcDialect {
         Map<String, String> properties = new LinkedHashMap<String, String>();
         properties.put("tinyInt1isBit", "false");
         properties.put("yearIsDateType", "false");
+        properties.put("rewriteBatchedStatements", "true");
         return Collections.unmodifiableMap(properties);
     }
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectFactory.java
@@ -6,7 +6,7 @@ import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
 
-/** GBase 8a bounded JDBC Source dialect factory. */
+/** GBase 8a bounded/offline JDBC dialect factory. */
 @AutoService(JdbcDialectFactory.class)
 public final class GBase8aDialectFactory implements JdbcDialectFactory {
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aJdbcRowConverter.java
@@ -3,7 +3,7 @@ package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
 import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 
-/** GBase 8a bounded Source row converter. */
+/** GBase 8a bounded/offline JDBC row converter for Source reads and existing-table Sink writes. */
 public final class GBase8aJdbcRowConverter extends AbstractJdbcRowConverter {
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapper.java
@@ -15,11 +15,11 @@ import java.sql.Types;
 import java.util.Locale;
 
 /**
- * GBase 8a bounded Source type mapper.
+ * GBase 8a bounded/offline JDBC type mapper.
  *
- * <p>The mapper follows the JDBC types documented by GBase 8a and keeps the contract read-only.
- * Unknown/extension types fall back to STRING so schema discovery stays usable without inventing
- * GBase-specific runtime types.</p>
+ * <p>The mapper follows the JDBC types documented by GBase 8a for metadata discovery and row
+ * conversion. Unknown/extension types fall back to STRING. Target DDL type generation stays
+ * disabled because the current Sink writes pre-created tables only.</p>
  */
 public final class GBase8aTypeMapper implements JdbcTypeMapper {
 
@@ -67,7 +67,7 @@ public final class GBase8aTypeMapper implements JdbcTypeMapper {
     @Override
     public String toDatabaseType(Column column) {
         throw new UnsupportedOperationException(
-                "GBase 8a Stage 1 is source-only; target type generation belongs to the Sink stage");
+                "GBase 8a existing-table Sink does not generate target DDL types");
     }
 
     private static FluxDataType<?> mapType(

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8aSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8aSinkSupport.java
@@ -1,0 +1,80 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aJdbcUrl;
+
+/** Target-path normalization and validation for the GBase 8a existing-table JDBC Sink. */
+final class GBase8aSinkSupport {
+
+    private GBase8aSinkSupport() {
+    }
+
+    static boolean accepts(JdbcConnectionConfig config) {
+        if (config == null) {
+            return false;
+        }
+        if (hasText(config.getDialect())) {
+            return DatabaseIdentifier.GBASE8A.equalsIgnoreCase(config.getDialect());
+        }
+        return GBase8aJdbcUrl.accepts(config.getUrl());
+    }
+
+    /**
+     * The Sink JDBC URL owns the target database. Source database/schema metadata is never reused
+     * implicitly across databases.
+     */
+    static TablePath resolveTargetPath(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+        if (config == null || tablePath == null) {
+            return tablePath;
+        }
+
+        String database = GBase8aJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(database)) {
+            return null;
+        }
+        if (!hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("GBase 8a target table name must not be empty");
+        }
+
+        return TablePath.of(database, tablePath.getTableName());
+    }
+
+    /**
+     * Explicit target mappings may be unqualified or repeat the URL database, but may not redirect
+     * one Sink connection to another database silently.
+     */
+    static void validateExplicitTargetPath(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+        if (config == null || tablePath == null) {
+            return;
+        }
+
+        String urlDatabase = GBase8aJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(urlDatabase)) {
+            throw new IllegalArgumentException("GBase 8a Sink JDBC URL must specify database");
+        }
+
+        String pathDatabase = tablePath.getDatabaseName();
+        if (!hasText(pathDatabase)) {
+            pathDatabase = tablePath.getSchemaName();
+        }
+        if (hasText(pathDatabase)
+                && !urlDatabase.equals(pathDatabase.trim())) {
+            throw new IllegalArgumentException(
+                    "GBase 8a explicit target database must match Sink JDBC URL database; "
+                            + "urlDatabase="
+                            + urlDatabase
+                            + ", targetDatabase="
+                            + pathDatabase);
+        }
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -110,6 +110,11 @@ final class JdbcSinkPreparer implements SinkPreparer {
         CatalogTable mapped = path == null
                 ? source
                 : source.withPath(dialect.parseTablePath(path));
+        if (path != null && GBase8aSinkSupport.accepts(config.getConnectionConfig())) {
+            GBase8aSinkSupport.validateExplicitTargetPath(
+                    config.getConnectionConfig(),
+                    mapped.getTablePath());
+        }
         TablePath targetPath = resolveTargetPath(mapped.getTablePath());
         return targetPath == null || mapped.getTablePath().equals(targetPath)
                 ? mapped
@@ -141,6 +146,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return GoldenDbSinkSupport.resolveTargetPath(
                     config.getConnectionConfig(), tablePath);
         }
+        if (GBase8aSinkSupport.accepts(config.getConnectionConfig())) {
+            return GBase8aSinkSupport.resolveTargetPath(
+                    config.getConnectionConfig(), tablePath);
+        }
         return JdbcCreateTableSqlResolver.resolveTargetPath(
                 config.getConnectionConfig(), tablePath);
     }
@@ -167,6 +176,9 @@ final class JdbcSinkPreparer implements SinkPreparer {
                     config.getConnectionConfig(), table);
         }
         if (GoldenDbSinkSupport.accepts(config.getConnectionConfig())) {
+            return null;
+        }
+        if (GBase8aSinkSupport.accepts(config.getConnectionConfig())) {
             return null;
         }
         return JdbcCreateTableSqlResolver.resolve(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalogTest.java
@@ -1,0 +1,97 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8a;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class GBase8aCatalogTest {
+
+    @Test
+    public void existingTableSinkRejectsAutomaticTableCreation() {
+        GBase8aCatalog catalog = catalog();
+        try {
+            catalog.createTable(table(), false);
+            fail("GBase 8a existing-table Sink must not auto-create target tables");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("create table"));
+        }
+    }
+
+    @Test
+    public void existingTableSinkRejectsDestructiveDropBeforeRecreate() {
+        GBase8aCatalog catalog = catalog();
+        try {
+            catalog.dropTable(TablePath.of("target_db", "orders"), false);
+            fail("GBase 8a existing-table Sink must not drop target tables");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("drop table"));
+        }
+    }
+
+    @Test
+    public void existingTableSinkRejectsRuntimeAddColumn() {
+        GBase8aCatalog catalog = catalog();
+        try {
+            catalog.addColumn(
+                    TablePath.of("target_db", "orders"),
+                    Column.builder("new_col", BasicType.STRING_TYPE).build());
+            fail("GBase 8a existing-table Sink must not mutate target schema");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("add column"));
+        }
+    }
+
+    @Test
+    public void existingTableSinkRejectsDatabaseDdl() {
+        GBase8aCatalog catalog = catalog();
+        try {
+            catalog.createDatabase("archive", false);
+            fail("GBase 8a existing-table Sink must not create databases");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("create database"));
+        }
+
+        try {
+            catalog.dropDatabase("archive", false);
+            fail("GBase 8a existing-table Sink must not drop databases");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("drop database"));
+        }
+    }
+
+    private static GBase8aCatalog catalog() {
+        return new GBase8aCatalog(
+                "gbase8a",
+                new JdbcCatalogConfig(
+                        "jdbc:gbase://127.0.0.1:5258/target_db",
+                        "gbase",
+                        "password",
+                        "com.gbase.jdbc.Driver",
+                        Collections.emptyMap(),
+                        false),
+                "target_db");
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Collections.singletonList(
+                        Column.builder("id", BasicType.LONG_TYPE)
+                                .nullable(false)
+                                .build()))
+                .build();
+        return CatalogTable.builder(
+                        TablePath.of("target_db", "orders"),
+                        schema)
+                .build();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectTest.java
@@ -83,10 +83,15 @@ public class GBase8aDialectTest {
     }
 
     @Test
-    public void sourceCatalogIsReadOnlyAndSinkSemanticsStayDisabled() {
+    public void existingTableSinkUsesPortableInsertAndStillRejectsUpsert() {
         GBase8aDialect dialect = dialect();
         Catalog catalog = dialect.createCatalog(config(baseUrl(), null, null));
-        assertFalse(catalog instanceof WritableCatalog);
+        assertTrue(catalog instanceof WritableCatalog);
+        assertEquals(
+                "INSERT INTO `app`.`orders` (`id`, `name`) VALUES (?, ?)",
+                dialect.buildInsertSql(
+                        TablePath.of("app", "orders"),
+                        Arrays.asList("id", "name")));
         assertFalse(dialect.buildUpsertSql(
                 TablePath.of("app", "orders"),
                 Arrays.asList("id", "name"),
@@ -99,10 +104,11 @@ public class GBase8aDialectTest {
     }
 
     @Test
-    public void sourceDefaultsRemoveTinyintAndYearAmbiguity() {
+    public void dialectDefaultsRemoveTypeAmbiguityAndEnableBatchRewrite() {
         Map<String, String> properties = dialect().defaultConnectionProperties();
         assertEquals("false", properties.get("tinyInt1isBit"));
         assertEquals("false", properties.get("yearIsDateType"));
+        assertEquals("true", properties.get("rewriteBatchedStatements"));
     }
 
     @Test

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8aSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8aSinkSupportTest.java
@@ -1,0 +1,115 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aDialect;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8aSinkSupportTest {
+
+    @Test
+    public void sourceDatabaseAndSchemaDoNotLeakIntoTarget() {
+        TablePath target = GBase8aSinkSupport.resolveTargetPath(
+                config("target_db", DatabaseIdentifier.GBASE8A),
+                TablePath.of("source_db", "source_schema", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "orders"),
+                target);
+    }
+
+    @Test
+    public void unqualifiedTargetUsesJdbcUrlDatabase() {
+        TablePath target = GBase8aSinkSupport.resolveTargetPath(
+                config("target_db", DatabaseIdentifier.GBASE8A),
+                TablePath.of("orders"));
+
+        assertEquals(TablePath.of("target_db", "orders"), target);
+    }
+
+    @Test
+    public void explicitTargetMayRepeatUrlDatabase() {
+        JdbcConnectionConfig config = config("target_db", DatabaseIdentifier.GBASE8A);
+        GBase8aSinkSupport.validateExplicitTargetPath(
+                config,
+                TablePath.of("target_db", "orders"));
+
+        assertEquals(
+                TablePath.of("target_db", "orders"),
+                GBase8aSinkSupport.resolveTargetPath(
+                        config,
+                        TablePath.of("target_db", "orders")));
+    }
+
+    @Test
+    public void explicitCrossDatabaseTargetFailsClearly() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> GBase8aSinkSupport.validateExplicitTargetPath(
+                        config("target_db", DatabaseIdentifier.GBASE8A),
+                        TablePath.of("archive", "orders")));
+
+        assertTrue(error.getMessage().contains("must match Sink JDBC URL database"));
+    }
+
+    @Test
+    public void dedicatedUrlCanSelectSinkSupportWithoutExplicitDialect() {
+        assertTrue(GBase8aSinkSupport.accepts(config("target_db", null)));
+        assertTrue(GBase8aSinkSupport.accepts(
+                config("target_db", DatabaseIdentifier.GBASE8A)));
+        assertFalse(GBase8aSinkSupport.accepts(
+                config("target_db", DatabaseIdentifier.POSTGRESQL)));
+    }
+
+    @Test
+    public void existingTableSinkDoesNotGenerateAutomaticCreateTableSql() {
+        JdbcConnectionConfig config = config("target_db", DatabaseIdentifier.GBASE8A);
+        assertNull(
+                JdbcCreateTableSqlResolver.resolve(
+                        new GBase8aDialect(config),
+                        config,
+                        table()));
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Collections.singletonList(
+                        Column.builder("id", BasicType.LONG_TYPE)
+                                .nullable(false)
+                                .build()))
+                .build();
+        return CatalogTable.builder(
+                        TablePath.of("source_db", "orders"),
+                        schema)
+                .build();
+    }
+
+    private static JdbcConnectionConfig config(
+            String database,
+            String dialect) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", "jdbc:gbase://127.0.0.1:5258/" + database);
+        values.put("driver", "com.gbase.jdbc.Driver");
+        values.put("username", "gbase");
+        if (dialect != null) {
+            values.put("dialect", dialect);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}


### PR DESCRIPTION
## Summary

Add the second GBase 8a runtime stage: a bounded/offline **existing-table JDBC Sink**.

This PR is based directly on the current `main` after #124. It keeps the write contract intentionally conservative: standard JDBC INSERT + batch execution into pre-created GBase 8a tables. POC/native high-speed loading, automatic distributed-table DDL, MERGE/UPSERT, CDC and realtime semantics remain separate stages.

## Sink contract

```hocon
sink {
  type = "jdbc"
  url = "jdbc:gbase://gbase8a:5258/archive"
  driver = "com.gbase.jdbc.Driver"
  dialect = "gbase8a"
  table = "orders"
  schema_save_mode = "ERROR_WHEN_SCHEMA_NOT_EXIST"
  data_save_mode = "APPEND_DATA"
}
```

The Sink reuses the shared JDBC writer:

- generated parameterized `INSERT`
- configured `batch_size`
- `PreparedStatement.addBatch()` / `executeBatch()`
- one task-local JDBC transaction
- commit / rollback
- existing savepoint retry behavior
- existing dirty-data handling

No GBase 8a-specific writer is introduced.

## Batch optimization

Add `rewriteBatchedStatements=true` as a GBase 8a dialect default.

The vendor JDBC driver documents this option as the batch-INSERT rewrite path used by `executeBatch()` to combine INSERT values and reduce round trips. Explicit connector `properties` still override dialect defaults.

## Existing-table safety boundary

`GBase8aCatalog` now implements `WritableCatalog` so the common Sink save-mode lifecycle can validate existing targets and support `DROP_DATA`, while all structure-changing DDL remains blocked.

Allowed:

- database/table/column/primary-key metadata discovery
- target schema compatibility validation
- INSERT / JDBC batch write
- `TRUNCATE TABLE` for `DROP_DATA`

Blocked:

- CREATE DATABASE
- DROP DATABASE
- CREATE TABLE
- DROP TABLE
- ADD COLUMN
- automatic target DDL type generation
- runtime schema evolution

This means:

- `ERROR_WHEN_SCHEMA_NOT_EXIST` / `IGNORE` work for compatible pre-created tables
- `CREATE_SCHEMA_WHEN_NOT_EXIST` remains safe for an existing table but fails clearly if the table is absent
- `RECREATE_SCHEMA` is rejected before a destructive DROP
- `CREATE_OR_ADD_COLUMNS` may validate a compatible table, but missing target columns fail instead of mutating MPP table structure

## Target routing

Add `GBase8aSinkSupport` and wire it into `JdbcSinkPreparer`.

The Sink JDBC URL owns the target database.

- source database/schema metadata never leaks into the target
- `table = "orders"` resolves to the database in the Sink URL
- `table = "archive.orders"` is accepted when the URL database is also `archive`
- an explicit different target database fails during Sink preparation instead of being silently rewritten

This keeps one Sink connection aligned with one explicit target database.

## UPSERT / MERGE boundary

This stage intentionally does **not** advertise UPSERT.

GBase 8a supports MERGE only under distribution-specific constraints (including HASH-distributed-table requirements and key/distribution conditions). The generic JDBC Sink therefore does not guess distribution keys or business-key semantics.

`write_mode = UPSERT` continues to fail during Sink preparation because `GBase8aDialect.buildUpsertSql()` is not implemented.

## Native-load boundary

GBase 8a documentation recommends bulk LOAD paths ahead of row-oriented INSERT for maximum ingestion performance. This PR deliberately keeps standard JDBC batch INSERT as the usable baseline. POC/native/high-speed MPP loading remains a separate follow-up stage so its topology, load semantics and failure behavior do not leak into the generic JDBC contract.

## Tests

Focused tests cover:

- portable quoted INSERT SQL
- `WritableCatalog` availability for existing-table Sink preparation
- UPSERT remains unsupported
- target DDL type generation remains disabled
- `rewriteBatchedStatements=true` default
- automatic table creation rejected
- destructive DROP rejected
- ADD COLUMN rejected
- database DDL rejected
- source database/schema do not leak into the target
- URL database fallback for unqualified targets
- explicit same-database target accepted
- explicit cross-database target rejected
- dedicated URL auto-detection for Sink support
- no automatic CREATE TABLE SQL

## Explicit non-goals

- MERGE / UPSERT
- automatic database/table creation
- runtime schema evolution
- distribution-key / HASH-table design
- VC/topology management
- POC/native/high-speed load
- CDC / streaming
- coordinated MPP-wide snapshots
- GBase 8s runtime support

## Verification

- based directly on current `main` after #124
- final branch is one atomic commit
- final compare: `ahead=1`, `behind=0`
- diff is limited to 11 files: GBase 8a existing-table Sink integration, focused tests, and JDBC README documentation
- no vendor JDBC Maven coordinate is guessed or added; runtime must provide the official `com.gbase.jdbc.Driver`
- Maven execution was attempted, but this execution environment still cannot resolve `github.com`, so the repository could not be cloned and the Maven suite was not executed here
- tests are added but are not claimed as executed
- a real GBase 8a environment plus the vendor JDBC driver is still required before Ready for Review to verify INSERT batching, transaction commit/rollback, target metadata compatibility and `DROP_DATA` end to end

## Repository note

This PR does not address the separate GBase 8c stacked-PR roll-up issue noted in #124; it keeps the GBase 8a Sink diff independent.