### PR TITLE
feat(gbase8c): add compatibility-aware automatic target creation

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/README.md
+++ b/link-up-connectors/link-up-connector-jdbc/README.md
@@ -103,12 +103,101 @@ The shared `gbase/common` layer only carries stable product metadata and family-
 product-specific: URL parsing, identifiers, catalog behavior, type mapping, row conversion, Sink SQL and MPP behavior
 must stay in the concrete product adapter unless completed implementations prove that behavior is genuinely common.
 
-The bounded/offline implementation is staged per product. GBase 8a and GBase 8s now support bounded Source, JDBC Sink and
-safe automatic creation of a missing target table. GBase 8a native/high-speed MPP loading remains a later performance
-stage. GBase 8c keeps its compatibility-sensitive runtime and DDL work separate from the other two products.
+GBase 8c, GBase 8a and GBase 8s now support bounded Source, JDBC Sink and safe automatic creation of a missing target
+table. Each product keeps its own target-type and DDL semantics. GBase 8c resolves the actual database compatibility mode
+before automatic DDL; users do not configure A/B/C/PG manually. GBase 8a native/high-speed MPP loading remains a later
+performance stage.
 
-CDC, compatibility-mode expansion, automatic distributed-table design and product-native bulk-loading paths stay outside
-this family-level contract.
+CDC, automatic distributed-table design, unverified compatibility-mode expansion and product-native bulk-loading paths
+stay outside this family-level contract.
+
+### GBase 8c bounded Source + JDBC Sink + compatibility-aware automatic target creation
+
+GBase 8c is exposed as the first-class `gbase8c` JDBC dialect and uses the dedicated GBase 8c JDBC protocol:
+
+```hocon
+source {
+  type = "jdbc"
+  url = "jdbc:gbase8c://gbase8c:5432/app"
+  driver = "com.gbase8c.Driver"
+  dialect = "gbase8c"
+  schema = "public"
+  table_path = "public.orders"
+}
+
+sink {
+  type = "jdbc"
+  url = "jdbc:gbase8c://gbase8c:5432/archive"
+  driver = "com.gbase8c.Driver"
+  dialect = "gbase8c"
+  schema = "landing"
+  table = "orders"
+  schema_save_mode = "CREATE_SCHEMA_WHEN_NOT_EXIST"
+  data_save_mode = "APPEND_DATA"
+}
+```
+
+One GBase 8c JDBC connection stays bound to the database in its URL. SQL uses `schema.table` inside that database. For an
+implicit Sink target, Link-Up keeps only the source table name and resolves database/schema from the Sink connection, so
+source routing metadata cannot leak into the target even when source and target database names happen to match. Explicit
+`schema.table` targets are preserved; an explicit three-part target must repeat the Sink URL database.
+
+When the target table is missing, Link-Up resolves the target database's actual `pg_database.datcompatibility` value and
+recognizes the stable GBase 8c modes `A`, `B`, `C` and `PG`. The mode is detected from the database itself instead of being
+exposed as another user-facing connector option. Unknown/newer modes fail closed for automatic DDL rather than silently
+assuming PostgreSQL semantics. Ordinary existing-table jobs do not query compatibility mode unless a documented
+mode-specific metadata difference needs normalization.
+
+Automatic DDL copies only the relational shape needed by the bounded Sink:
+
+- column names
+- compatibility-aware target types
+- NULL / NOT NULL
+- source primary key only when the shared `create_primary_key` option keeps it
+
+It deliberately does **not** copy source DEFAULT/identity/SERIAL/AUTO_INCREMENT behavior, comments, indexes, foreign
+keys, partitions, storage orientation, replication or hash-distribution policy. The generated baseline contains no
+`DISTRIBUTE BY` or replication clause; Link-Up does not guess a physical MPP distribution key from source metadata.
+
+The compatibility-aware target type baseline keeps stable GBase/PostgreSQL-core scalar types where they round-trip safely:
+
+- TINYINT / SMALLINT -> SMALLINT
+- INT -> INTEGER
+- BIGINT -> BIGINT
+- FLOAT -> REAL
+- DOUBLE -> DOUBLE PRECISION
+- DECIMAL -> NUMERIC(precision, scale)
+- BOOLEAN -> BOOLEAN
+- BYTES -> BYTEA
+- TIME -> TIME
+- TIMESTAMP -> TIMESTAMP
+- B/C/PG DATE -> DATE
+- A-mode DATE -> TIMESTAMP(0) WITHOUT TIME ZONE
+- PG-mode STRING with a safe known length -> VARCHAR(length)
+- A/B/C STRING -> TEXT
+
+A/B/C string targets use `TEXT` because GBase 8c documents PG-mode CHAR/VARCHAR length in characters while the other
+stable compatibility modes count bytes; a cross-database source length is therefore not safely reusable as a target byte
+limit. `TIMESTAMP_TZ` is enabled only for the currently verified PG-mode contract. ARRAY/MAP/ROW and other types without a
+safe automatic target contract fail before DDL execution.
+
+A-mode DATE has a deliberate physical/logical round-trip rule. GBase 8c represents A-mode DATE as
+`TIMESTAMP(0) WITHOUT TIME ZONE`, so JDBC metadata reads that physical column back as TIMESTAMP. GBase 8c Sink validation
+normalizes only the corresponding source-DATE/target-TIMESTAMP pair back to logical DATE for A mode; the generic JDBC
+conversion contract remains unchanged for every other database and mode. This keeps a table created on the first job
+compatible when the same job runs again.
+
+`CREATE_SCHEMA_WHEN_NOT_EXIST` creates a missing table and validates an existing table. `CREATE_OR_ADD_COLUMNS` may also
+create a missing table, but it still cannot mutate an existing target: `ADD COLUMN` remains blocked. `RECREATE_SCHEMA`
+cannot destructively recreate an existing table because `DROP TABLE` remains blocked. CREATE/DROP DATABASE is also
+disabled. The target database/schema must already exist and the JDBC user must have permission to create a table there.
+
+After preparation, row writing still reuses the shared JDBC path: parameterized `INSERT`, configured batch size,
+`PreparedStatement.addBatch()` / `executeBatch()`, task-local transaction, commit/rollback, savepoint retry and dirty-data
+handling. UPSERT/MERGE, runtime schema evolution, CDC and native bulk-loading remain out of scope.
+
+The vendor GBase 8c JDBC driver is not guessed as a Maven dependency by this module. Deployments must provide the official
+driver on the runtime classpath and configure `driver = "com.gbase8c.Driver"`.
 
 ### GBase 8a bounded Source + JDBC Sink + safe automatic target creation
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalog.java
@@ -30,12 +30,12 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * GBase 8c Catalog for bounded Source and existing-table Sink jobs.
+ * GBase 8c Catalog for bounded Source, JDBC Sink and compatibility-aware automatic targets.
  *
  * <p>Metadata follows the PG-compatible information_schema contract, while the JDBC connection
