### PR TITLE
feat(gbase8s): add safe automatic target table creation

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -103,10 +103,9 @@ The shared `gbase/common` layer only carries stable product metadata and family-
 product-specific: URL parsing, identifiers, catalog behavior, type mapping, row conversion, Sink SQL and MPP behavior
 must stay in the concrete product adapter unless completed implementations prove that behavior is genuinely common.
 
-The bounded/offline implementation is staged per product. GBase 8a now supports bounded Source, JDBC Sink and safe
-automatic creation of a missing target table; native/high-speed MPP loading remains a later performance stage. GBase 8s
-currently supports bounded Source plus existing-table Sink, with automatic target creation handled separately. GBase 8c
-keeps its compatibility-sensitive runtime and DDL work separate from the other two products.
+The bounded/offline implementation is staged per product. GBase 8a and GBase 8s now support bounded Source, JDBC Sink and
+safe automatic creation of a missing target table. GBase 8a native/high-speed MPP loading remains a later performance
+stage. GBase 8c keeps its compatibility-sensitive runtime and DDL work separate from the other two products.
 
 CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths stay outside
 this family-level contract.
@@ -193,7 +192,7 @@ For large bounded reads, a positive Link-Up `fetch_size` selects the GBase JDBC 
 The vendor GBase JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official
 GBase 8a JDBC driver on the runtime classpath and configure `driver = "com.gbase.jdbc.Driver"`.
 
-### GBase 8s bounded Source + existing-table JDBC Sink
+### GBase 8s bounded Source + JDBC Sink + safe automatic target creation
 
 GBase 8s is exposed as the first-class `gbase8s` JDBC dialect and uses the native GBase 8s JDBC protocol:
 
