### PR TITLE
fix(test): correct GBase8c compatibility test compilation

### DIFF
--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/savemode/GBase8cSchemaCompatibilityTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/sink/savemode/GBase8cSchemaCompatibilityTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertTrue;
 public class GBase8cSchemaCompatibilityTest {
 
     @Test
-    public void detectsA-modeDatePhysicalTimestampCandidateCaseInsensitively() {
+    public void detectsAModeDatePhysicalTimestampCandidateCaseInsensitively() {
         TableSchema source = TableSchema.builder()
                 .columns(Arrays.asList(
                         Column.builder("Business_Date", BasicType.DATE_TYPE).build(),


### PR DESCRIPTION
## Summary

Fix the JDBC connector test compilation failure in `GBase8cSchemaCompatibilityTest`.

The test method name contained a hyphen:

```java
detectsA-modeDatePhysicalTimestampCandidateCaseInsensitively
```

A hyphen is not valid in a Java identifier, so `maven-compiler-plugin:testCompile` failed before the remaining reactor modules could build.

This PR renames it to:

```java
detectsAModeDatePhysicalTimestampCandidateCaseInsensitively
```

## Scope

- Test-only change
- No production behavior changes
- No GBase8c compatibility logic changes

## Verification

The change is limited to correcting the invalid Java test method identifier that caused the reported `testCompile` syntax errors.