### PR TITLE
feat(gbase8a): add safe automatic target table creation

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -103,16 +103,15 @@ The shared `gbase/common` layer only carries stable product metadata and family-
 product-specific: URL parsing, identifiers, catalog behavior, type mapping, row conversion, Sink SQL and MPP behavior
 must stay in the concrete product adapter unless completed implementations prove that behavior is genuinely common.
 
-The planned bounded/offline implementation order is:
-
-1. GBase 8c Source, then existing-table Sink.
-2. GBase 8a Source, then existing-table JDBC Sink; native/high-speed MPP loading is a later stage.
-3. GBase 8s Source, then existing-table Sink.
+The bounded/offline implementation is staged per product. GBase 8a now supports bounded Source, JDBC Sink and safe
+automatic creation of a missing target table; native/high-speed MPP loading remains a later performance stage. GBase 8s
+currently supports bounded Source plus existing-table Sink, with automatic target creation handled separately. GBase 8c
+keeps its compatibility-sensitive runtime and DDL work separate from the other two products.
 
 CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths stay outside
 this family-level contract.
 
-### GBase 8a bounded Source + existing-table JDBC Sink
+### GBase 8a bounded Source + JDBC Sink + safe automatic target creation
 
 GBase 8a is exposed as the first-class `gbase8a` JDBC dialect and uses the vendor JDBC protocol/driver:
 