@@ -214,7 +213,7 @@ sink {
   dialect = "gbase8s"
   schema = "gbasedbt" # target owner; defaults to username
   table = "orders"
-  schema_save_mode = "ERROR_WHEN_SCHEMA_NOT_EXIST"
+  schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
   data_save_mode = "APPEND_DATA"
 }
 ```
@@ -223,68 +222,75 @@ The database and `GBASEDBTSERVER` instance identity are connection-level concern
 database in its JDBC URL. GBase 8s reports table owner through the JDBC schema field, so Link-Up models physical tables as
 `database.owner.table` metadata while SQL inside the selected database uses `owner.table`.
 
-For Source, the normal user-facing paths are `table` and `owner.table`; a three-part `database.owner.table` path is
-accepted only when its database equals the URL database. For Sink, an implicit target keeps only the source table name and
-resolves owner from the Sink `schema` option, then the Sink username. Source database/schema/owner metadata is never reused
-implicitly. An explicit `owner.table` may choose the target owner. An explicit three-part target must repeat the database
-from the Sink URL; a different database fails during preparation instead of silently rebinding one connection.
+For Sink, the JDBC URL owns the target database. An implicit target keeps only the source table name and resolves owner
+from the Sink `schema` option, then the Sink username. Source database/schema/owner metadata is never reused implicitly.
+An explicit `owner.table` may choose the target owner, while an explicit three-part target must repeat the database from
+the Sink URL. A different database fails during preparation instead of silently rebinding one connection.
 
-`GBase8sCatalog` uses standard JDBC `DatabaseMetaData` for owner, table, column and primary-key discovery. It implements
-`WritableCatalog` only so the shared Sink save-mode lifecycle can validate existing targets and support `TRUNCATE TABLE`
-for `DROP_DATA`. Structure-changing DDL stays blocked:
+When `schema_save_mode = CREATE_SCHEMA_WHEN_NOT_EXIST` and the target table is missing, Link-Up creates the table before
+writing rows. The target database and owner themselves must already exist and the JDBC user must have CREATE permission.
+`CREATE_OR_ADD_COLUMNS` also creates a missing table, but an existing table with missing target columns still fails because
+`ADD COLUMN` remains blocked. `RECREATE_SCHEMA` cannot destructively recreate an existing target because `DROP TABLE`
+remains blocked. CREATE/DROP DATABASE is also disabled.
 
-- no CREATE/DROP DATABASE
-- no CREATE/DROP TABLE
-- no ADD COLUMN or runtime schema evolution
-- no automatic target-table creation
+Automatic DDL copies only the relational shape needed by the bounded Sink:
 
-Create the target database/owner/table before the job. `CREATE_SCHEMA_WHEN_NOT_EXIST` is safe for an existing compatible
-table but fails clearly when the table is absent. `RECREATE_SCHEMA` cannot destructively drop a target because DROP TABLE
-is rejected before recreation. `CREATE_OR_ADD_COLUMNS` may validate an already compatible target, but a missing target
-column fails instead of mutating the table.
+- column names
+- portable native GBase 8s target types
+- NULL / NOT NULL
+- source primary key only when the shared `create_primary_key` option keeps it
 
-The Sink reuses the shared JDBC writer: parameterized `INSERT`, configured batch size, `PreparedStatement.addBatch()` /
-`executeBatch()`, one task-local transaction and the existing commit/rollback, retry/savepoint and dirty-data behavior.
-The vendor `IFX_USEPUT=1` bulk-insert extension is deliberately **opt-in**, not a Link-Up default. It can improve repeated
-INSERT performance, but the vendor extension requires compatible Java/target column types and excludes opaque/complex
-types. Deployments that have verified a compatible scalar target may add `IFX_USEPUT=1` to the JDBC URL/properties.
+It deliberately does **not** copy source DEFAULT expressions, SERIAL/BIGSERIAL generation, comments, indexes, foreign
+keys, partitions or SQLMODE-specific DDL. The JDBC writer continues to insert the source value explicitly, so a source
+SERIAL/BIGSERIAL column is recreated as an ordinary integer column rather than a new target-side sequence generator.
 
-UPSERT is intentionally not advertised. Native GBase 8s `MERGE` supports a broader update/insert/delete contract than the
-generic Link-Up UPSERT abstraction, so this bounded stage does not guess conflict keys or collapse database-specific MERGE
-semantics into `write_mode=UPSERT`.
+The automatic target type contract is conservative and targets native/normal GBase 8s mode:
 
-GBase 8s JDBC defaults `DELIMIDENT=n`. In that mode double-quoted SQL identifiers are not valid, so the dialect does not
-blindly quote every table/column name. Ordinary unquoted identifiers are normalized to lowercase. If a deployment
-explicitly enables `DELIMIDENT=y` in the URL or JDBC properties, quoted `table_path` parts preserve case and SQL
-identifiers are emitted with double quotes.
-
-The read-side type boundary covers common built-ins without exposing GBase JDBC private objects:
-
+- STRING with a known length up to 8000 -> VARCHAR(length)
+- longer or unknown-length STRING -> TEXT
 - BOOLEAN -> BOOLEAN
-- SMALLINT -> SMALLINT
-- SERIAL / INTEGER / INT -> INT
-- INT8 / SERIAL8 / BIGINT / BIGSERIAL -> BIGINT
-- SMALLFLOAT / REAL -> FLOAT
-- FLOAT / DOUBLE PRECISION -> DOUBLE
-- DEC / DECIMAL / NUMERIC / MONEY -> DECIMAL when precision fits Link-Up
+- TINYINT / SMALLINT -> SMALLINT
+- INT -> INTEGER
+- BIGINT -> BIGINT
+- FLOAT -> SMALLFLOAT
+- DOUBLE -> FLOAT
+- DECIMAL -> DECIMAL(precision, scale), with target precision limited to 32
+- BYTES -> BYTE
 - DATE -> DATE
-- DATETIME -> TIMESTAMP
-- BYTE / BLOB -> BYTES
-- CHAR / VARCHAR / LVARCHAR / NCHAR / NVARCHAR / TEXT / CLOB -> STRING
-- INTERVAL -> STRING
-- unknown, opaque and extension JDBC types -> STRING
+- TIME -> DATETIME HOUR TO SECOND
+- TIMESTAMP -> DATETIME YEAR TO FRACTION(5)
 
-DECIMAL precision above Link-Up's limit falls back to STRING rather than silently truncating numeric precision. INTERVAL
-also stays STRING because the GBase 8s JDBC driver represents intervals with vendor-specific `com.gbasedbt.lang.Interval*`
-classes. Target DDL type generation remains disabled because this existing-table Sink never auto-creates GBase 8s tables.
+`TIMESTAMP_TZ`, ARRAY, MAP, ROW and other types without a safe native GBase 8s target contract fail before DDL execution.
+`TIMESTAMP WITH TIME ZONE` is not silently introduced because that behavior belongs to compatibility-mode work rather
+than the native connector stage.
 
-The Source supports bounded single-table and multi-table jobs, custom SQL and the shared safe JDBC range partition
-planner. It advertises `BEST_EFFORT` read consistency only and does not claim a coordinated point-in-time snapshot across
-independent parallel JDBC readers.
+GBase 8s also restricts large-object columns in unique/reference constraints. If an automatically copied primary key would
+map to `TEXT` or `BYTE`, Link-Up rejects the DDL before execution and asks for a bounded scalar target type or
+`create_primary_key=false` instead of returning a vendor-specific constraint error later.
 
-Still out of scope: automatic DDL, SQLMODE MySQL/Oracle compatibility expansion, CDC/realtime synchronization,
-logical-log integration, coordinated snapshots, complex ROW/COLLECTION native object modeling and runtime schema
-evolution.
+GBase 8s JDBC defaults `DELIMIDENT=n`. In that mode automatic target owner/table names and ordinary identifiers are
+normalized to lowercase, and identifiers that require quoting are rejected. If `DELIMIDENT=y` is explicitly configured,
+quoted/case-preserving owner, table and column identifiers are supported. Target routing, metadata lookup, CREATE TABLE,
+SELECT/INSERT and TRUNCATE use the same identifier rule so mixed-case Source metadata cannot create a different physical
+target than the one validated during preparation.
+
+The Sink continues to reuse the shared JDBC writer: parameterized `INSERT`, configured batch size,
+`PreparedStatement.addBatch()` / `executeBatch()`, one task-local transaction and the existing commit/rollback,
+retry/savepoint and dirty-data behavior. The vendor `IFX_USEPUT=1` bulk-insert extension remains **opt-in**, not a Link-Up
+default; deployments that have verified compatible scalar target types may enable it explicitly.
+
+UPSERT is intentionally not advertised. Native GBase 8s `MERGE` has a broader database-specific contract than the generic
+Link-Up UPSERT abstraction, so this stage does not guess conflict keys or collapse MERGE semantics into
+`write_mode=UPSERT`.
+
+The read-side type boundary remains unchanged: SERIAL/INT map to INT, INT8/SERIAL8/BIGINT/BIGSERIAL to BIGINT,
+SMALLFLOAT to FLOAT, FLOAT to DOUBLE, DATE/DATETIME to DATE/TIMESTAMP, BYTE/BLOB to BYTES, text types to STRING, and
+INTERVAL/unknown extension types stay behind the conservative STRING boundary. The Source advertises `BEST_EFFORT` read
+consistency only and does not claim a coordinated point-in-time snapshot across independent JDBC readers.
+
+Still out of scope: CREATE/DROP database, destructive table recreation, runtime ADD COLUMN/schema evolution, SQLMODE
+MySQL/Oracle compatibility expansion, CDC/realtime synchronization, logical-log integration, coordinated snapshots and
+complex ROW/COLLECTION native object modeling.
 
 The vendor JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official GBase
 8s JDBC driver on the runtime classpath and configure `driver = "com.gbasedbt.jdbc.Driver"` (or an older vendor-provided

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalog.java
@@ -33,13 +33,12 @@ import java.util.Set;
 import java.util.TreeMap;
 
 /**
- * GBase 8s Catalog for bounded/offline Source and existing-table JDBC Sink jobs.
+ * GBase 8s Catalog for bounded/offline Source, JDBC Sink and safe automatic target creation.
  *
  * <p>GBase 8s JDBC exposes database as catalog and table owner as schema. The JDBC URL binds this
- * Catalog to one database. Sink support deliberately implements {@link WritableCatalog} only so
- * the shared save-mode lifecycle can validate pre-created targets and optionally truncate their
- * data. Structure-changing DDL, cross-database rebinding and SQLMODE expansion remain outside this
- * stage.</p>
+ * Catalog to one database. The Sink may create a missing target table using a conservative native
+ * type subset, while CREATE/DROP DATABASE, DROP TABLE, ADD COLUMN, cross-database rebinding and
+ * SQLMODE expansion remain outside this stage.</p>
  */
 public final class GBase8sCatalog implements WritableCatalog {
 
@@ -75,10 +74,10 @@ public final class GBase8sCatalog implements WritableCatalog {
         this.catalogName = catalogName.trim();
         this.config = config;
         this.defaultDatabase = defaultDatabase.trim();
-        this.defaultOwner = hasText(defaultOwner) ? defaultOwner.trim() : null;
         this.delimitedIdentifiers = GBase8sJdbcUrl.delimitedIdentifiersEnabled(
                 config.getUrl(),
                 config.getProperties());
+        this.defaultOwner = normalizeIdentifier(defaultOwner);
     }
 
     @Override
@@ -155,7 +154,7 @@ public final class GBase8sCatalog implements WritableCatalog {
         checkOpened();
         requireCurrentDatabase(databaseName);
         String owner = hasText(schemaName)
-                ? schemaName.trim()
+                ? normalizeIdentifier(schemaName)
                 : defaultOwner;
 
         try (Connection connection = newConnection();
@@ -243,12 +242,43 @@ public final class GBase8sCatalog implements WritableCatalog {
         throw unsupportedSchemaDdl("drop database");
     }
 
+    /** Creates only a missing table inside the database selected by the JDBC URL. */
     @Override
     public void createTable(
             CatalogTable table,
             boolean ignoreIfExists)
             throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
-        throw unsupportedSchemaDdl("create table");
+        checkOpened();
+        if (table == null) {
+            throw new IllegalArgumentException("table must not be null");
+        }
+
+        TablePath normalized = normalizeCreateTablePath(table.getTablePath());
+        if (tableExists(normalized)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new TableAlreadyExistsException(catalogName, normalized);
+        }
+
+        CatalogTable ddlTable = table.getTablePath().equals(normalized)
+                ? table
+                : table.withPath(normalized);
+        String sql = new GBase8sCreateTableSqlBuilder(
+                normalized,
+                ddlTable,
+                typeMapper,
+                delimitedIdentifiers)
+                .build();
+
+        try (Connection connection = newConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "自动创建 GBase 8s 目标表失败，table=" + normalized,
+                    e);
+        }
     }
 
     @Override
@@ -335,6 +365,23 @@ public final class GBase8sCatalog implements WritableCatalog {
         }
     }
 
+    private TablePath normalizeCreateTablePath(TablePath tablePath) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        requireCurrentDatabase(tablePath.getDatabaseName());
+        if (!hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("table name must not be empty");
+        }
+        String owner = hasText(tablePath.getSchemaName())
+                ? normalizeIdentifier(tablePath.getSchemaName())
+                : defaultOwner;
+        return TablePath.of(
+                defaultDatabase,
+                owner,
+                normalizeIdentifier(tablePath.getTableName()));
+    }
+
     private TablePath normalizeTablePath(
             Connection connection,
             TablePath tablePath,
@@ -348,9 +395,9 @@ public final class GBase8sCatalog implements WritableCatalog {
         }
 
         String owner = hasText(tablePath.getSchemaName())
-                ? tablePath.getSchemaName().trim()
+                ? normalizeIdentifier(tablePath.getSchemaName())
                 : defaultOwner;
-        String tableName = tablePath.getTableName().trim();
+        String tableName = normalizeIdentifier(tablePath.getTableName());
 
         try (ResultSet resultSet = connection.getMetaData().getTables(
                 defaultDatabase,
@@ -364,13 +411,13 @@ public final class GBase8sCatalog implements WritableCatalog {
                     continue;
                 }
                 String candidate = resultSet.getString("TABLE_NAME");
-                if (!tableName.equals(candidate)) {
+                if (!identifierEquals(tableName, candidate)) {
                     continue;
                 }
                 String candidateOwner = resultSet.getString("TABLE_SCHEM");
                 if (hasText(owner)
                         && hasText(candidateOwner)
-                        && !owner.equals(candidateOwner.trim())) {
+                        && !identifierEquals(owner, candidateOwner.trim())) {
                     continue;
                 }
                 matches++;
@@ -400,7 +447,7 @@ public final class GBase8sCatalog implements WritableCatalog {
         if (hasText(databaseName)
                 && !defaultDatabase.equalsIgnoreCase(databaseName.trim())) {
             throw new IllegalArgumentException(
-                    "GBase 8s existing-table JDBC stage 不支持跨 database table_path；当前 JDBC database="
+                    "GBase 8s JDBC stage 不支持跨 database table_path；当前 JDBC database="
                             + defaultDatabase
                             + "，请求 database="
                             + databaseName);
@@ -430,6 +477,25 @@ public final class GBase8sCatalog implements WritableCatalog {
         return value.toLowerCase(Locale.ROOT);
     }
 
+    private String normalizeIdentifier(String value) {
+        if (!hasText(value)) {
+            return null;
+        }
+        String normalized = value.trim();
+        return delimitedIdentifiers
+                ? normalized
+                : normalized.toLowerCase(Locale.ROOT);
+    }
+
+    private boolean identifierEquals(String expected, String actual) {
+        if (expected == null || actual == null) {
+            return expected == null && actual == null;
+        }
+        return delimitedIdentifiers
+                ? expected.equals(actual)
+                : expected.equalsIgnoreCase(actual);
+    }
+
     private Connection newConnection() throws SQLException {
         return DriverManager.getConnection(config.getUrl(), config.toConnectionProperties());
     }
@@ -453,9 +519,9 @@ public final class GBase8sCatalog implements WritableCatalog {
 
     private static CatalogException unsupportedSchemaDdl(String operation) {
         return new CatalogException(
-                "GBase 8s existing-table JDBC Sink does not support "
+                "GBase 8s automatic-target JDBC Sink does not support "
                         + operation
-                        + "; pre-create the target database/owner/table and keep schema mutation outside this stage");
+                        + "; only safe creation of a missing target table is enabled in this stage");
     }
 
     private static boolean isBaseTable(String tableType) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCreateTableSqlBuilder.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCreateTableSqlBuilder.java
@@ -1,0 +1,171 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8s;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sTypeMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+/**
+ * Builds the conservative CREATE TABLE statement used by GBase 8s automatic target creation.
+ *
+ * <p>The builder copies only column names, portable target types, nullability and an optional
+ * primary key. Source defaults, SERIAL/BIGSERIAL generation, comments, indexes, partitions and
+ * compatibility-mode DDL are intentionally not copied.</p>
+ */
+public final class GBase8sCreateTableSqlBuilder {
+
+    private final TablePath tablePath;
+    private final CatalogTable catalogTable;
+    private final GBase8sTypeMapper typeMapper;
+    private final boolean delimitedIdentifiers;
+
+    public GBase8sCreateTableSqlBuilder(
+            TablePath tablePath,
+            CatalogTable catalogTable,
+            GBase8sTypeMapper typeMapper,
+            boolean delimitedIdentifiers) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (catalogTable == null) {
+            throw new IllegalArgumentException("catalogTable must not be null");
+        }
+        if (typeMapper == null) {
+            throw new IllegalArgumentException("typeMapper must not be null");
+        }
+        this.tablePath = tablePath;
+        this.catalogTable = catalogTable;
+        this.typeMapper = typeMapper;
+        this.delimitedIdentifiers = delimitedIdentifiers;
+    }
+
+    public String build() {
+        TableSchema schema = catalogTable.getTableSchema();
+        if (schema == null || schema.getColumns().isEmpty()) {
+            throw new IllegalArgumentException("GBase 8s CREATE TABLE requires at least one column");
+        }
+
+        List<String> definitions = new ArrayList<String>();
+        for (Column column : schema.getColumns()) {
+            definitions.add(buildColumnDefinition(column));
+        }
+
+        PrimaryKey primaryKey = schema.getPrimaryKey();
+        if (primaryKey != null) {
+            definitions.add(buildPrimaryKey(primaryKey, schema));
+        }
+
+        return "CREATE TABLE "
+                + quoteTable(tablePath)
+                + " (\n    "
+                + String.join(",\n    ", definitions)
+                + "\n);";
+    }
+
+    public String buildColumnDefinition(Column column) {
+        if (column == null) {
+            throw new IllegalArgumentException("column must not be null");
+        }
+        List<String> parts = new ArrayList<String>();
+        parts.add(quoteIdentifier(column.getName()));
+        parts.add(typeMapper.toDatabaseType(column));
+        parts.add(column.isNullable() ? "NULL" : "NOT NULL");
+        return String.join(" ", parts);
+    }
+
+    private String buildPrimaryKey(
+            PrimaryKey primaryKey,
+            TableSchema schema) {
+        for (String columnName : primaryKey.getColumnNames()) {
+            Column column = findColumn(schema, columnName);
+            if (column == null) {
+                throw new IllegalArgumentException(
+                        "GBase 8s primary key column is missing from table schema: " + columnName);
+            }
+            String targetType = typeMapper.toDatabaseType(column);
+            if ("TEXT".equalsIgnoreCase(targetType)
+                    || "BYTE".equalsIgnoreCase(targetType)) {
+                throw new UnsupportedOperationException(
+                        "GBase 8s automatic target primary key cannot use "
+                                + targetType
+                                + " column '"
+                                + columnName
+                                + "'; configure a bounded scalar target type or set create_primary_key=false");
+            }
+        }
+
+        String columns = primaryKey.getColumnNames().stream()
+                .map(this::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        return "PRIMARY KEY (" + columns + ")";
+    }
+
+    private static Column findColumn(
+            TableSchema schema,
+            String columnName) {
+        for (Column column : schema.getColumns()) {
+            if (column.getName().equalsIgnoreCase(columnName)) {
+                return column;
+            }
+        }
+        return null;
+    }
+
+    private String quoteTable(TablePath path) {
+        if (!hasText(path.getTableName())) {
+            throw new IllegalArgumentException("GBase 8s target table name must not be empty");
+        }
+        String owner = path.getSchemaName();
+        return hasText(owner)
+                ? quoteIdentifier(owner) + "." + quoteIdentifier(path.getTableName())
+                : quoteIdentifier(path.getTableName());
+    }
+
+    private String quoteIdentifier(String identifier) {
+        if (!hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        String value = identifier.trim();
+        if (delimitedIdentifiers) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        if (!isSimpleIdentifier(value)) {
+            throw new IllegalArgumentException(
+                    "GBase 8s JDBC 默认 DELIMIDENT=n，不支持需要双引号的标识符："
+                            + identifier
+                            + "；如确需大小写敏感/特殊标识符，请在 JDBC URL/properties 设置 DELIMIDENT=y");
+        }
+        return value.toLowerCase(Locale.ROOT);
+    }
+
+    private static boolean isSimpleIdentifier(String value) {
+        if (!hasText(value)) {
+            return false;
+        }
+        char first = value.charAt(0);
+        if (!(Character.isLetter(first) || first == '_')) {
+            return false;
+        }
+        for (int i = 1; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (!(Character.isLetterOrDigit(current)
+                    || current == '_'
+                    || current == '$'
+                    || current == '#')) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialect.java
@@ -17,8 +17,8 @@ import java.util.Locale;
 /**
  * GBase 8s bounded/offline JDBC dialect.
  *
- * <p>The current stages cover bounded Source plus an existing-table INSERT/batch Sink on the
- * native GBase 8s JDBC protocol and normal SQL mode. Automatic DDL, MERGE/UPSERT abstraction,
+ * <p>The current native/normal-mode stage covers bounded Source, JDBC INSERT/batch Sink and safe
+ * creation of a missing target table. Destructive/evolution DDL, MERGE/UPSERT abstraction,
  * SQLMODE compatibility expansion, CDC and realtime semantics remain separate stages.</p>
  */
 public final class GBase8sDialect implements JdbcDialect {
@@ -236,7 +236,7 @@ public final class GBase8sDialect implements JdbcDialect {
         if (!JdbcDialect.hasText(requestedDatabase)
                 || !databaseName.equalsIgnoreCase(requestedDatabase.trim())) {
             throw new IllegalArgumentException(
-                    "GBase 8s existing-table JDBC stage 不支持跨 database table_path；当前 JDBC database="
+                    "GBase 8s JDBC stage 不支持跨 database table_path；当前 JDBC database="
                             + databaseName
                             + "，请求 database="
                             + requestedDatabase);

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapper.java
@@ -15,18 +15,24 @@ import java.sql.Types;
 import java.util.Locale;
 
 /**
- * GBase 8s read-side type mapper.
+ * GBase 8s read-side and safe automatic-target type mapper.
  *
- * <p>The mapper covers stable built-in scalar and large-object types. INTERVAL and unknown or
- * extension types use a STRING boundary instead of leaking driver-specific Java objects into
- * Link-Up. Target DDL type generation remains disabled because the current Sink writes only to
- * pre-created tables.</p>
+ * <p>The read path covers stable built-in scalar and large-object types. INTERVAL and unknown or
+ * extension types keep the existing STRING boundary instead of leaking driver-specific Java
+ * objects into Link-Up. Automatic target creation deliberately exposes only a conservative native
+ * GBase 8s type subset and does not assume Oracle/MySQL SQLMODE compatibility.</p>
  */
 public final class GBase8sTypeMapper implements JdbcTypeMapper {
 
     private static final int MAX_DECIMAL_PRECISION = 38;
     private static final int DEFAULT_DECIMAL_PRECISION = 38;
     private static final int DEFAULT_DECIMAL_SCALE = 18;
+
+    /** Conservative V8.8 target limits used by automatic table creation. */
+    private static final int TARGET_MAX_DECIMAL_PRECISION = 32;
+    private static final int TARGET_DEFAULT_DECIMAL_PRECISION = 32;
+    private static final int TARGET_DEFAULT_DECIMAL_SCALE = 18;
+    private static final long SAFE_VARCHAR_LENGTH = 8000L;
 
     @Override
     public Column map(ResultSetMetaData metadata, int columnIndex) throws SQLException {
@@ -68,10 +74,106 @@ public final class GBase8sTypeMapper implements JdbcTypeMapper {
         return builder.build();
     }
 
+    /**
+     * Maps a Link-Up column to the portable native GBase 8s type used for automatic target creation.
+     *
+     * <p>Defaults, SERIAL/BIGSERIAL generation, comments and compatibility-mode type aliases are
+     * intentionally not copied here.</p>
+     */
     @Override
     public String toDatabaseType(Column column) {
-        throw new UnsupportedOperationException(
-                "GBase 8s existing-table JDBC Sink does not generate target DDL types");
+        if (column == null || column.getDataType() == null) {
+            throw new IllegalArgumentException("column/dataType must not be null");
+        }
+
+        SqlType type = column.getDataType().getSqlType();
+        switch (type) {
+            case STRING:
+                return stringTargetType(column);
+            case BOOLEAN:
+                return "BOOLEAN";
+            case TINYINT:
+            case SMALLINT:
+                return "SMALLINT";
+            case INT:
+                return "INTEGER";
+            case BIGINT:
+                return "BIGINT";
+            case FLOAT:
+                return "SMALLFLOAT";
+            case DOUBLE:
+                return "FLOAT";
+            case DECIMAL:
+                return decimalTargetType(column);
+            case BYTES:
+                return "BYTE";
+            case DATE:
+                return "DATE";
+            case TIME:
+                return "DATETIME HOUR TO SECOND";
+            case TIMESTAMP:
+                return "DATETIME YEAR TO FRACTION(5)";
+            case TIMESTAMP_TZ:
+                throw unsupportedTargetType(
+                        column,
+                        "TIMESTAMP WITH TIME ZONE is compatibility-mode specific and is not enabled in the native GBase 8s stage");
+            case ARRAY:
+            case MAP:
+            case ROW:
+            case NULL:
+            default:
+                throw unsupportedTargetType(
+                        column,
+                        "automatic target creation only supports scalar relational types");
+        }
+    }
+
+    private static String stringTargetType(Column column) {
+        Long length = column.getLength();
+        if (length != null && length > 0 && length <= SAFE_VARCHAR_LENGTH) {
+            return "VARCHAR(" + length + ")";
+        }
+        return "TEXT";
+    }
+
+    private static String decimalTargetType(Column column) {
+        int precision = TARGET_DEFAULT_DECIMAL_PRECISION;
+        int scale = TARGET_DEFAULT_DECIMAL_SCALE;
+
+        if (column.getDataType() instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) column.getDataType();
+            precision = decimal.getPrecision();
+            scale = decimal.getScale();
+        } else {
+            if (column.getPrecision() != null && column.getPrecision() > 0) {
+                precision = column.getPrecision();
+            }
+            if (column.getScale() != null && column.getScale() >= 0) {
+                scale = column.getScale();
+            }
+        }
+
+        if (precision <= 0
+                || precision > TARGET_MAX_DECIMAL_PRECISION
+                || scale < 0
+                || scale > precision) {
+            throw unsupportedTargetType(
+                    column,
+                    "native GBase 8s automatic DECIMAL target requires precision <= 32 and scale <= precision");
+        }
+        return "DECIMAL(" + precision + "," + scale + ")";
+    }
+
+    private static UnsupportedOperationException unsupportedTargetType(
+            Column column,
+            String reason) {
+        return new UnsupportedOperationException(
+                "GBase 8s cannot auto-create target column '"
+                        + column.getName()
+                        + "' from Flux type "
+                        + column.getDataType().getSqlType()
+                        + ": "
+                        + reason);
     }
 
     private static FluxDataType<?> mapType(

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8sSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8sSinkSupport.java
@@ -1,11 +1,16 @@
 package com.link.up.connector.jdbc.sink;
 
+import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.gbase.gbase8s.GBase8sCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
 import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sJdbcUrl;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sTypeMapper;
 
-/** Target-path normalization and validation for the GBase 8s existing-table JDBC Sink. */
+import java.util.Locale;
+
+/** Target-path and automatic-DDL support for the GBase 8s JDBC Sink. */
 final class GBase8sSinkSupport {
 
     private GBase8sSinkSupport() {
@@ -34,7 +39,7 @@ final class GBase8sSinkSupport {
         return TablePath.of(
                 requireUrlDatabase(config),
                 defaultOwner(config),
-                requireTableName(sourcePath));
+                requireTableName(config, sourcePath));
     }
 
     /**
@@ -49,12 +54,12 @@ final class GBase8sSinkSupport {
         }
         validateExplicitTargetPath(config, targetPath);
         String owner = hasText(targetPath.getSchemaName())
-                ? targetPath.getSchemaName().trim()
+                ? normalizeIdentifier(config, targetPath.getSchemaName())
                 : defaultOwner(config);
         return TablePath.of(
                 requireUrlDatabase(config),
                 owner,
-                requireTableName(targetPath));
+                requireTableName(config, targetPath));
     }
 
     /** Normalizes an already prepared target while preserving its selected owner. */
@@ -70,9 +75,9 @@ final class GBase8sSinkSupport {
             throw crossDatabase(database, tablePath.getDatabaseName());
         }
         String owner = hasText(tablePath.getSchemaName())
-                ? tablePath.getSchemaName().trim()
+                ? normalizeIdentifier(config, tablePath.getSchemaName())
                 : defaultOwner(config);
-        return TablePath.of(database, owner, requireTableName(tablePath));
+        return TablePath.of(database, owner, requireTableName(config, tablePath));
     }
 
     static void validateExplicitTargetPath(
@@ -88,12 +93,35 @@ final class GBase8sSinkSupport {
         }
     }
 
+    /** Builds the same safe CREATE TABLE SQL used by {@code GBase8sCatalog#createTable}. */
+    static String resolveCreateTableSql(
+            JdbcConnectionConfig config,
+            CatalogTable table) {
+        if (config == null || table == null) {
+            return null;
+        }
+
+        TablePath targetPath = resolvePreparedTargetPath(config, table.getTablePath());
+        CatalogTable ddlTable = table.getTablePath().equals(targetPath)
+                ? table
+                : table.withPath(targetPath);
+        boolean delimitedIdentifiers = GBase8sJdbcUrl.delimitedIdentifiersEnabled(
+                config.getUrl(),
+                config.getProperties());
+        return new GBase8sCreateTableSqlBuilder(
+                targetPath,
+                ddlTable,
+                new GBase8sTypeMapper(),
+                delimitedIdentifiers)
+                .build();
+    }
+
     private static String defaultOwner(JdbcConnectionConfig config) {
         if (hasText(config.getSchema())) {
-            return config.getSchema().trim();
+            return normalizeIdentifier(config, config.getSchema());
         }
         return hasText(config.getUsername())
-                ? config.getUsername().trim()
+                ? normalizeIdentifier(config, config.getUsername())
                 : null;
     }
 
@@ -105,11 +133,28 @@ final class GBase8sSinkSupport {
         return database.trim();
     }
 
-    private static String requireTableName(TablePath tablePath) {
+    private static String requireTableName(
+            JdbcConnectionConfig config,
+            TablePath tablePath) {
         if (!hasText(tablePath.getTableName())) {
             throw new IllegalArgumentException("GBase 8s target table name must not be empty");
         }
-        return tablePath.getTableName().trim();
+        return normalizeIdentifier(config, tablePath.getTableName());
+    }
+
+    private static String normalizeIdentifier(
+            JdbcConnectionConfig config,
+            String value) {
+        String normalized = value == null ? null : value.trim();
+        if (!hasText(normalized)) {
+            return normalized;
+        }
+        if (GBase8sJdbcUrl.delimitedIdentifiersEnabled(
+                config.getUrl(),
+                config.getProperties())) {
+            return normalized;
+        }
+        return normalized.toLowerCase(Locale.ROOT);
     }
 
     private static IllegalArgumentException crossDatabase(

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -205,7 +205,8 @@ final class JdbcSinkPreparer implements SinkPreparer {
                     config.getConnectionConfig(), table);
         }
         if (GBase8sSinkSupport.accepts(config.getConnectionConfig())) {
-            return null;
+            return GBase8sSinkSupport.resolveCreateTableSql(
+                    config.getConnectionConfig(), table);
         }
         return JdbcCreateTableSqlResolver.resolve(
                 dialect,

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCatalogTest.java
@@ -19,28 +19,29 @@ import static org.junit.Assert.assertTrue;
 public class GBase8sCatalogTest {
 
     @Test
-    public void existingTableSinkCatalogStaysBoundToOneDatabase() {
-        GBase8sCatalog catalog = new GBase8sCatalog(
-                "gbase8s",
-                config(),
-                "testdb",
-                "gbasedbt");
+    public void sinkCatalogStaysBoundToOneDatabase() {
+        GBase8sCatalog catalog = catalog();
 
         assertEquals("testdb", catalog.getDefaultDatabase().get());
         assertTrue(catalog instanceof WritableCatalog);
     }
 
     @Test
-    public void existingTableSinkRejectsStructureChangingDdl() {
-        GBase8sCatalog catalog = new GBase8sCatalog(
-                "gbase8s",
-                config(),
-                "testdb",
-                "gbasedbt");
+    public void automaticCreateTableIsEnabledInsteadOfRejectedAsUnsupportedDdl() {
+        GBase8sCatalog catalog = catalog();
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> catalog.createTable(table(), false));
+        assertTrue(error.getMessage().contains("Catalog 尚未打开"));
+    }
+
+    @Test
+    public void destructiveAndEvolutionDdlRemainBlocked() {
+        GBase8sCatalog catalog = catalog();
 
         assertBlocked(() -> catalog.createDatabase("archive", false), "create database");
         assertBlocked(() -> catalog.dropDatabase("archive", false), "drop database");
-        assertBlocked(() -> catalog.createTable(table(), false), "create table");
         assertBlocked(
                 () -> catalog.addColumn(
                         TablePath.of("testdb", "gbasedbt", "orders"),
@@ -70,6 +71,14 @@ public class GBase8sCatalogTest {
                         "gbasedbt"));
     }
 
+    private static GBase8sCatalog catalog() {
+        return new GBase8sCatalog(
+                "gbase8s",
+                config(),
+                "testdb",
+                "gbasedbt");
+    }
+
     private static CatalogTable table() {
         TableSchema schema = TableSchema.builder()
                 .columns(Collections.singletonList(
@@ -88,7 +97,7 @@ public class GBase8sCatalogTest {
             String operationName) {
         CatalogException error = assertThrows(CatalogException.class, operation::run);
         assertTrue(error.getMessage().contains(operationName));
-        assertTrue(error.getMessage().contains("pre-create"));
+        assertTrue(error.getMessage().contains("only safe creation"));
     }
 
     private static JdbcCatalogConfig config() {

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCreateTableSqlBuilderTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8s/GBase8sCreateTableSqlBuilderTest.java
@@ -1,0 +1,143 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8s;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sTypeMapper;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8sCreateTableSqlBuilderTest {
+
+    @Test
+    public void buildsConservativeNativeCreateTableSql() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("id", BasicType.LONG_TYPE)
+                                .nullable(false)
+                                .autoIncrement(true)
+                                .defaultValue(1)
+                                .comment("ignored")
+                                .build(),
+                        Column.builder("name", BasicType.STRING_TYPE)
+                                .length(128L)
+                                .nullable(true)
+                                .defaultValue("anonymous")
+                                .build(),
+                        Column.builder("amount", new DecimalType(20, 4))
+                                .nullable(false)
+                                .build(),
+                        Column.builder("payload", BasicType.BYTES_TYPE)
+                                .nullable(true)
+                                .build(),
+                        Column.builder("created_at", BasicType.TIMESTAMP_TYPE)
+                                .nullable(false)
+                                .build()))
+                .primaryKey(PrimaryKey.of(Arrays.asList("id")))
+                .build();
+        CatalogTable table = CatalogTable.builder(
+                        TablePath.of("targetdb", "gbasedbt", "orders"),
+                        schema)
+                .comment("ignored table comment")
+                .build();
+
+        String sql = new GBase8sCreateTableSqlBuilder(
+                table.getTablePath(),
+                table,
+                new GBase8sTypeMapper(),
+                false)
+                .build();
+
+        assertTrue(sql.startsWith("CREATE TABLE gbasedbt.orders ("));
+        assertTrue(sql.contains("id BIGINT NOT NULL"));
+        assertTrue(sql.contains("name VARCHAR(128) NULL"));
+        assertTrue(sql.contains("amount DECIMAL(20,4) NOT NULL"));
+        assertTrue(sql.contains("payload BYTE NULL"));
+        assertTrue(sql.contains("created_at DATETIME YEAR TO FRACTION(5) NOT NULL"));
+        assertTrue(sql.contains("PRIMARY KEY (id)"));
+        assertFalse(sql.contains("SERIAL"));
+        assertFalse(sql.contains("DEFAULT"));
+        assertFalse(sql.contains("COMMENT"));
+    }
+
+    @Test
+    public void delimidentControlsQuotedCasePreservingIdentifiers() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("OrderId", BasicType.INT_TYPE)
+                                .nullable(false)
+                                .build()))
+                .build();
+        CatalogTable table = CatalogTable.builder(
+                        TablePath.of("targetdb", "MixedOwner", "Orders"),
+                        schema)
+                .build();
+
+        String sql = new GBase8sCreateTableSqlBuilder(
+                table.getTablePath(),
+                table,
+                new GBase8sTypeMapper(),
+                true)
+                .build();
+
+        assertTrue(sql.contains("CREATE TABLE \"MixedOwner\".\"Orders\""));
+        assertTrue(sql.contains("\"OrderId\" INTEGER NOT NULL"));
+    }
+
+    @Test
+    public void defaultModeRejectsIdentifiersThatNeedDelimident() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("order-id", BasicType.INT_TYPE).build()))
+                .build();
+        CatalogTable table = CatalogTable.builder(
+                        TablePath.of("targetdb", "gbasedbt", "orders"),
+                        schema)
+                .build();
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> new GBase8sCreateTableSqlBuilder(
+                        table.getTablePath(),
+                        table,
+                        new GBase8sTypeMapper(),
+                        false)
+                        .build());
+    }
+
+    @Test
+    public void lobPrimaryKeyFailsBeforeExecutingUnsafeDdl() {
+        TableSchema schema = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("external_id", BasicType.STRING_TYPE)
+                                .nullable(false)
+                                .build()))
+                .primaryKey(PrimaryKey.of(Arrays.asList("external_id")))
+                .build();
+        CatalogTable table = CatalogTable.builder(
+                        TablePath.of("targetdb", "gbasedbt", "orders"),
+                        schema)
+                .build();
+
+        UnsupportedOperationException error = assertThrows(
+                UnsupportedOperationException.class,
+                () -> new GBase8sCreateTableSqlBuilder(
+                        table.getTablePath(),
+                        table,
+                        new GBase8sTypeMapper(),
+                        false)
+                        .build());
+
+        assertTrue(error.getMessage().contains("create_primary_key=false"));
+        assertTrue(error.getMessage().contains("TEXT"));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sDialectTest.java
@@ -125,7 +125,7 @@ public class GBase8sDialectTest {
     }
 
     @Test
-    public void existingTableSinkUsesInsertAndStillRejectsUpsertAndDdlTypes() {
+    public void sinkUsesInsertSupportsAutomaticDdlTypesAndStillRejectsUpsert() {
         GBase8sDialect dialect = dialect(null, null);
         Catalog catalog = dialect.createCatalog(config(baseUrl(), null, null, null));
         assertTrue(catalog instanceof WritableCatalog);
@@ -139,10 +139,10 @@ public class GBase8sDialectTest {
                 Arrays.asList("id", "name"),
                 Collections.singletonList("id")).isPresent());
 
-        Column column = Column.builder("name", BasicType.STRING_TYPE).build();
-        assertThrows(
-                UnsupportedOperationException.class,
-                () -> dialect.typeMapper().toDatabaseType(column));
+        Column column = Column.builder("name", BasicType.STRING_TYPE)
+                .length(128L)
+                .build();
+        assertEquals("VARCHAR(128)", dialect.typeMapper().toDatabaseType(column));
     }
 
     @Test

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8s/GBase8sTypeMapperTest.java
@@ -1,6 +1,8 @@
 package com.link.up.connector.jdbc.core.dialect.gbase.gbase8s;
 
 import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
 import com.link.up.api.table.type.SqlType;
 import org.junit.Test;
 
@@ -9,6 +11,7 @@ import java.sql.ResultSetMetaData;
 import java.sql.Types;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class GBase8sTypeMapperTest {
@@ -80,6 +83,61 @@ public class GBase8sTypeMapperTest {
                 SqlType.STRING,
                 map("SOME_OPAQUE_TYPE", Types.OTHER, 0, 0)
                         .getDataType().getSqlType());
+    }
+
+    @Test
+    public void mapsPortableAutomaticTargetTypes() {
+        assertEquals(
+                "VARCHAR(8000)",
+                mapper.toDatabaseType(
+                        Column.builder("name", BasicType.STRING_TYPE)
+                                .length(8000L)
+                                .build()));
+        assertEquals(
+                "TEXT",
+                mapper.toDatabaseType(
+                        Column.builder("name", BasicType.STRING_TYPE)
+                                .length(8001L)
+                                .build()));
+        assertEquals(
+                "TEXT",
+                mapper.toDatabaseType(Column.builder("name", BasicType.STRING_TYPE).build()));
+
+        assertEquals("BOOLEAN", target(BasicType.BOOLEAN_TYPE));
+        assertEquals("SMALLINT", target(BasicType.BYTE_TYPE));
+        assertEquals("SMALLINT", target(BasicType.SHORT_TYPE));
+        assertEquals("INTEGER", target(BasicType.INT_TYPE));
+        assertEquals("BIGINT", target(BasicType.LONG_TYPE));
+        assertEquals("SMALLFLOAT", target(BasicType.FLOAT_TYPE));
+        assertEquals("FLOAT", target(BasicType.DOUBLE_TYPE));
+        assertEquals("BYTE", target(BasicType.BYTES_TYPE));
+        assertEquals("DATE", target(BasicType.DATE_TYPE));
+        assertEquals("DATETIME HOUR TO SECOND", target(BasicType.TIME_TYPE));
+        assertEquals("DATETIME YEAR TO FRACTION(5)", target(BasicType.TIMESTAMP_TYPE));
+        assertEquals(
+                "DECIMAL(20,4)",
+                mapper.toDatabaseType(
+                        Column.builder("amount", new DecimalType(20, 4)).build()));
+    }
+
+    @Test
+    public void rejectsUnsafeAutomaticTargetTypesAndPrecision() {
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> mapper.toDatabaseType(
+                        Column.builder("amount", new DecimalType(33, 4)).build()));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> mapper.toDatabaseType(
+                        Column.builder("event_time", BasicType.TIMESTAMP_TZ_TYPE).build()));
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> mapper.toDatabaseType(
+                        Column.builder("unknown", BasicType.NULL_TYPE).build()));
+    }
+
+    private String target(com.link.up.api.table.type.FluxDataType<?> type) {
+        return mapper.toDatabaseType(Column.builder("value", type).build());
     }
 
     private Column map(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8sSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8sSinkSupportTest.java
@@ -8,7 +8,6 @@ import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.type.BasicType;
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
-import com.link.up.connector.jdbc.core.dialect.gbase.gbase8s.GBase8sDialect;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -17,7 +16,6 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -32,6 +30,37 @@ public class GBase8sSinkSupportTest {
         assertEquals(
                 TablePath.of("targetdb", "sinkowner", "orders"),
                 target);
+    }
+
+    @Test
+    public void defaultModeNormalizesImplicitTargetIdentifiersToLowercase() {
+        TablePath target = GBase8sSinkSupport.resolveImplicitTargetPath(
+                config("targetdb", "SinkOwner", DatabaseIdentifier.GBASE8S),
+                TablePath.of("SOURCE_DB", "PUBLIC", "Orders"));
+
+        assertEquals(
+                TablePath.of("targetdb", "sinkowner", "orders"),
+                target);
+    }
+
+    @Test
+    public void delimidentModePreservesExplicitTargetCase() {
+        JdbcConnectionConfig config = delimitedConfig(
+                "targetdb",
+                "DefaultOwner",
+                DatabaseIdentifier.GBASE8S);
+        TablePath target = GBase8sSinkSupport.resolveExplicitTargetPath(
+                config,
+                TablePath.of(null, "MixedOwner", "Orders"));
+
+        assertEquals(
+                TablePath.of("targetdb", "MixedOwner", "Orders"),
+                target);
+
+        String sql = GBase8sSinkSupport.resolveCreateTableSql(
+                config,
+                table().withPath(target));
+        assertTrue(sql.startsWith("CREATE TABLE \"MixedOwner\".\"Orders\" ("));
     }
 
     @Test
@@ -88,17 +117,36 @@ public class GBase8sSinkSupportTest {
     }
 
     @Test
-    public void existingTableSinkDoesNotGenerateAutomaticCreateTableSql() {
+    public void automaticCreateTableSqlUsesPreparedTargetOwnerAndTypes() {
         JdbcConnectionConfig config = config(
                 "targetdb",
                 "sinkowner",
                 DatabaseIdentifier.GBASE8S);
+        TablePath targetPath = GBase8sSinkSupport.resolveImplicitTargetPath(
+                config,
+                table().getTablePath());
+        CatalogTable target = table().withPath(targetPath);
 
-        assertNull(
-                JdbcCreateTableSqlResolver.resolve(
-                        new GBase8sDialect(config),
-                        config,
-                        table()));
+        String sql = GBase8sSinkSupport.resolveCreateTableSql(config, target);
+
+        assertTrue(sql.startsWith("CREATE TABLE sinkowner.orders ("));
+        assertTrue(sql.contains("id INTEGER NOT NULL"));
+        assertFalse(sql.contains("source_db"));
+        assertFalse(sql.contains("public.orders"));
+    }
+
+    @Test
+    public void automaticDdlPreviewRejectsCrossDatabasePreparedTarget() {
+        JdbcConnectionConfig config = config(
+                "targetdb",
+                "sinkowner",
+                DatabaseIdentifier.GBASE8S);
+        CatalogTable target = table().withPath(
+                TablePath.of("otherdb", "sinkowner", "orders"));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GBase8sSinkSupport.resolveCreateTableSql(config, target));
     }
 
     private static CatalogTable table() {
@@ -119,12 +167,28 @@ public class GBase8sSinkSupportTest {
             String database,
             String schema,
             String dialect) {
+        return config(database, schema, dialect, false);
+    }
+
+    private static JdbcConnectionConfig delimitedConfig(
+            String database,
+            String schema,
+            String dialect) {
+        return config(database, schema, dialect, true);
+    }
+
+    private static JdbcConnectionConfig config(
+            String database,
+            String schema,
+            String dialect,
+            boolean delimident) {
         Map<String, Object> values = new LinkedHashMap<String, Object>();
         values.put(
                 "url",
                 "jdbc:gbasedbt-sqli://127.0.0.1:9088/"
                         + database
-                        + ":GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10");
+                        + ":GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10"
+                        + (delimident ? ";DELIMIDENT=y" : ""));
         values.put("driver", "com.gbasedbt.jdbc.Driver");
         values.put("username", "gbasedbt");
         if (schema != null) {


### PR DESCRIPTION
## Summary

Enable safe automatic target-table creation for the native/normal-mode GBase 8s JDBC Sink.

This PR is based directly on current `main` after #128. With the default `CREATE_SCHEMA_WHEN_NOT_EXIST` save mode, users no longer need to pre-create the GBase 8s target table: Link-Up derives a conservative target schema from Source metadata, creates the missing table in the Sink URL database/target owner, then continues through the existing JDBC INSERT/batch writer.

## User-facing flow

```text
Source table/schema
  -> resolve Sink database + owner + table
  -> normalize identifiers for DELIMIDENT mode
  -> target exists?
     -> yes: validate existing schema
     -> no: build safe CREATE TABLE DDL
            -> create target table
  -> generated INSERT
  -> JDBC batch write
