### PR TITLE
feat(gbase8s): add bounded JDBC source support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -178,6 +178,72 @@ For large bounded reads, a positive Link-Up `fetch_size` selects the GBase JDBC 
 The vendor GBase JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official
 GBase 8a JDBC driver on the runtime classpath and configure `driver = "com.gbase.jdbc.Driver"`.
 
+### GBase 8s bounded Source
+
+GBase 8s is exposed as the first-class `gbase8s` JDBC dialect. Stage 1 uses the native GBase 8s JDBC protocol and keeps
+normal GBase SQL semantics separate from later SQLMODE compatibility work:
+
+```hocon
+source {
+  type = "jdbc"
+  url = "jdbc:gbasedbt-sqli://gbase8s:9088/app:GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10"
+  driver = "com.gbasedbt.jdbc.Driver"
+  dialect = "gbase8s"
+  schema = "gbasedbt" # optional table owner; defaults to username
+  table_path = "gbasedbt.orders"
+}
+```
+
+The database and `GBASEDBTSERVER` instance identity are connection-level concerns and must be present in the JDBC URL or
+connection properties. One Stage 1 Source connection is bound to the database in its URL. GBase 8s reports table owner
+through the JDBC schema field, so Link-Up models physical tables as `database.owner.table` metadata while SQL inside the
+selected database uses `owner.table`. The normal user-facing paths are `table` and `owner.table`; a three-part
+`database.owner.table` path is accepted only when its database equals the URL database. Cross-database rebinding is not
+performed implicitly.
+
+The read-only `GBase8sCatalog` uses standard JDBC `DatabaseMetaData` for owner, table, column and primary-key discovery.
+If no owner is supplied, the connector uses the explicit `schema` option and then the JDBC username as the default owner.
+When neither gives an owner and the same table name is visible under multiple owners, metadata preparation fails and asks
+for an explicit `owner.table` instead of guessing.
+
+GBase 8s JDBC defaults `DELIMIDENT=n`. In that mode double-quoted SQL identifiers are not valid, so the dialect does not
+blindly quote every table/column name. Ordinary unquoted identifiers are normalized to GBase 8s lowercase behavior. If a
+deployment explicitly enables `DELIMIDENT=y` in the URL or JDBC properties, quoted `table_path` parts preserve case and
+SQL identifiers are emitted with double quotes. This keeps the default path compatible while still allowing deliberate
+case-sensitive database objects.
+
+The Stage 1 type boundary covers common built-ins without exposing GBase JDBC private objects:
+
+- BOOLEAN -> BOOLEAN
+- SMALLINT -> SMALLINT
+- SERIAL / INTEGER / INT -> INT
+- INT8 / SERIAL8 / BIGINT / BIGSERIAL -> BIGINT
+- SMALLFLOAT / REAL -> FLOAT
+- FLOAT / DOUBLE PRECISION -> DOUBLE
+- DEC / DECIMAL / NUMERIC / MONEY -> DECIMAL when precision fits Link-Up
+- DATE -> DATE
+- DATETIME -> TIMESTAMP
+- BYTE / BLOB -> BYTES
+- CHAR / VARCHAR / LVARCHAR / NCHAR / NVARCHAR / TEXT / CLOB -> STRING
+- INTERVAL -> STRING
+- unknown, opaque and extension JDBC types -> STRING
+
+DECIMAL precision above Link-Up's limit falls back to STRING rather than silently truncating numeric precision. INTERVAL
+also stays STRING in this stage because the GBase 8s JDBC driver represents intervals with vendor-specific
+`com.gbasedbt.lang.Interval*` classes. Target type generation remains disabled until the dedicated 8s Sink stage.
+
+The Source supports bounded single-table and multi-table jobs, custom SQL and the shared safe JDBC range partition
+planner. It advertises `BEST_EFFORT` read consistency only. Although GBase 8s provides transactional isolation levels,
+this stage does not claim a coordinated point-in-time snapshot across independent parallel JDBC readers.
+
+Out of scope for this stage: JDBC Sink, WritableCatalog, automatic DDL, SQLMODE MySQL/Oracle compatibility expansion,
+CDC/realtime synchronization, logical-log integration, coordinated snapshots, complex ROW/COLLECTION native objects and
+runtime schema evolution.
+
+The vendor JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official GBase
+8s JDBC driver on the runtime classpath and configure `driver = "com.gbasedbt.jdbc.Driver"` (or an older vendor-provided
+compatible driver class when required by that deployment).
+
 ## SAP HANA
 
 SAP HANA is exposed as the `hana` JDBC dialect and is auto-detected from `jdbc:sap://` URLs. Stage 1 is deliberately

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalog.java
@@ -1,0 +1,365 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8s;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sTypeMapper;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Read-only GBase 8s Catalog for bounded/offline Source jobs.
+ *
+ * <p>GBase 8s JDBC exposes database as catalog and table owner as schema. Stage 1 binds one Catalog
+ * instance to the database in the JDBC URL and uses standard {@link DatabaseMetaData} for owner,
+ * table, column and primary-key discovery. Cross-database rebinding and writable DDL remain out of
+ * scope.</p>
+ */
+public final class GBase8sCatalog implements Catalog {
+
+    public static final String TABLE_OPTION_DIALECT = "dialect";
+
+    private static final String[] BASE_TABLE_TYPES = new String[]{"TABLE"};
+
+    private final String catalogName;
+    private final JdbcCatalogConfig config;
+    private final String defaultDatabase;
+    private final String defaultOwner;
+    private final GBase8sTypeMapper typeMapper = new GBase8sTypeMapper();
+    private volatile boolean opened;
+
+    public GBase8sCatalog(
+            String catalogName,
+            JdbcCatalogConfig config,
+            String defaultDatabase,
+            String defaultOwner) {
+        if (!hasText(catalogName)) {
+            throw new IllegalArgumentException("catalogName must not be empty");
+        }
+        if (config == null) {
+            throw new IllegalArgumentException("config must not be null");
+        }
+        if (!GBase8sJdbcUrl.accepts(config.getUrl())) {
+            throw new IllegalArgumentException("非法 GBase 8s JDBC URL：" + config.getUrl());
+        }
+        if (!hasText(defaultDatabase)) {
+            throw new IllegalArgumentException("GBase 8s Stage 1 必须指定默认 database");
+        }
+        this.catalogName = catalogName.trim();
+        this.config = config;
+        this.defaultDatabase = defaultDatabase.trim();
+        this.defaultOwner = hasText(defaultOwner) ? defaultOwner.trim() : null;
+    }
+
+    @Override
+    public String name() {
+        return catalogName;
+    }
+
+    @Override
+    public synchronized void open() throws CatalogException {
+        if (opened) {
+            return;
+        }
+        loadDriver();
+        try (Connection connection = newConnection()) {
+            if (!connection.isValid(5)) {
+                throw new CatalogException("GBase 8s Catalog 连接校验失败：" + config.getUrl());
+            }
+            opened = true;
+        } catch (SQLException e) {
+            throw new CatalogException("GBase 8s Catalog 连接失败：" + config.getUrl(), e);
+        }
+    }
+
+    @Override
+    public synchronized void close() {
+        opened = false;
+    }
+
+    @Override
+    public Optional<String> getDefaultDatabase() {
+        return Optional.of(defaultDatabase);
+    }
+
+    /** Stage 1 keeps one physical JDBC connection bound to one database. */
+    @Override
+    public List<String> listDatabases() throws CatalogException {
+        checkOpened();
+        return Collections.singletonList(defaultDatabase);
+    }
+
+    /** GBase 8s JDBC reports table owner through TABLE_SCHEM. */
+    @Override
+    public List<String> listSchemas(String databaseName) throws CatalogException {
+        checkOpened();
+        requireCurrentDatabase(databaseName);
+        try (Connection connection = newConnection();
+             ResultSet resultSet = connection.getMetaData().getTables(
+                     defaultDatabase,
+                     null,
+                     "%",
+                     BASE_TABLE_TYPES)) {
+            Set<String> owners = new LinkedHashSet<String>();
+            while (resultSet.next()) {
+                String owner = resultSet.getString("TABLE_SCHEM");
+                if (hasText(owner)) {
+                    owners.add(owner.trim());
+                }
+            }
+            if (hasText(defaultOwner)) {
+                owners.add(defaultOwner);
+            }
+            return new ArrayList<String>(owners);
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 GBase 8s Owner 列表失败，database=" + defaultDatabase,
+                    e);
+        }
+    }
+
+    @Override
+    public List<TablePath> listTables(
+            String databaseName,
+            String schemaName) throws CatalogException {
+        checkOpened();
+        requireCurrentDatabase(databaseName);
+        String owner = hasText(schemaName)
+                ? schemaName.trim()
+                : defaultOwner;
+
+        try (Connection connection = newConnection();
+             ResultSet resultSet = connection.getMetaData().getTables(
+                     defaultDatabase,
+                     owner,
+                     "%",
+                     BASE_TABLE_TYPES)) {
+            List<TablePath> tables = new ArrayList<TablePath>();
+            while (resultSet.next()) {
+                if (!isBaseTable(resultSet.getString("TABLE_TYPE"))) {
+                    continue;
+                }
+                String tableName = resultSet.getString("TABLE_NAME");
+                if (!hasText(tableName)) {
+                    continue;
+                }
+                String resolvedOwner = resultSet.getString("TABLE_SCHEM");
+                tables.add(TablePath.of(
+                        defaultDatabase,
+                        hasText(resolvedOwner) ? resolvedOwner.trim() : owner,
+                        tableName.trim()));
+            }
+            return tables;
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "获取 GBase 8s 表列表失败，database="
+                            + defaultDatabase
+                            + ", owner="
+                            + owner,
+                    e);
+        }
+    }
+
+    @Override
+    public boolean tableExists(TablePath tablePath) throws CatalogException {
+        checkOpened();
+        try (Connection connection = newConnection()) {
+            TablePath normalized = normalizeTablePath(connection, tablePath, false);
+            return normalized != null;
+        } catch (SQLException e) {
+            throw new CatalogException("检查 GBase 8s 表是否存在失败，table=" + tablePath, e);
+        }
+    }
+
+    @Override
+    public CatalogTable getTable(TablePath tablePath)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        try (Connection connection = newConnection()) {
+            TablePath normalized = normalizeTablePath(connection, tablePath, true);
+            DatabaseMetaData metadata = connection.getMetaData();
+            List<Column> columns = readColumns(metadata, normalized);
+            if (columns.isEmpty()) {
+                throw new TableNotFoundException(catalogName, normalized);
+            }
+            PrimaryKey primaryKey = readPrimaryKey(metadata, normalized);
+            TableSchema schema = TableSchema.builder()
+                    .columns(columns)
+                    .primaryKey(primaryKey)
+                    .build();
+            return CatalogTable.builder(normalized, schema)
+                    .option(TABLE_OPTION_DIALECT, DatabaseIdentifier.GBASE8S)
+                    .build();
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException("获取 GBase 8s 表结构失败，table=" + tablePath, e);
+        }
+    }
+
+    private List<Column> readColumns(
+            DatabaseMetaData metadata,
+            TablePath tablePath) throws SQLException {
+        try (ResultSet resultSet = metadata.getColumns(
+                defaultDatabase,
+                tablePath.getSchemaName(),
+                tablePath.getTableName(),
+                "%")) {
+            List<Column> columns = new ArrayList<Column>();
+            while (resultSet.next()) {
+                columns.add(typeMapper.toColumn(resultSet));
+            }
+            return columns;
+        }
+    }
+
+    private PrimaryKey readPrimaryKey(
+            DatabaseMetaData metadata,
+            TablePath tablePath) throws SQLException {
+        try (ResultSet resultSet = metadata.getPrimaryKeys(
+                defaultDatabase,
+                tablePath.getSchemaName(),
+                tablePath.getTableName())) {
+            String primaryKeyName = null;
+            Map<Integer, String> columnsBySequence = new TreeMap<Integer, String>();
+            while (resultSet.next()) {
+                if (primaryKeyName == null) {
+                    primaryKeyName = resultSet.getString("PK_NAME");
+                }
+                String column = resultSet.getString("COLUMN_NAME");
+                int sequence = resultSet.getInt("KEY_SEQ");
+                if (hasText(column)) {
+                    columnsBySequence.put(sequence, column.trim());
+                }
+            }
+            return columnsBySequence.isEmpty()
+                    ? null
+                    : PrimaryKey.of(
+                            primaryKeyName,
+                            new ArrayList<String>(columnsBySequence.values()));
+        }
+    }
+
+    private TablePath normalizeTablePath(
+            Connection connection,
+            TablePath tablePath,
+            boolean failWhenMissing) throws SQLException {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        requireCurrentDatabase(tablePath.getDatabaseName());
+        if (!hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("table name must not be empty");
+        }
+
+        String owner = hasText(tablePath.getSchemaName())
+                ? tablePath.getSchemaName().trim()
+                : defaultOwner;
+        String tableName = tablePath.getTableName().trim();
+
+        try (ResultSet resultSet = connection.getMetaData().getTables(
+                defaultDatabase,
+                owner,
+                tableName,
+                BASE_TABLE_TYPES)) {
+            String resolvedOwner = null;
+            int matches = 0;
+            while (resultSet.next()) {
+                if (!isBaseTable(resultSet.getString("TABLE_TYPE"))) {
+                    continue;
+                }
+                String candidate = resultSet.getString("TABLE_NAME");
+                if (!tableName.equals(candidate)) {
+                    continue;
+                }
+                String candidateOwner = resultSet.getString("TABLE_SCHEM");
+                if (hasText(owner)
+                        && hasText(candidateOwner)
+                        && !owner.equals(candidateOwner.trim())) {
+                    continue;
+                }
+                matches++;
+                resolvedOwner = hasText(candidateOwner)
+                        ? candidateOwner.trim()
+                        : owner;
+            }
+
+            if (matches == 0) {
+                if (failWhenMissing) {
+                    throw new TableNotFoundException(
+                            catalogName,
+                            TablePath.of(defaultDatabase, owner, tableName));
+                }
+                return null;
+            }
+            if (matches > 1 && !hasText(owner)) {
+                throw new CatalogException(
+                        "GBase 8s 表名在多个 owner 下存在，必须显式指定 owner.table："
+                                + tableName);
+            }
+            return TablePath.of(defaultDatabase, resolvedOwner, tableName);
+        }
+    }
+
+    private void requireCurrentDatabase(String databaseName) {
+        if (hasText(databaseName)
+                && !defaultDatabase.equalsIgnoreCase(databaseName.trim())) {
+            throw new IllegalArgumentException(
+                    "GBase 8s Stage 1 不支持跨 database table_path；当前 JDBC database="
+                            + defaultDatabase
+                            + "，请求 database="
+                            + databaseName);
+        }
+    }
+
+    private Connection newConnection() throws SQLException {
+        return DriverManager.getConnection(config.getUrl(), config.toConnectionProperties());
+    }
+
+    private void loadDriver() {
+        if (!hasText(config.getDriverClass())) {
+            return;
+        }
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new CatalogException("找不到 GBase 8s JDBC Driver：" + config.getDriverClass(), e);
+        }
+    }
+
+    private void checkOpened() {
+        if (!opened) {
+            throw new IllegalStateException("Catalog 尚未打开，请先调用 open()");
+        }
+    }
+
+    private static boolean isBaseTable(String tableType) {
+        return tableType != null
+                && ("TABLE".equalsIgnoreCase(tableType)
+                || "BASE TABLE".equalsIgnoreCase(tableType));
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialect.java
@@ -1,0 +1,264 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
+
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import com.link.up.connector.jdbc.catalog.gbase.gbase8s.GBase8sCatalog;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.converter.JdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * GBase 8s bounded/offline JDBC Source dialect.
+ *
+ * <p>Stage 1 targets the native GBase 8s JDBC protocol and normal SQL mode. Sink, schema-changing
+ * DDL, SQLMODE compatibility expansion, CDC and realtime semantics remain separate stages.</p>
+ */
+public final class GBase8sDialect implements JdbcDialect {
+
+    private final String databaseName;
+    private final String defaultOwner;
+    private final boolean delimitedIdentifiers;
+    private final GBase8sTypeMapper typeMapper;
+
+    public GBase8sDialect(JdbcConnectionConfig connectionConfig) {
+        if (connectionConfig == null) {
+            throw new IllegalArgumentException("connectionConfig must not be null");
+        }
+        if (!GBase8sJdbcUrl.accepts(connectionConfig.getUrl())) {
+            throw new IllegalArgumentException(
+                    "非法 GBase 8s JDBC URL：" + connectionConfig.getUrl());
+        }
+
+        String database = GBase8sJdbcUrl.databaseName(connectionConfig.getUrl());
+        if (!JdbcDialect.hasText(database)) {
+            throw new IllegalArgumentException("GBase 8s Stage 1 JDBC URL 必须指定 database");
+        }
+        String server = GBase8sJdbcUrl.serverName(
+                connectionConfig.getUrl(),
+                connectionConfig.getProperties());
+        if (!JdbcDialect.hasText(server)) {
+            throw new IllegalArgumentException(
+                    "GBase 8s JDBC URL/properties 必须指定 GBASEDBTSERVER");
+        }
+
+        this.databaseName = database.trim();
+        this.defaultOwner = JdbcDialect.hasText(connectionConfig.getSchema())
+                ? connectionConfig.getSchema().trim()
+                : JdbcDialect.hasText(connectionConfig.getUsername())
+                ? connectionConfig.getUsername().trim()
+                : null;
+        this.delimitedIdentifiers = GBase8sJdbcUrl.delimitedIdentifiersEnabled(
+                connectionConfig.getUrl(),
+                connectionConfig.getProperties());
+        this.typeMapper = new GBase8sTypeMapper();
+    }
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.GBASE8S;
+    }
+
+    @Override
+    public Catalog createCatalog(
+            String catalogName,
+            JdbcConnectionConfig connectionConfig) {
+        String owner = JdbcDialect.hasText(connectionConfig.getSchema())
+                ? connectionConfig.getSchema().trim()
+                : connectionConfig.getUsername();
+        return new GBase8sCatalog(
+                catalogName,
+                new JdbcCatalogConfig(
+                        connectionConfig.getUrl(),
+                        connectionConfig.getUsername(),
+                        connectionConfig.getPassword(),
+                        connectionConfig.getDriverName(),
+                        connectionConfig.getProperties(),
+                        false),
+                GBase8sJdbcUrl.databaseName(connectionConfig.getUrl()),
+                owner);
+    }
+
+    @Override
+    public JdbcTypeMapper typeMapper() {
+        return typeMapper;
+    }
+
+    @Override
+    public JdbcRowConverter rowConverter() {
+        return new GBase8sJdbcRowConverter();
+    }
+
+    /** GBase 8s Stage 1 accepts table, owner.table, or currentDatabase.owner.table. */
+    @Override
+    public TablePath parseTablePath(String tablePath) {
+        if (!JdbcDialect.hasText(tablePath)) {
+            throw new IllegalArgumentException("tablePath must not be empty");
+        }
+
+        List<String> parts = splitPath(tablePath.trim());
+        switch (parts.size()) {
+            case 1:
+                return TablePath.of(normalizePart(parts.get(0)));
+            case 2:
+                return TablePath.of(
+                        null,
+                        normalizePart(parts.get(0)),
+                        normalizePart(parts.get(1)));
+            case 3:
+                String database = normalizePart(parts.get(0));
+                requireCurrentDatabase(database);
+                return TablePath.of(
+                        databaseName,
+                        normalizePart(parts.get(1)),
+                        normalizePart(parts.get(2)));
+            default:
+                throw new IllegalArgumentException(
+                        "非法 GBase 8s 表路径：" + tablePath);
+        }
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        if (!JdbcDialect.hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        String value = identifier.trim();
+        if (delimitedIdentifiers) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        if (!isSimpleIdentifier(value)) {
+            throw new IllegalArgumentException(
+                    "GBase 8s JDBC 默认 DELIMIDENT=n，不支持需要双引号的标识符："
+                            + identifier
+                            + "；如确需大小写敏感/特殊标识符，请在 JDBC URL/properties 设置 DELIMIDENT=y");
+        }
+        return value.toLowerCase(Locale.ROOT);
+    }
+
+    /** Database is selected by the JDBC connection; SQL uses owner.table inside that database. */
+    @Override
+    public String tableIdentifier(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (JdbcDialect.hasText(tablePath.getDatabaseName())) {
+            requireCurrentDatabase(tablePath.getDatabaseName());
+        }
+        if (!JdbcDialect.hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("table name must not be empty");
+        }
+
+        String owner = JdbcDialect.hasText(tablePath.getSchemaName())
+                ? tablePath.getSchemaName().trim()
+                : defaultOwner;
+        if (JdbcDialect.hasText(owner)) {
+            return quoteIdentifier(owner)
+                    + "."
+                    + quoteIdentifier(tablePath.getTableName());
+        }
+        return quoteIdentifier(tablePath.getTableName());
+    }
+
+    private List<String> splitPath(String path) {
+        if (!delimitedIdentifiers) {
+            if (path.indexOf('"') >= 0) {
+                throw new IllegalArgumentException(
+                        "GBase 8s JDBC 默认 DELIMIDENT=n，table_path 不允许双引号标识符：" + path);
+            }
+            String[] raw = path.split("\\.", -1);
+            List<String> parts = new ArrayList<String>(raw.length);
+            for (String part : raw) {
+                parts.add(part);
+            }
+            return parts;
+        }
+
+        List<String> parts = new ArrayList<String>();
+        StringBuilder current = new StringBuilder();
+        boolean quoted = false;
+        for (int i = 0; i < path.length(); i++) {
+            char value = path.charAt(i);
+            if (value == '"') {
+                current.append(value);
+                if (quoted && i + 1 < path.length() && path.charAt(i + 1) == '"') {
+                    current.append('"');
+                    i++;
+                } else {
+                    quoted = !quoted;
+                }
+                continue;
+            }
+            if (value == '.' && !quoted) {
+                if (current.length() == 0) {
+                    throw new IllegalArgumentException("非法 GBase 8s 表路径：" + path);
+                }
+                parts.add(current.toString());
+                current.setLength(0);
+            } else {
+                current.append(value);
+            }
+        }
+        if (quoted || current.length() == 0) {
+            throw new IllegalArgumentException("非法 GBase 8s 表路径：" + path);
+        }
+        parts.add(current.toString());
+        return parts;
+    }
+
+    private String normalizePart(String part) {
+        String value = part == null ? "" : part.trim();
+        if (delimitedIdentifiers
+                && value.length() >= 2
+                && value.charAt(0) == '"'
+                && value.charAt(value.length() - 1) == '"') {
+            String unquoted = value.substring(1, value.length() - 1)
+                    .replace("\"\"", "\"");
+            if (!JdbcDialect.hasText(unquoted)) {
+                throw new IllegalArgumentException("GBase 8s table path contains an empty identifier");
+            }
+            return unquoted;
+        }
+        if (!JdbcDialect.hasText(value)) {
+            throw new IllegalArgumentException("GBase 8s table path contains an empty identifier");
+        }
+        return value.toLowerCase(Locale.ROOT);
+    }
+
+    private void requireCurrentDatabase(String requestedDatabase) {
+        if (!JdbcDialect.hasText(requestedDatabase)
+                || !databaseName.equalsIgnoreCase(requestedDatabase.trim())) {
+            throw new IllegalArgumentException(
+                    "GBase 8s Stage 1 不支持跨 database table_path；当前 JDBC database="
+                            + databaseName
+                            + "，请求 database="
+                            + requestedDatabase);
+        }
+    }
+
+    private static boolean isSimpleIdentifier(String value) {
+        if (!JdbcDialect.hasText(value)) {
+            return false;
+        }
+        char first = value.charAt(0);
+        if (!(Character.isLetter(first) || first == '_')) {
+            return false;
+        }
+        for (int i = 1; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (!(Character.isLetterOrDigit(current)
+                    || current == '_'
+                    || current == '$'
+                    || current == '#')) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectFactory.java
@@ -1,0 +1,27 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
+
+import com.google.auto.service.AutoService;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
+
+/** GBase 8s bounded JDBC Source dialect factory. */
+@AutoService(JdbcDialectFactory.class)
+public final class GBase8sDialectFactory implements JdbcDialectFactory {
+
+    @Override
+    public String identifier() {
+        return DatabaseIdentifier.GBASE8S;
+    }
+
+    @Override
+    public boolean acceptsUrl(String url) {
+        return GBase8sJdbcUrl.accepts(url);
+    }
+
+    @Override
+    public JdbcDialect create(JdbcConnectionConfig connectionConfig) {
+        return new GBase8sDialect(connectionConfig);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sJdbcRowConverter.java
@@ -1,0 +1,13 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
+
+import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+
+/** GBase 8s bounded Source row converter. */
+public final class GBase8sJdbcRowConverter extends AbstractJdbcRowConverter {
+
+    @Override
+    public String name() {
+        return DatabaseIdentifier.GBASE8S;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sJdbcUrl.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sJdbcUrl.java
@@ -1,0 +1,115 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
+
+import java.util.Locale;
+import java.util.Map;
+
+/** GBase 8s JDBC URL helpers. */
+public final class GBase8sJdbcUrl {
+
+    public static final String PREFIX = "jdbc:gbasedbt-sqli://";
+    public static final String SERVER_PROPERTY = "GBASEDBTSERVER";
+    public static final String DELIMIDENT_PROPERTY = "DELIMIDENT";
+
+    private GBase8sJdbcUrl() {
+    }
+
+    public static boolean accepts(String url) {
+        return hasText(url)
+                && url.trim().toLowerCase(Locale.ROOT).startsWith(PREFIX);
+    }
+
+    /** Returns the database selected by the JDBC URL, without connection properties. */
+    public static String databaseName(String url) {
+        if (!accepts(url)) {
+            return null;
+        }
+
+        String value = url.trim();
+        int databaseStart = value.indexOf('/', PREFIX.length());
+        if (databaseStart < 0 || databaseStart == value.length() - 1) {
+            return null;
+        }
+
+        int databaseEnd = value.length();
+        int propertiesStart = value.indexOf(':', databaseStart + 1);
+        if (propertiesStart >= 0) {
+            databaseEnd = propertiesStart;
+        }
+        int semicolon = value.indexOf(';', databaseStart + 1);
+        if (semicolon >= 0 && semicolon < databaseEnd) {
+            databaseEnd = semicolon;
+        }
+
+        String database = value.substring(databaseStart + 1, databaseEnd).trim();
+        return hasText(database) ? database : null;
+    }
+
+    /** Resolves GBASEDBTSERVER from explicit properties first, then the URL property segment. */
+    public static String serverName(String url, Map<String, String> properties) {
+        String configured = property(properties, SERVER_PROPERTY);
+        return hasText(configured) ? configured : urlProperty(url, SERVER_PROPERTY);
+    }
+
+    /** JDBC defaults DELIMIDENT to n; only an explicit true/y value enables quoted identifiers. */
+    public static boolean delimitedIdentifiersEnabled(
+            String url,
+            Map<String, String> properties) {
+        String value = property(properties, DELIMIDENT_PROPERTY);
+        if (!hasText(value)) {
+            value = urlProperty(url, DELIMIDENT_PROPERTY);
+        }
+        if (!hasText(value)) {
+            return false;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        return "y".equals(normalized)
+                || "yes".equals(normalized)
+                || "true".equals(normalized)
+                || "1".equals(normalized);
+    }
+
+    private static String urlProperty(String url, String key) {
+        if (!accepts(url) || !hasText(key)) {
+            return null;
+        }
+        String value = url.trim();
+        int databaseStart = value.indexOf('/', PREFIX.length());
+        if (databaseStart < 0) {
+            return null;
+        }
+        int propertiesStart = value.indexOf(':', databaseStart + 1);
+        if (propertiesStart < 0 || propertiesStart == value.length() - 1) {
+            return null;
+        }
+
+        String[] pairs = value.substring(propertiesStart + 1).split(";");
+        for (String pair : pairs) {
+            int equals = pair.indexOf('=');
+            if (equals <= 0) {
+                continue;
+            }
+            String propertyKey = pair.substring(0, equals).trim();
+            if (key.equalsIgnoreCase(propertyKey)) {
+                String propertyValue = pair.substring(equals + 1).trim();
+                return hasText(propertyValue) ? propertyValue : null;
+            }
+        }
+        return null;
+    }
+
+    private static String property(Map<String, String> properties, String key) {
+        if (properties == null || properties.isEmpty()) {
+            return null;
+        }
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (key.equalsIgnoreCase(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapper.java
@@ -1,0 +1,288 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.api.table.type.FluxDataType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Locale;
+
+/**
+ * GBase 8s bounded Source type mapper.
+ *
+ * <p>The mapper covers stable built-in scalar and large-object types. INTERVAL and unknown or
+ * extension types use a STRING boundary in Stage 1 instead of leaking driver-specific Java
+ * objects into Link-Up. Target DDL type generation remains disabled until the Sink stage.</p>
+ */
+public final class GBase8sTypeMapper implements JdbcTypeMapper {
+
+    private static final int MAX_DECIMAL_PRECISION = 38;
+    private static final int DEFAULT_DECIMAL_PRECISION = 38;
+    private static final int DEFAULT_DECIMAL_SCALE = 18;
+
+    @Override
+    public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
+        String name = firstText(
+                metadata.getColumnLabel(columnIndex),
+                metadata.getColumnName(columnIndex));
+        int jdbcType = metadata.getColumnType(columnIndex);
+        String sourceType = metadata.getColumnTypeName(columnIndex);
+        int precision = metadata.getPrecision(columnIndex);
+        int scale = metadata.getScale(columnIndex);
+        FluxDataType<?> type = mapType(jdbcType, sourceType, precision, scale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(metadata.isNullable(columnIndex) != ResultSetMetaData.columnNoNulls)
+                .sourceType(sourceType)
+                .autoIncrement(isSerial(sourceType));
+        applyProperties(builder, type.getSqlType(), precision, scale);
+        return builder.build();
+    }
+
+    /** Maps one row returned by {@link DatabaseMetaData#getColumns}. */
+    public Column toColumn(ResultSet row) throws SQLException {
+        String name = row.getString("COLUMN_NAME");
+        int jdbcType = row.getInt("DATA_TYPE");
+        String sourceType = row.getString("TYPE_NAME");
+        int precision = intValue(row, "COLUMN_SIZE");
+        int scale = intValue(row, "DECIMAL_DIGITS");
+        FluxDataType<?> type = mapType(jdbcType, sourceType, precision, scale);
+
+        Column.Builder builder = Column.builder(name, type)
+                .nullable(row.getInt("NULLABLE") != DatabaseMetaData.columnNoNulls)
+                .defaultValue(safeObject(row, "COLUMN_DEF"))
+                .autoIncrement(
+                        isSerial(sourceType)
+                                || "YES".equalsIgnoreCase(safeString(row, "IS_AUTOINCREMENT")))
+                .comment(safeString(row, "REMARKS"))
+                .sourceType(sourceType);
+        applyProperties(builder, type.getSqlType(), precision, scale);
+        return builder.build();
+    }
+
+    @Override
+    public String toDatabaseType(Column column) {
+        throw new UnsupportedOperationException(
+                "GBase 8s Stage 1 is source-only; target type generation belongs to the Sink stage");
+    }
+
+    private static FluxDataType<?> mapType(
+            int jdbcType,
+            String sourceType,
+            int precision,
+            int scale) {
+        String type = normalizeType(sourceType);
+
+        if ("BOOLEAN".equals(type)) {
+            return BasicType.BOOLEAN_TYPE;
+        }
+        if ("SMALLINT".equals(type)) {
+            return BasicType.SHORT_TYPE;
+        }
+        if ("SERIAL".equals(type)
+                || "INT".equals(type)
+                || "INTEGER".equals(type)) {
+            return BasicType.INT_TYPE;
+        }
+        if ("BIGINT".equals(type)
+                || "INT8".equals(type)
+                || "SERIAL8".equals(type)
+                || "BIGSERIAL".equals(type)) {
+            return BasicType.LONG_TYPE;
+        }
+        if ("SMALLFLOAT".equals(type) || "REAL".equals(type)) {
+            return BasicType.FLOAT_TYPE;
+        }
+        if ("FLOAT".equals(type) || "DOUBLE".equals(type)) {
+            return BasicType.DOUBLE_TYPE;
+        }
+        if ("DEC".equals(type)
+                || "DECIMAL".equals(type)
+                || "NUMERIC".equals(type)
+                || "MONEY".equals(type)) {
+            return decimal(precision, scale);
+        }
+        if ("DATE".equals(type)) {
+            return BasicType.DATE_TYPE;
+        }
+        if ("DATETIME".equals(type)) {
+            return BasicType.TIMESTAMP_TYPE;
+        }
+        if ("INTERVAL".equals(type)) {
+            return BasicType.STRING_TYPE;
+        }
+        if (isBinary(type)) {
+            return BasicType.BYTES_TYPE;
+        }
+        if (isString(type)) {
+            return BasicType.STRING_TYPE;
+        }
+
+        switch (jdbcType) {
+            case Types.BOOLEAN:
+            case Types.BIT:
+                return BasicType.BOOLEAN_TYPE;
+            case Types.TINYINT:
+            case Types.SMALLINT:
+                return BasicType.SHORT_TYPE;
+            case Types.INTEGER:
+                return BasicType.INT_TYPE;
+            case Types.BIGINT:
+                return BasicType.LONG_TYPE;
+            case Types.FLOAT:
+            case Types.REAL:
+                return BasicType.FLOAT_TYPE;
+            case Types.DOUBLE:
+                return BasicType.DOUBLE_TYPE;
+            case Types.DECIMAL:
+            case Types.NUMERIC:
+                return decimal(precision, scale);
+            case Types.DATE:
+                return BasicType.DATE_TYPE;
+            case Types.TIME:
+                return BasicType.TIME_TYPE;
+            case Types.TIMESTAMP:
+                return BasicType.TIMESTAMP_TYPE;
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return BasicType.TIMESTAMP_TZ_TYPE;
+            case Types.BINARY:
+            case Types.VARBINARY:
+            case Types.LONGVARBINARY:
+            case Types.BLOB:
+                return BasicType.BYTES_TYPE;
+            case Types.CHAR:
+            case Types.VARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.NCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGNVARCHAR:
+            case Types.CLOB:
+            case Types.NCLOB:
+            case Types.SQLXML:
+            case Types.OTHER:
+            default:
+                return BasicType.STRING_TYPE;
+        }
+    }
+
+    private static FluxDataType<?> decimal(int precision, int scale) {
+        if (precision > MAX_DECIMAL_PRECISION) {
+            return BasicType.STRING_TYPE;
+        }
+        int resolvedPrecision = precision > 0
+                ? Math.max(1, precision)
+                : DEFAULT_DECIMAL_PRECISION;
+        int resolvedScale = scale >= 0
+                ? Math.min(scale, resolvedPrecision)
+                : DEFAULT_DECIMAL_SCALE;
+        return new DecimalType(resolvedPrecision, resolvedScale);
+    }
+
+    private static void applyProperties(
+            Column.Builder builder,
+            SqlType type,
+            int precision,
+            int scale) {
+        if ((type == SqlType.STRING || type == SqlType.BYTES) && precision > 0) {
+            builder.length((long) precision);
+            return;
+        }
+        if (type == SqlType.DECIMAL) {
+            if (precision > 0 && precision <= MAX_DECIMAL_PRECISION) {
+                builder.precision(precision);
+            }
+            if (scale >= 0 && precision > 0 && precision <= MAX_DECIMAL_PRECISION) {
+                builder.scale(Math.min(scale, precision));
+            }
+            return;
+        }
+        if ((type == SqlType.TIME || type == SqlType.TIMESTAMP) && scale > 0) {
+            builder.precision(scale);
+        }
+    }
+
+    private static boolean isSerial(String sourceType) {
+        String type = normalizeType(sourceType);
+        return "SERIAL".equals(type)
+                || "SERIAL8".equals(type)
+                || "BIGSERIAL".equals(type);
+    }
+
+    private static boolean isBinary(String type) {
+        return "BYTE".equals(type)
+                || "BLOB".equals(type)
+                || "BINARY".equals(type)
+                || "VARBINARY".equals(type);
+    }
+
+    private static boolean isString(String type) {
+        return "CHAR".equals(type)
+                || "CHARACTER".equals(type)
+                || "VARCHAR".equals(type)
+                || "LVARCHAR".equals(type)
+                || "NCHAR".equals(type)
+                || "NVARCHAR".equals(type)
+                || "TEXT".equals(type)
+                || "CLOB".equals(type);
+    }
+
+    private static String normalizeType(String value) {
+        if (value == null) {
+            return "";
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        int parenthesis = normalized.indexOf('(');
+        if (parenthesis > 0) {
+            normalized = normalized.substring(0, parenthesis).trim();
+        }
+        if (normalized.startsWith("DOUBLE PRECISION")) {
+            return "DOUBLE";
+        }
+        if (normalized.startsWith("CHARACTER VARYING")) {
+            return "VARCHAR";
+        }
+        int space = normalized.indexOf(' ');
+        if (space > 0) {
+            normalized = normalized.substring(0, space).trim();
+        }
+        return normalized;
+    }
+
+    private static String firstText(String first, String second) {
+        if (first != null && !first.trim().isEmpty()) {
+            return first.trim();
+        }
+        if (second != null && !second.trim().isEmpty()) {
+            return second.trim();
+        }
+        throw new IllegalArgumentException("column name must not be empty");
+    }
+
+    private static int intValue(ResultSet row, String column) throws SQLException {
+        Object value = row.getObject(column);
+        return value == null ? 0 : ((Number) value).intValue();
+    }
+
+    private static String safeString(ResultSet row, String column) {
+        try {
+            return row.getString(column);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+
+    private static Object safeObject(ResultSet row, String column) {
+        try {
+            return row.getObject(column);
+        } catch (SQLException ignored) {
+            return null;
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalogTest.java
@@ -1,0 +1,53 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8s;
+
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+
+public class GBase8sCatalogTest {
+
+    @Test
+    public void sourceCatalogIsBoundToOneDatabaseAndRemainsReadOnly() {
+        GBase8sCatalog catalog = new GBase8sCatalog(
+                "gbase8s",
+                config(),
+                "testdb",
+                "gbasedbt");
+
+        assertEquals("testdb", catalog.getDefaultDatabase().get());
+        assertFalse(catalog instanceof WritableCatalog);
+    }
+
+    @Test
+    public void rejectsNonGBase8sJdbcUrl() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new GBase8sCatalog(
+                        "gbase8s",
+                        new JdbcCatalogConfig(
+                                "jdbc:gbase://127.0.0.1:5258/testdb",
+                                "gbasedbt",
+                                "password",
+                                "com.gbasedbt.jdbc.Driver",
+                                Collections.<String, String>emptyMap(),
+                                false),
+                        "testdb",
+                        "gbasedbt"));
+    }
+
+    private static JdbcCatalogConfig config() {
+        return new JdbcCatalogConfig(
+                "jdbc:gbasedbt-sqli://127.0.0.1:9088/testdb:GBASEDBTSERVER=gbase01",
+                "gbasedbt",
+                "password",
+                "com.gbasedbt.jdbc.Driver",
+                Collections.<String, String>emptyMap(),
+                false);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectTest.java
@@ -1,0 +1,212 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.Catalog;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.config.ReadConsistency;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
+import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8sDialectTest {
+
+    @Test
+    public void loadsDedicatedGBase8sDialectFromJdbcUrlThroughSpi() {
+        JdbcDialect dialect = JdbcDialectLoader.load(config(baseUrl(), null, null, null));
+        assertEquals(DatabaseIdentifier.GBASE8S, dialect.name());
+    }
+
+    @Test
+    public void factoryOnlyAcceptsDedicatedGBase8sProtocol() {
+        GBase8sDialectFactory factory = new GBase8sDialectFactory();
+        assertTrue(factory.acceptsUrl(baseUrl()));
+        assertFalse(factory.acceptsUrl("jdbc:gbase://127.0.0.1:5258/app"));
+        assertFalse(factory.acceptsUrl("jdbc:gbase8c://127.0.0.1:5432/app"));
+        assertFalse(factory.acceptsUrl("jdbc:mysql://127.0.0.1:3306/app"));
+    }
+
+    @Test
+    public void explicitDialectKeepsFirstClassIdentity() {
+        JdbcDialect dialect = JdbcDialectLoader.load(
+                config(baseUrl(), null, null, DatabaseIdentifier.GBASE8S));
+        assertEquals(DatabaseIdentifier.GBASE8S, dialect.name());
+    }
+
+    @Test
+    public void extractsDatabaseAndServerFromCanonicalUrl() {
+        assertEquals("testdb", GBase8sJdbcUrl.databaseName(baseUrl()));
+        assertEquals(
+                "gbase01",
+                GBase8sJdbcUrl.serverName(baseUrl(), Collections.<String, String>emptyMap()));
+
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put("gbasedbtserver", "property-server");
+        assertEquals(
+                "property-server",
+                GBase8sJdbcUrl.serverName(baseUrl(), properties));
+    }
+
+    @Test
+    public void usesDatabaseOwnerTablePathSemantics() {
+        GBase8sDialect dialect = dialect(null, null);
+        assertEquals(TablePath.of("orders"), dialect.parseTablePath("orders"));
+        assertEquals(
+                TablePath.of(null, "appowner", "orders"),
+                dialect.parseTablePath("appowner.orders"));
+        assertEquals(
+                TablePath.of("testdb", "appowner", "orders"),
+                dialect.parseTablePath("testdb.appowner.orders"));
+
+        assertEquals(
+                "gbasedbt.orders",
+                dialect.tableIdentifier(TablePath.of("orders")));
+        assertEquals(
+                "appowner.orders",
+                dialect.tableIdentifier(TablePath.of(null, "appowner", "orders")));
+    }
+
+    @Test
+    public void configuredSchemaActsAsDefaultOwner() {
+        assertEquals(
+                "appowner.orders",
+                dialect("appowner", null).tableIdentifier(TablePath.of("orders")));
+    }
+
+    @Test
+    public void rejectsCrossDatabasePath() {
+        GBase8sDialect dialect = dialect(null, null);
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> dialect.parseTablePath("archive.appowner.orders"));
+        assertTrue(error.getMessage().contains("不支持跨 database"));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> dialect.tableIdentifier(
+                        TablePath.of("archive", "appowner", "orders")));
+    }
+
+    @Test
+    public void defaultDelimidentRejectsQuotedOrSpecialIdentifiers() {
+        GBase8sDialect dialect = dialect(null, null);
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> dialect.parseTablePath("\"MixedOwner\".\"Orders\""));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> dialect.quoteIdentifier("order-items"));
+    }
+
+    @Test
+    public void explicitDelimidentPreservesQuotedIdentifierCase() {
+        String url = baseUrl() + ";DELIMIDENT=y";
+        GBase8sDialect dialect = new GBase8sDialect(config(url, null, null, null));
+        assertEquals(
+                TablePath.of(null, "MixedOwner", "OrderItems"),
+                dialect.parseTablePath("\"MixedOwner\".\"OrderItems\""));
+        assertEquals(
+                "\"MixedOwner\".\"OrderItems\"",
+                dialect.tableIdentifier(TablePath.of(null, "MixedOwner", "OrderItems")));
+    }
+
+    @Test
+    public void sourceCatalogIsReadOnlyAndSinkSpecificSemanticsStayDisabled() {
+        GBase8sDialect dialect = dialect(null, null);
+        Catalog catalog = dialect.createCatalog(config(baseUrl(), null, null, null));
+        assertFalse(catalog instanceof WritableCatalog);
+        assertFalse(dialect.buildUpsertSql(
+                TablePath.of("testdb", "gbasedbt", "orders"),
+                Arrays.asList("id", "name"),
+                Collections.singletonList("id")).isPresent());
+
+        Column column = Column.builder("name", BasicType.STRING_TYPE).build();
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> dialect.typeMapper().toDatabaseType(column));
+    }
+
+    @Test
+    public void boundedSourceAdvertisesBestEffortOnlyAndKeepsIdentity() {
+        assertEquals(
+                Collections.singleton(ReadConsistency.BEST_EFFORT),
+                dialect(null, null).supportedReadConsistencies());
+        assertEquals(
+                DatabaseIdentifier.GBASE8S,
+                dialect(null, null).rowConverter().name());
+    }
+
+    @Test
+    public void requiresDatabaseAndServerIdentity() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new GBase8sDialect(config(
+                        "jdbc:gbasedbt-sqli://127.0.0.1:9088/:GBASEDBTSERVER=gbase01",
+                        null,
+                        null,
+                        null)));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new GBase8sDialect(config(
+                        "jdbc:gbasedbt-sqli://127.0.0.1:9088/testdb",
+                        null,
+                        null,
+                        null)));
+
+        Map<String, String> properties = new LinkedHashMap<String, String>();
+        properties.put("GBASEDBTSERVER", "gbase01");
+        assertEquals(
+                DatabaseIdentifier.GBASE8S,
+                new GBase8sDialect(config(
+                        "jdbc:gbasedbt-sqli://127.0.0.1:9088/testdb",
+                        null,
+                        properties,
+                        null)).name());
+    }
+
+    private static GBase8sDialect dialect(
+            String schema,
+            Map<String, String> properties) {
+        return new GBase8sDialect(config(baseUrl(), schema, properties, null));
+    }
+
+    private static JdbcConnectionConfig config(
+            String url,
+            String schema,
+            Map<String, String> properties,
+            String dialect) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put("url", url);
+        values.put("driver", "com.gbasedbt.jdbc.Driver");
+        values.put("username", "gbasedbt");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (properties != null) {
+            values.put("properties", properties);
+        }
+        if (dialect != null) {
+            values.put("dialect", dialect);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+
+    private static String baseUrl() {
+        return "jdbc:gbasedbt-sqli://127.0.0.1:9088/testdb:GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10";
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapperTest.java
@@ -1,0 +1,145 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.SqlType;
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.ResultSetMetaData;
+import java.sql.Types;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8sTypeMapperTest {
+
+    private final GBase8sTypeMapper mapper = new GBase8sTypeMapper();
+
+    @Test
+    public void mapsNativeIntegerAndSerialFamilies() throws Exception {
+        Column serial = map("SERIAL", Types.INTEGER, 10, 0);
+        assertEquals(SqlType.INT, serial.getDataType().getSqlType());
+        assertTrue(serial.isAutoIncrement());
+
+        assertEquals(
+                SqlType.BIGINT,
+                map("INT8", Types.BIGINT, 19, 0).getDataType().getSqlType());
+        assertEquals(
+                SqlType.BIGINT,
+                map("BIGSERIAL", Types.BIGINT, 19, 0).getDataType().getSqlType());
+        assertEquals(
+                SqlType.SMALLINT,
+                map("SMALLINT", Types.SMALLINT, 5, 0).getDataType().getSqlType());
+    }
+
+    @Test
+    public void mapsNativeFloatingDecimalAndMoneyFamilies() throws Exception {
+        assertEquals(
+                SqlType.FLOAT,
+                map("SMALLFLOAT", Types.REAL, 8, 0).getDataType().getSqlType());
+        assertEquals(
+                SqlType.DOUBLE,
+                map("FLOAT", Types.DOUBLE, 16, 0).getDataType().getSqlType());
+        assertEquals(
+                SqlType.DOUBLE,
+                map("DOUBLE PRECISION", Types.DOUBLE, 16, 0).getDataType().getSqlType());
+        assertEquals(
+                SqlType.DECIMAL,
+                map("MONEY(16,2)", Types.DECIMAL, 16, 2).getDataType().getSqlType());
+    }
+
+    @Test
+    public void mapsDatetimeIntervalAndLargeObjectsConservatively() throws Exception {
+        assertEquals(
+                SqlType.TIMESTAMP,
+                map("DATETIME YEAR TO SECOND", Types.TIMESTAMP, 0, 0)
+                        .getDataType().getSqlType());
+        assertEquals(
+                SqlType.STRING,
+                map("INTERVAL DAY TO SECOND", Types.OTHER, 0, 0)
+                        .getDataType().getSqlType());
+        assertEquals(
+                SqlType.BYTES,
+                map("BYTE", Types.LONGVARBINARY, 1024, 0)
+                        .getDataType().getSqlType());
+        assertEquals(
+                SqlType.STRING,
+                map("TEXT", Types.LONGVARCHAR, 1024, 0)
+                        .getDataType().getSqlType());
+    }
+
+    @Test
+    public void oversizedDecimalFallsBackToStringWithoutPrecisionLoss() throws Exception {
+        Column column = map("DECIMAL(50,20)", Types.DECIMAL, 50, 20);
+        assertEquals(SqlType.STRING, column.getDataType().getSqlType());
+    }
+
+    @Test
+    public void unknownDriverExtensionFallsBackToString() throws Exception {
+        assertEquals(
+                SqlType.STRING,
+                map("SOME_OPAQUE_TYPE", Types.OTHER, 0, 0)
+                        .getDataType().getSqlType());
+    }
+
+    private Column map(
+            String sourceType,
+            int jdbcType,
+            int precision,
+            int scale) throws Exception {
+        ResultSetMetaData metadata = (ResultSetMetaData) Proxy.newProxyInstance(
+                getClass().getClassLoader(),
+                new Class<?>[]{ResultSetMetaData.class},
+                (proxy, method, args) -> {
+                    switch (method.getName()) {
+                        case "getColumnLabel":
+                        case "getColumnName":
+                            return "value";
+                        case "getColumnType":
+                            return jdbcType;
+                        case "getColumnTypeName":
+                            return sourceType;
+                        case "getPrecision":
+                            return precision;
+                        case "getScale":
+                            return scale;
+                        case "isNullable":
+                            return ResultSetMetaData.columnNullable;
+                        default:
+                            return defaultValue(method.getReturnType());
+                    }
+                });
+        return mapper.map(metadata, 1);
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary

Add the first runtime stage for GBase 8s: a bounded/offline JDBC Source.

This PR is based directly on the current `main` after #125 and keeps the scope source-only. GBase 8s remains its own first-class `gbase8s` runtime dialect; it does not reuse the GBase 8a/8c implementation or expand SQLMODE compatibility semantics.

## Canonical connection contract

```hocon
source {
  type = "jdbc"
  url = "jdbc:gbasedbt-sqli://gbase8s:9088/app:GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10"
  driver = "com.gbasedbt.jdbc.Driver"
  dialect = "gbase8s"
  schema = "gbasedbt" # optional table owner; defaults to username
  table_path = "gbasedbt.orders"
}
```

Stage 1 requires:

- the native `jdbc:gbasedbt-sqli://` protocol
- a database in the JDBC URL
- `GBASEDBTSERVER` in the JDBC URL or connection properties

The repository does not guess or bundle a vendor Maven coordinate. Runtime deployments must provide the official GBase 8s JDBC driver.

## Source implementation

- add `GBase8sDialectFactory` through AutoService SPI
- add dedicated `GBase8sDialect`
- add `GBase8sJdbcUrl`
  - product-specific URL detection
  - URL database extraction
  - `GBASEDBTSERVER` resolution
  - `DELIMIDENT` detection
- add `GBase8sJdbcRowConverter` with first-class `gbase8s` identity
- add source-only `GBase8sTypeMapper`
- add dedicated read-only `GBase8sCatalog`
  - standard JDBC `DatabaseMetaData`
  - owner/schema discovery
  - table discovery
  - column discovery
  - primary-key discovery
  - does not implement `WritableCatalog`

## Database / owner / table semantics

GBase 8s JDBC exposes database as catalog and table owner as schema.

Link-Up Stage 1 therefore supports:

- `table` -> default owner from connector `schema`, then JDBC username
- `owner.table` -> explicit table owner
- `database.owner.table` -> accepted only when database equals the JDBC URL database

One Source connection stays bound to one database. Cross-database rebinding and GBase 8s-specific `database:owner.table` SQL are intentionally not introduced into the generic JDBC path.

If no owner can be inferred and the same table name exists under multiple owners, Catalog preparation fails and asks for `owner.table` instead of guessing.

## DELIMIDENT boundary

GBase 8s JDBC defaults to `DELIMIDENT=n`, where double-quoted SQL identifiers are not valid.

Stage 1 therefore:

- uses ordinary unquoted identifiers by default
- normalizes ordinary unquoted table-path parts to lowercase
- rejects identifiers that require double quotes while `DELIMIDENT=n`
- enables double-quoted, case-preserving identifiers only when `DELIMIDENT=y` is explicitly configured in the URL/properties

This avoids a generic JDBC quoting strategy that would break the default GBase 8s JDBC mode.

## Read-side type contract

Common mappings include:

- BOOLEAN -> BOOLEAN
- SMALLINT -> SMALLINT
- SERIAL / INTEGER / INT -> INT
- INT8 / SERIAL8 / BIGINT / BIGSERIAL -> BIGINT
- SMALLFLOAT / REAL -> FLOAT
- FLOAT / DOUBLE PRECISION -> DOUBLE
- DEC / DECIMAL / NUMERIC / MONEY -> DECIMAL when precision fits Link-Up
- DATE -> DATE
- DATETIME -> TIMESTAMP
- BYTE / BLOB -> BYTES
- CHAR / VARCHAR / LVARCHAR / NCHAR / NVARCHAR / TEXT / CLOB -> STRING
- INTERVAL -> STRING
- unknown / opaque / extension JDBC types -> STRING

DECIMAL precision above Link-Up's supported precision falls back to STRING instead of silently truncating precision.

INTERVAL stays STRING in this stage because the GBase 8s JDBC driver represents intervals with vendor-specific Java classes. Complex ROW/COLLECTION/native opaque object semantics remain outside this bounded relational Source stage.

Target database type generation is explicitly disabled until the dedicated GBase 8s Sink stage.

## Supported Stage 1 behavior

- bounded single-table Source
- bounded multi-table Source through the shared JDBC path
- custom query reads
- owner/table/column/primary-key metadata discovery
- shared safe JDBC range partition planning
- GBase 8s read-side type mapping
- `BEST_EFFORT` read consistency

Although GBase 8s supports transactional isolation levels, this PR does not claim a coordinated point-in-time snapshot across multiple independent JDBC readers.

## Explicit non-goals

- JDBC Sink
- `WritableCatalog`
- automatic CREATE / ALTER / DROP DDL
- UPSERT / database-specific write semantics
- SQLMODE MySQL / Oracle compatibility expansion
- cross-database implicit rebinding
- CDC / logical-log integration / realtime synchronization
- coordinated multi-reader snapshots
- ROW / COLLECTION native object modeling
- runtime schema evolution

## Tests

Focused tests cover:

- SPI loading from `jdbc:gbasedbt-sqli://`
- URL discrimination from GBase 8a / GBase 8c / MySQL
- explicit `dialect=gbase8s`
- database and `GBASEDBTSERVER` extraction
- `table`, `owner.table`, and current-database three-part paths
- default owner from username / configured schema
- cross-database rejection
- default `DELIMIDENT=n` quoting rejection
- explicit `DELIMIDENT=y` case-preserving identifiers
- read-only Catalog / no `WritableCatalog`
- UPSERT remains unadvertised
- no target type generation
- `BEST_EFFORT`-only consistency
- first-class row-converter identity
- required database/server connection identity
- SERIAL / INT8 / BIGSERIAL mapping
- SMALLFLOAT / FLOAT mapping
- DATETIME / INTERVAL boundaries
- BYTE / TEXT boundaries
- oversized DECIMAL precision-safe fallback
- unknown/opaque fallback to STRING

## Verification

- based directly on current `main` after #125
- final branch is one atomic commit
- final compare: `ahead=1`, `behind=0`
- diff is limited to 10 files: GBase 8s Source implementation, focused tests, and JDBC README documentation
- Maven execution was attempted, but this execution environment still cannot resolve `github.com`; the repository could not be cloned and the Maven suite was not executed here
- tests are added but are not claimed as executed
- there is currently no pull-request workflow run for this commit
- a real GBase 8s environment plus the vendor JDBC driver is still required before Ready for Review to validate connection properties, owner metadata, common type reads, primary-key discovery, DELIMIDENT behavior, custom SQL, and bounded single/multi-table execution end to end

## Follow-up

The next bounded stage is GBase 8s existing-table JDBC Sink. It should preserve the same conservative boundary as 8c/8a: pre-created targets first, no automatic schema mutation, and no CDC/realtime semantics.