@@ -131,45 +130,61 @@ sink {
   driver = "com.gbase.jdbc.Driver"
   dialect = "gbase8a"
   table = "orders"
-  schema_save_mode = "ERROR_WHEN_SCHEMA_NOT_EXIST"
+  schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
   data_save_mode = "APPEND_DATA"
 }
 ```
 
-GBase 8a uses `database.table` semantics with no separate schema layer in this bounded JDBC stage. The JDBC URL owns the
-active database. Source metadata may come from another database/schema, but an unqualified Sink target is always rebound
+GBase 8a uses `database.table` semantics with no separate schema layer in this bounded JDBC stage. The Sink JDBC URL owns
+the target database. Source metadata may come from another database/schema, but an unqualified target is always rebound
 to the Sink URL database so source routing metadata cannot leak into the target. An explicit target may be `orders` or
-repeat the URL database as `archive.orders`; an explicit different database fails during Sink preparation instead of
-silently redirecting one connection to another database.
+repeat the URL database as `archive.orders`; an explicit different database fails during Sink preparation.
 
-Metadata discovery remains based on standard JDBC `DatabaseMetaData` for databases, tables, columns and primary keys.
-The Catalog now implements `WritableCatalog` only to participate in the shared JDBC Sink save-mode lifecycle. The stage
-supports metadata validation and `TRUNCATE TABLE` for `DROP_DATA`, while structure-changing DDL remains blocked:
+When `schema_save_mode = CREATE_SCHEMA_WHEN_NOT_EXIST` and the target table is absent, Link-Up now creates a conservative
+target table automatically before writing rows. `CREATE_OR_ADD_COLUMNS` also creates a missing table, but it still does
+not mutate an existing table: `ADD COLUMN` remains blocked. `RECREATE_SCHEMA` remains non-destructive because `DROP TABLE`
+is still blocked. CREATE/DROP DATABASE is also disabled.
 
-- no CREATE/DROP DATABASE
-- no CREATE/DROP TABLE
-- no ADD COLUMN or runtime schema evolution
-- no automatic target-table creation
+Automatic DDL copies only the relational shape needed to receive synchronized rows:
 
-Create the target table before running the job. `CREATE_SCHEMA_WHEN_NOT_EXIST` is safe for an existing compatible table
-but fails clearly when the table is absent. `RECREATE_SCHEMA` cannot destructively drop a table because DROP TABLE is
-blocked before recreation. `CREATE_OR_ADD_COLUMNS` may validate an already compatible target, but a missing column fails
-instead of mutating MPP table structure.
+- column names
+- portable GBase 8a target types
+- NULL / NOT NULL
+- source primary key only when the shared `create_primary_key` option keeps it
 
-The Sink reuses the shared JDBC writer: parameterized `INSERT`, configured batch size, `PreparedStatement.addBatch()` /
-`executeBatch()`, one task-local transaction and the existing commit/rollback, retry/savepoint and dirty-data behavior.
-`rewriteBatchedStatements=true` is a GBase 8a dialect default because the vendor JDBC driver can rewrite batched INSERTs
-into multi-value INSERT statements; explicit user `properties` may override it.
+It deliberately does **not** copy source defaults, AUTO_INCREMENT/identity behavior, comments, indexes, foreign keys,
+partitions, compression, replication or distribution-key policy. The generated SQL contains no `DISTRIBUTED BY` or
+`REPLICATED` clause. Link-Up therefore does not guess a business hash key; the target GBase 8a version/database owns its
+default physical distribution behavior.
 
-UPSERT/MERGE is intentionally not advertised. GBase 8a MERGE has distribution-specific constraints, so this generic
-existing-table stage does not guess HASH distribution keys or business-key semantics. POC/native high-speed loading is
-also a later stage; this PR keeps JDBC batch INSERT as the usable baseline before introducing a separate MPP-native load
-path.
+The automatic target type contract is conservative:
 
-The read-side type contract covers common numeric, string/text, binary/BLOB, DATE, TIME, DATETIME and TIMESTAMP types.
-DATETIME/TIMESTAMP map to the Link-Up `TIMESTAMP` boundary. DECIMAL values above Link-Up's precision limit fall back to
-STRING instead of silently losing precision. Target database type generation remains disabled because this stage never
-auto-creates GBase 8a tables.
+- BOOLEAN -> BOOLEAN
+- TINYINT / SMALLINT / INT / BIGINT -> matching integer type
+- FLOAT / DOUBLE -> matching floating type
+- DECIMAL -> DECIMAL(precision, scale), with GBase limits validated
+- STRING with a known safe length up to 8191 -> VARCHAR(length)
+- longer or unknown-length STRING -> LONGTEXT
+- BYTES -> LONGBLOB
+- DATE -> DATE
+- TIME -> TIME
+- TIMESTAMP -> DATETIME
+
+`TIMESTAMP_TZ`, ARRAY, MAP, ROW and other types without a safe portable GBase 8a target contract fail before unsafe DDL is
+executed rather than being silently narrowed. Source auto-increment metadata is never copied because the JDBC Sink writes
+the source value explicitly.
+
+The Sink continues to reuse the shared JDBC writer: parameterized `INSERT`, configured batch size,
+`PreparedStatement.addBatch()` / `executeBatch()`, one task-local transaction and the existing commit/rollback,
+retry/savepoint and dirty-data behavior. `rewriteBatchedStatements=true` remains a GBase 8a dialect default; explicit user
+`properties` may override it.
+
+UPSERT/MERGE is intentionally not advertised. GBase 8a MERGE has distribution-specific constraints, so this generic stage
+does not guess HASH distribution keys or business-key semantics. POC/native high-speed loading is also a later stage.
+
+The read-side type contract still covers common numeric, string/text, binary/BLOB, DATE, TIME, DATETIME and TIMESTAMP
+types. DATETIME/TIMESTAMP map to the Link-Up `TIMESTAMP` boundary. DECIMAL values above Link-Up's read precision limit
+fall back to STRING instead of silently losing precision.
 
 For large bounded reads, a positive Link-Up `fetch_size` selects the GBase JDBC streaming-result sentinel
 `Integer.MIN_VALUE`. `tinyInt1isBit=false` and `yearIsDateType=false` remain safe type defaults. The Source advertises

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalog.java
@@ -32,12 +32,12 @@ import java.util.Set;
 import java.util.TreeMap;
 
 /**
- * GBase 8a Catalog for bounded/offline Source and existing-table JDBC Sink jobs.
+ * GBase 8a Catalog for bounded/offline Source and JDBC Sink jobs.
  *
- * <p>Metadata uses the standard JDBC {@link DatabaseMetaData} contract. The Sink stage deliberately
- * exposes {@link WritableCatalog} only so the shared save-mode lifecycle can validate existing
- * targets and optionally truncate their data. Structure-changing DDL stays disabled until GBase 8a
- * distribution/MPP table design is modeled explicitly.</p>
+ * <p>Metadata uses the standard JDBC {@link DatabaseMetaData} contract. The Sink can safely create
+ * a missing target table from Link-Up schema metadata and truncate existing data. Database DDL,
+ * destructive table recreation and runtime schema evolution stay disabled; the automatic-target
+ * path never guesses MPP distribution, partition or replication design.</p>
  */
 public final class GBase8aCatalog implements WritableCatalog {
 
@@ -218,12 +218,44 @@ public final class GBase8aCatalog implements WritableCatalog {
         throw unsupportedSchemaDdl("drop database");
     }
 
+    /**
+     * Creates a safe baseline target table. Distribution, partitioning, defaults, identity and
+     * other source physical-design semantics are intentionally not inferred here.
+     */
     @Override
     public void createTable(
             CatalogTable table,
             boolean ignoreIfExists)
             throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
-        throw unsupportedSchemaDdl("create table");
+        checkOpened();
+        if (table == null) {
+            throw new IllegalArgumentException("table must not be null");
+        }
+
+        TablePath normalized = normalizeTablePath(table.getTablePath());
+        requireCurrentDatabase(normalized.getDatabaseName());
+        if (tableExists(normalized)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new TableAlreadyExistsException(catalogName, normalized);
+        }
+
+        CatalogTable ddlTable = table.getTablePath().equals(normalized)
+                ? table
+                : table.withPath(normalized);
+        String sql = new GBase8aCreateTableSqlBuilder(
+                normalized,
+                ddlTable,
+                typeMapper)
+                .build();
+
+        try (Connection connection = newConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new CatalogException("创建 GBase 8a 目标表失败，table=" + normalized, e);
+        }
     }
 
     @Override
@@ -249,6 +281,7 @@ public final class GBase8aCatalog implements WritableCatalog {
             throws CatalogException, TableNotFoundException {
         checkOpened();
         TablePath normalized = normalizeTablePath(tablePath);
+        requireCurrentDatabase(normalized.getDatabaseName());
         if (!tableExists(normalized)) {
             if (ignoreIfNotExists) {
                 return;
@@ -331,6 +364,18 @@ public final class GBase8aCatalog implements WritableCatalog {
         return defaultDatabase;
     }
 
+    private void requireCurrentDatabase(String databaseName) {
+        if (!hasText(databaseName)
+                || !defaultDatabase.equalsIgnoreCase(databaseName.trim())) {
+            throw new IllegalArgumentException(
+                    "GBase 8a automatic-target JDBC stage does not support cross-database DDL; "
+                            + "urlDatabase="
+                            + defaultDatabase
+                            + ", targetDatabase="
+                            + databaseName);
+        }
+    }
+
     private String quoteTable(TablePath tablePath) {
         return quoteIdentifier(tablePath.getDatabaseName())
                 + "."
@@ -367,9 +412,9 @@ public final class GBase8aCatalog implements WritableCatalog {
 
     private static CatalogException unsupportedSchemaDdl(String operation) {
         return new CatalogException(
-                "GBase 8a existing-table JDBC Sink does not support "
+                "GBase 8a automatic-target JDBC stage does not support "
                         + operation
-                        + "; pre-create the target table and keep MPP distribution DDL outside this stage");
+                        + "; only safe CREATE TABLE for a missing target and TRUNCATE are enabled");
     }
 
     private static boolean isBaseTable(String tableType) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCreateTableSqlBuilder.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCreateTableSqlBuilder.java
@@ -1,0 +1,111 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8a;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aTypeMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Builds the conservative CREATE TABLE statement used by the GBase 8a automatic-target stage.
+ *
+ * <p>The builder intentionally copies only the relational shape needed for offline synchronization:
+ * columns, target types, nullability and (when requested by the shared sink lifecycle) the primary
+ * key. Source defaults, auto-increment/identity behavior, comments, indexes, foreign keys,
+ * partitions and MPP distribution policy are not copied.</p>
+ *
+ * <p>No DISTRIBUTED BY or REPLICATED clause is generated. The target database therefore keeps its
+ * normal GBase 8a default table-distribution behavior instead of Link-Up guessing a business hash
+ * key.</p>
+ */
+public final class GBase8aCreateTableSqlBuilder {
+
+    private final TablePath tablePath;
+    private final CatalogTable catalogTable;
+    private final GBase8aTypeMapper typeMapper;
+
+    public GBase8aCreateTableSqlBuilder(
+            TablePath tablePath,
+            CatalogTable catalogTable,
+            GBase8aTypeMapper typeMapper) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (catalogTable == null) {
+            throw new IllegalArgumentException("catalogTable must not be null");
+        }
+        if (typeMapper == null) {
+            throw new IllegalArgumentException("typeMapper must not be null");
+        }
+        if (!hasText(tablePath.getDatabaseName())) {
+            throw new IllegalArgumentException("GBase 8a CREATE TABLE requires database: " + tablePath);
+        }
+        this.tablePath = tablePath;
+        this.catalogTable = catalogTable;
+        this.typeMapper = typeMapper;
+    }
+
+    public String build() {
+        TableSchema schema = catalogTable.getTableSchema();
+        if (schema == null || schema.getColumns() == null || schema.getColumns().isEmpty()) {
+            throw new IllegalArgumentException("GBase 8a CREATE TABLE requires at least one column");
+        }
+
+        List<String> definitions = new ArrayList<String>();
+        for (Column column : schema.getColumns()) {
+            definitions.add(buildColumnDefinition(column));
+        }
+
+        PrimaryKey primaryKey = schema.getPrimaryKey();
+        if (primaryKey != null && !primaryKey.getColumnNames().isEmpty()) {
+            definitions.add(buildPrimaryKey(primaryKey));
+        }
+
+        return "CREATE TABLE "
+                + quoteTable(tablePath)
+                + " (\n    "
+                + String.join(",\n    ", definitions)
+                + "\n);";
+    }
+
+    public String buildColumnDefinition(Column column) {
+        if (column == null) {
+            throw new IllegalArgumentException("column must not be null");
+        }
+
+        List<String> parts = new ArrayList<String>();
+        parts.add(quoteIdentifier(column.getName()));
+        parts.add(typeMapper.toDatabaseType(column));
+        parts.add(column.isNullable() ? "NULL" : "NOT NULL");
+        return String.join(" ", parts);
+    }
+
+    private static String buildPrimaryKey(PrimaryKey primaryKey) {
+        String columns = primaryKey.getColumnNames().stream()
+                .map(GBase8aCreateTableSqlBuilder::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        return "PRIMARY KEY (" + columns + ")";
+    }
+
+    private static String quoteTable(TablePath path) {
+        return quoteIdentifier(path.getDatabaseName())
+                + "."
+                + quoteIdentifier(path.getTableName());
+    }
+
+    private static String quoteIdentifier(String value) {
+        if (!hasText(value)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "`" + value.trim().replace("`", "``") + "`";
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialect.java
@@ -21,8 +21,10 @@ import java.util.Map;
 /**
  * GBase 8a bounded/offline JDBC dialect.
  *
- * <p>The adapter supports bounded reads and an existing-table INSERT/batch Sink. MPP-native loading,
- * structure-changing Sink DDL, UPSERT/MERGE, CDC and streaming job semantics remain separate stages.</p>
+ * <p>The adapter supports bounded reads plus INSERT/batch Sink writes and safe automatic creation
+ * of a missing target table. Automatic DDL deliberately copies only the relational target shape;
+ * MPP distribution/replication design, destructive recreation, runtime schema evolution,
+ * UPSERT/MERGE, native loading, CDC and streaming semantics remain separate stages.</p>
  */
 public final class GBase8aDialect implements JdbcDialect {
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapper.java
@@ -17,15 +17,22 @@ import java.util.Locale;
 /**
  * GBase 8a bounded/offline JDBC type mapper.
  *
- * <p>The mapper follows the JDBC types documented by GBase 8a for metadata discovery and row
- * conversion. Unknown/extension types fall back to STRING. Target DDL type generation stays
- * disabled because the current Sink writes pre-created tables only.</p>
+ * <p>The read side follows the JDBC types documented by GBase 8a. The automatic-target stage also
+ * exposes a conservative Flux-to-GBase DDL mapping. It deliberately favors value safety over
+ * source-type fidelity: long/unknown strings become LONGTEXT, binary values become LONGBLOB and
+ * Link-Up TIMESTAMP becomes GBase DATETIME so the target is not constrained by GBase TIMESTAMP's
+ * narrower range/fractional-second behavior.</p>
  */
 public final class GBase8aTypeMapper implements JdbcTypeMapper {
 
-    private static final int MAX_DECIMAL_PRECISION = 38;
+    private static final int MAX_FLUX_DECIMAL_PRECISION = 38;
     private static final int DEFAULT_DECIMAL_PRECISION = 38;
     private static final int DEFAULT_DECIMAL_SCALE = 18;
+
+    /** Conservative VARCHAR ceiling that is valid for GBase 8a utf8mb4 deployments. */
+    private static final long SAFE_VARCHAR_LENGTH = 8191L;
+    private static final int GBASE_MAX_DECIMAL_PRECISION = 65;
+    private static final int GBASE_MAX_DECIMAL_SCALE = 30;
 
     @Override
     public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
@@ -64,10 +71,108 @@ public final class GBase8aTypeMapper implements JdbcTypeMapper {
         return builder.build();
     }
 
+    /**
+     * Maps a Link-Up column to the portable GBase 8a type used for automatic target creation.
+     *
+     * <p>Defaults, identity/auto-increment behavior and source-specific type decorations are
+     * intentionally not copied by this method.</p>
+     */
     @Override
     public String toDatabaseType(Column column) {
-        throw new UnsupportedOperationException(
-                "GBase 8a existing-table Sink does not generate target DDL types");
+        if (column == null || column.getDataType() == null) {
+            throw new IllegalArgumentException("column/dataType must not be null");
+        }
+
+        SqlType type = column.getDataType().getSqlType();
+        switch (type) {
+            case STRING:
+                return stringTargetType(column);
+            case BOOLEAN:
+                return "BOOLEAN";
+            case TINYINT:
+                return "TINYINT";
+            case SMALLINT:
+                return "SMALLINT";
+            case INT:
+                return "INT";
+            case BIGINT:
+                return "BIGINT";
+            case FLOAT:
+                return "FLOAT";
+            case DOUBLE:
+                return "DOUBLE";
+            case DECIMAL:
+                return decimalTargetType(column);
+            case BYTES:
+                return "LONGBLOB";
+            case DATE:
+                return "DATE";
+            case TIME:
+                return "TIME";
+            case TIMESTAMP:
+                return "DATETIME";
+            case TIMESTAMP_TZ:
+                throw unsupportedTargetType(
+                        column,
+                        "GBase 8a has no portable TIMESTAMP WITH TIME ZONE target contract");
+            case ARRAY:
+            case MAP:
+            case ROW:
+            case NULL:
+            default:
+                throw unsupportedTargetType(
+                        column,
+                        "automatic target creation only supports scalar relational types");
+        }
+    }
+
+    private static String stringTargetType(Column column) {
+        Long length = column.getLength();
+        if (length != null && length > 0 && length <= SAFE_VARCHAR_LENGTH) {
+            return "VARCHAR(" + length + ")";
+        }
+        return "LONGTEXT";
+    }
+
+    private static String decimalTargetType(Column column) {
+        int precision = DEFAULT_DECIMAL_PRECISION;
+        int scale = DEFAULT_DECIMAL_SCALE;
+
+        if (column.getDataType() instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) column.getDataType();
+            precision = decimal.getPrecision();
+            scale = decimal.getScale();
+        } else {
+            if (column.getPrecision() != null && column.getPrecision() > 0) {
+                precision = column.getPrecision();
+            }
+            if (column.getScale() != null && column.getScale() >= 0) {
+                scale = column.getScale();
+            }
+        }
+
+        if (precision <= 0
+                || precision > GBASE_MAX_DECIMAL_PRECISION
+                || scale < 0
+                || scale > precision
+                || scale > GBASE_MAX_DECIMAL_SCALE) {
+            throw unsupportedTargetType(
+                    column,
+                    "GBase 8a DECIMAL requires precision <= 65, scale <= 30 and scale <= precision");
+        }
+        return "DECIMAL(" + precision + "," + scale + ")";
+    }
+
+    private static UnsupportedOperationException unsupportedTargetType(
+            Column column,
+            String reason) {
+        return new UnsupportedOperationException(
+                "GBase 8a cannot auto-create target column '"
+                        + column.getName()
+                        + "' from Flux type "
+                        + column.getDataType().getSqlType()
+                        + ": "
+                        + reason);
     }
 
     private static FluxDataType<?> mapType(
@@ -163,7 +268,7 @@ public final class GBase8aTypeMapper implements JdbcTypeMapper {
     }
 
     private static FluxDataType<?> decimal(int precision, int scale) {
-        if (precision > MAX_DECIMAL_PRECISION) {
+        if (precision > MAX_FLUX_DECIMAL_PRECISION) {
             return BasicType.STRING_TYPE;
         }
         int resolvedPrecision = precision > 0
@@ -185,10 +290,10 @@ public final class GBase8aTypeMapper implements JdbcTypeMapper {
             return;
         }
         if (type == SqlType.DECIMAL) {
-            if (precision > 0 && precision <= MAX_DECIMAL_PRECISION) {
+            if (precision > 0 && precision <= MAX_FLUX_DECIMAL_PRECISION) {
                 builder.precision(precision);
             }
-            if (scale >= 0 && precision > 0 && precision <= MAX_DECIMAL_PRECISION) {
+            if (scale >= 0 && precision > 0 && precision <= MAX_FLUX_DECIMAL_PRECISION) {
                 builder.scale(Math.min(scale, precision));
             }
             return;

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8aSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8aSinkSupport.java
@@ -1,11 +1,14 @@
 package com.link.up.connector.jdbc.sink;
 
+import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.gbase.gbase8a.GBase8aCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aTypeMapper;
 
-/** Target-path normalization and validation for the GBase 8a existing-table JDBC Sink. */
+/** Target-path and automatic-DDL support for the GBase 8a JDBC Sink. */
 final class GBase8aSinkSupport {
 
     private GBase8aSinkSupport() {
@@ -72,6 +75,28 @@ final class GBase8aSinkSupport {
                             + ", targetDatabase="
                             + pathDatabase);
         }
+    }
+
+    /** Builds the same safe CREATE TABLE SQL used by {@code GBase8aCatalog#createTable}. */
+    static String resolveCreateTableSql(
+            JdbcConnectionConfig config,
+            CatalogTable table) {
+        if (config == null || table == null) {
+            return null;
+        }
+
+        TablePath targetPath = resolveTargetPath(config, table.getTablePath());
+        if (targetPath == null) {
+            return null;
+        }
+        CatalogTable ddlTable = table.getTablePath().equals(targetPath)
+                ? table
+                : table.withPath(targetPath);
+        return new GBase8aCreateTableSqlBuilder(
+                targetPath,
+                ddlTable,
+                new GBase8aTypeMapper())
+                .build();
     }
 
     private static boolean hasText(String value) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -201,7 +201,8 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return null;
         }
         if (GBase8aSinkSupport.accepts(config.getConnectionConfig())) {
-            return null;
+            return GBase8aSinkSupport.resolveCreateTableSql(
+                    config.getConnectionConfig(), table);
         }
         if (GBase8sSinkSupport.accepts(config.getConnectionConfig())) {
             return null;

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCatalogTest.java
@@ -1,9 +1,7 @@
 package com.link.up.connector.jdbc.catalog.gbase.gbase8a;
 
-import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.Column;
 import com.link.up.api.table.catalog.TablePath;
-import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.catalog.exception.CatalogException;
 import com.link.up.api.table.type.BasicType;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
@@ -17,53 +15,42 @@ import static org.junit.Assert.fail;
 public class GBase8aCatalogTest {
 
     @Test
-    public void existingTableSinkRejectsAutomaticTableCreation() {
-        GBase8aCatalog catalog = catalog();
-        try {
-            catalog.createTable(table(), false);
-            fail("GBase 8a existing-table Sink must not auto-create target tables");
-        } catch (CatalogException expected) {
-            assertTrue(expected.getMessage().contains("create table"));
-        }
-    }
-
-    @Test
-    public void existingTableSinkRejectsDestructiveDropBeforeRecreate() {
+    public void automaticTargetStageStillRejectsDestructiveDropBeforeRecreate() {
         GBase8aCatalog catalog = catalog();
         try {
             catalog.dropTable(TablePath.of("target_db", "orders"), false);
-            fail("GBase 8a existing-table Sink must not drop target tables");
+            fail("GBase 8a automatic-target stage must not drop target tables");
         } catch (CatalogException expected) {
             assertTrue(expected.getMessage().contains("drop table"));
         }
     }
 
     @Test
-    public void existingTableSinkRejectsRuntimeAddColumn() {
+    public void automaticTargetStageStillRejectsRuntimeAddColumn() {
         GBase8aCatalog catalog = catalog();
         try {
             catalog.addColumn(
                     TablePath.of("target_db", "orders"),
                     Column.builder("new_col", BasicType.STRING_TYPE).build());
-            fail("GBase 8a existing-table Sink must not mutate target schema");
+            fail("GBase 8a automatic-target stage must not mutate existing target schema");
         } catch (CatalogException expected) {
             assertTrue(expected.getMessage().contains("add column"));
         }
     }
 
     @Test
-    public void existingTableSinkRejectsDatabaseDdl() {
+    public void automaticTargetStageStillRejectsDatabaseDdl() {
         GBase8aCatalog catalog = catalog();
         try {
             catalog.createDatabase("archive", false);
-            fail("GBase 8a existing-table Sink must not create databases");
+            fail("GBase 8a automatic-target stage must not create databases");
         } catch (CatalogException expected) {
             assertTrue(expected.getMessage().contains("create database"));
         }
 
         try {
             catalog.dropDatabase("archive", false);
-            fail("GBase 8a existing-table Sink must not drop databases");
+            fail("GBase 8a automatic-target stage must not drop databases");
         } catch (CatalogException expected) {
             assertTrue(expected.getMessage().contains("drop database"));
         }
@@ -80,18 +67,5 @@ public class GBase8aCatalogTest {
                         Collections.emptyMap(),
                         false),
                 "target_db");
-    }
-
-    private static CatalogTable table() {
-        TableSchema schema = TableSchema.builder()
-                .columns(Collections.singletonList(
-                        Column.builder("id", BasicType.LONG_TYPE)
-                                .nullable(false)
-                                .build()))
-                .build();
-        return CatalogTable.builder(
-                        TablePath.of("target_db", "orders"),
-                        schema)
-                .build();
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCreateTableSqlBuilderTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8a/GBase8aCreateTableSqlBuilderTest.java
@@ -1,0 +1,96 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8a;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aTypeMapper;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8aCreateTableSqlBuilderTest {
+
+    @Test
+    public void buildsSafeRandomDistributionBaselineWithoutCopyingSourcePhysicalSemantics() {
+        Column id = Column.builder("id", BasicType.LONG_TYPE)
+                .nullable(false)
+                .autoIncrement(true)
+                .defaultValue(1)
+                .comment("source identity")
+                .build();
+        Column name = Column.builder("name", BasicType.STRING_TYPE)
+                .length(255L)
+                .nullable(true)
+                .defaultValue("anonymous")
+                .build();
+        Column amount = Column.builder("amount", new DecimalType(18, 2))
+                .nullable(true)
+                .build();
+        Column createdAt = Column.builder("created_at", BasicType.TIMESTAMP_TYPE)
+                .nullable(false)
+                .build();
+
+        TableSchema schema = TableSchema.builder()
+                .columns(Arrays.asList(id, name, amount, createdAt))
+                .primaryKey(PrimaryKey.of(Collections.singletonList("id")))
+                .build();
+        CatalogTable table = CatalogTable.builder(
+                        TablePath.of("archive", "orders"),
+                        schema)
+                .comment("source table comment")
+                .build();
+
+        String sql = new GBase8aCreateTableSqlBuilder(
+                table.getTablePath(),
+                table,
+                new GBase8aTypeMapper())
+                .build();
+
+        assertEquals(
+                "CREATE TABLE `archive`.`orders` (\n"
+                        + "    `id` BIGINT NOT NULL,\n"
+                        + "    `name` VARCHAR(255) NULL,\n"
+                        + "    `amount` DECIMAL(18,2) NULL,\n"
+                        + "    `created_at` DATETIME NOT NULL,\n"
+                        + "    PRIMARY KEY (`id`)\n"
+                        + ");",
+                sql);
+
+        assertFalse(sql.contains("AUTO_INCREMENT"));
+        assertFalse(sql.contains("DEFAULT"));
+        assertFalse(sql.contains("COMMENT"));
+        assertFalse(sql.contains("DISTRIBUTED"));
+        assertFalse(sql.contains("REPLICATED"));
+    }
+
+    @Test
+    public void usesLongTypesForUnknownOrLargePayloads() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("text_payload", BasicType.STRING_TYPE).build(),
+                        Column.builder("binary_payload", BasicType.BYTES_TYPE).build()))
+                .build();
+        CatalogTable table = CatalogTable.builder(
+                        TablePath.of("archive", "payloads"),
+                        schema)
+                .build();
+
+        String sql = new GBase8aCreateTableSqlBuilder(
+                table.getTablePath(),
+                table,
+                new GBase8aTypeMapper())
+                .build();
+
+        assertTrue(sql.contains("`text_payload` LONGTEXT NULL"));
+        assertTrue(sql.contains("`binary_payload` LONGBLOB NULL"));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aDialectTest.java
@@ -83,7 +83,7 @@ public class GBase8aDialectTest {
     }
 
     @Test
-    public void existingTableSinkUsesPortableInsertAndStillRejectsUpsert() {
+    public void sinkUsesPortableInsertAndAutomaticDdlTypesButStillRejectsUpsert() {
         GBase8aDialect dialect = dialect();
         Catalog catalog = dialect.createCatalog(config(baseUrl(), null, null));
         assertTrue(catalog instanceof WritableCatalog);
@@ -97,10 +97,10 @@ public class GBase8aDialectTest {
                 Arrays.asList("id", "name"),
                 Collections.singletonList("id")).isPresent());
 
-        Column column = Column.builder("name", BasicType.STRING_TYPE).build();
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> dialect.typeMapper().toDatabaseType(column));
+        Column column = Column.builder("name", BasicType.STRING_TYPE)
+                .length(255L)
+                .build();
+        assertEquals("VARCHAR(255)", dialect.typeMapper().toDatabaseType(column));
     }
 
     @Test

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8a/GBase8aTypeMapperTest.java
@@ -1,6 +1,8 @@
 package com.link.up.connector.jdbc.core.dialect.gbase.gbase8a;
 
 import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
 import com.link.up.api.table.type.SqlType;
 import org.junit.Test;
 
@@ -9,6 +11,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.Types;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class GBase8aTypeMapperTest {
 
@@ -31,8 +34,61 @@ public class GBase8aTypeMapperTest {
     }
 
     @Test
-    public void oversizedDecimalFallsBackToStringInsteadOfLosingPrecision() throws Exception {
+    public void oversizedReadDecimalFallsBackToStringInsteadOfLosingPrecision() throws Exception {
         assertType(SqlType.STRING, "DECIMAL", Types.DECIMAL, 65, 30);
+    }
+
+    @Test
+    public void mapsSafeAutomaticTargetTypes() {
+        assertEquals(
+                "VARCHAR(255)",
+                mapper.toDatabaseType(
+                        Column.builder("name", BasicType.STRING_TYPE)
+                                .length(255L)
+                                .build()));
+        assertEquals(
+                "LONGTEXT",
+                mapper.toDatabaseType(
+                        Column.builder("payload", BasicType.STRING_TYPE)
+                                .length(9000L)
+                                .build()));
+        assertEquals(
+                "LONGTEXT",
+                mapper.toDatabaseType(
+                        Column.builder("unknown_text", BasicType.STRING_TYPE)
+                                .build()));
+        assertEquals(
+                "LONGBLOB",
+                mapper.toDatabaseType(
+                        Column.builder("payload_bin", BasicType.BYTES_TYPE)
+                                .build()));
+        assertEquals(
+                "DATETIME",
+                mapper.toDatabaseType(
+                        Column.builder("created_at", BasicType.TIMESTAMP_TYPE)
+                                .build()));
+        assertEquals(
+                "DECIMAL(38,18)",
+                mapper.toDatabaseType(
+                        Column.builder("amount", new DecimalType(38, 18))
+                                .build()));
+    }
+
+    @Test
+    public void rejectsAutomaticTargetTypesThatWouldLoseSemantics() {
+        UnsupportedOperationException timezone = assertThrows(
+                UnsupportedOperationException.class,
+                () -> mapper.toDatabaseType(
+                        Column.builder("created_at", BasicType.TIMESTAMP_TZ_TYPE)
+                                .build()));
+        assertEquals(true, timezone.getMessage().contains("TIMESTAMP WITH TIME ZONE"));
+
+        UnsupportedOperationException decimal = assertThrows(
+                UnsupportedOperationException.class,
+                () -> mapper.toDatabaseType(
+                        Column.builder("amount", new DecimalType(65, 31))
+                                .build()));
+        assertEquals(true, decimal.getMessage().contains("scale <= 30"));
     }
 
     private void assertType(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8aSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8aSinkSupportTest.java
@@ -8,7 +8,6 @@ import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.type.BasicType;
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
-import com.link.up.connector.jdbc.core.dialect.gbase.gbase8a.GBase8aDialect;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -17,7 +16,6 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -78,13 +76,17 @@ public class GBase8aSinkSupportTest {
     }
 
     @Test
-    public void existingTableSinkDoesNotGenerateAutomaticCreateTableSql() {
+    public void automaticCreateTableSqlUsesResolvedTargetDatabaseAndSafeBaseline() {
         JdbcConnectionConfig config = config("target_db", DatabaseIdentifier.GBASE8A);
-        assertNull(
-                JdbcCreateTableSqlResolver.resolve(
-                        new GBase8aDialect(config),
-                        config,
-                        table()));
+        String sql = GBase8aSinkSupport.resolveCreateTableSql(config, table());
+
+        assertEquals(
+                "CREATE TABLE `target_db`.`orders` (\n"
+                        + "    `id` BIGINT NOT NULL\n"
+                        + ");",
+                sql);
+        assertFalse(sql.contains("DISTRIBUTED"));
+        assertFalse(sql.contains("REPLICATED"));
     }
 
     private static CatalogTable table() {


### PR DESCRIPTION
## Summary

Enable safe automatic target-table creation for the GBase 8a JDBC Sink.

This PR is based directly on current `main` after #127. The user no longer needs to pre-create a GBase 8a target table when using the default `CREATE_SCHEMA_WHEN_NOT_EXIST` lifecycle: Link-Up derives a conservative target schema from the Source metadata, creates the missing table, then continues through the existing JDBC batch Sink.

## User-facing flow

```text
Source table/schema
  -> resolve GBase 8a target database/table
  -> target exists?
     -> yes: validate existing schema
     -> no: build safe CREATE TABLE DDL
            -> create target table
  -> generated INSERT
  -> JDBC batch write
```

Example:

```hocon
sink {
  type = "jdbc"
  url = "jdbc:gbase://gbase8a:5258/archive"
  driver = "com.gbase.jdbc.Driver"
  dialect = "gbase8a"
  table = "orders"
  schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
  data_save_mode = "APPEND_DATA"
}
```

The Sink JDBC URL remains the source of truth for the target database. Source database/schema metadata cannot leak into the target, and an explicit different target database still fails during preparation.

## Automatic DDL implementation

Add `GBase8aCreateTableSqlBuilder` and enable `GBase8aCatalog#createTable`.

The same builder is used for:

- the SQL executed by `GBase8aCatalog`
- the `TableDdl` preview/metadata exposed by `JdbcSinkPreparer`

This keeps reported DDL and executed DDL aligned.

## Target type contract

`GBase8aTypeMapper#toDatabaseType` now supports the safe automatic-target boundary:

- STRING with known length `<= 8191` -> `VARCHAR(length)`
- longer/unknown STRING -> `LONGTEXT`
- BOOLEAN -> `BOOLEAN`
- TINYINT -> `TINYINT`
- SMALLINT -> `SMALLINT`
- INT -> `INT`
- BIGINT -> `BIGINT`
- FLOAT -> `FLOAT`
- DOUBLE -> `DOUBLE`
- DECIMAL -> `DECIMAL(precision,scale)` with GBase bounds validated
- BYTES -> `LONGBLOB`
- DATE -> `DATE`
- TIME -> `TIME`
- TIMESTAMP -> `DATETIME`

`TIMESTAMP_TZ`, ARRAY, MAP, ROW and other types without a safe portable GBase 8a target contract fail before unsafe DDL is executed.

`TIMESTAMP` intentionally maps to `DATETIME` rather than GBase `TIMESTAMP`, avoiding the narrower TIMESTAMP range/fractional-second boundary for a generic cross-database target.

## DDL safety boundary

Automatic creation copies only the relational shape needed to receive synchronized rows:

- column name
- target data type
- NULL / NOT NULL
- primary key when the existing shared `create_primary_key` option keeps it

It deliberately does not copy:

- DEFAULT expressions
- AUTO_INCREMENT / identity behavior
- comments
- indexes
- foreign keys
- partitions
- compression
- replication policy
- distribution/hash key policy

`CREATE DATABASE`, `DROP DATABASE`, `DROP TABLE` and `ADD COLUMN` remain blocked.

## Distribution boundary

The generated SQL contains no `DISTRIBUTED BY` and no `REPLICATED` clause.

GBase 8a versions/documentation differ on the physical default chosen when the distribution clause is omitted. Link-Up therefore does not claim or guess a distribution strategy in this PR; the target GBase 8a version/database keeps ownership of its default physical behavior. Explicit distribution-key design remains a separate advanced capability.

## Save-mode behavior

- `CREATE_SCHEMA_WHEN_NOT_EXIST`
  - existing table: validate schema
  - missing table: create automatically
- `CREATE_OR_ADD_COLUMNS`
  - missing table: create automatically
  - existing table with missing columns: still fails because `ADD COLUMN` remains blocked
- `ERROR_WHEN_SCHEMA_NOT_EXIST` / `IGNORE`
  - retain existing behavior
- `RECREATE_SCHEMA`
  - existing table cannot be destructively recreated because `DROP TABLE` remains blocked

## Existing Sink behavior retained

After preparation, row writing still uses the existing shared JDBC execution path:

- parameterized `INSERT`
- configured batch size
- `PreparedStatement.addBatch()` / `executeBatch()`
- existing transaction / commit / rollback behavior
- existing savepoint retry behavior
- existing dirty-data handling
- `rewriteBatchedStatements=true` dialect default

UPSERT/MERGE and native/high-speed MPP loading remain out of scope.

## Tests

Focused tests cover:

- automatic target type mapping
- VARCHAR vs LONGTEXT boundary
- LONGBLOB mapping
- TIMESTAMP -> DATETIME
- DECIMAL target bounds
- TIMESTAMP_TZ rejection
- safe CREATE TABLE SQL generation
- NULL / NOT NULL generation
- source AUTO_INCREMENT / DEFAULT / COMMENT not copied
- optional primary-key DDL contract
- no DISTRIBUTED / REPLICATED clause
- target database normalization
- automatic DDL preview generation
- destructive DROP / ADD COLUMN / database DDL remain blocked
- existing INSERT path and UPSERT boundary remain unchanged

## Verification

- based directly on current `main` after #127
- final branch is one atomic commit
- final compare: `ahead=1`, `behind=0`
- diff is limited to 12 files: GBase 8a auto-create implementation, focused tests, Sink preparation hook and README documentation
- no vendor JDBC Maven dependency was added
- local checkout/test execution was attempted, but this execution environment still cannot resolve `github.com`, so the repository could not be cloned and the Maven suite was not executed here
- tests are added but are not claimed as executed
- a real GBase 8a environment plus the vendor JDBC driver is still required before Ready for Review to validate CREATE TABLE execution, metadata round-trip, common target types, primary-key creation options and subsequent batch INSERT end to end

## Non-goals

- CREATE/DROP DATABASE
- DROP/recreate existing tables
- runtime ADD COLUMN/schema evolution
- automatic HASH/distribution-key selection
- REPLICATED-table selection
- partition design
- source DEFAULT / identity semantics replication
- UPSERT/MERGE
- native/high-speed MPP loading
- CDC/realtime semantics