```

Example:

```hocon
sink {
  type = "jdbc"
  url = "jdbc:gbasedbt-sqli://gbase8s:9088/archive:GBASEDBTSERVER=gbase01;IFX_LOCK_MODE_WAIT=10"
  driver = "com.gbasedbt.jdbc.Driver"
  dialect = "gbase8s"
  schema = "gbasedbt"
  table = "orders"
  schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
  data_save_mode = "APPEND_DATA"
}
```

The target database still comes only from the Sink JDBC URL. The target owner comes from Sink `schema`, then Sink username. Source database/schema/owner metadata is never copied implicitly.

## Automatic DDL implementation

Add `GBase8sCreateTableSqlBuilder` and enable `GBase8sCatalog#createTable`.

The same builder is used for both:

- DDL executed by `GBase8sCatalog`
- `TableDdl` preview/metadata produced by `JdbcSinkPreparer`

This keeps reported DDL and executed DDL aligned.

## Native target type contract

`GBase8sTypeMapper#toDatabaseType` now exposes a conservative automatic-target mapping for native/normal GBase 8s mode:

- STRING with known length `<= 8000` -> `VARCHAR(length)`
- longer/unknown STRING -> `TEXT`
- BOOLEAN -> `BOOLEAN`
- TINYINT / SMALLINT -> `SMALLINT`
- INT -> `INTEGER`
- BIGINT -> `BIGINT`
- FLOAT -> `SMALLFLOAT`
- DOUBLE -> `FLOAT`
- DECIMAL -> `DECIMAL(precision,scale)`, target precision limited to 32
- BYTES -> `BYTE`
- DATE -> `DATE`
- TIME -> `DATETIME HOUR TO SECOND`
- TIMESTAMP -> `DATETIME YEAR TO FRACTION(5)`

