### PR TITLE
feat(gbase8s): add existing-table JDBC sink support

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -178,10 +178,9 @@ For large bounded reads, a positive Link-Up `fetch_size` selects the GBase JDBC 
 The vendor GBase JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official
 GBase 8a JDBC driver on the runtime classpath and configure `driver = "com.gbase.jdbc.Driver"`.
 
-### GBase 8s bounded Source
+### GBase 8s bounded Source + existing-table JDBC Sink
 
-GBase 8s is exposed as the first-class `gbase8s` JDBC dialect. Stage 1 uses the native GBase 8s JDBC protocol and keeps
-normal GBase SQL semantics separate from later SQLMODE compatibility work:
+GBase 8s is exposed as the first-class `gbase8s` JDBC dialect and uses the native GBase 8s JDBC protocol:
 
 ```hocon
 source {
@@ -192,27 +191,59 @@ source {
   schema = "gbasedbt" # optional table owner; defaults to username
   table_path = "gbasedbt.orders"
 }
+
+sink {
+  type = "jdbc"
+  url = "jdbc:gbasedbt-sqli://gbase8s:9088/archive:GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10"
+  driver = "com.gbasedbt.jdbc.Driver"
+  dialect = "gbase8s"
+  schema = "gbasedbt" # target owner; defaults to username
+  table = "orders"
+  schema_save_mode = "ERROR_WHEN_SCHEMA_NOT_EXIST"
+  data_save_mode = "APPEND_DATA"
+}
 ```
 
-The database and `GBASEDBTSERVER` instance identity are connection-level concerns and must be present in the JDBC URL or
-connection properties. One Stage 1 Source connection is bound to the database in its URL. GBase 8s reports table owner
-through the JDBC schema field, so Link-Up models physical tables as `database.owner.table` metadata while SQL inside the
-selected database uses `owner.table`. The normal user-facing paths are `table` and `owner.table`; a three-part
-`database.owner.table` path is accepted only when its database equals the URL database. Cross-database rebinding is not
-performed implicitly.
+The database and `GBASEDBTSERVER` instance identity are connection-level concerns. One connection stays bound to the
+database in its JDBC URL. GBase 8s reports table owner through the JDBC schema field, so Link-Up models physical tables as
+`database.owner.table` metadata while SQL inside the selected database uses `owner.table`.
 
-The read-only `GBase8sCatalog` uses standard JDBC `DatabaseMetaData` for owner, table, column and primary-key discovery.
-If no owner is supplied, the connector uses the explicit `schema` option and then the JDBC username as the default owner.
-When neither gives an owner and the same table name is visible under multiple owners, metadata preparation fails and asks
-for an explicit `owner.table` instead of guessing.
+For Source, the normal user-facing paths are `table` and `owner.table`; a three-part `database.owner.table` path is
+accepted only when its database equals the URL database. For Sink, an implicit target keeps only the source table name and
+resolves owner from the Sink `schema` option, then the Sink username. Source database/schema/owner metadata is never reused
+implicitly. An explicit `owner.table` may choose the target owner. An explicit three-part target must repeat the database
+from the Sink URL; a different database fails during preparation instead of silently rebinding one connection.
+
+`GBase8sCatalog` uses standard JDBC `DatabaseMetaData` for owner, table, column and primary-key discovery. It implements
+`WritableCatalog` only so the shared Sink save-mode lifecycle can validate existing targets and support `TRUNCATE TABLE`
+for `DROP_DATA`. Structure-changing DDL stays blocked:
+
+- no CREATE/DROP DATABASE
+- no CREATE/DROP TABLE
+- no ADD COLUMN or runtime schema evolution
+- no automatic target-table creation
+
+Create the target database/owner/table before the job. `CREATE_SCHEMA_WHEN_NOT_EXIST` is safe for an existing compatible
+table but fails clearly when the table is absent. `RECREATE_SCHEMA` cannot destructively drop a target because DROP TABLE
+is rejected before recreation. `CREATE_OR_ADD_COLUMNS` may validate an already compatible target, but a missing target
+column fails instead of mutating the table.
+
+The Sink reuses the shared JDBC writer: parameterized `INSERT`, configured batch size, `PreparedStatement.addBatch()` /
+`executeBatch()`, one task-local transaction and the existing commit/rollback, retry/savepoint and dirty-data behavior.
+The vendor `IFX_USEPUT=1` bulk-insert extension is deliberately **opt-in**, not a Link-Up default. It can improve repeated
+INSERT performance, but the vendor extension requires compatible Java/target column types and excludes opaque/complex
+types. Deployments that have verified a compatible scalar target may add `IFX_USEPUT=1` to the JDBC URL/properties.
+
+UPSERT is intentionally not advertised. Native GBase 8s `MERGE` supports a broader update/insert/delete contract than the
+generic Link-Up UPSERT abstraction, so this bounded stage does not guess conflict keys or collapse database-specific MERGE
+semantics into `write_mode=UPSERT`.
 
 GBase 8s JDBC defaults `DELIMIDENT=n`. In that mode double-quoted SQL identifiers are not valid, so the dialect does not
