### PR TITLE
fix: repair backend CI compatibility and ES8 mapping serialization

### DIFF
--- a/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkWriterTest.java
+++ b/link-up-connectors/link-up-connector-clickhouse/src/test/java/com/link/up/connector/clickhouse/sink/ClickHouseSinkWriterTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -31,7 +32,7 @@ public class ClickHouseSinkWriterTest {
 
         writer.open();
         writer.write(
-                RecordBatch.data(
+                batch(
                         Arrays.asList(
                                 FluxRow.of(1L, "a"),
                                 FluxRow.of(2L, "b"),
@@ -59,7 +60,7 @@ public class ClickHouseSinkWriterTest {
 
         writer.open();
         writer.write(
-                RecordBatch.data(Collections.singletonList(FluxRow.of(1L, "a"))),
+                batch(Collections.singletonList(FluxRow.of(1L, "a"))),
                 source);
         assertEquals(1, executor.pendingRows);
         assertEquals(0, executor.flushCount);
@@ -89,14 +90,18 @@ public class ClickHouseSinkWriterTest {
         writer.open();
         try {
             writer.write(
-                    RecordBatch.data(Collections.singletonList(FluxRow.of(1L, "a"))),
+                    batch(Collections.singletonList(FluxRow.of(1L, "a"))),
                     source);
             writer.write(
-                    RecordBatch.data(Collections.singletonList(FluxRow.of(2L, "b", "x"))),
+                    batch(Collections.singletonList(FluxRow.of(2L, "b", "x"))),
                     sourceTable(changed));
         } finally {
             writer.close();
         }
+    }
+
+    private static RecordBatch<FluxRow> batch(List<FluxRow> rows) {
+        return RecordBatch.of("source.orders", "split-0", rows);
     }
 
     private static ClickHouseSinkWriter writer(

--- a/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SinkConfigTest.java
+++ b/link-up-connectors/link-up-connector-elasticsearch7/src/test/java/com/link/up/connector/elasticsearch7/config/Elasticsearch7SinkConfigTest.java
@@ -15,7 +15,8 @@ public class Elasticsearch7SinkConfigTest {
 
     @Test
     public void parsesBoundedSinkDefaults() {
-        Elasticsearch7SinkConfig config = Elasticsearch7SinkConfig.of(config("orders"));
+        Elasticsearch7SinkConfig config =
+                Elasticsearch7SinkConfig.of(ReadonlyConfig.fromMap(config("orders")));
         assertEquals(1000, config.getBatchSize());
         assertEquals(3, config.getMaxRetries());
         assertEquals(200L, config.getRetryBackoffMs());

--- a/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/schema/Elasticsearch8TypeMapper.java
+++ b/link-up-connectors/link-up-connector-elasticsearch8/src/main/java/com/link/up/connector/elasticsearch8/schema/Elasticsearch8TypeMapper.java
@@ -1,5 +1,7 @@
 package com.link.up.connector.elasticsearch8.schema;
 
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.link.up.api.table.catalog.Column;
@@ -7,9 +9,10 @@ import com.link.up.api.table.catalog.TableSchema;
 import com.link.up.api.table.type.BasicType;
 import com.link.up.api.table.type.DecimalType;
 import com.link.up.api.table.type.FluxDataType;
-import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import jakarta.json.stream.JsonGenerator;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -30,15 +33,25 @@ public final class Elasticsearch8TypeMapper {
         if (mapping == null) {
             throw new IllegalArgumentException("Elasticsearch index mapping must not be null");
         }
-        final Map<String, Object> raw;
+        return toTableSchema(toRawMapping(mapping), projectedFields);
+    }
+
+    private static Map<String, Object> toRawMapping(TypeMapping mapping) {
         try {
-            raw = OBJECT_MAPPER.readValue(
-                    mapping.toString(),
+            JacksonJsonpMapper jsonpMapper = new JacksonJsonpMapper(OBJECT_MAPPER);
+            StringWriter json = new StringWriter();
+            JsonGenerator generator = jsonpMapper.jsonProvider().createGenerator(json);
+            try {
+                mapping.serialize(generator, jsonpMapper);
+            } finally {
+                generator.close();
+            }
+            return OBJECT_MAPPER.readValue(
+                    json.toString(),
                     new TypeReference<Map<String, Object>>() { });
-        } catch (IOException failure) {
+        } catch (IOException | RuntimeException failure) {
             throw new IllegalArgumentException("Failed to read Elasticsearch 8 mapping JSON", failure);
         }
-        return toTableSchema(raw, projectedFields);
     }
 
     static TableSchema toTableSchema(

--- a/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/config/JdbcSinkConfigTest.java
+++ b/link-up-connectors/link-up-connector-jdbc/src/test/java/com/link/up/connector/jdbc/config/JdbcSinkConfigTest.java
@@ -11,6 +11,8 @@ import static org.junit.Assert.*;
 
 public class JdbcSinkConfigTest {
 
+    private static final String MYSQL_DRIVER = "com.mysql.cj.jdbc.Driver";
+
     @Test
     public void shouldResolveTargetTableTemplateForMySqlPath() {
         JdbcSinkConfig config = config("table = \"sink_${schema_name}_${table_name}\"");
@@ -43,6 +45,7 @@ public class JdbcSinkConfigTest {
                 ReadonlyConfig.fromConfig(
                         ConfigFactory.parseString(
                                 "url = \"jdbc:mysql://localhost:3306/test1\"\n"
+                                        + "driver = \"" + MYSQL_DRIVER + "\"\n"
                                         + "table = \"test1.sink_${table_name}\"")
                                 .resolve(
                                         ConfigResolveOptions.defaults()
@@ -79,6 +82,8 @@ public class JdbcSinkConfigTest {
         return JdbcSinkConfig.of(
                 ReadonlyConfig.fromConfig(
                         ConfigFactory.parseString(
-                                "url = \"jdbc:mysql://localhost:3306/flux_test\"\n" + sinkOptions)));
+                                "url = \"jdbc:mysql://localhost:3306/flux_test\"\n"
+                                        + "driver = \"" + MYSQL_DRIVER + "\"\n"
+                                        + sinkOptions)));
     }
 }

--- a/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/sink/StarRocksSinkWriterTest.java
+++ b/link-up-connectors/link-up-connector-starrocks/src/test/java/com/link/up/connector/starrocks/sink/StarRocksSinkWriterTest.java
@@ -38,7 +38,7 @@ public class StarRocksSinkWriterTest {
 
         writer.open();
         writer.write(
-                RecordBatch.data(
+                batch(
                         Arrays.asList(
                                 FluxRow.of(1L, "a"),
                                 FluxRow.of(2L, "b"),
@@ -66,7 +66,7 @@ public class StarRocksSinkWriterTest {
 
         writer.open();
         writer.write(
-                RecordBatch.data(Collections.singletonList(FluxRow.of(1L, "a"))),
+                batch(Collections.singletonList(FluxRow.of(1L, "a"))),
                 sourceTable(schema()));
         assertEquals(0, executor.payloads.size());
 
@@ -92,10 +92,10 @@ public class StarRocksSinkWriterTest {
         writer.open();
         try {
             writer.write(
-                    RecordBatch.data(Collections.singletonList(FluxRow.of(1L, "a"))),
+                    batch(Collections.singletonList(FluxRow.of(1L, "a"))),
                     sourceTable(first));
             writer.write(
-                    RecordBatch.data(Collections.singletonList(FluxRow.of(2L, "b", "x"))),
+                    batch(Collections.singletonList(FluxRow.of(2L, "b", "x"))),
                     sourceTable(second));
         } finally {
             writer.close();
@@ -122,7 +122,7 @@ public class StarRocksSinkWriterTest {
 
         writer.open();
         writer.write(
-                RecordBatch.data(
+                batch(
                         Arrays.asList(
                                 FluxRow.of(1L, "a"),
                                 FluxRow.of(2L, "b"))),
@@ -135,6 +135,10 @@ public class StarRocksSinkWriterTest {
         assertEquals(1, summary.getSampleCount());
 
         writer.close();
+    }
+
+    private static RecordBatch<FluxRow> batch(List<FluxRow> rows) {
+        return RecordBatch.of("source.orders", "split-0", rows);
     }
 
     private static StarRocksSinkWriter writer(


### PR DESCRIPTION
## Summary

Repair the failures exposed by the new full backend CI (`mvn clean verify`) and fix a real Elasticsearch 8 typed-mapping serialization bug found by that CI.

## Fixes

### JDBC sink config tests

`JdbcConnectionConfig` requires the JDBC `driver`, while `JdbcSinkConfigTest` still created configs with only `url`. The fixtures now provide `com.mysql.cj.jdbc.Driver`.

### StarRocks / ClickHouse writer tests

The tests still used the removed `RecordBatch.data(...)` API. They now use the current identity-aware API:

```java
RecordBatch.of("source.orders", "split-0", rows)
```

### Elasticsearch 7 sink config test

The test now wraps its map with `ReadonlyConfig.fromMap(...)`, matching the current `Elasticsearch7SinkConfig.of(...)` contract.

### Elasticsearch 8 typed mapping conversion

`Elasticsearch8TypeMapper` previously parsed `TypeMapping.toString()` as JSON. The current Elasticsearch Java client returns a debug representation beginning with `TypeMapping:`, so this is not a valid or stable JSON serialization path.

The public `TypeMapping` boundary now serializes through `JacksonJsonpMapper` and a JSON-P `JsonGenerator`, then converts the resulting JSON into the existing map-based schema mapping path.

This fixes the actual runtime path rather than weakening or skipping the test.

## Scope

- Keeps all backend tests enabled
- Test compatibility fixes for stale fixtures/APIs
- One production fix in the Elasticsearch 8 mapping conversion boundary
- No release/deployment changes

## Verification

GitHub Actions completed successfully with the canonical full build:

```bash
mvn --batch-mode --no-transfer-progress clean verify
```

`Backend CI / Maven Verify (Java 8)` is green on the latest PR commit. The complete Maven reactor, including Elasticsearch 8, Link-Up Server, and `link-up-dist`, now passes.