`TIMESTAMP_TZ`, ARRAY, MAP, ROW and other types without a safe native target contract fail before DDL execution. `TIMESTAMP WITH TIME ZONE` is not silently introduced because it is compatibility-mode-specific rather than part of this native stage.

## DDL safety boundary

Automatic creation copies only the relational shape needed to receive synchronized rows:

- column names
- target data types
- NULL / NOT NULL
- primary key when the shared `create_primary_key` option keeps it

It deliberately does not copy:

- DEFAULT expressions
- SERIAL / BIGSERIAL generation semantics
- comments
- indexes
- foreign keys
- partitions
- SQLMODE-specific DDL

Source SERIAL/BIGSERIAL values are written explicitly by the JDBC Sink, so auto-created targets use ordinary integer columns rather than creating a second target-side sequence generator.

`CREATE DATABASE`, `DROP DATABASE`, `DROP TABLE` and `ADD COLUMN` remain blocked.

## Primary-key / LOB guard

GBase 8s large-object types have constraint limitations. If a copied primary-key column would map to `TEXT` or `BYTE`, automatic DDL fails before execution with a clear message to use a bounded scalar target type or set `create_primary_key=false`.

This avoids deferring the problem to a vendor-specific CREATE TABLE constraint error.

## DELIMIDENT and identifier consistency

