### PR TITLE
feat(gbase8c): add compatibility-aware DDL foundation

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
@@ -13,6 +13,8 @@ import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
 import com.link.up.api.table.catalog.exception.TableNotFoundException;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityResolver;
 import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cJdbcUrl;
 import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cTypeMapper;
 
@@ -31,9 +33,9 @@ import java.util.Optional;
  * GBase 8c Catalog for bounded Source and existing-table Sink jobs.
  *
  * <p>Metadata follows the PG-compatible information_schema contract, while the JDBC connection
- * remains bound to one GBase 8c database. Sink preparation may validate and truncate an existing
- * target table, but all structure-changing DDL stays blocked until GBase 8c distribution and
- * compatibility-mode semantics are modeled explicitly.</p>
+ * remains bound to one GBase 8c database. Compatibility-sensitive DDL code can explicitly resolve
+ * the database-level DBCOMPATIBILITY mode without making ordinary Source/Sink startup depend on
+ * that detection. Structure-changing DDL remains blocked in this foundation stage.</p>
  */
 public final class GBase8cCatalog implements WritableCatalog {
 
@@ -139,6 +141,23 @@ public final class GBase8cCatalog implements WritableCatalog {
     @Override
     public Optional<String> getDefaultDatabase() {
         return Optional.of(defaultDatabase);
+    }
+
+    /**
+     * Resolves the target database DBCOMPATIBILITY mode for compatibility-sensitive DDL only.
+     *
+     * <p>This is deliberately not called from {@link #open()}; existing bounded Source/Sink jobs
+     * therefore remain usable even if a newer GBase 8c release introduces an unrecognized mode.</p>
+     */
+    public GBase8cCompatibilityMode resolveCompatibilityMode() throws CatalogException {
+        checkOpened();
+        try (Connection connection = newConnection()) {
+            return GBase8cCompatibilityResolver.resolve(connection);
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "解析 GBase 8c 数据库兼容模式失败，database=" + defaultDatabase,
+                    e);
+        }
     }
 
     @Override
@@ -397,7 +416,7 @@ public final class GBase8cCatalog implements WritableCatalog {
         return new CatalogException(
                 "GBase 8c existing-table Sink supports target-table DML only; "
                         + operation
-                        + " is disabled until distribution and compatibility-mode DDL is modeled");
+                        + " is disabled until compatibility-aware automatic DDL is enabled");
     }
 
     private static boolean hasText(String value) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cCompatibilityMode.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cCompatibilityMode.java