-blindly quote every table/column name. Ordinary unquoted identifiers are normalized to GBase 8s lowercase behavior. If a
-deployment explicitly enables `DELIMIDENT=y` in the URL or JDBC properties, quoted `table_path` parts preserve case and
-SQL identifiers are emitted with double quotes. This keeps the default path compatible while still allowing deliberate
-case-sensitive database objects.
+blindly quote every table/column name. Ordinary unquoted identifiers are normalized to lowercase. If a deployment
+explicitly enables `DELIMIDENT=y` in the URL or JDBC properties, quoted `table_path` parts preserve case and SQL
+identifiers are emitted with double quotes.
 
-The Stage 1 type boundary covers common built-ins without exposing GBase JDBC private objects:
+The read-side type boundary covers common built-ins without exposing GBase JDBC private objects:
 
 - BOOLEAN -> BOOLEAN
 - SMALLINT -> SMALLINT
@@ -229,16 +260,16 @@ The Stage 1 type boundary covers common built-ins without exposing GBase JDBC pr
 - unknown, opaque and extension JDBC types -> STRING
 
 DECIMAL precision above Link-Up's limit falls back to STRING rather than silently truncating numeric precision. INTERVAL
-also stays STRING in this stage because the GBase 8s JDBC driver represents intervals with vendor-specific
-`com.gbasedbt.lang.Interval*` classes. Target type generation remains disabled until the dedicated 8s Sink stage.
+also stays STRING because the GBase 8s JDBC driver represents intervals with vendor-specific `com.gbasedbt.lang.Interval*`
+classes. Target DDL type generation remains disabled because this existing-table Sink never auto-creates GBase 8s tables.
 
 The Source supports bounded single-table and multi-table jobs, custom SQL and the shared safe JDBC range partition
-planner. It advertises `BEST_EFFORT` read consistency only. Although GBase 8s provides transactional isolation levels,
-this stage does not claim a coordinated point-in-time snapshot across independent parallel JDBC readers.
+planner. It advertises `BEST_EFFORT` read consistency only and does not claim a coordinated point-in-time snapshot across
+independent parallel JDBC readers.
 