The Source/Sink identifier boundary is preserved for automatic DDL:

- default `DELIMIDENT=n`
  - ordinary owner/table/column identifiers are normalized to lowercase
  - identifiers requiring double quotes are rejected
- explicit `DELIMIDENT=y`
  - quoted/case-sensitive owner/table/column identifiers preserve case

Target routing, metadata lookup, CREATE TABLE, INSERT and TRUNCATE now use the same normalization rule. This also prevents an uppercase/mixed-case Source table name from being checked as one target but created as another in default mode.

## Save-mode behavior

- `CREATE_SCHEMA_WHEN_NOT_EXIST`
  - existing table: validate schema
  - missing table: create automatically
- `CREATE_OR_ADD_COLUMNS`
  - missing table: create automatically
  - existing table with missing columns: still fails because `ADD COLUMN` remains blocked
- `ERROR_WHEN_SCHEMA_NOT_EXIST` / `IGNORE`
  - retain existing behavior
- `RECREATE_SCHEMA`
  - an existing target cannot be destructively recreated because `DROP TABLE` remains blocked

The database/owner themselves are not created automatically; they must exist and the JDBC user must have permission to create a table there.

## Existing Sink behavior retained

Row writing still uses the shared JDBC path:

- parameterized `INSERT`
- configured batch size
- `PreparedStatement.addBatch()` / `executeBatch()`
- task-local transaction
- commit / rollback
- existing savepoint retry behavior
- existing dirty-data handling