@@ -1,0 +1,65 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import java.util.Locale;
+
+/**
+ * Stable GBase 8c database compatibility modes exposed by pg_database.datcompatibility.
+ *
+ * <p>The database chooses this mode when it is created. Automatic target DDL must resolve and
+ * honor the actual target database mode instead of assuming PostgreSQL semantics.</p>
+ */
+public enum GBase8cCompatibilityMode {
+
+    /** Oracle-compatible database. */
+    A("A", "oracle"),
+
+    /** MySQL-compatible database. */
+    B("B", "mysql"),
+
+    /** Teradata-compatible database. */
+    C("C", "teradata"),
+
+    /** PostgreSQL-compatible database. */
+    PG("PG", "postgresql");
+
+    private final String databaseValue;
+    private final String compatibleProduct;
+
+    GBase8cCompatibilityMode(
+            String databaseValue,
+            String compatibleProduct) {
+        this.databaseValue = databaseValue;
+        this.compatibleProduct = compatibleProduct;
+    }
+
+    public String databaseValue() {
+        return databaseValue;
+    }
+
+    public String compatibleProduct() {
+        return compatibleProduct;
+    }
+
+    /**
+     * Parses the exact value returned by {@code pg_database.datcompatibility}.
+     *
+     * <p>Unknown/newer modes are rejected deliberately. Existing Source/Sink execution does not
+     * depend on this parser; only compatibility-sensitive DDL code should invoke it.</p>
+     */
+    public static GBase8cCompatibilityMode fromDatabaseValue(String value) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "GBase 8c datcompatibility must not be empty");
+        }
+        String normalized = value.trim().toUpperCase(Locale.ROOT);
+        for (GBase8cCompatibilityMode mode : values()) {
+            if (mode.databaseValue.equals(normalized)) {
+                return mode;
+            }
+        }
+        throw new IllegalArgumentException(
+                "Unsupported GBase 8c datcompatibility='"
+                        + value
+                        + "'; safe automatic DDL currently recognizes A, B, C and PG only");
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cCompatibilityResolver.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cCompatibilityResolver.java
@@ -1,0 +1,38 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/** Resolves the current GBase 8c database compatibility mode from pg_database. */
+public final class GBase8cCompatibilityResolver {
+
+    static final String RESOLVE_SQL =
+            "SELECT datcompatibility FROM pg_database WHERE datname = current_database()";
+
+    private GBase8cCompatibilityResolver() {
+    }
+
+    public static GBase8cCompatibilityMode resolve(Connection connection) throws SQLException {
+        if (connection == null) {
+            throw new IllegalArgumentException("connection must not be null");
+        }
+        try (PreparedStatement statement = connection.prepareStatement(RESOLVE_SQL);
+             ResultSet resultSet = statement.executeQuery()) {
+            if (!resultSet.next()) {
+                throw new SQLException(
+                        "Unable to resolve GBase 8c datcompatibility for current database");
+            }
+            String value = resultSet.getString(1);
+            try {
+                return GBase8cCompatibilityMode.fromDatabaseValue(value);
+            } catch (IllegalArgumentException e) {
+                throw new SQLException(
+                        "Unsupported GBase 8c compatibility mode for automatic target DDL: "
+                                + value,
+                        e);
+            }
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTargetTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTargetTypeMapper.java
@@ -1,0 +1,98 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.postgres.PostgresTypeMapper;
+
+/**
+ * Compatibility-aware target type mapping foundation for GBase 8c automatic DDL.
+ *
+ * <p>Where GBase 8c core scalar types round-trip cleanly through the existing PG-compatible
+ * metadata contract, this mapper intentionally keeps those portable core types instead of copying
+ * source-vendor aliases. Compatibility mode is used only where the target database changes the
+ * actual semantics.</p>
+ */
+public final class GBase8cTargetTypeMapper {
+
+    private final GBase8cCompatibilityMode compatibilityMode;
+    private final PostgresTypeMapper portableMapper = new PostgresTypeMapper();
+
+    public GBase8cTargetTypeMapper(GBase8cCompatibilityMode compatibilityMode) {
+        if (compatibilityMode == null) {
+            throw new IllegalArgumentException("compatibilityMode must not be null");
+        }
+        this.compatibilityMode = compatibilityMode;
+    }
+
+    public GBase8cCompatibilityMode compatibilityMode() {
+        return compatibilityMode;
+    }
+
+    /**
+     * Maps one Flux column to a safe physical GBase 8c target type for the resolved database mode.
+     */
+    public String toDatabaseType(Column column) {
+        if (column == null || column.getDataType() == null) {
+            throw new IllegalArgumentException("column/dataType must not be null");
+        }
+
+        SqlType type = column.getDataType().getSqlType();
+        switch (type) {
+            case STRING:
+                return stringType(column);
+            case DATE:
+                return dateType();
+            case TIMESTAMP_TZ:
+                if (compatibilityMode == GBase8cCompatibilityMode.PG) {
+                    return portableMapper.toDatabaseType(column);
+                }
+                throw unsupported(
+                        column,
+                        "TIMESTAMP_TZ automatic DDL is only verified for PG compatibility mode");
+            case ARRAY:
+            case MAP:
+            case ROW:
+            case NULL:
+                throw unsupported(
+                        column,
+                        "automatic DDL foundation only supports scalar relational types");
+            default:
+                return portableMapper.toDatabaseType(column);
+        }
+    }
+
+    private String stringType(Column column) {
+        if (compatibilityMode == GBase8cCompatibilityMode.PG) {
+            return portableMapper.toDatabaseType(column);
+        }
+
+        /*
+         * GBase 8c documents PG-mode CHAR/VARCHAR lengths as characters while the other stable
+         * compatibility modes count bytes. Source metadata lengths are not guaranteed to carry
+         * byte semantics, so TEXT is the safe cross-database baseline outside PG mode.
+         */
+        return "TEXT";
+    }
+
+    private String dateType() {
+        /*
+         * In A mode GBase 8c documents DATE as TIMESTAMP(0) WITHOUT TIME ZONE internally. Emit the
+         * physical contract explicitly so DDL preview and later metadata normalization can agree.
+         */
+        return compatibilityMode == GBase8cCompatibilityMode.A
+                ? "TIMESTAMP(0) WITHOUT TIME ZONE"
+                : "DATE";
+    }
+
+    private UnsupportedOperationException unsupported(Column column, String reason) {
+        return new UnsupportedOperationException(
+                "GBase 8c cannot map target column '"
+                        + column.getName()
+                        + "' from Flux type "
+                        + column.getDataType().getSqlType()
+                        + " in compatibility mode "
+                        + compatibilityMode.databaseValue()
+                        + ": "
+                        + reason);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTypeMapper.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTypeMapper.java
@@ -9,11 +9,11 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 
 /**
- * GBase 8c type mapper for bounded Source and existing-table Sink jobs.
+ * GBase 8c type mapper for bounded Source/Sink jobs.
  *
- * <p>The adapter reuses the mature PostgreSQL-compatible read-side type contract. The current Sink
- * writes only to pre-created tables, so target DDL type generation stays disabled until a later
- * GBase 8c table-creation stage models distribution and compatibility-mode semantics.</p>
+ * <p>The adapter keeps PostgreSQL-compatible metadata mapping for reads. Target DDL mapping requires
+ * an explicitly resolved {@link GBase8cCompatibilityMode}; the mode-less JdbcTypeMapper method
+ * remains blocked so callers cannot accidentally assume PG semantics.</p>
  */
 public final class GBase8cTypeMapper implements JdbcTypeMapper {
 
@@ -32,6 +32,14 @@ public final class GBase8cTypeMapper implements JdbcTypeMapper {
     @Override
     public String toDatabaseType(Column column) {
         throw new UnsupportedOperationException(
-                "GBase 8c existing-table Sink does not generate target DDL types");
+                "GBase 8c target DDL requires a resolved compatibility mode; "
+                        + "use toDatabaseType(column, compatibilityMode)");
+    }
+
+    public String toDatabaseType(
+            Column column,
+            GBase8cCompatibilityMode compatibilityMode) {
+        return new GBase8cTargetTypeMapper(compatibilityMode)
+                .toDatabaseType(column);
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cCompatibilityModeTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cCompatibilityModeTest.java
@@ -1,0 +1,46 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cCompatibilityModeTest {
+
+    @Test
+    public void parsesStableDatabaseCompatibilityValues() {
+        assertEquals(
+                GBase8cCompatibilityMode.A,
+                GBase8cCompatibilityMode.fromDatabaseValue("A"));
+        assertEquals(
+                GBase8cCompatibilityMode.B,
+                GBase8cCompatibilityMode.fromDatabaseValue("b"));
+        assertEquals(
+                GBase8cCompatibilityMode.C,
+                GBase8cCompatibilityMode.fromDatabaseValue(" C "));
+        assertEquals(
+                GBase8cCompatibilityMode.PG,
+                GBase8cCompatibilityMode.fromDatabaseValue("pg"));
+    }
+
+    @Test
+    public void exposesCompatibleProductNames() {
+        assertEquals("oracle", GBase8cCompatibilityMode.A.compatibleProduct());
+        assertEquals("mysql", GBase8cCompatibilityMode.B.compatibleProduct());
+        assertEquals("teradata", GBase8cCompatibilityMode.C.compatibleProduct());
+        assertEquals("postgresql", GBase8cCompatibilityMode.PG.compatibleProduct());
+    }
+
+    @Test
+    public void rejectsUnknownOrFutureModeInsteadOfAssumingPostgresql() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> GBase8cCompatibilityMode.fromDatabaseValue("MSSQL"));
+
+        assertTrue(error.getMessage().contains("A, B, C and PG"));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GBase8cCompatibilityMode.fromDatabaseValue(" "));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cCompatibilityResolverTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cCompatibilityResolverTest.java
@@ -1,0 +1,130 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import org.junit.Test;
+
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cCompatibilityResolverTest {
+
+    @Test
+    public void resolvesModeFromCurrentDatabaseCatalogRow() throws Exception {
+        AtomicReference<String> preparedSql = new AtomicReference<String>();
+        Connection connection = connection("B", true, preparedSql);
+
+        assertEquals(
+                GBase8cCompatibilityMode.B,
+                GBase8cCompatibilityResolver.resolve(connection));
+        assertEquals(
+                "SELECT datcompatibility FROM pg_database WHERE datname = current_database()",
+                preparedSql.get());
+    }
+
+    @Test
+    public void rejectsUnknownModeWithoutPostgresqlFallback() {
+        SQLException error = assertThrows(
+                SQLException.class,
+                () -> GBase8cCompatibilityResolver.resolve(
+                        connection("MSSQL", true, new AtomicReference<String>())));
+
+        assertTrue(error.getMessage().contains("Unsupported GBase 8c compatibility mode"));
+        assertTrue(error.getCause() instanceof IllegalArgumentException);
+    }
+
+    @Test
+    public void failsWhenCurrentDatabaseRowIsMissing() {
+        SQLException error = assertThrows(
+                SQLException.class,
+                () -> GBase8cCompatibilityResolver.resolve(
+                        connection(null, false, new AtomicReference<String>())));
+
+        assertTrue(error.getMessage().contains("Unable to resolve"));
+    }
+
+    private static Connection connection(
+            String value,
+            boolean hasRow,
+            AtomicReference<String> preparedSql) {
+        ResultSet resultSet = (ResultSet) Proxy.newProxyInstance(
+                GBase8cCompatibilityResolverTest.class.getClassLoader(),
+                new Class<?>[]{ResultSet.class},
+                new java.lang.reflect.InvocationHandler() {
+                    private boolean advanced;
+
+                    @Override
+                    public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) {
+                        if ("next".equals(method.getName())) {
+                            if (advanced || !hasRow) {
+                                return false;
+                            }
+                            advanced = true;
+                            return true;
+                        }
+                        if ("getString".equals(method.getName())) {
+                            return value;
+                        }
+                        return defaultValue(method.getReturnType());
+                    }
+                });
+
+        PreparedStatement statement = (PreparedStatement) Proxy.newProxyInstance(
+                GBase8cCompatibilityResolverTest.class.getClassLoader(),
+                new Class<?>[]{PreparedStatement.class},
+                (proxy, method, args) -> {
+                    if ("executeQuery".equals(method.getName())) {
+                        return resultSet;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+
+        return (Connection) Proxy.newProxyInstance(
+                GBase8cCompatibilityResolverTest.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                (proxy, method, args) -> {
+                    if ("prepareStatement".equals(method.getName())) {
+                        preparedSql.set((String) args[0]);
+                        return statement;
+                    }
+                    return defaultValue(method.getReturnType());
+                });
+    }
+
+    private static Object defaultValue(Class<?> type) {
+        if (!type.isPrimitive()) {
+            return null;
+        }
+        if (type == boolean.class) {
+            return false;
+        }
+        if (type == byte.class) {
+            return (byte) 0;
+        }
+        if (type == short.class) {
+            return (short) 0;
+        }
+        if (type == int.class) {
+            return 0;
+        }
+        if (type == long.class) {
+            return 0L;
+        }
+        if (type == float.class) {
+            return 0F;
+        }
+        if (type == double.class) {
+            return 0D;
+        }
+        if (type == char.class) {
+            return '\0';
+        }
+        return null;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTargetTypeMapperTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cTargetTypeMapperTest.java
@@ -1,0 +1,126 @@
+package com.link.up.connector.jdbc.core.dialect.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cTargetTypeMapperTest {
+
+    @Test
+    public void pgModeMayPreserveBoundedVarcharLength() {
+        Column column = Column.builder("name", BasicType.STRING_TYPE)
+                .length(120L)
+                .build();
+
+        assertEquals(
+                "VARCHAR(120)",
+                mapper(GBase8cCompatibilityMode.PG).toDatabaseType(column));
+    }
+
+    @Test
+    public void nonPgModesUseTextToAvoidCharacterVsByteLengthGuessing() {
+        Column column = Column.builder("name", BasicType.STRING_TYPE)
+                .length(120L)
+                .build();
+
+        assertEquals("TEXT", mapper(GBase8cCompatibilityMode.A).toDatabaseType(column));
+        assertEquals("TEXT", mapper(GBase8cCompatibilityMode.B).toDatabaseType(column));
+        assertEquals("TEXT", mapper(GBase8cCompatibilityMode.C).toDatabaseType(column));
+    }
+
+    @Test
+    public void oracleCompatibleDateUsesDocumentedPhysicalTimestampContract() {
+        Column date = Column.builder("biz_date", BasicType.DATE_TYPE).build();
+
+        assertEquals(
+                "TIMESTAMP(0) WITHOUT TIME ZONE",
+                mapper(GBase8cCompatibilityMode.A).toDatabaseType(date));
+        assertEquals("DATE", mapper(GBase8cCompatibilityMode.B).toDatabaseType(date));
+        assertEquals("DATE", mapper(GBase8cCompatibilityMode.C).toDatabaseType(date));
+        assertEquals("DATE", mapper(GBase8cCompatibilityMode.PG).toDatabaseType(date));
+    }
+
+    @Test
+    public void portableCoreScalarTypesRoundTripAcrossModes() {
+        for (GBase8cCompatibilityMode mode : GBase8cCompatibilityMode.values()) {
+            GBase8cTargetTypeMapper mapper = mapper(mode);
+            assertEquals(
+                    "SMALLINT",
+                    mapper.toDatabaseType(
+                            Column.builder("tiny", BasicType.BYTE_TYPE).build()));
+            assertEquals(
+                    "INTEGER",
+                    mapper.toDatabaseType(
+                            Column.builder("id", BasicType.INT_TYPE).build()));
+            assertEquals(
+                    "BIGINT",
+                    mapper.toDatabaseType(
+                            Column.builder("big_id", BasicType.LONG_TYPE).build()));
+            assertEquals(
+                    "REAL",
+                    mapper.toDatabaseType(
+                            Column.builder("ratio", BasicType.FLOAT_TYPE).build()));
+            assertEquals(
+                    "DOUBLE PRECISION",
+                    mapper.toDatabaseType(
+                            Column.builder("score", BasicType.DOUBLE_TYPE).build()));
+            assertEquals(
+                    "NUMERIC(20,4)",
+                    mapper.toDatabaseType(
+                            Column.builder("amount", new DecimalType(20, 4))
+                                    .precision(20)
+                                    .scale(4)
+                                    .build()));
+            assertEquals(
+                    "BYTEA",
+                    mapper.toDatabaseType(
+                            Column.builder("payload", BasicType.BYTES_TYPE).build()));
+            assertEquals(
+                    "TIMESTAMP",
+                    mapper.toDatabaseType(
+                            Column.builder("created_at", BasicType.TIMESTAMP_TYPE).build()));
+        }
+    }
+
+    @Test
+    public void timezoneTimestampIsOnlyEnabledForVerifiedPgMode() {
+        Column column = Column.builder("event_at", BasicType.TIMESTAMP_TZ_TYPE).build();
+
+        assertEquals(
+                "TIMESTAMP WITH TIME ZONE",
+                mapper(GBase8cCompatibilityMode.PG).toDatabaseType(column));
+
+        for (GBase8cCompatibilityMode mode : new GBase8cCompatibilityMode[]{
+                GBase8cCompatibilityMode.A,
+                GBase8cCompatibilityMode.B,
+                GBase8cCompatibilityMode.C}) {
+            UnsupportedOperationException error = assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> mapper(mode).toDatabaseType(column));
+            assertTrue(error.getMessage().contains("TIMESTAMP_TZ"));
+            assertTrue(error.getMessage().contains(mode.databaseValue()));
+        }
+    }
+
+    @Test
+    public void modeLessJdbcTypeMapperEntryPointRemainsBlocked() {
+        GBase8cTypeMapper mapper = new GBase8cTypeMapper();
+        Column column = Column.builder("id", BasicType.INT_TYPE).build();
+
+        assertThrows(
+                UnsupportedOperationException.class,
+                () -> mapper.toDatabaseType(column));
+        assertEquals(
+                "INTEGER",
+                mapper.toDatabaseType(column, GBase8cCompatibilityMode.PG));
+    }
+
+    private static GBase8cTargetTypeMapper mapper(GBase8cCompatibilityMode mode) {
+        return new GBase8cTargetTypeMapper(mode);
+    }
+}


### PR DESCRIPTION
## Summary

Add the compatibility-aware DDL foundation required before GBase 8c automatic target-table creation can be enabled safely.

This PR is based directly on current `main` after #130. It intentionally does **not** enable `CREATE TABLE` yet. Instead it establishes three prerequisites:

1. a stable compatibility-mode model for the target database;
2. explicit runtime detection of the current database's `pg_database.datcompatibility` value;
3. mode-aware Flux -> GBase 8c target type mapping that cannot be called accidentally without a resolved mode.

## Compatibility model

Add `GBase8cCompatibilityMode` for the stable documented database-level modes:

- `A` -> Oracle-compatible
- `B` -> MySQL-compatible
- `C` -> Teradata-compatible
- `PG` -> PostgreSQL-compatible

The mode is a database-creation property, not a generic connector preference.

Unknown/newer values are rejected for automatic DDL instead of silently falling back to PostgreSQL. This is deliberate future-proofing: ordinary Source/existing-table Sink execution does not depend on this parser, so a newer GBase 8c mode does not break the already-supported runtime.

## Runtime detection

Add `GBase8cCompatibilityResolver` using the target database catalog:

```sql
SELECT datcompatibility
FROM pg_database
WHERE datname = current_database()
```

`GBase8cCatalog#resolveCompatibilityMode()` exposes this detection explicitly for future DDL code.

It is deliberately **not** invoked from `Catalog#open()`. Existing bounded Source and existing-table Sink jobs therefore retain their current behavior and do not become dependent on compatibility-mode recognition.

## Target type foundation

Add `GBase8cTargetTypeMapper`.

The mapping policy is usability/data-correctness first:

- keep stable GBase/PostgreSQL-core scalar types when they round-trip cleanly through the existing metadata mapper;
- use compatibility mode only where GBase 8c documents a real semantic difference;
- do not copy source-vendor aliases, identity/default semantics or compatibility-specific convenience syntax merely because the target mode supports them.

Core scalar baseline:

- TINYINT -> SMALLINT
- SMALLINT -> SMALLINT
- INT -> INTEGER
- BIGINT -> BIGINT
- FLOAT -> REAL
- DOUBLE -> DOUBLE PRECISION
- DECIMAL -> NUMERIC(p,s)
- BOOLEAN -> BOOLEAN
- BYTES -> BYTEA
- TIME -> TIME
- TIMESTAMP -> TIMESTAMP

Compatibility-sensitive behavior:

- PG mode STRING with safe known length -> existing PostgreSQL-compatible `VARCHAR(n)` contract
- A/B/C STRING -> `TEXT`, because GBase 8c documents PG-mode CHAR/VARCHAR lengths as characters while other stable modes count bytes; cross-database source lengths cannot safely be assumed to have byte semantics
- A mode DATE -> `TIMESTAMP(0) WITHOUT TIME ZONE`, matching GBase 8c's documented physical A-mode DATE behavior
- B/C/PG DATE -> `DATE`
- TIMESTAMP_TZ is enabled only for the currently verified PG-mode contract; A/B/C fail closed for now
- ARRAY/MAP/ROW/NULL remain unsupported for automatic DDL

## Mode-less safety gate

`GBase8cTypeMapper#toDatabaseType(Column)` remains blocked.

DDL callers must explicitly use:

```java
mapper.toDatabaseType(column, compatibilityMode)
```

This prevents generic JDBC code from accidentally generating GBase 8c target DDL under an implicit PostgreSQL assumption.

## Existing Sink boundary remains unchanged

This PR does not enable structure-changing DDL.

Still blocked:

- CREATE TABLE
- DROP TABLE
- ADD COLUMN
- CREATE/DROP DATABASE
- runtime schema evolution
- UPSERT/MERGE abstraction

Existing Source, INSERT/batch Sink and `DROP_DATA -> TRUNCATE TABLE` behavior remain unchanged.

## A-mode DATE follow-up boundary

A-mode DATE is intentionally represented by its documented physical target contract: `TIMESTAMP(0) WITHOUT TIME ZONE`.

The current generic `SchemaCompatibilityReport` does not consider Flux DATE and TIMESTAMP identical. Therefore the follow-up auto-create PR must add the corresponding mode-specific metadata/schema round-trip handling before enabling CREATE TABLE. This PR establishes the physical contract but does not bypass that correctness requirement.

## Tests

Focused tests cover:

- A/B/C/PG parsing and product identity
- case/whitespace normalization
- unknown/newer compatibility mode rejection
- exact `pg_database.datcompatibility` detection query
- missing compatibility metadata failure
- PG bounded VARCHAR behavior
- non-PG TEXT fallback for safe string sizing
- A-mode DATE physical contract
- portable integer/floating/decimal/bytea/timestamp mappings
- PG-only TIMESTAMP_TZ boundary
- mode-less `JdbcTypeMapper#toDatabaseType` remains blocked
- explicit mode-aware target mapping is available

## Verification

- based directly on current `main` after #130
- final branch is one atomic commit
- final compare: `ahead=1`, `behind=0`
- diff is limited to 8 GBase 8c foundation/test files
- `JdbcSinkPreparer` is untouched
- `GBase8cCatalog#createTable` remains blocked
- no vendor JDBC dependency or connection protocol change is introduced
- local checkout/Maven execution was attempted, but the execution environment still cannot resolve `github.com`, so the Maven suite was not executed here
- tests are added but are not claimed as executed
- real GBase 8c environments should validate `datcompatibility` detection for A/B/C/PG before this PR is marked Ready for Review

## Non-goals

- automatic CREATE TABLE
- CREATE/DROP database
- DROP/recreate existing tables
- ADD COLUMN/schema evolution
- source DEFAULT/identity replication
- compatibility-mode-specific UPSERT/MERGE
- automatic compatibility-mode selection or mutation
- unverified newer compatibility modes
- CDC/realtime semantics