-Out of scope for this stage: JDBC Sink, WritableCatalog, automatic DDL, SQLMODE MySQL/Oracle compatibility expansion,
-CDC/realtime synchronization, logical-log integration, coordinated snapshots, complex ROW/COLLECTION native objects and
-runtime schema evolution.
+Still out of scope: automatic DDL, SQLMODE MySQL/Oracle compatibility expansion, CDC/realtime synchronization,
+logical-log integration, coordinated snapshots, complex ROW/COLLECTION native object modeling and runtime schema
+evolution.
 
 The vendor JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official GBase
 8s JDBC driver on the runtime classpath and configure `driver = "com.gbasedbt.jdbc.Driver"` (or an older vendor-provided

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalog.java
@@ -1,12 +1,15 @@
 package com.link.up.connector.jdbc.catalog.gbase.gbase8s;
 
-import com.link.up.api.table.catalog.Catalog;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.Column;
 import com.link.up.api.table.catalog.PrimaryKey;
 import com.link.up.api.table.catalog.TablePath;
 import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
 import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
 import com.link.up.api.table.catalog.exception.TableNotFoundException;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
@@ -16,26 +19,29 @@ import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sTypeMapper;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.DriverManager;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 
 /**
- * Read-only GBase 8s Catalog for bounded/offline Source jobs.
+ * GBase 8s Catalog for bounded/offline Source and existing-table JDBC Sink jobs.
  *
- * <p>GBase 8s JDBC exposes database as catalog and table owner as schema. Stage 1 binds one Catalog
- * instance to the database in the JDBC URL and uses standard {@link DatabaseMetaData} for owner,
- * table, column and primary-key discovery. Cross-database rebinding and writable DDL remain out of
- * scope.</p>
+ * <p>GBase 8s JDBC exposes database as catalog and table owner as schema. The JDBC URL binds this
+ * Catalog to one database. Sink support deliberately implements {@link WritableCatalog} only so
+ * the shared save-mode lifecycle can validate pre-created targets and optionally truncate their
+ * data. Structure-changing DDL, cross-database rebinding and SQLMODE expansion remain outside this
+ * stage.</p>
  */
-public final class GBase8sCatalog implements Catalog {
+public final class GBase8sCatalog implements WritableCatalog {
 
     public static final String TABLE_OPTION_DIALECT = "dialect";
 
@@ -45,6 +51,7 @@ public final class GBase8sCatalog implements Catalog {
     private final JdbcCatalogConfig config;
     private final String defaultDatabase;
     private final String defaultOwner;
+    private final boolean delimitedIdentifiers;
     private final GBase8sTypeMapper typeMapper = new GBase8sTypeMapper();
     private volatile boolean opened;
 
@@ -63,12 +70,15 @@ public final class GBase8sCatalog implements Catalog {
             throw new IllegalArgumentException("非法 GBase 8s JDBC URL：" + config.getUrl());
         }
         if (!hasText(defaultDatabase)) {
-            throw new IllegalArgumentException("GBase 8s Stage 1 必须指定默认 database");
+            throw new IllegalArgumentException("GBase 8s JDBC URL 必须指定默认 database");
         }
         this.catalogName = catalogName.trim();
         this.config = config;
         this.defaultDatabase = defaultDatabase.trim();
         this.defaultOwner = hasText(defaultOwner) ? defaultOwner.trim() : null;
+        this.delimitedIdentifiers = GBase8sJdbcUrl.delimitedIdentifiersEnabled(
+                config.getUrl(),
+                config.getProperties());
     }
 
     @Override
@@ -102,7 +112,7 @@ public final class GBase8sCatalog implements Catalog {
         return Optional.of(defaultDatabase);
     }
 
-    /** Stage 1 keeps one physical JDBC connection bound to one database. */
+    /** One physical JDBC connection remains bound to the database in the URL. */
     @Override
     public List<String> listDatabases() throws CatalogException {
         checkOpened();
@@ -217,6 +227,71 @@ public final class GBase8sCatalog implements Catalog {
         }
     }
 
+    @Override
+    public void createDatabase(
+            String databaseName,
+            boolean ignoreIfExists)
+            throws CatalogException, DatabaseAlreadyExistsException {
+        throw unsupportedSchemaDdl("create database");
+    }
+
+    @Override
+    public void dropDatabase(
+            String databaseName,
+            boolean ignoreIfNotExists)
+            throws CatalogException, DatabaseNotFoundException {
+        throw unsupportedSchemaDdl("drop database");
+    }
+
+    @Override
+    public void createTable(
+            CatalogTable table,
+            boolean ignoreIfExists)
+            throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+        throw unsupportedSchemaDdl("create table");
+    }
+
+    @Override
+    public void addColumn(
+            TablePath tablePath,
+            Column column)
+            throws CatalogException, TableNotFoundException {
+        throw unsupportedSchemaDdl("add column");
+    }
+
+    @Override
+    public void dropTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        throw unsupportedSchemaDdl("drop table");
+    }
+
+    @Override
+    public void truncateTable(
+            TablePath tablePath,
+            boolean ignoreIfNotExists)
+            throws CatalogException, TableNotFoundException {
+        checkOpened();
+        try (Connection connection = newConnection()) {
+            TablePath normalized = normalizeTablePath(
+                    connection,
+                    tablePath,
+                    !ignoreIfNotExists);
+            if (normalized == null) {
+                return;
+            }
+            String sql = "TRUNCATE TABLE " + quoteTable(normalized);
+            try (PreparedStatement statement = connection.prepareStatement(sql)) {
+                statement.executeUpdate();
+            }
+        } catch (TableNotFoundException e) {
+            throw e;
+        } catch (SQLException e) {
+            throw new CatalogException("清空 GBase 8s 表失败，table=" + tablePath, e);
+        }
+    }
+
     private List<Column> readColumns(
             DatabaseMetaData metadata,
             TablePath tablePath) throws SQLException {
@@ -325,11 +400,34 @@ public final class GBase8sCatalog implements Catalog {
         if (hasText(databaseName)
                 && !defaultDatabase.equalsIgnoreCase(databaseName.trim())) {
             throw new IllegalArgumentException(
-                    "GBase 8s Stage 1 不支持跨 database table_path；当前 JDBC database="
+                    "GBase 8s existing-table JDBC stage 不支持跨 database table_path；当前 JDBC database="
                             + defaultDatabase
                             + "，请求 database="
                             + databaseName);
         }
+    }
+
+    private String quoteTable(TablePath tablePath) {
+        String owner = tablePath.getSchemaName();
+        return hasText(owner)
+                ? quoteIdentifier(owner) + "." + quoteIdentifier(tablePath.getTableName())
+                : quoteIdentifier(tablePath.getTableName());
+    }
+
+    private String quoteIdentifier(String identifier) {
+        if (!hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        String value = identifier.trim();
+        if (delimitedIdentifiers) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        if (!isSimpleIdentifier(value)) {
+            throw new IllegalArgumentException(
+                    "GBase 8s JDBC 默认 DELIMIDENT=n，不支持需要双引号的标识符："
+                            + identifier);
+        }
+        return value.toLowerCase(Locale.ROOT);
     }
 
     private Connection newConnection() throws SQLException {
@@ -353,10 +451,37 @@ public final class GBase8sCatalog implements Catalog {
         }
     }
 
+    private static CatalogException unsupportedSchemaDdl(String operation) {
+        return new CatalogException(
+                "GBase 8s existing-table JDBC Sink does not support "
+                        + operation
+                        + "; pre-create the target database/owner/table and keep schema mutation outside this stage");
+    }
+
     private static boolean isBaseTable(String tableType) {
         return tableType != null
                 && ("TABLE".equalsIgnoreCase(tableType)
                 || "BASE TABLE".equalsIgnoreCase(tableType));
+    }
+
+    private static boolean isSimpleIdentifier(String value) {
+        if (!hasText(value)) {
+            return false;
+        }
+        char first = value.charAt(0);
+        if (!(Character.isLetter(first) || first == '_')) {
+            return false;
+        }
+        for (int i = 1; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (!(Character.isLetterOrDigit(current)
+                    || current == '_'
+                    || current == '$'
+                    || current == '#')) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static boolean hasText(String value) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialect.java
@@ -15,10 +15,11 @@ import java.util.List;
 import java.util.Locale;
 
 /**
- * GBase 8s bounded/offline JDBC Source dialect.
+ * GBase 8s bounded/offline JDBC dialect.
  *
- * <p>Stage 1 targets the native GBase 8s JDBC protocol and normal SQL mode. Sink, schema-changing
- * DDL, SQLMODE compatibility expansion, CDC and realtime semantics remain separate stages.</p>
+ * <p>The current stages cover bounded Source plus an existing-table INSERT/batch Sink on the
+ * native GBase 8s JDBC protocol and normal SQL mode. Automatic DDL, MERGE/UPSERT abstraction,
+ * SQLMODE compatibility expansion, CDC and realtime semantics remain separate stages.</p>
  */
 public final class GBase8sDialect implements JdbcDialect {
 
@@ -38,7 +39,7 @@ public final class GBase8sDialect implements JdbcDialect {
 
         String database = GBase8sJdbcUrl.databaseName(connectionConfig.getUrl());
         if (!JdbcDialect.hasText(database)) {
-            throw new IllegalArgumentException("GBase 8s Stage 1 JDBC URL 必须指定 database");
+            throw new IllegalArgumentException("GBase 8s JDBC URL 必须指定 database");
         }
         String server = GBase8sJdbcUrl.serverName(
                 connectionConfig.getUrl(),
@@ -95,7 +96,7 @@ public final class GBase8sDialect implements JdbcDialect {
         return new GBase8sJdbcRowConverter();
     }
 
-    /** GBase 8s Stage 1 accepts table, owner.table, or currentDatabase.owner.table. */
+    /** GBase 8s accepts table, owner.table, or currentDatabase.owner.table. */
     @Override
     public TablePath parseTablePath(String tablePath) {
         if (!JdbcDialect.hasText(tablePath)) {
@@ -235,7 +236,7 @@ public final class GBase8sDialect implements JdbcDialect {
         if (!JdbcDialect.hasText(requestedDatabase)
                 || !databaseName.equalsIgnoreCase(requestedDatabase.trim())) {
             throw new IllegalArgumentException(
-                    "GBase 8s Stage 1 不支持跨 database table_path；当前 JDBC database="
+                    "GBase 8s existing-table JDBC stage 不支持跨 database table_path；当前 JDBC database="
                             + databaseName
                             + "，请求 database="
                             + requestedDatabase);

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectFactory.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectFactory.java
@@ -6,7 +6,7 @@ import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialectFactory;
 
-/** GBase 8s bounded JDBC Source dialect factory. */
+/** GBase 8s bounded/offline JDBC dialect factory. */
 @AutoService(JdbcDialectFactory.class)
 public final class GBase8sDialectFactory implements JdbcDialectFactory {
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sJdbcRowConverter.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sJdbcRowConverter.java
@@ -3,7 +3,7 @@ package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
 import com.link.up.connector.jdbc.core.converter.AbstractJdbcRowConverter;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 
-/** GBase 8s bounded Source row converter. */
+/** GBase 8s bounded/offline JDBC row converter. */
 public final class GBase8sJdbcRowConverter extends AbstractJdbcRowConverter {
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapper.java
@@ -15,11 +15,12 @@ import java.sql.Types;
 import java.util.Locale;
 
 /**
- * GBase 8s bounded Source type mapper.
+ * GBase 8s read-side type mapper.
  *
  * <p>The mapper covers stable built-in scalar and large-object types. INTERVAL and unknown or
- * extension types use a STRING boundary in Stage 1 instead of leaking driver-specific Java
- * objects into Link-Up. Target DDL type generation remains disabled until the Sink stage.</p>
+ * extension types use a STRING boundary instead of leaking driver-specific Java objects into
+ * Link-Up. Target DDL type generation remains disabled because the current Sink writes only to
+ * pre-created tables.</p>
  */
 public final class GBase8sTypeMapper implements JdbcTypeMapper {
 
@@ -70,7 +71,7 @@ public final class GBase8sTypeMapper implements JdbcTypeMapper {
     @Override
     public String toDatabaseType(Column column) {
         throw new UnsupportedOperationException(
-                "GBase 8s Stage 1 is source-only; target type generation belongs to the Sink stage");
+                "GBase 8s existing-table JDBC Sink does not generate target DDL types");
     }
 
     private static FluxDataType<?> mapType(

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8sSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8sSinkSupport.java
@@ -1,0 +1,129 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sJdbcUrl;
+
+/** Target-path normalization and validation for the GBase 8s existing-table JDBC Sink. */
+final class GBase8sSinkSupport {
+
+    private GBase8sSinkSupport() {
+    }
+
+    static boolean accepts(JdbcConnectionConfig config) {
+        if (config == null) {
+            return false;
+        }
+        if (hasText(config.getDialect())) {
+            return DatabaseIdentifier.GBASE8S.equalsIgnoreCase(config.getDialect());
+        }
+        return GBase8sJdbcUrl.accepts(config.getUrl());
+    }
+
+    /**
+     * An implicit target keeps only the source table name. Source database/schema/owner metadata
+     * must never leak into a different GBase 8s target connection.
+     */
+    static TablePath resolveImplicitTargetPath(
+            JdbcConnectionConfig config,
+            TablePath sourcePath) {
+        if (config == null || sourcePath == null) {
+            return sourcePath;
+        }
+        return TablePath.of(
+                requireUrlDatabase(config),
+                defaultOwner(config),
+                requireTableName(sourcePath));
+    }
+
+    /**
+     * Explicit target mappings may choose an owner, but the database must remain the database from
+     * the Sink JDBC URL.
+     */
+    static TablePath resolveExplicitTargetPath(
+            JdbcConnectionConfig config,
+            TablePath targetPath) {
+        if (config == null || targetPath == null) {
+            return targetPath;
+        }
+        validateExplicitTargetPath(config, targetPath);
+        String owner = hasText(targetPath.getSchemaName())
+                ? targetPath.getSchemaName().trim()
+                : defaultOwner(config);
+        return TablePath.of(
+                requireUrlDatabase(config),
+                owner,
+                requireTableName(targetPath));
+    }
+
+    /** Normalizes an already prepared target while preserving its selected owner. */
+    static TablePath resolvePreparedTargetPath(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+        if (config == null || tablePath == null) {
+            return tablePath;
+        }
+        String database = requireUrlDatabase(config);
+        if (hasText(tablePath.getDatabaseName())
+                && !database.equalsIgnoreCase(tablePath.getDatabaseName().trim())) {
+            throw crossDatabase(database, tablePath.getDatabaseName());
+        }
+        String owner = hasText(tablePath.getSchemaName())
+                ? tablePath.getSchemaName().trim()
+                : defaultOwner(config);
+        return TablePath.of(database, owner, requireTableName(tablePath));
+    }
+
+    static void validateExplicitTargetPath(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
+        if (config == null || tablePath == null) {
+            return;
+        }
+        String database = requireUrlDatabase(config);
+        if (hasText(tablePath.getDatabaseName())
+                && !database.equalsIgnoreCase(tablePath.getDatabaseName().trim())) {
+            throw crossDatabase(database, tablePath.getDatabaseName());
+        }
+    }
+
+    private static String defaultOwner(JdbcConnectionConfig config) {
+        if (hasText(config.getSchema())) {
+            return config.getSchema().trim();
+        }
+        return hasText(config.getUsername())
+                ? config.getUsername().trim()
+                : null;
+    }
+
+    private static String requireUrlDatabase(JdbcConnectionConfig config) {
+        String database = GBase8sJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(database)) {
+            throw new IllegalArgumentException("GBase 8s Sink JDBC URL must specify database");
+        }
+        return database.trim();
+    }
+
+    private static String requireTableName(TablePath tablePath) {
+        if (!hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("GBase 8s target table name must not be empty");
+        }
+        return tablePath.getTableName().trim();
+    }
+
+    private static IllegalArgumentException crossDatabase(
+            String urlDatabase,
+            String targetDatabase) {
+        return new IllegalArgumentException(
+                "GBase 8s explicit target database must match Sink JDBC URL database; "
+                        + "urlDatabase="
+                        + urlDatabase
+                        + ", targetDatabase="
+                        + targetDatabase);
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -107,6 +107,24 @@ final class JdbcSinkPreparer implements SinkPreparer {
 
     private CatalogTable resolveTargetTable(CatalogTable source) {
         String path = config.resolveTargetTablePath(source.getTablePath());
+
+        if (GBase8sSinkSupport.accepts(config.getConnectionConfig())) {
+            TablePath targetPath;
+            if (path == null) {
+                targetPath = GBase8sSinkSupport.resolveImplicitTargetPath(
+                        config.getConnectionConfig(),
+                        source.getTablePath());
+            } else {
+                TablePath explicit = dialect.parseTablePath(path);
+                targetPath = GBase8sSinkSupport.resolveExplicitTargetPath(
+                        config.getConnectionConfig(),
+                        explicit);
+            }
+            return source.getTablePath().equals(targetPath)
+                    ? source
+                    : source.withPath(targetPath);
+        }
+
         CatalogTable mapped = path == null
                 ? source
                 : source.withPath(dialect.parseTablePath(path));
@@ -150,6 +168,10 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return GBase8aSinkSupport.resolveTargetPath(
                     config.getConnectionConfig(), tablePath);
         }
+        if (GBase8sSinkSupport.accepts(config.getConnectionConfig())) {
+            return GBase8sSinkSupport.resolvePreparedTargetPath(
+                    config.getConnectionConfig(), tablePath);
+        }
         return JdbcCreateTableSqlResolver.resolveTargetPath(
                 config.getConnectionConfig(), tablePath);
     }
@@ -179,6 +201,9 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return null;
         }
         if (GBase8aSinkSupport.accepts(config.getConnectionConfig())) {
+            return null;
+        }
+        if (GBase8sSinkSupport.accepts(config.getConnectionConfig())) {
             return null;
         }
         return JdbcCreateTableSqlResolver.resolve(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalogTest.java
@@ -1,19 +1,25 @@
 package com.link.up.connector.jdbc.catalog.gbase.gbase8s;
 
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.type.BasicType;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
 import org.junit.Test;
 
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class GBase8sCatalogTest {
 
     @Test
-    public void sourceCatalogIsBoundToOneDatabaseAndRemainsReadOnly() {
+    public void existingTableSinkCatalogStaysBoundToOneDatabase() {
         GBase8sCatalog catalog = new GBase8sCatalog(
                 "gbase8s",
                 config(),
@@ -21,7 +27,30 @@ public class GBase8sCatalogTest {
                 "gbasedbt");
 
         assertEquals("testdb", catalog.getDefaultDatabase().get());
-        assertFalse(catalog instanceof WritableCatalog);
+        assertTrue(catalog instanceof WritableCatalog);
+    }
+
+    @Test
+    public void existingTableSinkRejectsStructureChangingDdl() {
+        GBase8sCatalog catalog = new GBase8sCatalog(
+                "gbase8s",
+                config(),
+                "testdb",
+                "gbasedbt");
+
+        assertBlocked(() -> catalog.createDatabase("archive", false), "create database");
+        assertBlocked(() -> catalog.dropDatabase("archive", false), "drop database");
+        assertBlocked(() -> catalog.createTable(table(), false), "create table");
+        assertBlocked(
+                () -> catalog.addColumn(
+                        TablePath.of("testdb", "gbasedbt", "orders"),
+                        Column.builder("extra", BasicType.STRING_TYPE).build()),
+                "add column");
+        assertBlocked(
+                () -> catalog.dropTable(
+                        TablePath.of("testdb", "gbasedbt", "orders"),
+                        false),
+                "drop table");
     }
 
     @Test
@@ -39,6 +68,27 @@ public class GBase8sCatalogTest {
                                 false),
                         "testdb",
                         "gbasedbt"));
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Collections.singletonList(
+                        Column.builder("id", BasicType.INT_TYPE)
+                                .nullable(false)
+                                .build()))
+                .build();
+        return CatalogTable.builder(
+                        TablePath.of("testdb", "gbasedbt", "orders"),
+                        schema)
+                .build();
+    }
+
+    private static void assertBlocked(
+            Runnable operation,
+            String operationName) {
+        CatalogException error = assertThrows(CatalogException.class, operation::run);
+        assertTrue(error.getMessage().contains(operationName));
+        assertTrue(error.getMessage().contains("pre-create"));
     }
 
     private static JdbcCatalogConfig config() {

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectTest.java
@@ -125,10 +125,15 @@ public class GBase8sDialectTest {
     }
 
     @Test
-    public void sourceCatalogIsReadOnlyAndSinkSpecificSemanticsStayDisabled() {
+    public void existingTableSinkUsesInsertAndStillRejectsUpsertAndDdlTypes() {
         GBase8sDialect dialect = dialect(null, null);
         Catalog catalog = dialect.createCatalog(config(baseUrl(), null, null, null));
-        assertFalse(catalog instanceof WritableCatalog);
+        assertTrue(catalog instanceof WritableCatalog);
+        assertEquals(
+                "INSERT INTO gbasedbt.orders (id, name) VALUES (?, ?)",
+                dialect.buildInsertSql(
+                        TablePath.of("testdb", "gbasedbt", "orders"),
+                        Arrays.asList("id", "name")));
         assertFalse(dialect.buildUpsertSql(
                 TablePath.of("testdb", "gbasedbt", "orders"),
                 Arrays.asList("id", "name"),
@@ -138,6 +143,18 @@ public class GBase8sDialectTest {
         assertThrows(
                 UnsupportedOperationException.class,
                 () -> dialect.typeMapper().toDatabaseType(column));
+    }
+
+    @Test
+    public void bulkInsertExtensionRemainsOptIn() {
+        GBase8sDialect dialect = dialect(null, null);
+        assertFalse(dialect.defaultConnectionProperties().containsKey("IFX_USEPUT"));
+
+        Map<String, String> userProperties = new LinkedHashMap<String, String>();
+        userProperties.put("IFX_USEPUT", "1");
+        assertEquals(
+                "1",
+                dialect.resolveConnectionProperties(userProperties).get("IFX_USEPUT"));
     }
 
     @Test

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8sSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8sSinkSupportTest.java
@@ -1,0 +1,138 @@
+package com.link.up.connector.jdbc.sink;
+
+import com.link.up.api.configuration.ReadonlyConfig;
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
+import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sDialect;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8sSinkSupportTest {
+
+    @Test
+    public void implicitTargetDropsSourceDatabaseAndOwnerMetadata() {
+        TablePath target = GBase8sSinkSupport.resolveImplicitTargetPath(
+                config("targetdb", "sinkowner", DatabaseIdentifier.GBASE8S),
+                TablePath.of("source_db", "public", "orders"));
+
+        assertEquals(
+                TablePath.of("targetdb", "sinkowner", "orders"),
+                target);
+    }
+
+    @Test
+    public void usernameIsDefaultOwnerWhenSchemaIsNotConfigured() {
+        TablePath target = GBase8sSinkSupport.resolveImplicitTargetPath(
+                config("targetdb", null, DatabaseIdentifier.GBASE8S),
+                TablePath.of("source_db", "public", "orders"));
+
+        assertEquals(
+                TablePath.of("targetdb", "gbasedbt", "orders"),
+                target);
+    }
+
+    @Test
+    public void explicitOwnerMappingWinsOverConfiguredDefaultOwner() {
+        TablePath target = GBase8sSinkSupport.resolveExplicitTargetPath(
+                config("targetdb", "sinkowner", DatabaseIdentifier.GBASE8S),
+                TablePath.of(null, "archive_owner", "orders"));
+
+        assertEquals(
+                TablePath.of("targetdb", "archive_owner", "orders"),
+                target);
+    }
+
+    @Test
+    public void explicitSameDatabaseOwnerMappingIsAccepted() {
+        TablePath target = GBase8sSinkSupport.resolveExplicitTargetPath(
+                config("targetdb", "sinkowner", DatabaseIdentifier.GBASE8S),
+                TablePath.of("targetdb", "archive_owner", "orders"));
+
+        assertEquals(
+                TablePath.of("targetdb", "archive_owner", "orders"),
+                target);
+    }
+
+    @Test
+    public void explicitCrossDatabaseMappingIsRejected() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> GBase8sSinkSupport.resolveExplicitTargetPath(
+                        config("targetdb", "sinkowner", DatabaseIdentifier.GBASE8S),
+                        TablePath.of("otherdb", "archive_owner", "orders")));
+
+        assertTrue(error.getMessage().contains("must match Sink JDBC URL database"));
+    }
+
+    @Test
+    public void dedicatedUrlCanSelectSinkSupportWithoutExplicitDialect() {
+        assertTrue(GBase8sSinkSupport.accepts(config("targetdb", null, null)));
+        assertTrue(GBase8sSinkSupport.accepts(
+                config("targetdb", null, DatabaseIdentifier.GBASE8S)));
+        assertFalse(GBase8sSinkSupport.accepts(
+                config("targetdb", null, DatabaseIdentifier.GBASE8A)));
+    }
+
+    @Test
+    public void existingTableSinkDoesNotGenerateAutomaticCreateTableSql() {
+        JdbcConnectionConfig config = config(
+                "targetdb",
+                "sinkowner",
+                DatabaseIdentifier.GBASE8S);
+
+        assertNull(
+                JdbcCreateTableSqlResolver.resolve(
+                        new GBase8sDialect(config),
+                        config,
+                        table()));
+    }
+
+    private static CatalogTable table() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Collections.singletonList(
+                        Column.builder("id", BasicType.INT_TYPE)
+                                .nullable(false)
+                                .build()))
+                .build();
+
+        return CatalogTable.builder(
+                        TablePath.of("source_db", "public", "orders"),
+                        schema)
+                .build();
+    }
+
+    private static JdbcConnectionConfig config(
+            String database,
+            String schema,
+            String dialect) {
+        Map<String, Object> values = new LinkedHashMap<String, Object>();
+        values.put(
+                "url",
+                "jdbc:gbasedbt-sqli://127.0.0.1:9088/"
+                        + database
+                        + ":GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10");
+        values.put("driver", "com.gbasedbt.jdbc.Driver");
+        values.put("username", "gbasedbt");
+        if (schema != null) {
+            values.put("schema", schema);
+        }
+        if (dialect != null) {
+            values.put("dialect", dialect);
+        }
+        return JdbcConnectionConfig.of(ReadonlyConfig.fromMap(values));
+    }
+}


### PR DESCRIPTION
## Summary

Add the second GBase 8s runtime stage: a bounded/offline **existing-table JDBC Sink**.

This PR is based directly on current `main` after #126. It keeps the write contract conservative: standard JDBC INSERT + batch execution into pre-created GBase 8s tables. Automatic DDL, MERGE/UPSERT abstraction, SQLMODE expansion, CDC and realtime semantics remain outside this stage.

## Sink contract

```hocon
sink {
  type = "jdbc"
  url = "jdbc:gbasedbt-sqli://gbase8s:9088/archive:GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10"
  driver = "com.gbasedbt.jdbc.Driver"
  dialect = "gbase8s"
  schema = "gbasedbt"
  table = "orders"
  schema_save_mode = "ERROR_WHEN_SCHEMA_NOT_EXIST"
  data_save_mode = "APPEND_DATA"
}
```

## Shared JDBC write path

The Sink reuses the existing JDBC writer:

- parameterized `INSERT`
- configured `batch_size`
- `PreparedStatement.addBatch()` / `executeBatch()`
- one task-local JDBC transaction
- commit / rollback
- existing savepoint retry behavior
- existing dirty-data handling

No GBase 8s-specific writer is introduced.

## Existing-table safety boundary

`GBase8sCatalog` now implements `WritableCatalog` only so the common Sink save-mode lifecycle can validate existing targets and support `DROP_DATA`.

Allowed:

- database/owner/table/column/primary-key metadata discovery
- target schema compatibility validation
- INSERT / JDBC batch write
- `TRUNCATE TABLE` for `DROP_DATA`

Blocked:

- CREATE DATABASE
- DROP DATABASE
- CREATE TABLE
- DROP TABLE
- ADD COLUMN
- automatic target DDL type generation
- runtime schema evolution

This means `ERROR_WHEN_SCHEMA_NOT_EXIST` / `IGNORE` work with compatible pre-created tables. `CREATE_SCHEMA_WHEN_NOT_EXIST` remains safe for an existing table but fails clearly if the table is absent. `RECREATE_SCHEMA` is rejected before destructive DROP, and `CREATE_OR_ADD_COLUMNS` cannot mutate a target schema.

## Target routing

Add `GBase8sSinkSupport` and wire it into `JdbcSinkPreparer`.

The Sink JDBC URL owns the target database.

- implicit targets keep only the source table name
- source database/schema/owner metadata never leaks into the target
- implicit target owner comes from Sink `schema`, then Sink username
- explicit `owner.table` may choose a target owner
- explicit `database.owner.table` is allowed only when database matches the Sink URL database
- explicit cross-database mappings fail during preparation

This keeps one Sink connection aligned with one database while preserving GBase 8s owner semantics.

## Batch optimization boundary

Standard JDBC batch execution is the default.

The vendor `IFX_USEPUT=1` bulk-insert extension remains **opt-in**, not a Link-Up default. The vendor extension requires compatible Java/target column types and excludes opaque/complex types, while the bounded connector deliberately keeps INTERVAL/extension types behind conservative read boundaries. Deployments that have verified compatible scalar target schemas may enable `IFX_USEPUT=1` explicitly in JDBC URL/properties.

## UPSERT / MERGE boundary

This stage intentionally does **not** advertise UPSERT.

Native GBase 8s `MERGE` has a broader update/insert/delete contract than Link-Up's generic UPSERT abstraction. This stage therefore does not guess conflict keys or collapse database-specific MERGE semantics into `write_mode=UPSERT`.

## DELIMIDENT boundary

Preserve the Source-stage identifier behavior:

- default `DELIMIDENT=n`: ordinary simple identifiers, normalized to lowercase
- explicit `DELIMIDENT=y`: quoted, case-preserving identifiers

`TRUNCATE TABLE` uses the same identifier rule as normal SELECT/INSERT SQL.

## Tests

Focused tests cover:

- portable existing-table INSERT SQL
- `WritableCatalog` availability
- UPSERT remains unsupported
- target DDL type generation remains disabled
- vendor bulk insert remains opt-in
- CREATE/DROP database blocked
- CREATE/DROP table blocked
- ADD COLUMN blocked
- implicit source database/owner isolation
- owner fallback from Sink schema / username
- explicit owner preservation
- explicit same-database target support
- explicit cross-database rejection
- dedicated URL auto-detection
- no automatic CREATE TABLE SQL

## Explicit non-goals

- MERGE / UPSERT
- automatic database/table creation
- runtime schema evolution
- SQLMODE MySQL / Oracle compatibility expansion
- cross-database implicit rebinding
- CDC / logical-log integration / realtime synchronization
- coordinated multi-reader snapshots
- ROW / COLLECTION native object modeling

## Verification

- based directly on current `main` after #126
- final branch is one atomic commit
- final compare: `ahead=1`, `behind=0`
- diff is limited to 11 files: GBase 8s existing-table Sink integration, focused tests, and JDBC README documentation
- no vendor JDBC Maven coordinate is guessed or added; runtime must provide the official GBase 8s JDBC driver
- Maven execution was attempted, but this execution environment still cannot resolve `github.com`, so the repository could not be cloned and the Maven suite was not executed here
- tests are added but are not claimed as executed
- a real GBase 8s environment plus the vendor JDBC driver is still required before Ready for Review to verify INSERT batching, transaction commit/rollback, owner metadata compatibility, DELIMIDENT behavior, optional IFX_USEPUT tuning, and `DROP_DATA` end to end