The vendor `IFX_USEPUT=1` bulk-insert extension remains opt-in. UPSERT/MERGE remains unsupported.

## Tests

Focused tests cover:

- native automatic target type mapping
- VARCHAR(8000) / TEXT boundary
- BYTE mapping
- TIME / TIMESTAMP DATETIME qualifiers
- DECIMAL target precision boundary
- TIMESTAMP_TZ rejection
- safe CREATE TABLE SQL generation
- NULL / NOT NULL generation
- source SERIAL/default/comment metadata not copied
- primary-key generation
- TEXT/BYTE primary-key guard
- DELIMIDENT=n special-identifier rejection
- DELIMIDENT=y case-preserving DDL
- default-mode lowercase target normalization
- Source database/owner isolation
- explicit cross-database rejection
- automatic DDL preview generation
- destructive/evolution DDL remains blocked
- INSERT path and no-UPSERT boundary remain unchanged

## Verification

- based directly on current `main` after #128
- final branch is one atomic commit
- final compare: `ahead=1`, `behind=0`
- diff is limited to 12 files: GBase 8s automatic target creation, focused tests, Sink preview hook and README documentation
- no vendor JDBC Maven dependency was added
- local checkout/test execution was attempted, but this execution environment still cannot resolve `github.com`; the repository could not be cloned and the Maven suite was not executed here
- tests are added but are not claimed as executed
- a real GBase 8s environment plus the vendor JDBC driver is still required before Ready for Review to validate CREATE TABLE execution, metadata round-trip, owner permissions, DELIMIDENT behavior, common target types, primary-key options and subsequent JDBC batch INSERT end to end

## Non-goals

- CREATE/DROP database
- DROP/recreate existing tables
- runtime ADD COLUMN/schema evolution
- MySQL/Oracle SQLMODE compatibility expansion
- automatic compatibility-mode selection
- UPSERT/MERGE abstraction
- IFX_USEPUT default enablement
- CDC/logical-log/realtime semantics
- complex ROW/COLLECTION native object modeling