### PR TITLE
ci: add backend Maven verification workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,42 @@
+name: Backend CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: backend-ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Maven Verify (Java 8)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Java 8
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '8'
+          cache: maven
+
+      - name: Show tool versions
+        run: |
+          java -version
+          mvn -version
+
+      - name: Verify
+        run: mvn --batch-mode --no-transfer-progress clean verify


### PR DESCRIPTION
## Summary

Add a GitHub Actions backend CI workflow for Link-Up.

## What it does

- Runs on pull requests targeting `main`
- Runs on pushes to `main`
- Supports manual `workflow_dispatch`
- Uses Java 8 to match the project's configured target/runtime baseline
- Enables Maven dependency caching
- Runs the repository's canonical build command with full tests: `mvn --batch-mode --no-transfer-progress clean verify`
- Cancels stale in-progress runs when newer commits are pushed to the same ref
- Uses read-only repository permissions

## Scope

- Adds `.github/workflows/backend-ci.yml`
- No production code changes
- No release/deploy behavior changes