- * remains bound to one GBase 8c database. Compatibility-sensitive DDL code can explicitly resolve
- * the database-level DBCOMPATIBILITY mode without making ordinary Source/Sink startup depend on
- * that detection. Structure-changing DDL remains blocked in this foundation stage.</p>
+ * remains bound to one GBase 8c database. Missing target tables may be created after the Catalog
+ * resolves the database-level DBCOMPATIBILITY mode. Destructive DDL and runtime schema evolution
+ * remain blocked.</p>
  */
 public final class GBase8cCatalog implements WritableCatalog {
 
@@ -88,6 +88,7 @@ public final class GBase8cCatalog implements WritableCatalog {
     private final String defaultSchema;
     private final GBase8cTypeMapper typeMapper = new GBase8cTypeMapper();
     private volatile boolean opened;
+    private volatile GBase8cCompatibilityMode resolvedCompatibilityMode;
 
     public GBase8cCatalog(
             String catalogName,
@@ -144,19 +145,32 @@ public final class GBase8cCatalog implements WritableCatalog {
     }
 
     /**
-     * Resolves the target database DBCOMPATIBILITY mode for compatibility-sensitive DDL only.
+     * Resolves and caches the target database DBCOMPATIBILITY mode for compatibility-sensitive DDL.
      *
-     * <p>This is deliberately not called from {@link #open()}; existing bounded Source/Sink jobs
-     * therefore remain usable even if a newer GBase 8c release introduces an unrecognized mode.</p>
+     * <p>The mode is immutable for a GBase 8c database after creation, so keeping it for the life of
+     * this Catalog avoids repeated pg_database lookups. This method is still deliberately not called
+     * from {@link #open()} so ordinary existing-table execution does not require mode recognition.</p>
      */
     public GBase8cCompatibilityMode resolveCompatibilityMode() throws CatalogException {
+        GBase8cCompatibilityMode cached = resolvedCompatibilityMode;
+        if (cached != null) {
+            return cached;
+        }
         checkOpened();
-        try (Connection connection = newConnection()) {
-            return GBase8cCompatibilityResolver.resolve(connection);
-        } catch (SQLException e) {
-            throw new CatalogException(
-                    "解析 GBase 8c 数据库兼容模式失败，database=" + defaultDatabase,
-                    e);
+        synchronized (this) {
+            cached = resolvedCompatibilityMode;
+            if (cached != null) {
+                return cached;
+            }
+            try (Connection connection = newConnection()) {
+                cached = GBase8cCompatibilityResolver.resolve(connection);
+                resolvedCompatibilityMode = cached;
+                return cached;
+            } catch (SQLException e) {
+                throw new CatalogException(
+                        "解析 GBase 8c 数据库兼容模式失败，database=" + defaultDatabase,
+                        e);
+            }
         }
     }
 
@@ -272,12 +286,46 @@ public final class GBase8cCatalog implements WritableCatalog {
         throw unsupportedSchemaDdl("drop database");
     }
 
+    /** Creates a missing target table after resolving the actual target database compatibility mode. */
     @Override
     public void createTable(
             CatalogTable table,
             boolean ignoreIfExists)
             throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
-        throw unsupportedSchemaDdl("create table");
+        checkOpened();
+        if (table == null) {
+            throw new IllegalArgumentException("table must not be null");
+        }
+
+        TablePath normalized = normalizeTablePath(table.getTablePath());
+        if (tableExists(normalized)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new TableAlreadyExistsException(catalogName, normalized);
+        }
+
+        GBase8cCompatibilityMode compatibilityMode = resolveCompatibilityMode();
+        CatalogTable ddlTable = table.getTablePath().equals(normalized)
+                ? table
+                : table.withPath(normalized);
+        String sql = new GBase8cCreateTableSqlBuilder(
+                normalized,
+                ddlTable,
+                compatibilityMode)
+                .build();
+
+        try (Connection connection = newConnection();
+             PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.executeUpdate();
+        } catch (SQLException e) {
+            throw new CatalogException(
+                    "创建 GBase 8c 目标表失败，table="
+                            + normalized
+                            + ", compatibility="
+                            + compatibilityMode.databaseValue(),
+                    e);
+        }
     }
 
     @Override
@@ -414,9 +462,9 @@ public final class GBase8cCatalog implements WritableCatalog {
 
     private static CatalogException unsupportedSchemaDdl(String operation) {
         return new CatalogException(
-                "GBase 8c existing-table Sink supports target-table DML only; "
+                "GBase 8c automatic-target Sink supports safe CREATE TABLE for missing targets, but "
                         + operation
-                        + " is disabled until compatibility-aware automatic DDL is enabled");
+                        + " remains disabled; destructive DDL and runtime schema evolution stay out of scope");
     }
 
     private static boolean hasText(String value) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCreateTableSqlBuilder.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCreateTableSqlBuilder.java
@@ -1,0 +1,116 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cTargetTypeMapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Builds the conservative, compatibility-aware CREATE TABLE used by GBase 8c automatic targets.
+ *
+ * <p>The builder copies only the relational shape needed to receive synchronized rows: column
+ * names, mode-aware physical target types, nullability and an optional primary key. Source
+ * defaults, identity/serial behavior, comments, indexes, foreign keys, partitions and distributed
+ * physical-design clauses are intentionally not copied.</p>
+ *
+ * <p>No DISTRIBUTE BY / REPLICATION clause is generated. Distribution-key selection is a business
+ * and workload decision and remains outside safe cross-database automatic table creation.</p>
+ */
+public final class GBase8cCreateTableSqlBuilder {
+
+    private final TablePath tablePath;
+    private final CatalogTable catalogTable;
+    private final GBase8cCompatibilityMode compatibilityMode;
+    private final GBase8cTargetTypeMapper typeMapper;
+
+    public GBase8cCreateTableSqlBuilder(
+            TablePath tablePath,
+            CatalogTable catalogTable,
+            GBase8cCompatibilityMode compatibilityMode) {
+        if (tablePath == null) {
+            throw new IllegalArgumentException("tablePath must not be null");
+        }
+        if (catalogTable == null) {
+            throw new IllegalArgumentException("catalogTable must not be null");
+        }
+        if (compatibilityMode == null) {
+            throw new IllegalArgumentException("compatibilityMode must not be null");
+        }
+        if (!hasText(tablePath.getSchemaName())) {
+            throw new IllegalArgumentException(
+                    "GBase 8c CREATE TABLE requires target schema: " + tablePath);
+        }
+        if (!hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("GBase 8c CREATE TABLE requires target table name");
+        }
+        this.tablePath = tablePath;
+        this.catalogTable = catalogTable;
+        this.compatibilityMode = compatibilityMode;
+        this.typeMapper = new GBase8cTargetTypeMapper(compatibilityMode);
+    }
+
+    public GBase8cCompatibilityMode compatibilityMode() {
+        return compatibilityMode;
+    }
+
+    public String build() {
+        TableSchema schema = catalogTable.getTableSchema();
+        if (schema == null || schema.getColumns() == null || schema.getColumns().isEmpty()) {
+            throw new IllegalArgumentException("GBase 8c CREATE TABLE requires at least one column");
+        }
+
+        List<String> definitions = new ArrayList<String>();
+        for (Column column : schema.getColumns()) {
+            definitions.add(buildColumnDefinition(column));
+        }
+
+        PrimaryKey primaryKey = schema.getPrimaryKey();
+        if (primaryKey != null && !primaryKey.getColumnNames().isEmpty()) {
+            definitions.add(buildPrimaryKey(primaryKey));
+        }
+
+        return "CREATE TABLE "
+                + quoteIdentifier(tablePath.getSchemaName())
+                + "."
+                + quoteIdentifier(tablePath.getTableName())
+                + " (\n    "
+                + String.join(",\n    ", definitions)
+                + "\n);";
+    }
+
+    public String buildColumnDefinition(Column column) {
+        if (column == null) {
+            throw new IllegalArgumentException("column must not be null");
+        }
+        List<String> parts = new ArrayList<String>();
+        parts.add(quoteIdentifier(column.getName()));
+        parts.add(typeMapper.toDatabaseType(column));
+        parts.add(column.isNullable() ? "NULL" : "NOT NULL");
+        return String.join(" ", parts);
+    }
+
+    private static String buildPrimaryKey(PrimaryKey primaryKey) {
+        String columns = primaryKey.getColumnNames().stream()
+                .map(GBase8cCreateTableSqlBuilder::quoteIdentifier)
+                .collect(Collectors.joining(", "));
+        return "PRIMARY KEY (" + columns + ")";
+    }
+
+    private static String quoteIdentifier(String identifier) {
+        if (!hasText(identifier)) {
+            throw new IllegalArgumentException("identifier must not be empty");
+        }
+        return "\"" + identifier.trim().replace("\"", "\"\"") + "\"";
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialect.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/core/dialect/gbase/gbase8c/GBase8cDialect.java
@@ -14,8 +14,10 @@ import com.link.up.connector.jdbc.core.dialect.JdbcTypeMapper;
  * GBase 8c bounded/offline JDBC dialect.
  *
  * <p>The adapter targets the dedicated GBase 8c JDBC protocol and PG-compatible metadata/read
- * semantics. The existing-table Sink stage reuses the portable INSERT/batch path only; UPSERT,
- * structure-changing DDL, CDC and compatibility-mode expansion remain separate stages.</p>
+ * semantics. The JDBC Sink supports portable INSERT/batch writes and safe creation of a missing
+ * target table after resolving the actual A/B/C/PG database compatibility mode. Destructive DDL,
+ * runtime schema evolution, UPSERT/MERGE, CDC and native bulk-loading semantics remain separate
+ * capabilities.</p>
  */
 public final class GBase8cDialect implements JdbcDialect {
 

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupport.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupport.java
@@ -1,11 +1,14 @@
 package com.link.up.connector.jdbc.sink;
 
+import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.TablePath;
+import com.link.up.connector.jdbc.catalog.gbase.gbase8c.GBase8cCreateTableSqlBuilder;
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
 import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cJdbcUrl;
 
-/** Target-path normalization for the GBase 8c existing-table Sink stage. */
+/** Target-path and compatibility-aware automatic-DDL support for the GBase 8c JDBC Sink. */
 final class GBase8cSinkSupport {
 
     private static final String DEFAULT_SCHEMA = "public";
@@ -23,41 +26,105 @@ final class GBase8cSinkSupport {
         return GBase8cJdbcUrl.accepts(config.getUrl());
     }
 
+    /**
+     * An implicit target keeps only the source table name. Source database/schema metadata must
+     * never choose the GBase 8c target schema merely because two databases happen to share a name.
+     */
+    static TablePath resolveImplicitTargetPath(
+            JdbcConnectionConfig config,
+            TablePath sourcePath) {
+        if (config == null || sourcePath == null) {
+            return sourcePath;
+        }
+        return TablePath.of(
+                requireUrlDatabase(config),
+                defaultSchema(config),
+                requireTableName(sourcePath));
+    }
+
+    /** Explicit schema.table mappings are preserved, but one connection cannot change database. */
+    static TablePath resolveExplicitTargetPath(
+            JdbcConnectionConfig config,
+            TablePath targetPath) {
+        if (config == null || targetPath == null) {
+            return targetPath;
+        }
+        String database = requireUrlDatabase(config);
+        if (hasText(targetPath.getDatabaseName())
+                && !database.equals(targetPath.getDatabaseName().trim())) {
+            throw crossDatabase(database, targetPath.getDatabaseName());
+        }
+        String schema = hasText(targetPath.getSchemaName())
+                ? targetPath.getSchemaName().trim()
+                : defaultSchema(config);
+        return TablePath.of(database, schema, requireTableName(targetPath));
+    }
+
+    /** Normalizes an already prepared target while preserving its selected target schema. */
     static TablePath resolveTargetPath(
             JdbcConnectionConfig config,
             TablePath tablePath) {
         if (config == null || tablePath == null) {
             return tablePath;
         }
+        String database = requireUrlDatabase(config);
+        if (hasText(tablePath.getDatabaseName())
+                && !database.equals(tablePath.getDatabaseName().trim())) {
+            throw crossDatabase(database, tablePath.getDatabaseName());
+        }
+        String schema = hasText(tablePath.getSchemaName())
+                ? tablePath.getSchemaName().trim()
+                : defaultSchema(config);
+        return TablePath.of(database, schema, requireTableName(tablePath));
+    }
 
-        String database = GBase8cJdbcUrl.databaseName(config.getUrl());
-        if (!hasText(database)) {
+    /** Builds the same compatibility-aware CREATE TABLE statement used by GBase8cCatalog. */
+    static String resolveCreateTableSql(
+            JdbcConnectionConfig config,
+            CatalogTable table,
+            GBase8cCompatibilityMode compatibilityMode) {
+        if (config == null || table == null || compatibilityMode == null) {
             return null;
         }
+        TablePath targetPath = resolveTargetPath(config, table.getTablePath());
+        CatalogTable ddlTable = table.getTablePath().equals(targetPath)
+                ? table
+                : table.withPath(targetPath);
+        return new GBase8cCreateTableSqlBuilder(
+                targetPath,
+                ddlTable,
+                compatibilityMode)
+                .build();
+    }
 
-        String pathDatabase = tablePath.getDatabaseName();
-        String pathSchema = tablePath.getSchemaName();
-        String schema;
+    private static String defaultSchema(JdbcConnectionConfig config) {
+        return hasText(config.getSchema()) ? config.getSchema().trim() : DEFAULT_SCHEMA;
+    }
 
-        /*
-         * Keep schema.table from an explicit target mapping. A three-part source path is safe to
-         * reuse only when its database is already the target database; otherwise prefer target
-         * connection settings so source database/schema metadata cannot leak into the Sink.
-         */
-        if (hasText(pathSchema)
-                && (!hasText(pathDatabase)
-                || database.equals(pathDatabase.trim()))) {
-            schema = pathSchema.trim();
-        } else if (hasText(config.getSchema())) {
-            schema = config.getSchema().trim();
-        } else {
-            schema = DEFAULT_SCHEMA;
+    private static String requireUrlDatabase(JdbcConnectionConfig config) {
+        String database = GBase8cJdbcUrl.databaseName(config.getUrl());
+        if (!hasText(database)) {
+            throw new IllegalArgumentException("GBase 8c Sink JDBC URL must specify database");
         }
+        return database.trim();
+    }
 
-        return TablePath.of(
-                database,
-                schema,
-                tablePath.getTableName());
+    private static String requireTableName(TablePath tablePath) {
+        if (!hasText(tablePath.getTableName())) {
+            throw new IllegalArgumentException("GBase 8c target table name must not be empty");
+        }
+        return tablePath.getTableName().trim();
+    }
+
+    private static IllegalArgumentException crossDatabase(
+            String urlDatabase,
+            String targetDatabase) {
+        return new IllegalArgumentException(
+                "GBase 8c explicit target database must match Sink JDBC URL database; "
+                        + "urlDatabase="
+                        + urlDatabase
+                        + ", targetDatabase="
+                        + targetDatabase);
     }
 
     private static boolean hasText(String value) {

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/JdbcSinkPreparer.java
@@ -5,9 +5,11 @@ import com.link.up.api.sink.SinkPrepareContext;
 import com.link.up.api.sink.SinkPreparer;
 import com.link.up.api.sink.TableDdl;
 import com.link.up.api.table.catalog.*;
+import com.link.up.connector.jdbc.catalog.gbase.gbase8c.GBase8cCatalog;
 import com.link.up.connector.jdbc.config.JdbcSinkConfig;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialect;
 import com.link.up.connector.jdbc.core.dialect.JdbcDialectLoader;
+import com.link.up.connector.jdbc.sink.savemode.GBase8cJdbcSaveModeHandler;
 import com.link.up.connector.jdbc.sink.savemode.JdbcSaveModeHandler;
 
 import java.util.ArrayList;
@@ -51,12 +53,7 @@ final class JdbcSinkPreparer implements SinkPreparer {
                 if (config.isUpsert() && !dialect.buildUpsertSql(target.getTablePath(), columnNames(target), primaryKeys).isPresent())
                     throw new IllegalArgumentException("Dialect does not support UPSERT: " + dialect.name());
 
-                JdbcSaveModeHandler handler = new JdbcSaveModeHandler(
-                        config.getSchemaSaveMode(),
-                        config.getDataSaveMode(),
-                        writableCatalog,
-                        target,
-                        config.isCreatePrimaryKey());
+                JdbcSaveModeHandler handler = createSaveModeHandler(writableCatalog, target);
 
                 boolean targetExistedBefore;
                 long startedAtNanos;
@@ -87,7 +84,7 @@ final class JdbcSinkPreparer implements SinkPreparer {
                         ddlTargetPath == null
                                 ? target.getTablePath().toString()
                                 : ddlTargetPath.toString(),
-                        resolveCreateTableSql(createDefinition),
+                        resolveCreateTableSql(createDefinition, handler),
                         executed,
                         executed ? TableDdl.STATUS_SUCCEEDED : TableDdl.STATUS_SKIPPED,
                         reason,
@@ -105,8 +102,50 @@ final class JdbcSinkPreparer implements SinkPreparer {
         }
     }
 
+    private JdbcSaveModeHandler createSaveModeHandler(
+            WritableCatalog writableCatalog,
+            CatalogTable target) {
+        if (GBase8cSinkSupport.accepts(config.getConnectionConfig())) {
+            if (!(writableCatalog instanceof GBase8cCatalog)) {
+                throw new IllegalStateException(
+                        "GBase 8c dialect must provide GBase8cCatalog for compatibility-aware DDL");
+            }
+            GBase8cCatalog gbase8cCatalog = (GBase8cCatalog) writableCatalog;
+            return new GBase8cJdbcSaveModeHandler(
+                    config.getSchemaSaveMode(),
+                    config.getDataSaveMode(),
+                    writableCatalog,
+                    target,
+                    config.isCreatePrimaryKey(),
+                    gbase8cCatalog::resolveCompatibilityMode);
+        }
+        return new JdbcSaveModeHandler(
+                config.getSchemaSaveMode(),
+                config.getDataSaveMode(),
+                writableCatalog,
+                target,
+                config.isCreatePrimaryKey());
+    }
+
     private CatalogTable resolveTargetTable(CatalogTable source) {
         String path = config.resolveTargetTablePath(source.getTablePath());
+
+        if (GBase8cSinkSupport.accepts(config.getConnectionConfig())) {
+            TablePath targetPath;
+            if (path == null) {
+                targetPath = GBase8cSinkSupport.resolveImplicitTargetPath(
+                        config.getConnectionConfig(),
+                        source.getTablePath());
+            } else {
+                TablePath explicit = dialect.parseTablePath(path);
+                targetPath = GBase8cSinkSupport.resolveExplicitTargetPath(
+                        config.getConnectionConfig(),
+                        explicit);
+            }
+            return source.getTablePath().equals(targetPath)
+                    ? source
+                    : source.withPath(targetPath);
+        }
 
         if (GBase8sSinkSupport.accepts(config.getConnectionConfig())) {
             TablePath targetPath;
@@ -180,7 +219,9 @@ final class JdbcSinkPreparer implements SinkPreparer {
                 config.getConnectionConfig(), tablePath);
     }
 
-    private String resolveCreateTableSql(CatalogTable table) {
+    private String resolveCreateTableSql(
+            CatalogTable table,
+            JdbcSaveModeHandler handler) {
         if (DuckDbSinkSupport.accepts(config.getConnectionConfig())) {
             return DuckDbSinkSupport.resolveCreateTableSql(
                     config.getConnectionConfig(), table);
@@ -205,7 +246,20 @@ final class JdbcSinkPreparer implements SinkPreparer {
             return null;
         }
         if (GBase8cSinkSupport.accepts(config.getConnectionConfig())) {
-            return null;
+            if (!(handler instanceof GBase8cJdbcSaveModeHandler)) {
+                throw new IllegalStateException(
+                        "GBase 8c DDL preview requires GBase8cJdbcSaveModeHandler");
+            }
+            GBase8cJdbcSaveModeHandler gbase8cHandler =
+                    (GBase8cJdbcSaveModeHandler) handler;
+            if (gbase8cHandler.getResolvedCompatibilityMode() == null) {
+                // Existing compatible targets do not need compatibility detection or CREATE SQL.
+                return null;
+            }
+            return GBase8cSinkSupport.resolveCreateTableSql(
+                    config.getConnectionConfig(),
+                    table,
+                    gbase8cHandler.getResolvedCompatibilityMode());
         }
         if (GBase8aSinkSupport.accepts(config.getConnectionConfig())) {
             return GBase8aSinkSupport.resolveCreateTableSql(

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/DefaultSaveModeHandler.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/DefaultSaveModeHandler.java
@@ -3,6 +3,7 @@ package com.link.up.connector.jdbc.sink.savemode;
 import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.SchemaCompatibilityReport;
 import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.catalog.WritableCatalog;
 import com.link.up.api.table.catalog.exception.TableNotFoundException;
 import com.link.up.connector.jdbc.sink.DataSaveMode;
@@ -85,9 +86,22 @@ public class DefaultSaveModeHandler implements SaveModeHandler {
         }
     }
 
-    private SchemaCompatibilityReport validateExistingSchema(boolean allowMissingColumns) {
-        SchemaCompatibilityReport report = SchemaCompatibilityReport.compare(
-                table.getTableSchema(), catalog.getTable(tablePath).getTableSchema());
+    /**
+     * Validates an already-existing target table.
+     *
+     * <p>Database-specific handlers may normalize the physical target schema through
+     * {@link #normalizeTargetSchemaForValidation(TableSchema, TableSchema)} before the generic
+     * compatibility report runs. The default implementation returns the target schema unchanged.
+     * This keeps product-specific physical/logical type quirks out of the global type-conversion
+     * contract.</p>
+     */
+    protected SchemaCompatibilityReport validateExistingSchema(boolean allowMissingColumns) {
+        TableSchema sourceSchema = table.getTableSchema();
+        TableSchema targetSchema = catalog.getTable(tablePath).getTableSchema();
+        TableSchema normalizedTarget =
+                normalizeTargetSchemaForValidation(sourceSchema, targetSchema);
+        SchemaCompatibilityReport report =
+                SchemaCompatibilityReport.compare(sourceSchema, normalizedTarget);
         if (!report.getIncompatibleColumns().isEmpty()
                 || (!allowMissingColumns && !report.getMissingTargetColumns().isEmpty())) {
             throw new IllegalArgumentException("Incompatible target schema: "
@@ -95,6 +109,13 @@ public class DefaultSaveModeHandler implements SaveModeHandler {
                     + report.getMissingTargetColumns());
         }
         return report;
+    }
+
+    /** Hook for database-specific logical/physical schema normalization during validation only. */
+    protected TableSchema normalizeTargetSchemaForValidation(
+            TableSchema sourceSchema,
+            TableSchema targetSchema) {
+        return targetSchema;
     }
 
     @Override

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/GBase8cJdbcSaveModeHandler.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/GBase8cJdbcSaveModeHandler.java
@@ -1,0 +1,71 @@
+package com.link.up.connector.jdbc.sink.savemode;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
+import com.link.up.connector.jdbc.sink.DataSaveMode;
+import com.link.up.connector.jdbc.sink.SchemaSaveMode;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * GBase 8c save-mode handler with lazy compatibility-mode resolution.
+ *
+ * <p>Existing-table jobs stay on the generic validation path unless a documented A-mode
+ * DATE/TIMESTAMP physical mismatch is present. Missing-table creation resolves compatibility mode
+ * before DDL, so automatic CREATE TABLE can never run under an implicit PostgreSQL assumption.</p>
+ */
+public final class GBase8cJdbcSaveModeHandler extends JdbcSaveModeHandler {
+
+    private final Supplier<GBase8cCompatibilityMode> compatibilityModeResolver;
+    private GBase8cCompatibilityMode resolvedCompatibilityMode;
+
+    public GBase8cJdbcSaveModeHandler(
+            SchemaSaveMode schemaSaveMode,
+            DataSaveMode dataSaveMode,
+            WritableCatalog catalog,
+            CatalogTable table,
+            boolean createPrimaryKey,
+            Supplier<GBase8cCompatibilityMode> compatibilityModeResolver) {
+        super(schemaSaveMode, dataSaveMode, catalog, table, createPrimaryKey);
+        this.compatibilityModeResolver = Objects.requireNonNull(
+                compatibilityModeResolver,
+                "compatibilityModeResolver must not be null");
+    }
+
+    @Override
+    protected void createTable() {
+        // Resolve first so automatic DDL always has an explicit, verified database mode.
+        compatibilityMode();
+        super.createTable();
+    }
+
+    @Override
+    protected TableSchema normalizeTargetSchemaForValidation(
+            TableSchema sourceSchema,
+            TableSchema targetSchema) {
+        if (!GBase8cSchemaCompatibility.hasDateTimestampCandidate(sourceSchema, targetSchema)) {
+            return targetSchema;
+        }
+        return GBase8cSchemaCompatibility.normalizeTargetForValidation(
+                sourceSchema,
+                targetSchema,
+                compatibilityMode());
+    }
+
+    /** Returns the mode only when this handler already had a reason to resolve it. */
+    public GBase8cCompatibilityMode getResolvedCompatibilityMode() {
+        return resolvedCompatibilityMode;
+    }
+
+    private GBase8cCompatibilityMode compatibilityMode() {
+        if (resolvedCompatibilityMode == null) {
+            resolvedCompatibilityMode = Objects.requireNonNull(
+                    compatibilityModeResolver.get(),
+                    "GBase 8c compatibility resolver returned null");
+        }
+        return resolvedCompatibilityMode;
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/GBase8cSchemaCompatibility.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/GBase8cSchemaCompatibility.java
@@ -1,0 +1,100 @@
+package com.link.up.connector.jdbc.sink.savemode;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Logical/physical schema normalization used only while validating GBase 8c targets.
+ *
+ * <p>In A compatibility mode GBase 8c documents DATE as the physical type
+ * {@code TIMESTAMP(0) WITHOUT TIME ZONE}. The generic JDBC metadata mapper therefore reads an
+ * auto-created DATE target back as Flux TIMESTAMP. This helper treats that one documented
+ * physical representation as logical DATE when the corresponding source column is DATE. It does
+ * not globally widen DATE -> TIMESTAMP conversion for other databases or other GBase 8c modes.</p>
+ */
+public final class GBase8cSchemaCompatibility {
+
+    private GBase8cSchemaCompatibility() {
+    }
+
+    /** Returns true only when mode resolution could repair a DATE(source)/TIMESTAMP(target) pair. */
+    public static boolean hasDateTimestampCandidate(
+            TableSchema sourceSchema,
+            TableSchema targetSchema) {
+        if (sourceSchema == null || targetSchema == null) {
+            return false;
+        }
+        Map<String, Column> targetByName = columnsByName(targetSchema.getColumns());
+        for (Column source : sourceSchema.getColumns()) {
+            Column target = targetByName.get(normalize(source.getName()));
+            if (target != null
+                    && source.getDataType().getSqlType() == SqlType.DATE
+                    && target.getDataType().getSqlType() == SqlType.TIMESTAMP) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Normalizes only the target columns that correspond to source DATE columns in A mode.
+     */
+    public static TableSchema normalizeTargetForValidation(
+            TableSchema sourceSchema,
+            TableSchema targetSchema,
+            GBase8cCompatibilityMode compatibilityMode) {
+        if (sourceSchema == null || targetSchema == null) {
+            throw new IllegalArgumentException("sourceSchema/targetSchema must not be null");
+        }
+        if (compatibilityMode != GBase8cCompatibilityMode.A) {
+            return targetSchema;
+        }
+
+        Map<String, Column> sourceByName = columnsByName(sourceSchema.getColumns());
+        List<Column> normalized = new ArrayList<Column>(targetSchema.getColumns().size());
+        boolean changed = false;
+        for (Column target : targetSchema.getColumns()) {
+            Column source = sourceByName.get(normalize(target.getName()));
+            if (source != null
+                    && source.getDataType().getSqlType() == SqlType.DATE
+                    && target.getDataType().getSqlType() == SqlType.TIMESTAMP) {
+                normalized.add(target.withType(BasicType.DATE_TYPE));
+                changed = true;
+            } else {
+                normalized.add(target);
+            }
+        }
+
+        if (!changed) {
+            return targetSchema;
+        }
+        return TableSchema.builder()
+                .columns(normalized)
+                .primaryKey(targetSchema.getPrimaryKey())
+                .build();
+    }
+
+    private static Map<String, Column> columnsByName(List<Column> columns) {
+        Map<String, Column> result = new HashMap<String, Column>();
+        if (columns == null) {
+            return result;
+        }
+        for (Column column : columns) {
+            result.put(normalize(column.getName()), column);
+        }
+        return result;
+    }
+
+    private static String normalize(String value) {
+        return value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/JdbcSaveModeHandler.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/main/java/com/link/up/connector/jdbc/sink/savemode/JdbcSaveModeHandler.java
@@ -9,7 +9,7 @@ import com.link.up.connector.jdbc.sink.SchemaSaveMode;
 /**
  * JDBC-specific save-mode handler that controls whether copied primary keys are created.
  */
-public final class JdbcSaveModeHandler extends DefaultSaveModeHandler {
+public class JdbcSaveModeHandler extends DefaultSaveModeHandler {
     private final boolean createPrimaryKey;
     private final CatalogTable createTableDefinition;
     private boolean tableCreated;

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalogTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCatalogTest.java
@@ -1,9 +1,8 @@
 package com.link.up.connector.jdbc.catalog.gbase.gbase8c;
 
-import com.link.up.api.table.catalog.CatalogTable;
 import com.link.up.api.table.catalog.Column;
 import com.link.up.api.table.catalog.TablePath;
-import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
 import com.link.up.api.table.catalog.exception.CatalogException;
 import com.link.up.api.table.type.BasicType;
 import com.link.up.connector.jdbc.catalog.JdbcCatalogConfig;
@@ -17,43 +16,49 @@ import static org.junit.Assert.fail;
 public class GBase8cCatalogTest {
 
     @Test
-    public void existingTableSinkRejectsAutomaticTableCreation() {
-        GBase8cCatalog catalog = catalog();
-
-        try {
-            catalog.createTable(table(), false);
-            fail("GBase 8c existing-table Sink must not auto-create target tables");
-        } catch (CatalogException expected) {
-            assertTrue(expected.getMessage().contains("existing-table Sink"));
-            assertTrue(expected.getMessage().contains("create table"));
-        }
+    public void catalogExposesWritableLifecycleForSafeMissingTableCreation() {
+        assertTrue(catalog() instanceof WritableCatalog);
     }
 
     @Test
-    public void existingTableSinkRejectsDestructiveSchemaRecreationBeforeDrop() {
+    public void automaticTargetStageStillRejectsDestructiveSchemaRecreation() {
         GBase8cCatalog catalog = catalog();
 
         try {
             catalog.dropTable(
                     TablePath.of("app", "public", "orders"),
                     false);
-            fail("GBase 8c existing-table Sink must not drop target tables");
+            fail("GBase 8c automatic-target Sink must not drop target tables");
         } catch (CatalogException expected) {
             assertTrue(expected.getMessage().contains("drop table"));
+            assertTrue(expected.getMessage().contains("remains disabled"));
         }
     }
 
     @Test
-    public void existingTableSinkRejectsSchemaEvolution() {
+    public void automaticTargetStageStillRejectsSchemaEvolution() {
         GBase8cCatalog catalog = catalog();
 
         try {
             catalog.addColumn(
                     TablePath.of("app", "public", "orders"),
                     Column.builder("extra", BasicType.STRING_TYPE).build());
-            fail("GBase 8c existing-table Sink must not add target columns");
+            fail("GBase 8c automatic-target Sink must not add target columns");
         } catch (CatalogException expected) {
             assertTrue(expected.getMessage().contains("add column"));
+            assertTrue(expected.getMessage().contains("remains disabled"));
+        }
+    }
+
+    @Test
+    public void automaticTargetStageStillRejectsDatabaseDdl() {
+        GBase8cCatalog catalog = catalog();
+
+        try {
+            catalog.createDatabase("archive", false);
+            fail("GBase 8c automatic-target Sink must not create databases");
+        } catch (CatalogException expected) {
+            assertTrue(expected.getMessage().contains("create database"));
         }
     }
 
@@ -68,21 +73,5 @@ public class GBase8cCatalogTest {
                         Collections.emptyMap(),
                         false),
                 "public");
-    }
-
-    private static CatalogTable table() {
-        TableSchema schema =
-                TableSchema.builder()
-                        .columns(
-                                Collections.singletonList(
-                                        Column.builder("id", BasicType.LONG_TYPE)
-                                                .nullable(false)
-                                                .build()))
-                        .build();
-
-        return CatalogTable.builder(
-                        TablePath.of("app", "public", "orders"),
-                        schema)
-                .build();
     }
 }

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCreateTableSqlBuilderTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/catalog/gbase/gbase8c/GBase8cCreateTableSqlBuilderTest.java
@@ -1,0 +1,129 @@
+package com.link.up.connector.jdbc.catalog.gbase.gbase8c;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.PrimaryKey;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.DecimalType;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cCreateTableSqlBuilderTest {
+
+    @Test
+    public void pgModeBuildsConservativePortableTable() {
+        String sql = builder(
+                GBase8cCompatibilityMode.PG,
+                tableWithPrimaryKey())
+                .build();
+
+        assertTrue(sql.startsWith("CREATE TABLE \"landing\".\"orders\" ("));
+        assertTrue(sql.contains("\"id\" BIGINT NOT NULL"));
+        assertTrue(sql.contains("\"name\" VARCHAR(128) NULL"));
+        assertTrue(sql.contains("\"amount\" NUMERIC(18,2) NULL"));
+        assertTrue(sql.contains("\"business_date\" DATE NOT NULL"));
+        assertTrue(sql.contains("PRIMARY KEY (\"id\")"));
+        assertSafeBaseline(sql);
+    }
+
+    @Test
+    public void aModeUsesTextAndPhysicalDateContract() {
+        String sql = builder(
+                GBase8cCompatibilityMode.A,
+                tableWithPrimaryKey())
+                .build();
+
+        assertTrue(sql.contains("\"name\" TEXT NULL"));
+        assertTrue(sql.contains(
+                "\"business_date\" TIMESTAMP(0) WITHOUT TIME ZONE NOT NULL"));
+        assertSafeBaseline(sql);
+    }
+
+    @Test
+    public void bAndCModeKeepDateButUseSafeTextBoundary() {
+        String bSql = builder(GBase8cCompatibilityMode.B, tableWithPrimaryKey()).build();
+        String cSql = builder(GBase8cCompatibilityMode.C, tableWithPrimaryKey()).build();
+
+        assertTrue(bSql.contains("\"name\" TEXT NULL"));
+        assertTrue(bSql.contains("\"business_date\" DATE NOT NULL"));
+        assertTrue(cSql.contains("\"name\" TEXT NULL"));
+        assertTrue(cSql.contains("\"business_date\" DATE NOT NULL"));
+    }
+
+    @Test
+    public void sourceDefaultsIdentityAndCommentsAreNeverCopied() {
+        Column id = Column.builder("id", BasicType.LONG_TYPE)
+                .nullable(false)
+                .autoIncrement(true)
+                .defaultValue("nextval('source_seq')")
+                .comment("source id")
+                .build();
+        TableSchema schema = TableSchema.builder()
+                .columns(Collections.singletonList(id))
+                .build();
+        CatalogTable table = CatalogTable.builder(
+                        TablePath.of("targetdb", "landing", "orders"),
+                        schema)
+                .build();
+
+        String sql = builder(GBase8cCompatibilityMode.PG, table).build();
+        assertFalse(sql.toLowerCase().contains("nextval"));
+        assertFalse(sql.toLowerCase().contains("serial"));
+        assertFalse(sql.toLowerCase().contains("default"));
+        assertFalse(sql.toLowerCase().contains("comment"));
+    }
+
+    private static GBase8cCreateTableSqlBuilder builder(
+            GBase8cCompatibilityMode mode,
+            CatalogTable table) {
+        return new GBase8cCreateTableSqlBuilder(
+                TablePath.of("targetdb", "landing", "orders"),
+                table,
+                mode);
+    }
+
+    private static CatalogTable tableWithPrimaryKey() {
+        Column id = Column.builder("id", BasicType.LONG_TYPE)
+                .nullable(false)
+                .build();
+        Column name = Column.builder("name", BasicType.STRING_TYPE)
+                .length(128L)
+                .nullable(true)
+                .build();
+        Column amount = Column.builder("amount", new DecimalType(18, 2))
+                .precision(18)
+                .scale(2)
+                .nullable(true)
+                .build();
+        Column businessDate = Column.builder("business_date", BasicType.DATE_TYPE)
+                .nullable(false)
+                .build();
+        TableSchema schema = TableSchema.builder()
+                .columns(Arrays.asList(id, name, amount, businessDate))
+                .primaryKey(PrimaryKey.of(Collections.singletonList("id")))
+                .build();
+        return CatalogTable.builder(
+                        TablePath.of("targetdb", "landing", "orders"),
+                        schema)
+                .build();
+    }
+
+    private static void assertSafeBaseline(String sql) {
+        String lower = sql.toLowerCase();
+        assertFalse(lower.contains("default"));
+        assertFalse(lower.contains("auto_increment"));
+        assertFalse(lower.contains("serial"));
+        assertFalse(lower.contains("comment"));
+        assertFalse(lower.contains("partition by"));
+        assertFalse(lower.contains("distribute by"));
+        assertFalse(lower.contains("replication"));
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupportTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/GBase8cSinkSupportTest.java
@@ -8,66 +8,74 @@ import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.type.BasicType;
 import com.link.up.connector.jdbc.config.JdbcConnectionConfig;
 import com.link.up.connector.jdbc.core.dialect.DatabaseIdentifier;
-import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cDialect;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
 import org.junit.Test;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class GBase8cSinkSupportTest {
 
     @Test
-    public void sourceDatabaseAndSchemaDoNotLeakIntoGBase8cTarget() {
-        TablePath target =
-                GBase8cSinkSupport.resolveTargetPath(
-                        config("target_db", "landing", DatabaseIdentifier.GBASE8C),
-                        TablePath.of("source_db", "source_schema", "orders"));
+    public void implicitTargetDropsSourceDatabaseAndSchemaMetadata() {
+        TablePath target = GBase8cSinkSupport.resolveImplicitTargetPath(
+                config("target_db", "landing", DatabaseIdentifier.GBASE8C),
+                TablePath.of("source_db", "source_schema", "orders"));
 
-        assertEquals(
-                TablePath.of("target_db", "landing", "orders"),
-                target);
+        assertEquals(TablePath.of("target_db", "landing", "orders"), target);
     }
 
     @Test
-    public void foreignSourceSchemaFallsBackToPublicWithoutTargetSchema() {
-        TablePath target =
-                GBase8cSinkSupport.resolveTargetPath(
-                        config("target_db", null, DatabaseIdentifier.GBASE8C),
-                        TablePath.of("source_db", "source_schema", "orders"));
+    public void implicitTargetDoesNotLeakSchemaEvenWhenDatabaseNamesCoincide() {
+        TablePath target = GBase8cSinkSupport.resolveImplicitTargetPath(
+                config("target_db", "landing", DatabaseIdentifier.GBASE8C),
+                TablePath.of("target_db", "source_schema", "orders"));
 
-        assertEquals(
-                TablePath.of("target_db", "public", "orders"),
-                target);
+        assertEquals(TablePath.of("target_db", "landing", "orders"), target);
+    }
+
+    @Test
+    public void implicitTargetFallsBackToPublicWithoutConfiguredSchema() {
+        TablePath target = GBase8cSinkSupport.resolveImplicitTargetPath(
+                config("target_db", null, DatabaseIdentifier.GBASE8C),
+                TablePath.of("source_db", "source_schema", "orders"));
+
+        assertEquals(TablePath.of("target_db", "public", "orders"), target);
     }
 
     @Test
     public void explicitSchemaTableMappingWinsOverConfiguredDefaultSchema() {
-        TablePath target =
-                GBase8cSinkSupport.resolveTargetPath(
-                        config("target_db", "public", DatabaseIdentifier.GBASE8C),
-                        TablePath.of(null, "archive", "orders"));
+        TablePath target = GBase8cSinkSupport.resolveExplicitTargetPath(
+                config("target_db", "public", DatabaseIdentifier.GBASE8C),
+                TablePath.of(null, "archive", "orders"));
 
-        assertEquals(
-                TablePath.of("target_db", "archive", "orders"),
-                target);
+        assertEquals(TablePath.of("target_db", "archive", "orders"), target);
     }
 
     @Test
-    public void schemaCanBePreservedWhenPathAlreadyTargetsSameDatabase() {
-        TablePath target =
-                GBase8cSinkSupport.resolveTargetPath(
-                        config("target_db", "public", DatabaseIdentifier.GBASE8C),
-                        TablePath.of("target_db", "sales", "orders"));
+    public void explicitSameDatabaseSchemaMappingIsAccepted() {
+        TablePath target = GBase8cSinkSupport.resolveExplicitTargetPath(
+                config("target_db", "public", DatabaseIdentifier.GBASE8C),
+                TablePath.of("target_db", "sales", "orders"));
 
-        assertEquals(
-                TablePath.of("target_db", "sales", "orders"),
-                target);
+        assertEquals(TablePath.of("target_db", "sales", "orders"), target);
+    }
+
+    @Test
+    public void explicitCrossDatabaseMappingIsRejected() {
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class,
+                () -> GBase8cSinkSupport.resolveExplicitTargetPath(
+                        config("target_db", "public", DatabaseIdentifier.GBASE8C),
+                        TablePath.of("other_db", "sales", "orders")));
+
+        assertTrue(error.getMessage().contains("must match Sink JDBC URL database"));
     }
 
     @Test
@@ -80,26 +88,37 @@ public class GBase8cSinkSupportTest {
     }
 
     @Test
-    public void existingTableSinkDoesNotGenerateAutomaticCreateTableSql() {
+    public void automaticCreatePreviewUsesResolvedModeAndTargetSchema() {
         JdbcConnectionConfig config =
-                config("target_db", "public", DatabaseIdentifier.GBASE8C);
+                config("target_db", "landing", DatabaseIdentifier.GBASE8C);
+        TablePath targetPath = GBase8cSinkSupport.resolveImplicitTargetPath(
+                config,
+                table().getTablePath());
+        CatalogTable target = table().withPath(targetPath);
 
-        assertNull(
-                JdbcCreateTableSqlResolver.resolve(
-                        new GBase8cDialect(config),
-                        config,
-                        table()));
+        String sql = GBase8cSinkSupport.resolveCreateTableSql(
+                config,
+                target,
+                GBase8cCompatibilityMode.A);
+
+        assertTrue(sql.startsWith("CREATE TABLE \"landing\".\"orders\" ("));
+        assertTrue(sql.contains("\"id\" BIGINT NOT NULL"));
+        assertTrue(sql.contains(
+                "\"business_date\" TIMESTAMP(0) WITHOUT TIME ZONE NULL"));
+        assertFalse(sql.contains("source_db"));
+        assertFalse(sql.contains("source_schema"));
     }
 
     private static CatalogTable table() {
-        TableSchema schema =
-                TableSchema.builder()
-                        .columns(
-                                Collections.singletonList(
-                                        Column.builder("id", BasicType.LONG_TYPE)
-                                                .nullable(false)
-                                                .build()))
-                        .build();
+        TableSchema schema = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("id", BasicType.LONG_TYPE)
+                                .nullable(false)
+                                .build(),
+                        Column.builder("business_date", BasicType.DATE_TYPE)
+                                .nullable(true)
+                                .build()))
+                .build();
 
         return CatalogTable.builder(
                         TablePath.of("source_db", "source_schema", "orders"),

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/savemode/GBase8cJdbcSaveModeHandlerTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/savemode/GBase8cJdbcSaveModeHandlerTest.java
@@ -1,0 +1,205 @@
+package com.link.up.connector.jdbc.sink.savemode;
+
+import com.link.up.api.table.catalog.CatalogTable;
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TablePath;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.catalog.WritableCatalog;
+import com.link.up.api.table.catalog.exception.CatalogException;
+import com.link.up.api.table.catalog.exception.DatabaseAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.DatabaseNotFoundException;
+import com.link.up.api.table.catalog.exception.TableAlreadyExistsException;
+import com.link.up.api.table.catalog.exception.TableNotFoundException;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
+import com.link.up.connector.jdbc.sink.DataSaveMode;
+import com.link.up.connector.jdbc.sink.SchemaSaveMode;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cJdbcSaveModeHandlerTest {
+
+    @Test
+    public void ordinaryExistingTargetDoesNotResolveCompatibilityMode() {
+        CatalogTable source = table(BasicType.LONG_TYPE);
+        FakeCatalog catalog = new FakeCatalog(source, true);
+        AtomicInteger resolutions = new AtomicInteger();
+        GBase8cJdbcSaveModeHandler handler = handler(
+                catalog,
+                source,
+                resolutions,
+                GBase8cCompatibilityMode.A);
+
+        handler.open();
+        try {
+            handler.handleSaveMode();
+        } finally {
+            handler.close();
+        }
+
+        assertEquals(0, resolutions.get());
+        assertFalse(handler.isTableCreated());
+    }
+
+    @Test
+    public void missingTargetResolvesModeBeforeCreatingTable() {
+        CatalogTable source = table(BasicType.LONG_TYPE);
+        FakeCatalog catalog = new FakeCatalog(source, false);
+        AtomicInteger resolutions = new AtomicInteger();
+        GBase8cJdbcSaveModeHandler handler = handler(
+                catalog,
+                source,
+                resolutions,
+                GBase8cCompatibilityMode.PG);
+
+        handler.open();
+        try {
+            handler.handleSaveMode();
+        } finally {
+            handler.close();
+        }
+
+        assertEquals(1, resolutions.get());
+        assertTrue(handler.isTableCreated());
+        assertTrue(catalog.createTableCalled);
+        assertEquals(GBase8cCompatibilityMode.PG, handler.getResolvedCompatibilityMode());
+    }
+
+    @Test
+    public void aModeExistingPhysicalTimestampValidatesLogicalDate() {
+        CatalogTable source = table(BasicType.DATE_TYPE);
+        CatalogTable physicalTarget = table(BasicType.TIMESTAMP_TYPE);
+        FakeCatalog catalog = new FakeCatalog(physicalTarget, true);
+        AtomicInteger resolutions = new AtomicInteger();
+        GBase8cJdbcSaveModeHandler handler = handler(
+                catalog,
+                source,
+                resolutions,
+                GBase8cCompatibilityMode.A);
+
+        handler.open();
+        try {
+            handler.handleSaveMode();
+        } finally {
+            handler.close();
+        }
+
+        assertEquals(1, resolutions.get());
+        assertFalse(handler.isTableCreated());
+        assertEquals(GBase8cCompatibilityMode.A, handler.getResolvedCompatibilityMode());
+    }
+
+    private static GBase8cJdbcSaveModeHandler handler(
+            FakeCatalog catalog,
+            CatalogTable source,
+            AtomicInteger resolutions,
+            GBase8cCompatibilityMode mode) {
+        return new GBase8cJdbcSaveModeHandler(
+                SchemaSaveMode.CREATE_SCHEMA_WHEN_NOT_EXIST,
+                DataSaveMode.APPEND_DATA,
+                catalog,
+                source,
+                true,
+                () -> {
+                    resolutions.incrementAndGet();
+                    return mode;
+                });
+    }
+
+    private static CatalogTable table(com.link.up.api.table.type.FluxDataType<?> type) {
+        TableSchema schema = TableSchema.builder()
+                .columns(Collections.singletonList(
+                        Column.builder("value", type)
+                                .nullable(true)
+                                .build()))
+                .build();
+        return CatalogTable.builder(
+                        TablePath.of("app", "public", "orders"),
+                        schema)
+                .build();
+    }
+
+    private static final class FakeCatalog implements WritableCatalog {
+        private final CatalogTable table;
+        private final boolean exists;
+        private boolean createTableCalled;
+
+        private FakeCatalog(CatalogTable table, boolean exists) {
+            this.table = table;
+            this.exists = exists;
+        }
+
+        @Override
+        public String name() {
+            return "gbase8c-test";
+        }
+
+        @Override
+        public void open() {
+        }
+
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public List<String> listDatabases() {
+            return Collections.singletonList("app");
+        }
+
+        @Override
+        public List<TablePath> listTables(String databaseName, String schemaName) {
+            return Collections.singletonList(table.getTablePath());
+        }
+
+        @Override
+        public boolean tableExists(TablePath tablePath) {
+            return exists;
+        }
+
+        @Override
+        public CatalogTable getTable(TablePath tablePath)
+                throws CatalogException, TableNotFoundException {
+            if (!exists) {
+                throw new TableNotFoundException(name(), tablePath);
+            }
+            return table;
+        }
+
+        @Override
+        public void createDatabase(String databaseName, boolean ignoreIfExists)
+                throws CatalogException, DatabaseAlreadyExistsException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void dropDatabase(String databaseName, boolean ignoreIfNotExists)
+                throws CatalogException, DatabaseNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void createTable(CatalogTable table, boolean ignoreIfExists)
+                throws CatalogException, DatabaseNotFoundException, TableAlreadyExistsException {
+            createTableCalled = true;
+        }
+
+        @Override
+        public void dropTable(TablePath tablePath, boolean ignoreIfNotExists)
+                throws CatalogException, TableNotFoundException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void truncateTable(TablePath tablePath, boolean ignoreIfNotExists)
+                throws CatalogException, TableNotFoundException {
+        }
+    }
+}

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/savemode/GBase8cSchemaCompatibilityTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/savemode/GBase8cSchemaCompatibilityTest.java
@@ -1,0 +1,99 @@
+package com.link.up.connector.jdbc.sink.savemode;
+
+import com.link.up.api.table.catalog.Column;
+import com.link.up.api.table.catalog.TableSchema;
+import com.link.up.api.table.type.BasicType;
+import com.link.up.api.table.type.SqlType;
+import com.link.up.connector.jdbc.core.dialect.gbase.gbase8c.GBase8cCompatibilityMode;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class GBase8cSchemaCompatibilityTest {
+
+    @Test
+    public void detectsA-modeDatePhysicalTimestampCandidateCaseInsensitively() {
+        TableSchema source = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("Business_Date", BasicType.DATE_TYPE).build(),
+                        Column.builder("id", BasicType.LONG_TYPE).build()))
+                .build();
+        TableSchema target = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("business_date", BasicType.TIMESTAMP_TYPE).build(),
+                        Column.builder("id", BasicType.LONG_TYPE).build()))
+                .build();
+
+        assertTrue(GBase8cSchemaCompatibility.hasDateTimestampCandidate(source, target));
+    }
+
+    @Test
+    public void aModeNormalizesOnlyMatchingDateTimestampColumns() {
+        TableSchema source = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("business_date", BasicType.DATE_TYPE).build(),
+                        Column.builder("updated_at", BasicType.TIMESTAMP_TYPE).build()))
+                .build();
+        TableSchema target = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("business_date", BasicType.TIMESTAMP_TYPE).build(),
+                        Column.builder("updated_at", BasicType.TIMESTAMP_TYPE).build()))
+                .build();
+
+        TableSchema normalized = GBase8cSchemaCompatibility.normalizeTargetForValidation(
+                source,
+                target,
+                GBase8cCompatibilityMode.A);
+
+        assertEquals(SqlType.DATE, normalized.getColumns().get(0).getDataType().getSqlType());
+        assertEquals(
+                SqlType.TIMESTAMP,
+                normalized.getColumns().get(1).getDataType().getSqlType());
+    }
+
+    @Test
+    public void nonAModesDoNotRelaxDateTimestampValidation() {
+        TableSchema source = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("business_date", BasicType.DATE_TYPE).build()))
+                .build();
+        TableSchema target = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("business_date", BasicType.TIMESTAMP_TYPE).build()))
+                .build();
+
+        assertSame(
+                target,
+                GBase8cSchemaCompatibility.normalizeTargetForValidation(
+                        source,
+                        target,
+                        GBase8cCompatibilityMode.PG));
+        assertSame(
+                target,
+                GBase8cSchemaCompatibility.normalizeTargetForValidation(
+                        source,
+                        target,
+                        GBase8cCompatibilityMode.B));
+    }
+
+    @Test
+    public void ordinaryCompatibleSchemasDoNotRequireModeResolutionCandidate() {
+        TableSchema source = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("id", BasicType.LONG_TYPE).build(),
+                        Column.builder("created_at", BasicType.TIMESTAMP_TYPE).build()))
+                .build();
+        TableSchema target = TableSchema.builder()
+                .columns(Arrays.asList(
+                        Column.builder("id", BasicType.LONG_TYPE).build(),
+                        Column.builder("created_at", BasicType.TIMESTAMP_TYPE).build()))
+                .build();
+
+        assertFalse(GBase8cSchemaCompatibility.hasDateTimestampCandidate(source, target));
+    }
+}


### PR DESCRIPTION
## Summary

Enable safe automatic creation of missing GBase 8c target tables.

This PR builds on the compatibility-aware DDL foundation from #131. Users no longer need to pre-create the GBase 8c target table when the normal JDBC Sink lifecycle uses `CREATE_SCHEMA_WHEN_NOT_EXIST`: Link-Up resolves the Sink target path, detects the target database's actual A/B/C/PG compatibility mode only when needed, generates mode-aware CREATE TABLE DDL, creates the missing table, then continues through the existing JDBC INSERT/batch/transaction path.

## User-facing flow

```text
Source table/schema
  -> resolve Sink database + schema + table
  -> target exists?
     -> yes: validate existing schema
             -> ordinary schemas: no compatibility lookup
             -> A-mode DATE/TIMESTAMP candidate: resolve mode lazily and normalize validation
     -> no: resolve pg_database.datcompatibility
            -> A / B / C / PG
            -> build compatibility-aware CREATE TABLE
            -> create target table
  -> generated INSERT
  -> JDBC batch write
```

No manual compatibility-mode option is introduced. The database remains the source of truth for its compatibility mode.

## Target routing

The Sink JDBC URL owns the target database. For an implicit target, Link-Up keeps only the source table name and resolves target schema from the Sink `schema` option, falling back to `public`. Source database/schema metadata is never reused implicitly, even when source and target database names happen to be identical.

Explicit `schema.table` mappings are preserved. A three-part target may be used only when its database matches the Sink JDBC URL database; cross-database redirection is rejected during preparation.

## Compatibility-aware automatic DDL

Add `GBase8cCreateTableSqlBuilder` and enable `GBase8cCatalog#createTable` for missing targets. Automatic DDL always has an explicitly resolved compatibility mode. Unknown/newer `datcompatibility` values fail closed for automatic creation instead of being treated as PostgreSQL implicitly.

The DDL copies only column names, compatibility-aware target types, NULL / NOT NULL, and the primary key when the shared `create_primary_key` option keeps it. It deliberately does not copy DEFAULT expressions, identity / SERIAL / AUTO_INCREMENT semantics, comments, indexes, foreign keys, partitions, storage orientation, replication policy, or hash/distribution-key policy.

## Target type contract

The mode-aware type foundation from #131 is now used by real CREATE TABLE execution:

- TINYINT / SMALLINT -> SMALLINT
- INT -> INTEGER
- BIGINT -> BIGINT
- FLOAT -> REAL
- DOUBLE -> DOUBLE PRECISION
- DECIMAL -> NUMERIC(precision, scale)
- BOOLEAN -> BOOLEAN
- BYTES -> BYTEA
- TIME -> TIME
- TIMESTAMP -> TIMESTAMP
- B/C/PG DATE -> DATE
- A-mode DATE -> TIMESTAMP(0) WITHOUT TIME ZONE
- PG-mode STRING with a safe known length -> VARCHAR(length)
- A/B/C STRING -> TEXT

`TIMESTAMP_TZ` remains enabled only for the verified PG-mode contract. ARRAY/MAP/ROW and other types without a safe automatic-target contract fail before DDL execution.

## A-mode DATE round-trip

GBase 8c A mode physically represents DATE as `TIMESTAMP(0) WITHOUT TIME ZONE`. After auto-creation, JDBC metadata therefore reads that target column back as Flux TIMESTAMP.

This PR adds a GBase-8c-only schema-validation normalization:

```text
source Flux DATE
  -> A-mode CREATE TIMESTAMP(0) WITHOUT TIME ZONE
  -> metadata Flux TIMESTAMP
  -> validation normalizes only the matching target column back to logical DATE
```

The global `TypeUtil` and generic `SchemaCompatibilityReport` are not relaxed. PG/B/C modes still reject an unrelated DATE -> TIMESTAMP mismatch normally.

Compatibility-mode detection for existing tables is lazy: an ordinary already-compatible GBase 8c target does not query `datcompatibility` at all. Detection is required only for missing-table DDL or a DATE/TIMESTAMP candidate that may be the documented A-mode physical representation.

## Shared save-mode extension

`DefaultSaveModeHandler` receives one protected target-schema normalization hook whose default implementation is identity. `JdbcSaveModeHandler` is made extensible so GBase 8c can provide its product-specific validation behavior. All other JDBC databases keep the existing save-mode behavior unchanged.

## Save-mode behavior

- `CREATE_SCHEMA_WHEN_NOT_EXIST`: existing table validates; missing table auto-creates
- `CREATE_OR_ADD_COLUMNS`: missing table auto-creates; existing missing columns still fail because ADD COLUMN remains blocked
- `ERROR_WHEN_SCHEMA_NOT_EXIST` / `IGNORE`: unchanged
- `RECREATE_SCHEMA`: existing table still fails at DROP TABLE; destructive recreation remains blocked
- `DROP_DATA`: existing TRUNCATE TABLE behavior remains available

The target database/schema themselves are not created automatically.

## Distribution boundary

The generated SQL contains no `DISTRIBUTE BY` and no replication clause. GBase 8c distribution/replication design depends on table size, join/group access patterns, cardinality and data-skew considerations. Automatic synchronization therefore does not guess an MPP physical distribution key from source metadata.

## Existing Sink behavior retained

After preparation, row writing continues through the shared JDBC writer: parameterized INSERT, configured batch size, `PreparedStatement.addBatch()` / `executeBatch()`, task-local transaction, commit/rollback, savepoint retry and dirty-data handling. UPSERT/MERGE remains unsupported in this stage.

## Tests

Focused tests cover PG/A/B/C CREATE TABLE generation, compatibility-sensitive STRING/DATE types, NULL / NOT NULL, primary-key DDL, source DEFAULT/identity/comments not copied, no distribution/replication/partition clauses, source routing isolation, same-name DB schema-leak regression, explicit schema mapping, cross-database rejection, DDL preview, A-mode DATE round-trip, non-A mismatch behavior, lazy compatibility lookup, missing-target mode resolution, and destructive/evolution DDL remaining blocked.

The #131 compatibility-mode and target-type foundation tests remain in place as well.

## Verification

- based directly on current `main` after #131
- final branch is one atomic commit
- final compare: `ahead=1`, `behind=0`
- final diff is limited to 15 files: GBase 8c automatic-target implementation/tests, README, and the small generic save-mode extension hooks
- no vendor JDBC Maven dependency was added
- local checkout/Maven execution was attempted, but this execution environment still cannot resolve `github.com`, so the Maven suite was not executed here
- tests are added but are not claimed as executed
- real GBase 8c environments are still required before Ready for Review to validate A/B/C/PG mode detection, CREATE TABLE execution, metadata round-trip, A-mode DATE binding/second-run validation, target-schema permissions, primary-key options and subsequent JDBC batch INSERT end to end

## Non-goals

- CREATE/DROP database or schema
- DROP/recreate existing tables
- runtime ADD COLUMN/schema evolution
- automatic distribution/hash-key selection
- automatic replication-table selection
- source DEFAULT/identity semantics replication
- UPSERT/MERGE
- unverified newer compatibility modes
- CDC/realtime semantics
- native/bulk loading